### PR TITLE
feat: conso portfolio v2 — billing unified + conso audit + patrimoine-first UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Pilotage reglementaire et energetique multi-sites B2B France -- conformite, usag
 > | Authentification / IAM (JWT + 11 roles + scopes) | Stable |
 > | Patrimoine (import HELIOS, anomalies, impact, cockpit portfolio) | Stable -- V58-V63 |
 > | Facturation (org-scoping, PDF import, shadow billing, Action Center) | Stable -- V66 |
-> | Suite de tests automatises | **2 104 passes, 0 echec** |
+> | Timeline & couverture facturation (periods, coverage engine, /billing page) | Stable -- V67 |
+> | Suite de tests automatises | **2 118 passes, 0 echec** |
 
 > **Disclaimer**
 >
@@ -53,9 +54,9 @@ Pilotage reglementaire et energetique multi-sites B2B France -- conformite, usag
 <a id="tldr"></a>
 ## TL;DR
 
-- **Backend FastAPI** avec ~150 endpoints, 20+ modeles SQLAlchemy, 4 moteurs de regles reglementaires, 5 connecteurs de donnees, 4 watchers de veille, 5 agents IA (stub), module Patrimoine complet (import HELIOS, anomalies, impact reglementaire, cockpit portfolio V60-V63), module Facturation production-grade (org-scoping, PDF EDF/Engie, shadow billing, 12 regles d'anomalie, bridge Action Center).
-- **Frontend React 18 + Tailwind + Vite** avec 20+ pages : Dashboard, Cockpit Executif, Patrimoine (heatmap + portfolio), Detail Site, Plan d'action, RegOps, Conso & Usages, Tertiaire OPERAT, IAM Admin, Import, KB Explorer, Veille Reglementaire, Facturation (BillIntel + SiteBillingMini), et plus.
-- **2 104 tests passent, 0 echec** — pytest backend complet, seed de 120 sites + 10 personas IAM en une commande, demo operationnelle en 2 minutes.
+- **Backend FastAPI** avec ~150 endpoints, 20+ modeles SQLAlchemy, 4 moteurs de regles reglementaires, 5 connecteurs de donnees, 4 watchers de veille, 5 agents IA (stub), module Patrimoine complet (import HELIOS, anomalies, impact reglementaire, cockpit portfolio V60-V63), module Facturation production-grade (org-scoping, PDF EDF/Engie, shadow billing, 12 regles d'anomalie, bridge Action Center), timeline & couverture facturation (periods, coverage engine V67).
+- **Frontend React 18 + Tailwind + Vite** avec 20+ pages : Dashboard, Cockpit Executif, Patrimoine (heatmap + portfolio), Detail Site, Plan d'action, RegOps, Conso & Usages, Tertiaire OPERAT, IAM Admin, Import, KB Explorer, Veille Reglementaire, Facturation (BillIntel + BillingPage timeline + SiteBillingMini), et plus.
+- **2 118 tests passent, 0 echec** — pytest backend complet, seed de 120 sites + 10 personas IAM en une commande, demo operationnelle en 2 minutes.
 
 ---
 
@@ -409,6 +410,9 @@ Champs cles du Site :
 | `POST` | `/api/billing/audit-all` | Lancer les 12 regles d'anomalie sur toutes les factures |
 | `GET` | `/api/billing/site/{id}` | Facturation d'un site (factures + insights) |
 | `GET` | `/api/billing/anomalies-scoped` | Anomalies billing au format Patrimoine (FACTURATION) |
+| `GET` | `/api/billing/periods` | Timeline mensuelle paginee (coverage_status, ratio, total_ttc) |
+| `GET` | `/api/billing/coverage-summary` | KPIs globaux : mois couverts/partiels/manquants, top sites |
+| `GET` | `/api/billing/missing-periods` | Periodes manquantes/partielles paginées avec CTA import |
 | `GET` | `/health` | Health check |
 
 Documentation Swagger complete : `http://localhost:8000/docs`
@@ -433,6 +437,7 @@ Documentation Swagger complete : `http://localhost:8000/docs`
 | `/watchers` | Veille Reglementaire | Evenements Legifrance/CRE/RTE, revue manuelle |
 | `/kb` | KB Explorer | Knowledge Base : archetypes, regles anomalie, recommendations |
 | `/bill-intel` | Bill Intelligence | Import CSV/PDF, shadow billing 12 regles, anomalies, "Creer action" CTA |
+| `/billing` | Timeline Facturation | Vue mensuelle couverture (covered/partial/missing), CoverageBar, filtres, pagination |
 | `/monitoring` | Monitoring | Alertes actives, KPIs live, badges sidebar |
 | `/purchase` | Achat Energie | Assistant achat multi-sites, note decision, RFP |
 | `/admin/users` | Admin Utilisateurs | Gestion users/roles/scopes, journal d'audit |
@@ -530,7 +535,17 @@ Pour plus de details : [Security Notes](docs/security_notes.md) | [Demo Script](
   - Bridge `ActionItem` : chaque anomalie billing cree un ActionItem idempotent (`source_type=BILLING`)
   - `SiteBillingMini` : KPIs facturation integres dans l'onglet Factures de Site360
   - `GET /anomalies-scoped` : anomalies billing visibles dans la page Anomalies (framework FACTURATION)
-- **2 104 tests automatises (pytest), 0 echec**
+- **Timeline & Couverture Facturation (V67)** :
+  - `billing_coverage.py` : moteur de couverture mensuelle (`COVERAGE_THRESHOLD=0.80`, SoT `period_start/end` → fallback `issue_date` mois entier, avoirs exclus via `total_eur <= 0`, `set()` de jours anti-double-comptage)
+  - 4 index SQLAlchemy sur `EnergyInvoice` (`period_start`, `period_end`, `issue_date`, `(site_id, period_start)`)
+  - Fix N+1 `anomalies-scoped` : batch `Site.id.in_(...)` au lieu de 1+N queries
+  - 3 nouveaux endpoints pagines : `GET /billing/periods`, `/billing/coverage-summary`, `/billing/missing-periods`
+  - `BillingPage.jsx` : page `/billing` avec filtres URL (`?site_id=`), KPIs (covered/partial/missing), CoverageBar, periodes manquantes, timeline paginee "charger plus"
+  - `BillingTimeline.jsx` : liste mensuelle avec chips statut, totaux TTC, CTA Voir/Importer/Creer action
+  - `CoverageBar.jsx` : barre proportionnelle verte|orange|rouge
+  - Lien "Voir timeline complete" dans Site360 → `/billing?site_id=X`
+  - 14 tests backend + 31 tests frontend source-guard
+- **2 118 tests automatises (pytest), 0 echec**
 - 12 items KB valides (archetypes, regles, recommendations)
 - Smoke test "red button" (14 checks avant mise en pilote)
 
@@ -632,7 +647,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 cd backend
 python -m pytest tests/ -v --tb=short
 ```
-Resultat attendu : `2104 passed, 12 skipped`.
+Resultat attendu : `2118 passed, 12 skipped`.
 
 ### Tests IAM uniquement
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Pilotage reglementaire et energetique multi-sites B2B France -- conformite, usag
 > | Patrimoine (import HELIOS, anomalies, impact, cockpit portfolio) | Stable -- V58-V63 |
 > | Facturation (org-scoping, PDF import, shadow billing, Action Center) | Stable -- V66 |
 > | Timeline & couverture facturation (periods, coverage engine, /billing page) | Stable -- V67 |
-> | Suite de tests automatises | **2 118 passes, 0 echec** |
+> | Billing Unified (shadow V2 TURPE/CSPE, R13/R14, deep-links, seed 36 mois) | Stable -- V68 |
+> | Suite de tests automatises | **2 138 passes, 0 echec** |
 
 > **Disclaimer**
 >
@@ -54,9 +55,9 @@ Pilotage reglementaire et energetique multi-sites B2B France -- conformite, usag
 <a id="tldr"></a>
 ## TL;DR
 
-- **Backend FastAPI** avec ~150 endpoints, 20+ modeles SQLAlchemy, 4 moteurs de regles reglementaires, 5 connecteurs de donnees, 4 watchers de veille, 5 agents IA (stub), module Patrimoine complet (import HELIOS, anomalies, impact reglementaire, cockpit portfolio V60-V63), module Facturation production-grade (org-scoping, PDF EDF/Engie, shadow billing, 12 regles d'anomalie, bridge Action Center), timeline & couverture facturation (periods, coverage engine V67).
-- **Frontend React 18 + Tailwind + Vite** avec 20+ pages : Dashboard, Cockpit Executif, Patrimoine (heatmap + portfolio), Detail Site, Plan d'action, RegOps, Conso & Usages, Tertiaire OPERAT, IAM Admin, Import, KB Explorer, Veille Reglementaire, Facturation (BillIntel + BillingPage timeline + SiteBillingMini), et plus.
-- **2 118 tests passent, 0 echec** — pytest backend complet, seed de 120 sites + 10 personas IAM en une commande, demo operationnelle en 2 minutes.
+- **Backend FastAPI** avec ~150 endpoints, 20+ modeles SQLAlchemy, 4 moteurs de regles reglementaires, 5 connecteurs de donnees, 4 watchers de veille, 5 agents IA (stub), module Patrimoine complet (import HELIOS, anomalies, impact reglementaire, cockpit portfolio V60-V63), module Facturation production-grade (org-scoping, PDF EDF/Engie, shadow billing V2 TURPE/CSPE/TICGN, 14 regles d'anomalie, bridge Action Center), timeline & couverture facturation (periods, coverage engine V67), Billing Unified (InvoiceNormalized, deep-links bidirectionnels, seed 36 mois HELIOS V68).
+- **Frontend React 18 + Tailwind + Vite** avec 20+ pages : Dashboard, Cockpit Executif, Patrimoine (heatmap + portfolio), Detail Site, Plan d'action, RegOps, Conso & Usages, Tertiaire OPERAT, IAM Admin, Import, KB Explorer, Veille Reglementaire, Facturation (BillIntel deep-links site_id/month + BillingPage activeMonth highlight + BillingTimeline ring + SiteBillingMini), et plus.
+- **2 138 tests passent, 0 echec** — pytest backend complet, seed de 120 sites + 10 personas IAM + 36 mois facturation HELIOS en une commande, demo operationnelle en 2 minutes.
 
 ---
 
@@ -407,7 +408,8 @@ Champs cles du Site :
 | `GET` | `/api/billing/summary` | KPIs facturation (total factures, pertes estimees) |
 | `POST` | `/api/billing/import-csv` | Import factures CSV |
 | `POST` | `/api/billing/import-pdf` | Import facture PDF EDF/Engie (pymupdf) |
-| `POST` | `/api/billing/audit-all` | Lancer les 12 regles d'anomalie sur toutes les factures |
+| `GET` | `/api/billing/invoices/normalized` | Factures normalisees (ht/tva/fournisseur/energie calcules) |
+| `POST` | `/api/billing/audit-all` | Lancer les 14 regles d'anomalie sur toutes les factures |
 | `GET` | `/api/billing/site/{id}` | Facturation d'un site (factures + insights) |
 | `GET` | `/api/billing/anomalies-scoped` | Anomalies billing au format Patrimoine (FACTURATION) |
 | `GET` | `/api/billing/periods` | Timeline mensuelle paginee (coverage_status, ratio, total_ttc) |
@@ -545,7 +547,17 @@ Pour plus de details : [Security Notes](docs/security_notes.md) | [Demo Script](
   - `CoverageBar.jsx` : barre proportionnelle verte|orange|rouge
   - Lien "Voir timeline complete" dans Site360 → `/billing?site_id=X`
   - 14 tests backend + 31 tests frontend source-guard
-- **2 118 tests automatises (pytest), 0 echec**
+- **Billing Unified V68** :
+  - `billing_normalization.py` : `InvoiceNormalized` Pydantic schema + `normalize_invoice()` (ht=ENERGY+NETWORK lines, tva=TAX lines, fournisseur/energie depuis contrat) + `GET /billing/invoices/normalized`
+  - `billing_shadow_v2.py` : constantes TURPE/ATRD/ATRT/CSPE/TICGN + `shadow_billing_v2()` → 4 composantes (fourniture/reseau/taxes/tva) + deltas vs facture
+  - R13 (`_rule_reseau_mismatch` : delta reseau > 10% medium, > 20% high) + R14 (`_rule_taxes_mismatch` : delta taxes > 5% medium) → BILLING_RULES 14 regles
+  - Navigation bidirectionnelle : `BillingTimeline → /bill-intel?site_id=X&month=YYYY-MM` ; `BillIntelPage → /billing?site_id=X`
+  - `BillIntelPage.jsx` : `useSearchParams` → `siteFilter`/`monthFilter` pre-remplis depuis URL, filtrage front `filteredInvoices`, bouton "Voir timeline" (CalendarRange)
+  - `BillingPage.jsx` : lit `?month=YYYY-MM` → `activeMonth` state → passe a BillingTimeline
+  - `BillingTimeline.jsx` : `activeMonth` prop → `ring-2 ring-amber-400` sur la ligne du mois actif
+  - Seed 36 mois HELIOS : Jan 2023–Dec 2025 × 2 sites (site_a ELEC 9000 kWh, site_b GAZ 6000 kWh), 3 trous (2023-03, 2024-09, 2025-02), 2 partiels (2023-06 15j, 2024-01 20j), 3 anomalies controlees (2024-07 R1 shadow gap, 2024-11 R13 reseau, 2025-01 R14 taxes). Idempotent via `source="seed_36m"`, integre dans `seed_data.py`
+  - 20 tests backend + 49 tests frontend source-guard
+- **2 138 tests automatises (pytest), 0 echec**
 - 12 items KB valides (archetypes, regles, recommendations)
 - Smoke test "red button" (14 checks avant mise en pilote)
 
@@ -647,7 +659,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 cd backend
 python -m pytest tests/ -v --tb=short
 ```
-Resultat attendu : `2118 passed, 12 skipped`.
+Resultat attendu : `2138 passed, 12 skipped`.
 
 ### Tests IAM uniquement
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Pilotage reglementaire et energetique multi-sites B2B France -- conformite, usag
 > | Couche IA (5 agents, mode stub sans cle API) | Stable |
 > | Authentification / IAM (JWT + 11 roles + scopes) | Stable |
 > | Patrimoine (import HELIOS, anomalies, impact, cockpit portfolio) | Stable -- V58-V63 |
-> | Suite de tests automatises | **2 087 passes, 0 echec** |
+> | Facturation (org-scoping, PDF import, shadow billing, Action Center) | Stable -- V66 |
+> | Suite de tests automatises | **2 104 passes, 0 echec** |
 
 > **Disclaimer**
 >
@@ -52,9 +53,9 @@ Pilotage reglementaire et energetique multi-sites B2B France -- conformite, usag
 <a id="tldr"></a>
 ## TL;DR
 
-- **Backend FastAPI** avec ~150 endpoints, 20+ modeles SQLAlchemy, 4 moteurs de regles reglementaires, 5 connecteurs de donnees, 4 watchers de veille, 5 agents IA (stub), module Patrimoine complet (import HELIOS, anomalies, impact reglementaire, cockpit portfolio V60-V63).
-- **Frontend React 18 + Tailwind + Vite** avec 20+ pages : Dashboard, Cockpit Executif, Patrimoine (heatmap + portfolio), Detail Site, Plan d'action, RegOps, Conso & Usages, Tertiaire OPERAT, IAM Admin, Import, KB Explorer, Veille Reglementaire, et plus.
-- **2 087 tests passent, 0 echec** — pytest backend complet, seed de 120 sites + 10 personas IAM en une commande, demo operationnelle en 2 minutes.
+- **Backend FastAPI** avec ~150 endpoints, 20+ modeles SQLAlchemy, 4 moteurs de regles reglementaires, 5 connecteurs de donnees, 4 watchers de veille, 5 agents IA (stub), module Patrimoine complet (import HELIOS, anomalies, impact reglementaire, cockpit portfolio V60-V63), module Facturation production-grade (org-scoping, PDF EDF/Engie, shadow billing, 12 regles d'anomalie, bridge Action Center).
+- **Frontend React 18 + Tailwind + Vite** avec 20+ pages : Dashboard, Cockpit Executif, Patrimoine (heatmap + portfolio), Detail Site, Plan d'action, RegOps, Conso & Usages, Tertiaire OPERAT, IAM Admin, Import, KB Explorer, Veille Reglementaire, Facturation (BillIntel + SiteBillingMini), et plus.
+- **2 104 tests passent, 0 echec** — pytest backend complet, seed de 120 sites + 10 personas IAM en une commande, demo operationnelle en 2 minutes.
 
 ---
 
@@ -361,6 +362,13 @@ DataPoint         -- Donnees externes horodatees (CO2, meteo, PV)
 RegSourceEvent    -- Evenements de veille reglementaire (hash dedup)
 JobOutbox         -- File d'attente async (recompute, sync, watcher, IA)
 AiInsight         -- Sorties des agents IA (EXPLAIN | SUGGEST | EXEC_BRIEF | ...)
+ActionItem        -- Actions centralisees (source: MANUAL | INSIGHT | BILLING | COMPLIANCE)
+
+EnergyContract    -- Contrat fournisseur energie (site, type, dates, prix ref)
+EnergyInvoice     -- Facture energie (CSV ou PDF, status, raw_json evidence)
+  +-- EnergyInvoiceLine  -- Lignes HT/TVA/TAXES/ENERGY
+BillingInsight    -- Anomalie de facturation (type, severity, estimated_loss_eur)
+BillingImportBatch -- Batch d'import (CSV ou PDF, statut, nb lignes)
 ```
 
 Champs cles du Site :
@@ -393,6 +401,14 @@ Champs cles du Site :
 | `GET` | `/api/patrimoine/portfolio-summary` | Cockpit portfolio : risque global, top sites, trend |
 | `POST` | `/api/patrimoine/staging/upload` | Import HELIOS CSV/XLSX — pipeline staging |
 | `POST` | `/api/patrimoine/staging/{id}/activate` | Activation staging → entites reelles |
+| `GET` | `/api/billing/invoices` | Liste factures org-scopees |
+| `GET` | `/api/billing/insights` | Anomalies de facturation org-scopees |
+| `GET` | `/api/billing/summary` | KPIs facturation (total factures, pertes estimees) |
+| `POST` | `/api/billing/import-csv` | Import factures CSV |
+| `POST` | `/api/billing/import-pdf` | Import facture PDF EDF/Engie (pymupdf) |
+| `POST` | `/api/billing/audit-all` | Lancer les 12 regles d'anomalie sur toutes les factures |
+| `GET` | `/api/billing/site/{id}` | Facturation d'un site (factures + insights) |
+| `GET` | `/api/billing/anomalies-scoped` | Anomalies billing au format Patrimoine (FACTURATION) |
 | `GET` | `/health` | Health check |
 
 Documentation Swagger complete : `http://localhost:8000/docs`
@@ -416,7 +432,7 @@ Documentation Swagger complete : `http://localhost:8000/docs`
 | `/connectors` | Connecteurs | Statut des 5 connecteurs, test/sync manuels |
 | `/watchers` | Veille Reglementaire | Evenements Legifrance/CRE/RTE, revue manuelle |
 | `/kb` | KB Explorer | Knowledge Base : archetypes, regles anomalie, recommendations |
-| `/bill-intelligence` | Bill Intelligence | Analyse factures, shadow billing, 20 regles d'anomalie |
+| `/bill-intel` | Bill Intelligence | Import CSV/PDF, shadow billing 12 regles, anomalies, "Creer action" CTA |
 | `/monitoring` | Monitoring | Alertes actives, KPIs live, badges sidebar |
 | `/purchase` | Achat Energie | Assistant achat multi-sites, note decision, RFP |
 | `/admin/users` | Admin Utilisateurs | Gestion users/roles/scopes, journal d'audit |
@@ -506,7 +522,15 @@ Pour plus de details : [Security Notes](docs/security_notes.md) | [Demo Script](
   - Portfolio Health Bar enrichi (V61) : % sains/warning/critical, top 3 frameworks, trend
   - Portfolio Trend reel (V62) : cache in-memory par org_id, direction up/down/stable
   - Heatmap portefeuille (V63) : grille sites scalable top-15, risque x anomalies x framework
-- **2 087 tests automatises (pytest), 0 echec**
+- **Module Facturation production-grade (V66)** :
+  - Org-scoping sur 13 endpoints (`resolve_org_id` + join `site→portefeuille→entite_juridique→org`)
+  - `response_model` Pydantic sur tous les endpoints GET (Swagger + validation outbound)
+  - Import PDF EDF/Engie via pymupdf (fitz) — templates detectes, confiance >= 0.5
+  - 12 regles d'anomalie : R1-R10 shadow billing + R11 TTC coherence + R12 expiry contrat
+  - Bridge `ActionItem` : chaque anomalie billing cree un ActionItem idempotent (`source_type=BILLING`)
+  - `SiteBillingMini` : KPIs facturation integres dans l'onglet Factures de Site360
+  - `GET /anomalies-scoped` : anomalies billing visibles dans la page Anomalies (framework FACTURATION)
+- **2 104 tests automatises (pytest), 0 echec**
 - 12 items KB valides (archetypes, regles, recommendations)
 - Smoke test "red button" (14 checks avant mise en pilote)
 
@@ -517,7 +541,7 @@ Pour plus de details : [Security Notes](docs/security_notes.md) | [Demo Script](
 - Base de donnees PostgreSQL (SQLite uniquement)
 - CI/CD (fichiers GitHub Actions presents mais vides)
 - Rate limiting / throttling
-- Import de donnees reelles (factures, releves compteurs)
+- Import de donnees reelles (releves compteurs Enedis)
 - Notifications (email, webhook)
 
 ---
@@ -608,7 +632,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 cd backend
 python -m pytest tests/ -v --tb=short
 ```
-Resultat attendu : `2087 passed, 9 skipped`.
+Resultat attendu : `2104 passed, 12 skipped`.
 
 ### Tests IAM uniquement
 

--- a/backend/app/bill_intelligence/parsers/pdf_parser.py
+++ b/backend/app/bill_intelligence/parsers/pdf_parser.py
@@ -40,32 +40,32 @@ class PDFTemplate:
 # Text extraction
 # ========================================
 
+def extract_text_with_fitz(content: bytes) -> str:
+    """Extract text from PDF bytes via pymupdf (fitz) — in requirements.txt."""
+    import fitz  # pymupdf
+    doc = fitz.open(stream=content, filetype="pdf")
+    text = "\n".join(page.get_text() for page in doc)
+    doc.close()
+    return text
+
+
+def parse_pdf_bytes(content: bytes, source_filename: str = "upload.pdf"):
+    """Entry point: PDF bytes → Invoice domain object or None."""
+    text = extract_text_with_fitz(content)
+    return parse_pdf_text(text, source_filename)
+
+
 def extract_text_from_pdf(file_path: str) -> str:
     """
-    Extract text from a PDF file.
-    Tries pdfplumber first, falls back to basic extraction.
+    Extract text from a PDF file path (legacy — used in tests).
+    Reads file bytes and delegates to extract_text_with_fitz.
     """
-    try:
-        import pdfplumber
-        with pdfplumber.open(file_path) as pdf:
-            pages = []
-            for page in pdf.pages:
-                text = page.extract_text()
-                if text:
-                    pages.append(text)
-            return "\n".join(pages)
-    except ImportError:
-        pass
-
+    with open(file_path, "rb") as f:
+        content = f.read()
     # Fallback: if it's a .txt file pretending to be a PDF (demo mode)
     if file_path.endswith(".txt"):
-        with open(file_path, "r", encoding="utf-8") as f:
-            return f.read()
-
-    raise ValueError(
-        f"Cannot extract PDF text: pdfplumber not installed. "
-        f"Install with: pip install pdfplumber"
-    )
+        return content.decode("utf-8", errors="replace")
+    return extract_text_with_fitz(content)
 
 
 # ========================================

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -41,6 +41,9 @@ def run_migrations(engine):
     _add_dp_compteur_cascade_trigger(engine)
     # V39 — Tertiaire / OPERAT
     _create_tertiaire_tables(engine)
+    # V2-Conso — Dedup meter_reading + unique constraint
+    _dedup_meter_reading(engine)
+    _add_unique_meter_reading_index(engine)
 
 
 def _add_soft_delete_columns(engine):
@@ -571,3 +574,76 @@ def _create_tertiaire_tables(engine):
         logger.info("migration: V39 tertiaire — %d table(s) created", created)
     else:
         logger.debug("migration: V39 tertiaire tables already present — no changes")
+
+
+# ========================================
+# V2-Conso — meter_reading dedup + unique
+# ========================================
+
+def _dedup_meter_reading(engine):
+    """Remove duplicate (meter_id, timestamp) rows from meter_reading.
+
+    Strategy: keep the row with the best quality_score, ties broken by most
+    recent created_at, then highest id.  Idempotent — skips if no duplicates.
+    """
+    insp = inspect(engine)
+    if not insp.has_table("meter_reading"):
+        return
+
+    with engine.begin() as conn:
+        dupes = conn.execute(text("""
+            SELECT meter_id, timestamp, COUNT(*) AS cnt
+            FROM meter_reading
+            GROUP BY meter_id, timestamp
+            HAVING cnt > 1
+        """)).fetchall()
+
+        if not dupes:
+            logger.debug("migration: meter_reading — no duplicates found")
+            return
+
+        deleted = 0
+        for meter_id, ts, cnt in dupes:
+            # Keep the best row (highest quality_score, then latest created_at, then highest id)
+            keep = conn.execute(text("""
+                SELECT id FROM meter_reading
+                WHERE meter_id = :mid AND timestamp = :ts
+                ORDER BY
+                    COALESCE(quality_score, -1) DESC,
+                    COALESCE(created_at, '1970-01-01') DESC,
+                    id DESC
+                LIMIT 1
+            """), {"mid": meter_id, "ts": ts}).scalar()
+
+            if keep:
+                result = conn.execute(text("""
+                    DELETE FROM meter_reading
+                    WHERE meter_id = :mid AND timestamp = :ts AND id != :keep_id
+                """), {"mid": meter_id, "ts": ts, "keep_id": keep})
+                deleted += result.rowcount
+
+        logger.info("migration: meter_reading dedup — removed %d duplicate rows from %d pairs",
+                     deleted, len(dupes))
+
+
+def _add_unique_meter_reading_index(engine):
+    """Add UNIQUE index on (meter_id, timestamp) to prevent future duplicates."""
+    idx_name = "uq_meter_reading_meter_ts"
+    insp = inspect(engine)
+
+    if not insp.has_table("meter_reading"):
+        return
+
+    existing = {idx["name"] for idx in insp.get_indexes("meter_reading") if idx.get("name")}
+    if idx_name in existing:
+        return
+
+    with engine.begin() as conn:
+        try:
+            conn.execute(text(
+                f'CREATE UNIQUE INDEX IF NOT EXISTS "{idx_name}" '
+                f'ON "meter_reading" ("meter_id", "timestamp")'
+            ))
+            logger.info("migration: created unique index %s", idx_name)
+        except Exception as e:
+            logger.warning("migration: could not create index %s: %s", idx_name, e)

--- a/backend/main.py
+++ b/backend/main.py
@@ -107,6 +107,16 @@ app.include_router(tertiaire_router)  # Tertiaire / OPERAT V39 (EFA, controls, p
 from database import engine as _engine, run_migrations as _run_migrations
 _run_migrations(_engine)
 
+# Startup route validation: verify critical V67 billing routes are registered
+_REQUIRED_BILLING_PATHS = ["/api/billing/periods", "/api/billing/coverage-summary", "/api/billing/missing-periods"]
+_registered = {r.path for r in app.routes}
+_missing = [p for p in _REQUIRED_BILLING_PATHS if p not in _registered]
+if _missing:
+    import logging
+    logging.getLogger("promeos").error(f"[STARTUP] CRITICAL: billing routes missing from app: {_missing}. Restart uvicorn.")
+else:
+    print(f"[STARTUP] Billing V67 routes OK ({len(_REQUIRED_BILLING_PATHS)} verified)")
+
 
 @app.on_event("startup")
 async def restore_or_seed_helios():

--- a/backend/main.py
+++ b/backend/main.py
@@ -212,6 +212,30 @@ def api_health():
     }
 
 
+@app.get("/api/meta/version")
+def api_meta_version():
+    """V69: Git sha + branch — visible en mode Expert."""
+    import subprocess, datetime
+    git_sha, branch = "unknown", "unknown"
+    try:
+        git_sha = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=os.path.dirname(__file__), stderr=subprocess.DEVNULL,
+        ).decode().strip()
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=os.path.dirname(__file__), stderr=subprocess.DEVNULL,
+        ).decode().strip()
+    except Exception:
+        pass
+    return {
+        "sha": git_sha,
+        "branch": branch,
+        "build_time": datetime.datetime.now(datetime.UTC).isoformat(),
+        "version": "1.0.0",
+    }
+
+
 @app.get("/health")
 def health_check():
     return {

--- a/backend/main.py
+++ b/backend/main.py
@@ -107,6 +107,75 @@ app.include_router(tertiaire_router)  # Tertiaire / OPERAT V39 (EFA, controls, p
 from database import engine as _engine, run_migrations as _run_migrations
 _run_migrations(_engine)
 
+
+@app.on_event("startup")
+async def restore_or_seed_helios():
+    """
+    Au démarrage : si DEMO_MODE=true, restaurer DemoState depuis la DB
+    (org is_demo=True existante) ou seeder HELIOS fresh si aucune org demo.
+    Idempotent — ne re-seed pas si une org demo existe déjà en DB.
+    """
+    if os.environ.get("PROMEOS_DEMO_MODE", "false").lower() != "true":
+        return
+    # Never run during pytest — test fixtures manage their own DB isolation
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+
+    from database import SessionLocal
+    from services.demo_state import DemoState
+
+    if DemoState.get_demo_org_id():
+        return  # DemoState déjà rempli (ex: test ou rechargement uvicorn)
+
+    db = SessionLocal()
+    try:
+        from models import Organisation, Site, Portefeuille, EntiteJuridique
+        demo_org = (db.query(Organisation)
+            .filter(Organisation.actif == True, Organisation.is_demo == True)
+            .order_by(Organisation.id.desc())
+            .first())
+
+        if demo_org:
+            # Re-register après restart — pas de re-seed
+            pf_ids = [row.id for row in (
+                db.query(Portefeuille.id)
+                .join(EntiteJuridique,
+                      Portefeuille.entite_juridique_id == EntiteJuridique.id)
+                .filter(EntiteJuridique.organisation_id == demo_org.id)
+                .all()
+            )]
+            sites_q = db.query(Site).filter(
+                Site.portefeuille_id.in_(pf_ids), Site.actif == True
+            )
+            sites_count = sites_q.count()
+            first_site = sites_q.first()
+            DemoState.set_demo_org(
+                org_id=demo_org.id,
+                org_nom=demo_org.nom,
+                pack="helios",
+                size="S",
+                sites_count=sites_count,
+                default_site_id=first_site.id if first_site else None,
+                default_site_name=first_site.nom if first_site else None,
+            )
+        else:
+            # Fresh seed — premier démarrage, DB vide
+            from services.demo_seed import SeedOrchestrator
+            import logging
+            logging.getLogger("promeos.startup").info(
+                "[startup] Seeding HELIOS demo data..."
+            )
+            orch = SeedOrchestrator(db)
+            orch.seed(pack="helios", size="S", rng_seed=42)
+    except Exception as exc:
+        import logging
+        logging.getLogger("promeos.startup").warning(
+            f"[startup] HELIOS init failed (non-bloquant): {exc}"
+        )
+    finally:
+        db.close()
+
+
 # Route racine
 @app.get("/")
 def root():

--- a/backend/main.py
+++ b/backend/main.py
@@ -186,6 +186,58 @@ async def restore_or_seed_helios():
         db.close()
 
 
+@app.on_event("startup")
+async def seed_hourly_if_missing():
+    """Auto-seed hourly consumption data if only monthly data exists.
+
+    Required for diagnostics (hors_horaires, base_load, pointe, derive, data_gap)
+    which all need hourly readings (min 48+ readings threshold).
+    Idempotent — skips if hourly data already present.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+
+    from database import SessionLocal
+    from sqlalchemy import text
+    import logging
+
+    db = SessionLocal()
+    try:
+        hourly_count = db.execute(
+            text("SELECT COUNT(*) FROM meter_reading WHERE frequency = 'HOURLY'")
+        ).scalar()
+        if hourly_count and hourly_count > 0:
+            return  # Hourly data already exists
+
+        # Get demo sites (max 5)
+        from models import Site
+        sites = db.query(Site).filter(Site.actif == True).limit(5).all()
+        if not sites:
+            return
+
+        from services.consumption_diagnostic import generate_demo_consumption
+        seeded = 0
+        for site in sites:
+            try:
+                result = generate_demo_consumption(db, site.id, days=90)
+                if result and not result.get("error"):
+                    seeded += 1
+            except Exception:
+                pass
+
+        if seeded > 0:
+            logging.getLogger("promeos.startup").info(
+                f"[startup] Auto-seeded hourly consumption for {seeded} sites (90 days each)"
+            )
+    except Exception as exc:
+        import logging as _log
+        _log.getLogger("promeos.startup").warning(
+            f"[startup] Hourly seed failed (non-bloquant): {exc}"
+        )
+    finally:
+        db.close()
+
+
 # Route racine
 @app.get("/")
 def root():

--- a/backend/main.py
+++ b/backend/main.py
@@ -36,6 +36,7 @@ from routes import (
     dev_tools_router,
     flex_router,
     tertiaire_router,
+    portfolio_router,
 )
 
 # Import KB router
@@ -102,6 +103,7 @@ app.include_router(ems_router)  # EMS Consumption Explorer
 app.include_router(flex_router)  # Flex Mini V0 (demand-side flexibility)
 app.include_router(dev_tools_router)  # Dev Tools (reset_db)
 app.include_router(tertiaire_router)  # Tertiaire / OPERAT V39 (EFA, controls, precheck, export)
+app.include_router(portfolio_router)  # Portfolio Consumption (multi-site B2B view)
 
 # Run safe schema migrations (idempotent, no drop)
 from database import engine as _engine, run_migrations as _run_migrations

--- a/backend/models/billing_models.py
+++ b/backend/models/billing_models.py
@@ -5,7 +5,7 @@ Complement the dataclass-based domain model in app/bill_intelligence/domain.py.
 """
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, Float, Text, Boolean, ForeignKey, Date, DateTime, Enum, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Float, Text, Boolean, ForeignKey, Date, DateTime, Enum, UniqueConstraint, Index
 from sqlalchemy.orm import relationship
 
 from .base import Base, TimestampMixin
@@ -108,6 +108,13 @@ class EnergyInvoice(Base, TimestampMixin):
         "EnergyInvoiceLine", back_populates="invoice",
         cascade="all, delete-orphan",
     )
+
+
+# V67 — Indexes sur les champs période pour les range queries de couverture
+_idx_period_start = Index("ix_energy_invoices_period_start", EnergyInvoice.period_start)
+_idx_period_end = Index("ix_energy_invoices_period_end", EnergyInvoice.period_end)
+_idx_issue_date = Index("ix_energy_invoices_issue_date", EnergyInvoice.issue_date)
+_idx_site_period = Index("ix_energy_invoices_site_period", EnergyInvoice.site_id, EnergyInvoice.period_start)
 
 
 class EnergyInvoiceLine(Base, TimestampMixin):

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -36,6 +36,7 @@ from .ems import router as ems_router
 from .dev_tools import router as dev_tools_router
 from .flex import router as flex_router
 from .tertiaire import router as tertiaire_router
+from .portfolio import router as portfolio_router
 
 __all__ = [
     "sites_router",
@@ -73,4 +74,5 @@ __all__ = [
     "dev_tools_router",
     "flex_router",
     "tertiaire_router",
+    "portfolio_router",
 ]

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -676,8 +676,8 @@ def get_insight_detail(
 
     metrics = json.loads(insight.metrics_json or "{}")
 
-    # Recalcul V2 à la demande si breakdown absent
-    if metrics and metrics.get("expected_ttc") is None and metrics.get("expected_fourniture_ht") is None:
+    # Recalcul V2 à la demande si breakdown absent (metrics peut être {} ou None-like)
+    if metrics.get("expected_ttc") is None and metrics.get("expected_fourniture_ht") is None:
         try:
             from services.billing_shadow_v2 import shadow_billing_v2
             invoice = db.query(EnergyInvoice).filter(EnergyInvoice.id == insight.invoice_id).first()
@@ -693,6 +693,14 @@ def get_insight_detail(
                 if lines:
                     v2 = shadow_billing_v2(invoice, lines, contract)
                     metrics.update(v2)
+                    # Ajouter confidence/assumptions si absents
+                    if "confidence" not in metrics:
+                        metrics["confidence"] = "medium"
+                    if "assumptions" not in metrics:
+                        metrics["assumptions"] = [
+                            "Tarifs POC simplifiés (CRE / DGFiP publique)",
+                            "Calcul basé sur les lignes facture disponibles",
+                        ]
                     # Persister pour éviter recalcul futur
                     insight.metrics_json = json.dumps(metrics)
                     db.commit()

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -712,6 +712,64 @@ def resolve_insight(
     }
 
 
+@router.get("/invoices/normalized")
+def list_invoices_normalized(
+    request: Request,
+    site_id: Optional[int] = Query(None),
+    month_key: Optional[str] = Query(None, description="Filtre YYYY-MM"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Factures normalisées (ht/tva/fournisseur calculés) — scoped to org."""
+    from services.billing_normalization import normalize_invoice
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    q = _org_sites_query(db, EnergyInvoice, effective_org_id)
+    if site_id:
+        q = q.filter(EnergyInvoice.site_id == site_id)
+    invoices = q.order_by(EnergyInvoice.period_start.desc().nullslast()).all()
+
+    # Filtre month_key (post-query, simple)
+    if month_key:
+        filtered = []
+        for inv in invoices:
+            mk = None
+            if inv.period_start:
+                mk = inv.period_start.strftime("%Y-%m")
+            elif inv.issue_date:
+                mk = inv.issue_date.strftime("%Y-%m")
+            if mk == month_key:
+                filtered.append(inv)
+        invoices = filtered
+
+    total = len(invoices)
+    page = invoices[offset: offset + limit]
+
+    normalized = []
+    for inv in page:
+        lines = db.query(EnergyInvoiceLine).filter(
+            EnergyInvoiceLine.invoice_id == inv.id
+        ).all()
+        contract = (
+            db.query(EnergyContract).filter(
+                EnergyContract.id == inv.contract_id
+            ).first()
+            if inv.contract_id else None
+        )
+        normalized.append(
+            normalize_invoice(inv, lines, contract, effective_org_id).model_dump()
+        )
+
+    return {
+        "invoices": normalized,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+    }
+
+
 @router.get("/invoices", response_model=InvoiceListResponse)
 def list_invoices(
     request: Request,

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -861,9 +861,13 @@ def get_billing_anomalies_scoped(
         .all()
     )
 
+    # Fix N+1 : charger tous les sites en une seule requête
+    site_ids = list({i.site_id for i in insights})
+    sites_map = {s.id: s for s in db.query(Site).filter(Site.id.in_(site_ids)).all()} if site_ids else {}
+
     anomalies = []
     for i in insights:
-        site = db.query(Site).filter(Site.id == i.site_id).first()
+        site = sites_map.get(i.site_id)
         anomalies.append({
             "code": i.type or "billing_anomaly",
             "severity": (i.severity or "MEDIUM").upper(),
@@ -879,6 +883,202 @@ def get_billing_anomalies_scoped(
         })
 
     return {"anomalies": anomalies, "count": len(anomalies)}
+
+
+# ========================================
+# V67 — Coverage endpoints
+# ========================================
+
+@router.get("/periods")
+def get_billing_periods(
+    request: Request,
+    site_id: Optional[int] = Query(None),
+    month_from: Optional[str] = Query(None, description="YYYY-MM"),
+    month_to: Optional[str] = Query(None, description="YYYY-MM"),
+    limit: int = Query(24, ge=1, le=120),
+    offset: int = Query(0, ge=0),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """
+    Liste des périodes mensuelles avec statut de couverture (covered/partial/missing).
+    Paginée (limit/offset). Tri: plus récent en premier.
+    """
+    from services.billing_coverage import compute_coverage, compute_range
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+
+    q = _org_sites_query(db, EnergyInvoice, effective_org_id)
+    if site_id:
+        site = _check_site_belongs_to_org(db, site_id, effective_org_id)
+        q = q.filter(EnergyInvoice.site_id == site_id)
+    invoices = q.all()
+
+    range_start, range_end = compute_range(invoices)
+    if not range_start:
+        return {"periods": [], "total": 0, "offset": offset, "limit": limit}
+
+    # Appliquer filtres month_from / month_to
+    if month_from:
+        try:
+            y, m = map(int, month_from.split("-"))
+            from datetime import date as _date
+            range_start = max(range_start, _date(y, m, 1))
+        except (ValueError, TypeError):
+            pass
+    if month_to:
+        try:
+            y, m = map(int, month_to.split("-"))
+            from calendar import monthrange as _mr
+            from datetime import date as _date
+            _, last = _mr(y, m)
+            range_end = min(range_end, _date(y, m, last))
+        except (ValueError, TypeError):
+            pass
+
+    all_months = compute_coverage(invoices, range_start, range_end)
+    # Tri: plus récent en premier
+    all_months.sort(key=lambda x: x.month_key, reverse=True)
+    total = len(all_months)
+    page = all_months[offset: offset + limit]
+
+    return {
+        "periods": [
+            {
+                "month_key": mc.month_key,
+                "month_start": mc.month_start.isoformat(),
+                "month_end": mc.month_end.isoformat(),
+                "coverage_status": mc.coverage_status,
+                "coverage_ratio": mc.coverage_ratio,
+                "invoices_count": mc.invoices_count,
+                "total_ttc": mc.total_ttc,
+                "missing_reason": mc.missing_reason,
+            }
+            for mc in page
+        ],
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+    }
+
+
+@router.get("/coverage-summary")
+def get_coverage_summary(
+    request: Request,
+    site_id: Optional[int] = Query(None),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """
+    KPIs globaux de couverture : range, mois couverts/partiels/manquants,
+    liste des mois manquants (max 24), top sites avec le plus de trous.
+    """
+    from services.billing_coverage import compute_coverage, compute_range, compute_top_sites_missing
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+
+    q = _org_sites_query(db, EnergyInvoice, effective_org_id)
+    if site_id:
+        _check_site_belongs_to_org(db, site_id, effective_org_id)
+        q = q.filter(EnergyInvoice.site_id == site_id)
+    invoices = q.all()
+
+    range_start, range_end = compute_range(invoices)
+    if not range_start:
+        return {
+            "range": None,
+            "months_total": 0,
+            "covered": 0,
+            "partial": 0,
+            "missing": 0,
+            "missing_months": [],
+            "top_sites_missing": [],
+        }
+
+    months = compute_coverage(invoices, range_start, range_end)
+    covered = sum(1 for mc in months if mc.coverage_status == "covered")
+    partial = sum(1 for mc in months if mc.coverage_status == "partial")
+    missing = sum(1 for mc in months if mc.coverage_status == "missing")
+    missing_months = [
+        mc.month_key for mc in sorted(months, key=lambda x: x.month_key, reverse=True)
+        if mc.coverage_status != "covered"
+    ][:24]
+
+    top_sites = compute_top_sites_missing(db, effective_org_id, site_id_filter=site_id)
+
+    return {
+        "range": {
+            "min_month": range_start.strftime("%Y-%m"),
+            "max_month": range_end.strftime("%Y-%m"),
+        },
+        "months_total": len(months),
+        "covered": covered,
+        "partial": partial,
+        "missing": missing,
+        "missing_months": missing_months,
+        "top_sites_missing": top_sites,
+    }
+
+
+@router.get("/missing-periods")
+def get_missing_periods(
+    request: Request,
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """
+    Liste paginée des mois manquants/partiels, format patrimoine-anomaly.
+    Triée par gravité (missing avant partial) puis par mois décroissant.
+    Compatible avec AnomaliesPage (framework FACTURATION).
+    """
+    from services.billing_coverage import compute_coverage, compute_range
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+
+    # Charger toutes les factures + sites en 2 requêtes
+    invoices_all = _org_sites_query(db, EnergyInvoice, effective_org_id).all()
+
+    # Grouper par site
+    by_site: dict[int, list] = {}
+    for inv in invoices_all:
+        by_site.setdefault(inv.site_id, []).append(inv)
+
+    site_ids = list(by_site.keys())
+    sites_map = {s.id: s for s in db.query(Site).filter(Site.id.in_(site_ids)).all()} if site_ids else {}
+
+    all_missing: list = []
+    for site_id_key, invs in by_site.items():
+        rs, re = compute_range(invs)
+        if not rs:
+            continue
+        months = compute_coverage(invs, rs, re)
+        site = sites_map.get(site_id_key)
+        site_name = site.nom if site else f"Site {site_id_key}"
+        for mc in months:
+            if mc.coverage_status != "covered":
+                all_missing.append({
+                    "month_key": mc.month_key,
+                    "site_id": site_id_key,
+                    "site_name": site_name,
+                    "coverage_status": mc.coverage_status,
+                    "coverage_ratio": mc.coverage_ratio,
+                    "missing_reason": mc.missing_reason,
+                    "regulatory_impact": {"framework": "FACTURATION"},
+                    "cta_url": f"/bill-intel?site_id={site_id_key}&month={mc.month_key}",
+                })
+
+    # Tri: missing avant partial, puis mois décroissant
+    status_order = {"missing": 0, "partial": 1}
+    all_missing.sort(key=lambda x: (status_order.get(x["coverage_status"], 2), x["month_key"]), reverse=False)
+    all_missing.sort(key=lambda x: x["month_key"], reverse=True)
+    all_missing.sort(key=lambda x: status_order.get(x["coverage_status"], 2))
+
+    total = len(all_missing)
+    page = all_missing[offset: offset + limit]
+
+    return {"items": page, "total": total, "offset": offset, "limit": limit}
 
 
 # ========================================

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -641,6 +641,36 @@ def list_insights(
     }
 
 
+@router.get("/insights/{insight_id}")
+def get_insight_detail(
+    insight_id: int,
+    request: Request,
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Détail d'un insight avec metrics et recommended_actions."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    insight = db.query(BillingInsight).filter(BillingInsight.id == insight_id).first()
+    if not insight:
+        raise HTTPException(status_code=404, detail="Insight not found")
+    _check_site_belongs_to_org(db, insight.site_id, effective_org_id)
+    return {
+        "id": insight.id,
+        "site_id": insight.site_id,
+        "invoice_id": insight.invoice_id,
+        "type": insight.type,
+        "severity": insight.severity,
+        "message": insight.message,
+        "estimated_loss_eur": insight.estimated_loss_eur,
+        "insight_status": insight.insight_status.value if insight.insight_status else "open",
+        "owner": insight.owner,
+        "notes": insight.notes,
+        "metrics": json.loads(insight.metrics_json or "{}"),
+        "recommended_actions": json.loads(insight.recommended_actions_json or "[]"),
+    }
+
+
 # ========================================
 # Insight workflow (Sprint 7.1)
 # ========================================

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -1,6 +1,7 @@
 """
-PROMEOS — Bill Intelligence Routes (Sprint 7.1)
+PROMEOS — Bill Intelligence Routes (Sprint 7.1 → V66)
 CSV import (idempotent) + audit + summary + site billing + insight workflow.
+V66: org scoping (resolve_org_id), response_model Pydantic, PDF import, anomalies-scoped.
 Prefix: /api/billing
 """
 import csv
@@ -10,7 +11,7 @@ import json
 from datetime import date, datetime
 from typing import Optional, List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFile, File
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -19,6 +20,7 @@ from models import (
     Site, EnergyContract, EnergyInvoice, EnergyInvoiceLine, BillingInsight,
     BillingEnergyType, InvoiceLineType, BillingInvoiceStatus,
     InsightStatus, BillingImportBatch,
+    Portefeuille, EntiteJuridique,
 )
 from services.billing_service import (
     audit_invoice_full,
@@ -28,12 +30,13 @@ from services.billing_service import (
     BILLING_RULES,
 )
 from middleware.auth import get_optional_auth, AuthContext
+from services.scope_utils import resolve_org_id
 
 router = APIRouter(prefix="/api/billing", tags=["Bill Intelligence V2"])
 
 
 # ========================================
-# Pydantic schemas
+# Pydantic schemas — Input
 # ========================================
 
 class ContractCreate(BaseModel):
@@ -65,15 +68,138 @@ class InsightPatch(BaseModel):
 
 
 # ========================================
+# Pydantic schemas — Response (V66 P1.2)
+# ========================================
+
+class ContractResponse(BaseModel):
+    id: int
+    site_id: int
+    energy_type: str
+    supplier_name: str
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    price_ref_eur_per_kwh: Optional[float] = None
+    auto_renew: Optional[bool] = None
+
+    class Config:
+        from_attributes = True
+
+
+class InvoiceResponse(BaseModel):
+    id: int
+    site_id: int
+    invoice_number: str
+    period_start: Optional[str] = None
+    period_end: Optional[str] = None
+    total_eur: Optional[float] = None
+    energy_kwh: Optional[float] = None
+    status: Optional[str] = None
+    source: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class BillingInsightResponse(BaseModel):
+    id: int
+    site_id: int
+    invoice_id: Optional[int] = None
+    type: Optional[str] = None
+    severity: Optional[str] = None
+    message: Optional[str] = None
+    estimated_loss_eur: Optional[float] = None
+    insight_status: Optional[str] = None
+    owner: Optional[str] = None
+    notes: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class BillingSummaryResponse(BaseModel):
+    total_invoices: int
+    total_eur: float
+    total_kwh: float
+    total_insights: int
+    total_estimated_loss_eur: float
+    insights_by_type: dict
+    insights_by_severity: dict
+    invoices_with_anomalies: int
+    invoices_clean: int
+
+
+class ContractListResponse(BaseModel):
+    contracts: List[dict]
+    count: int
+
+
+class InvoiceListResponse(BaseModel):
+    invoices: List[dict]
+    count: int
+
+
+class InsightListResponse(BaseModel):
+    insights: List[dict]
+    count: int
+
+
+# ========================================
+# Org-scoping helpers (V66 P1.1)
+# ========================================
+
+def _org_sites_query(db: Session, model_class, effective_org_id: int):
+    """Filter model_class queries via site→portefeuille→entite_juridique→org."""
+    return (
+        db.query(model_class)
+        .join(Site, Site.id == model_class.site_id)
+        .join(Portefeuille, Portefeuille.id == Site.portefeuille_id)
+        .join(EntiteJuridique, EntiteJuridique.id == Portefeuille.entite_juridique_id)
+        .filter(EntiteJuridique.organisation_id == effective_org_id)
+    )
+
+
+def _get_org_site_ids(db: Session, effective_org_id: int) -> List[int]:
+    """Return all site IDs belonging to effective_org_id."""
+    rows = (
+        db.query(Site.id)
+        .join(Portefeuille, Portefeuille.id == Site.portefeuille_id)
+        .join(EntiteJuridique, EntiteJuridique.id == Portefeuille.entite_juridique_id)
+        .filter(EntiteJuridique.organisation_id == effective_org_id)
+        .all()
+    )
+    return [r[0] for r in rows]
+
+
+def _check_site_belongs_to_org(db: Session, site_id: int, effective_org_id: int) -> Site:
+    """Return site if it belongs to org, or raise 404."""
+    site = (
+        db.query(Site)
+        .join(Portefeuille, Portefeuille.id == Site.portefeuille_id)
+        .join(EntiteJuridique, EntiteJuridique.id == Portefeuille.entite_juridique_id)
+        .filter(Site.id == site_id, EntiteJuridique.organisation_id == effective_org_id)
+        .first()
+    )
+    if not site:
+        raise HTTPException(status_code=404, detail="Site non trouvé ou accès refusé")
+    return site
+
+
+# ========================================
 # Contract endpoints
 # ========================================
 
 @router.post("/contracts")
-def create_contract(data: ContractCreate, db: Session = Depends(get_db)):
+def create_contract(
+    data: ContractCreate,
+    request: Request,
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
     """Create an energy contract."""
-    site = db.query(Site).filter(Site.id == data.site_id).first()
-    if not site:
-        raise HTTPException(status_code=404, detail="Site non trouve")
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    _check_site_belongs_to_org(db, data.site_id, effective_org_id)
+
     try:
         energy_type = BillingEnergyType(data.energy_type)
     except ValueError:
@@ -107,10 +233,17 @@ def create_contract(data: ContractCreate, db: Session = Depends(get_db)):
     return {"status": "created", "contract_id": contract.id}
 
 
-@router.get("/contracts")
-def list_contracts(site_id: Optional[int] = Query(None), db: Session = Depends(get_db)):
+@router.get("/contracts", response_model=ContractListResponse)
+def list_contracts(
+    request: Request,
+    site_id: Optional[int] = Query(None),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
     """List contracts, optionally filtered by site."""
-    q = db.query(EnergyContract)
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    q = _org_sites_query(db, EnergyContract, effective_org_id)
     if site_id:
         q = q.filter(EnergyContract.site_id == site_id)
     contracts = q.all()
@@ -136,9 +269,11 @@ def list_contracts(site_id: Optional[int] = Query(None), db: Session = Depends(g
 
 @router.post("/import-csv")
 def import_invoices_csv(
+    request: Request,
     file: UploadFile = File(...),
     org_id: Optional[int] = Query(None),
     db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
     """
     Import invoices from CSV (idempotent).
@@ -146,6 +281,8 @@ def import_invoices_csv(
     Expected columns: site_id,invoice_number,period_start,period_end,issue_date,total_eur,energy_kwh,source
     Optional line columns: line_type,line_label,line_qty,line_unit,line_unit_price,line_amount_eur
     """
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+
     if not file.filename.endswith(".csv"):
         raise HTTPException(status_code=400, detail="Le fichier doit etre un CSV")
 
@@ -155,7 +292,7 @@ def import_invoices_csv(
     content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
     existing_batch = db.query(BillingImportBatch).filter(
         BillingImportBatch.content_hash == content_hash,
-        BillingImportBatch.org_id == org_id,
+        BillingImportBatch.org_id == effective_org_id,
     ).first()
     if existing_batch:
         return {
@@ -186,10 +323,16 @@ def import_invoices_csv(
                 errors.append({"row": row_num, "error": "invoice_number manquant"})
                 continue
 
-            # Verify site exists
-            site = db.query(Site).filter(Site.id == site_id).first()
+            # Verify site exists and belongs to org
+            site = (
+                db.query(Site)
+                .join(Portefeuille, Portefeuille.id == Site.portefeuille_id)
+                .join(EntiteJuridique, EntiteJuridique.id == Portefeuille.entite_juridique_id)
+                .filter(Site.id == site_id, EntiteJuridique.organisation_id == effective_org_id)
+                .first()
+            )
             if not site:
-                errors.append({"row": row_num, "error": f"Site {site_id} introuvable"})
+                errors.append({"row": row_num, "error": f"Site {site_id} introuvable ou accès refusé"})
                 continue
 
             # Check duplicate
@@ -248,7 +391,7 @@ def import_invoices_csv(
 
     # --- Record batch ---
     batch = BillingImportBatch(
-        org_id=org_id,
+        org_id=effective_org_id,
         filename=file.filename,
         content_hash=content_hash,
         rows_total=rows_total,
@@ -274,16 +417,21 @@ def import_invoices_csv(
 # Import batches listing (Sprint 7.1)
 # ========================================
 
-@router.get("/import/batches")
+@router.get("/import/batches", response_model=dict)
 def list_import_batches(
+    request: Request,
     org_id: Optional[int] = Query(None),
     db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
     """List CSV import batches with stats."""
-    q = db.query(BillingImportBatch)
-    if org_id is not None:
-        q = q.filter(BillingImportBatch.org_id == org_id)
-    batches = q.order_by(BillingImportBatch.imported_at.desc()).all()
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    batches = (
+        db.query(BillingImportBatch)
+        .filter(BillingImportBatch.org_id == effective_org_id)
+        .order_by(BillingImportBatch.imported_at.desc())
+        .all()
+    )
     return {
         "batches": [
             {
@@ -307,11 +455,16 @@ def list_import_batches(
 # ========================================
 
 @router.post("/invoices")
-def create_invoice(data: InvoiceCreate, db: Session = Depends(get_db)):
+def create_invoice(
+    data: InvoiceCreate,
+    request: Request,
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
     """Create a single invoice manually."""
-    site = db.query(Site).filter(Site.id == data.site_id).first()
-    if not site:
-        raise HTTPException(status_code=404, detail="Site non trouve")
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    _check_site_belongs_to_org(db, data.site_id, effective_org_id)
 
     invoice = EnergyInvoice(
         site_id=data.site_id,
@@ -356,8 +509,21 @@ def create_invoice(data: InvoiceCreate, db: Session = Depends(get_db)):
 # ========================================
 
 @router.post("/audit/{invoice_id}")
-def audit_invoice_endpoint(invoice_id: int, db: Session = Depends(get_db)):
+def audit_invoice_endpoint(
+    invoice_id: int,
+    request: Request,
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
     """Run shadow billing + anomaly engine on a persisted invoice."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    # Verify invoice belongs to org
+    invoice = _org_sites_query(db, EnergyInvoice, effective_org_id).filter(
+        EnergyInvoice.id == invoice_id
+    ).first()
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Facture non trouvée ou accès refusé")
     result = audit_invoice_full(db, invoice_id)
     if "error" in result:
         raise HTTPException(status_code=404, detail=result["error"])
@@ -365,9 +531,15 @@ def audit_invoice_endpoint(invoice_id: int, db: Session = Depends(get_db)):
 
 
 @router.post("/audit-all")
-def audit_all_invoices(db: Session = Depends(get_db)):
-    """Audit all imported invoices."""
-    invoices = db.query(EnergyInvoice).all()
+def audit_all_invoices(
+    request: Request,
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Audit all imported invoices (scoped to org)."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    invoices = _org_sites_query(db, EnergyInvoice, effective_org_id).all()
     results = []
     for inv in invoices:
         r = audit_invoice_full(db, inv.id)
@@ -388,25 +560,61 @@ def audit_all_invoices(db: Session = Depends(get_db)):
 # Read endpoints
 # ========================================
 
-@router.get("/summary")
-def billing_summary(db: Session = Depends(get_db)):
-    """Aggregate billing summary (invoices, insights, losses)."""
-    return get_billing_summary(db)
-
-
-@router.get("/insights")
-def list_insights(
-    site_id: Optional[int] = Query(None),
-    severity: Optional[str] = Query(None),
-    status: Optional[str] = Query(None),
+@router.get("/summary", response_model=BillingSummaryResponse)
+def billing_summary(
+    request: Request,
+    org_id: Optional[int] = Query(None),
     db: Session = Depends(get_db),
     auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
-    """List billing insights with optional filters (site, severity, status)."""
-    q = db.query(BillingInsight)
-    # Scope filtering
-    if auth and auth.site_ids is not None:
-        q = q.filter(BillingInsight.site_id.in_(auth.site_ids))
+    """Aggregate billing summary (invoices, insights, losses) — scoped to org."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    site_ids = _get_org_site_ids(db, effective_org_id)
+
+    invoices = db.query(EnergyInvoice).filter(
+        EnergyInvoice.site_id.in_(site_ids)
+    ).all() if site_ids else []
+
+    insights = db.query(BillingInsight).filter(
+        BillingInsight.site_id.in_(site_ids)
+    ).all() if site_ids else []
+
+    total_eur = sum(i.total_eur or 0 for i in invoices)
+    total_kwh = sum(i.energy_kwh or 0 for i in invoices)
+    total_loss = sum(i.estimated_loss_eur or 0 for i in insights)
+    by_type: dict = {}
+    for i in insights:
+        by_type[i.type] = by_type.get(i.type, 0) + 1
+    by_severity: dict = {}
+    for i in insights:
+        by_severity[i.severity] = by_severity.get(i.severity, 0) + 1
+
+    return {
+        "total_invoices": len(invoices),
+        "total_eur": round(total_eur, 2),
+        "total_kwh": round(total_kwh, 0),
+        "total_insights": len(insights),
+        "total_estimated_loss_eur": round(total_loss, 2),
+        "insights_by_type": by_type,
+        "insights_by_severity": by_severity,
+        "invoices_with_anomalies": len([i for i in invoices if i.status == BillingInvoiceStatus.ANOMALY]),
+        "invoices_clean": len([i for i in invoices if i.status == BillingInvoiceStatus.AUDITED]),
+    }
+
+
+@router.get("/insights", response_model=InsightListResponse)
+def list_insights(
+    request: Request,
+    site_id: Optional[int] = Query(None),
+    severity: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """List billing insights with optional filters (site, severity, status) — scoped to org."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    q = _org_sites_query(db, BillingInsight, effective_org_id)
     if site_id:
         q = q.filter(BillingInsight.site_id == site_id)
     if severity:
@@ -438,11 +646,21 @@ def list_insights(
 # ========================================
 
 @router.patch("/insights/{insight_id}")
-def patch_insight(insight_id: int, data: InsightPatch, db: Session = Depends(get_db)):
-    """Update insight status / owner / notes (ops workflow)."""
-    insight = db.query(BillingInsight).filter(BillingInsight.id == insight_id).first()
+def patch_insight(
+    insight_id: int,
+    data: InsightPatch,
+    request: Request,
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Update insight status / owner / notes (ops workflow) — scoped to org."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    insight = _org_sites_query(db, BillingInsight, effective_org_id).filter(
+        BillingInsight.id == insight_id
+    ).first()
     if not insight:
-        raise HTTPException(status_code=404, detail="Insight non trouve")
+        raise HTTPException(status_code=404, detail="Insight non trouve ou accès refusé")
 
     if data.status is not None:
         try:
@@ -466,11 +684,21 @@ def patch_insight(insight_id: int, data: InsightPatch, db: Session = Depends(get
 
 
 @router.post("/insights/{insight_id}/resolve")
-def resolve_insight(insight_id: int, notes: Optional[str] = Query(None), db: Session = Depends(get_db)):
-    """Shortcut: mark insight as RESOLVED with optional notes."""
-    insight = db.query(BillingInsight).filter(BillingInsight.id == insight_id).first()
+def resolve_insight(
+    insight_id: int,
+    request: Request,
+    notes: Optional[str] = Query(None),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Shortcut: mark insight as RESOLVED with optional notes — scoped to org."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    insight = _org_sites_query(db, BillingInsight, effective_org_id).filter(
+        BillingInsight.id == insight_id
+    ).first()
     if not insight:
-        raise HTTPException(status_code=404, detail="Insight non trouve")
+        raise HTTPException(status_code=404, detail="Insight non trouve ou accès refusé")
 
     insight.insight_status = InsightStatus.RESOLVED
     if notes:
@@ -484,14 +712,18 @@ def resolve_insight(insight_id: int, notes: Optional[str] = Query(None), db: Ses
     }
 
 
-@router.get("/invoices")
+@router.get("/invoices", response_model=InvoiceListResponse)
 def list_invoices(
+    request: Request,
     site_id: Optional[int] = Query(None),
     status: Optional[str] = Query(None),
+    org_id: Optional[int] = Query(None),
     db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
-    """List invoices with optional filters."""
-    q = db.query(EnergyInvoice)
+    """List invoices with optional filters — scoped to org."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    q = _org_sites_query(db, EnergyInvoice, effective_org_id)
     if site_id:
         q = q.filter(EnergyInvoice.site_id == site_id)
     if status:
@@ -516,9 +748,17 @@ def list_invoices(
     }
 
 
-@router.get("/site/{site_id}")
-def site_billing_endpoint(site_id: int, db: Session = Depends(get_db)):
-    """Full billing view for a site (contracts, invoices, insights)."""
+@router.get("/site/{site_id}", response_model=dict)
+def site_billing_endpoint(
+    site_id: int,
+    request: Request,
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Full billing view for a site (contracts, invoices, insights) — scoped to org."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    _check_site_belongs_to_org(db, site_id, effective_org_id)
     result = get_site_billing(db, site_id)
     if "error" in result:
         raise HTTPException(status_code=404, detail=result["error"])
@@ -535,6 +775,110 @@ def list_billing_rules():
         ],
         "count": len(BILLING_RULES),
     }
+
+
+# ========================================
+# PDF Import (V66 P2.2)
+# ========================================
+
+@router.post("/import-pdf")
+async def import_invoice_pdf(
+    request: Request,
+    site_id: int = Query(...),
+    file: UploadFile = File(...),
+    run_audit: bool = Query(True),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Upload PDF facture → parse EDF/Engie templates → normalise → stocke → audit."""
+    from app.bill_intelligence.parsers.pdf_parser import parse_pdf_bytes
+
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    _check_site_belongs_to_org(db, site_id, effective_org_id)
+
+    content = await file.read()
+    invoice_domain = parse_pdf_bytes(content, file.filename or "upload.pdf")
+
+    if not invoice_domain or invoice_domain.confidence < 0.5:
+        raise HTTPException(
+            status_code=422,
+            detail="PDF non reconnu ou confiance insuffisante (< 0.5). "
+                   "Vérifiez le format EDF/Engie ou saisissez manuellement.",
+        )
+
+    db_invoice = EnergyInvoice(
+        site_id=site_id,
+        invoice_number=invoice_domain.invoice_id or f"PDF-{file.filename}",
+        period_start=invoice_domain.period_start,
+        period_end=invoice_domain.period_end,
+        issue_date=invoice_domain.invoice_date,
+        total_eur=invoice_domain.total_ttc,
+        energy_kwh=invoice_domain.total_kwh,
+        status=BillingInvoiceStatus.IMPORTED,
+        source="pdf",
+        raw_json=json.dumps({
+            "supplier": invoice_domain.supplier,
+            "confidence": invoice_domain.confidence,
+            "filename": file.filename,
+        }),
+    )
+    db.add(db_invoice)
+    db.flush()
+
+    anomalies_count = 0
+    if run_audit:
+        result = audit_invoice_full(db, db_invoice.id)
+        anomalies_count = len(result.get("anomalies", []))
+
+    db.commit()
+    return {
+        "status": "imported",
+        "invoice_id": db_invoice.id,
+        "confidence": invoice_domain.confidence,
+        "supplier": invoice_domain.supplier,
+        "anomalies_count": anomalies_count,
+    }
+
+
+# ========================================
+# Anomalies scoped (V66 P2.8)
+# ========================================
+
+@router.get("/anomalies-scoped")
+def get_billing_anomalies_scoped(
+    request: Request,
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """BillingInsights OPEN de l'org → format Patrimoine anomalies pour AnomaliesPage."""
+    effective_org_id = resolve_org_id(request, auth, db, org_id_override=org_id)
+    insights = (
+        _org_sites_query(db, BillingInsight, effective_org_id)
+        .filter(BillingInsight.insight_status == InsightStatus.OPEN)
+        .order_by(BillingInsight.estimated_loss_eur.desc().nullslast())
+        .all()
+    )
+
+    anomalies = []
+    for i in insights:
+        site = db.query(Site).filter(Site.id == i.site_id).first()
+        anomalies.append({
+            "code": i.type or "billing_anomaly",
+            "severity": (i.severity or "MEDIUM").upper(),
+            "title_fr": i.message or "Anomalie facturation",
+            "detail_fr": i.notes or i.message or "",
+            "fix_hint_fr": "Vérifier la facture dans le module Facturation.",
+            "business_impact": {"estimated_risk_eur": i.estimated_loss_eur or 0},
+            "priority_score": 90 if i.severity == "CRITICAL" else 70 if i.severity == "HIGH" else 50,
+            "framework": "FACTURATION",
+            "site_id": i.site_id,
+            "site_nom": site.nom if site else f"Site {i.site_id}",
+            "insight_id": i.id,
+        })
+
+    return {"anomalies": anomalies, "count": len(anomalies)}
 
 
 # ========================================

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -30,6 +30,7 @@ from services.billing_service import (
     shadow_billing_simple,
     BILLING_RULES,
 )
+from services.billing_shadow_v2 import shadow_billing_v2
 from middleware.auth import get_optional_auth, AuthContext
 from services.scope_utils import resolve_org_id
 
@@ -673,6 +674,31 @@ def get_insight_detail(
         ActionItem.source_type == ActionSourceType.BILLING,
         ActionItem.source_id == str(insight.id),
     ).first()
+
+    metrics = json.loads(insight.metrics_json or "{}")
+
+    # Recalcul V2 à la demande si breakdown absent
+    if metrics and metrics.get("expected_ttc") is None and metrics.get("expected_fourniture_ht") is None:
+        try:
+            invoice = db.query(EnergyInvoice).filter(EnergyInvoice.id == insight.invoice_id).first()
+            if invoice:
+                lines = db.query(EnergyInvoiceLine).filter(
+                    EnergyInvoiceLine.invoice_id == invoice.id
+                ).all()
+                contract = None
+                if invoice.contract_id:
+                    contract = db.query(EnergyContract).filter(
+                        EnergyContract.id == invoice.contract_id
+                    ).first()
+                if lines:
+                    v2 = shadow_billing_v2(invoice, lines, contract)
+                    metrics.update(v2)
+                    # Persister pour éviter recalcul futur
+                    insight.metrics_json = json.dumps(metrics)
+                    db.commit()
+        except Exception:
+            pass  # Garder métriques originales
+
     return {
         "id": insight.id,
         "site_id": insight.site_id,
@@ -685,7 +711,7 @@ def get_insight_detail(
         "owner": insight.owner,
         "notes": insight.notes,
         "action_id": action.id if action else None,
-        "metrics": json.loads(insight.metrics_json or "{}"),
+        "metrics": metrics,
         "recommended_actions": json.loads(insight.recommended_actions_json or "[]"),
     }
 

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -21,6 +21,7 @@ from models import (
     BillingEnergyType, InvoiceLineType, BillingInvoiceStatus,
     InsightStatus, BillingImportBatch,
     Portefeuille, EntiteJuridique,
+    ActionItem, ActionSourceType,
 )
 from services.billing_service import (
     audit_invoice_full,
@@ -625,6 +626,17 @@ def list_insights(
         except ValueError:
             pass
     insights = q.order_by(BillingInsight.estimated_loss_eur.desc().nullslast()).all()
+
+    # Resolve action_id for each insight (batch query via source_id)
+    insight_ids_str = [str(i.id) for i in insights]
+    action_map = {}
+    if insight_ids_str:
+        actions = db.query(ActionItem.source_id, ActionItem.id).filter(
+            ActionItem.source_type == ActionSourceType.BILLING,
+            ActionItem.source_id.in_(insight_ids_str),
+        ).all()
+        action_map = {a.source_id: a.id for a in actions}
+
     return {
         "insights": [
             {
@@ -634,6 +646,7 @@ def list_insights(
                 "insight_status": i.insight_status.value if i.insight_status else "open",
                 "owner": i.owner,
                 "notes": i.notes,
+                "action_id": action_map.get(str(i.id)),
             }
             for i in insights
         ],
@@ -655,6 +668,11 @@ def get_insight_detail(
     if not insight:
         raise HTTPException(status_code=404, detail="Insight not found")
     _check_site_belongs_to_org(db, insight.site_id, effective_org_id)
+    # Resolve linked action
+    action = db.query(ActionItem).filter(
+        ActionItem.source_type == ActionSourceType.BILLING,
+        ActionItem.source_id == str(insight.id),
+    ).first()
     return {
         "id": insight.id,
         "site_id": insight.site_id,
@@ -666,6 +684,7 @@ def get_insight_detail(
         "insight_status": insight.insight_status.value if insight.insight_status else "open",
         "owner": insight.owner,
         "notes": insight.notes,
+        "action_id": action.id if action else None,
         "metrics": json.loads(insight.metrics_json or "{}"),
         "recommended_actions": json.loads(insight.recommended_actions_json or "[]"),
     }

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -1066,6 +1066,7 @@ def get_billing_periods(
                 "missing_reason": mc.missing_reason,
                 "energy_kwh": mc.energy_kwh,   # P0-2
                 "pdl_prm": mc.pdl_prm,         # P0-2
+                "invoice_ids": mc.invoice_ids,  # V70
             }
             for mc in page
         ],

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -836,8 +836,40 @@ def list_billing_rules():
 
 
 # ========================================
-# PDF Import (V66 P2.2)
+# PDF Import (V66 P2.2 / DoD P0-1)
 # ========================================
+
+# ComponentType.value (lowercase) → InvoiceLineType mapping for P0-1
+_COMPONENT_TO_LINE_TYPE = {
+    # Energie / fourniture
+    "conso_hp": InvoiceLineType.ENERGY,
+    "conso_hc": InvoiceLineType.ENERGY,
+    "conso_base": InvoiceLineType.ENERGY,
+    "conso_pointe": InvoiceLineType.ENERGY,
+    "conso_hph": InvoiceLineType.ENERGY,
+    "conso_hch": InvoiceLineType.ENERGY,
+    "conso_hpe": InvoiceLineType.ENERGY,
+    "conso_hce": InvoiceLineType.ENERGY,
+    "terme_variable": InvoiceLineType.ENERGY,
+    # Réseau / acheminement
+    "turpe_fixe": InvoiceLineType.NETWORK,
+    "turpe_puissance": InvoiceLineType.NETWORK,
+    "turpe_energie": InvoiceLineType.NETWORK,
+    "terme_fixe": InvoiceLineType.NETWORK,
+    # Taxes / contributions
+    "cta": InvoiceLineType.TAX,
+    "accise": InvoiceLineType.TAX,
+    "tva_reduite": InvoiceLineType.TAX,
+    "tva_normale": InvoiceLineType.TAX,
+    "cee": InvoiceLineType.TAX,
+}
+
+
+def _component_to_line_type(comp_type) -> InvoiceLineType:
+    """Mappe ComponentType.value (str lowercase) → InvoiceLineType. Fallback = OTHER."""
+    key = comp_type.value if hasattr(comp_type, "value") else str(comp_type)
+    return _COMPONENT_TO_LINE_TYPE.get(key, InvoiceLineType.OTHER)
+
 
 @router.post("/import-pdf")
 async def import_invoice_pdf(
@@ -858,7 +890,8 @@ async def import_invoice_pdf(
     content = await file.read()
     invoice_domain = parse_pdf_bytes(content, file.filename or "upload.pdf")
 
-    if not invoice_domain or invoice_domain.confidence < 0.5:
+    confidence = getattr(invoice_domain, "parsing_confidence", 0) or 0
+    if not invoice_domain or confidence < 0.5:
         raise HTTPException(
             status_code=422,
             detail="PDF non reconnu ou confiance insuffisante (< 0.5). "
@@ -872,30 +905,50 @@ async def import_invoice_pdf(
         period_end=invoice_domain.period_end,
         issue_date=invoice_domain.invoice_date,
         total_eur=invoice_domain.total_ttc,
-        energy_kwh=invoice_domain.total_kwh,
+        energy_kwh=getattr(invoice_domain, "conso_kwh", None),  # P0-3: correct field name
         status=BillingInvoiceStatus.IMPORTED,
         source="pdf",
         raw_json=json.dumps({
-            "supplier": invoice_domain.supplier,
-            "confidence": invoice_domain.confidence,
-            "filename": file.filename,
+            "supplier": getattr(invoice_domain, "supplier", "") or "",
+            "confidence": getattr(invoice_domain, "parsing_confidence", 0) or 0,
+            "filename": file.filename or "",
+            "pdl_prm": getattr(invoice_domain, "pdl_pce", None) or "",  # P0-3: store PDL
         }),
     )
     db.add(db_invoice)
     db.flush()
 
-    anomalies_count = 0
+    # P0-1: créer les lignes EnergyInvoiceLine depuis les composantes PDF
+    for comp in (getattr(invoice_domain, "components", None) or []):
+        line_type = _component_to_line_type(comp.component_type)
+        db.add(EnergyInvoiceLine(
+            invoice_id=db_invoice.id,
+            line_type=line_type,
+            label=getattr(comp, "label", "") or "",
+            qty=getattr(comp, "quantity", None),
+            unit=getattr(comp, "unit", None),
+            unit_price=getattr(comp, "unit_price", None),
+            amount_eur=(
+                comp.amount_ht if getattr(comp, "amount_ht", None) is not None
+                else getattr(comp, "amount_ttc", None)
+            ),
+        ))
+
+    anomalies_list = []
     if run_audit:
         result = audit_invoice_full(db, db_invoice.id)
-        anomalies_count = len(result.get("anomalies", []))
+        anomalies_list = result.get("anomalies", [])
 
     db.commit()
+
     return {
         "status": "imported",
         "invoice_id": db_invoice.id,
-        "confidence": invoice_domain.confidence,
-        "supplier": invoice_domain.supplier,
-        "anomalies_count": anomalies_count,
+        "confidence": round(float(confidence), 2),
+        "supplier": getattr(invoice_domain, "supplier", "") or "",
+        "anomalies_count": len(anomalies_list),
+        "kb_updated": run_audit,                                              # P0-5
+        "kb_rules_applied": [a.get("rule_id") for a in anomalies_list],      # P0-5
     }
 
 
@@ -1011,6 +1064,8 @@ def get_billing_periods(
                 "invoices_count": mc.invoices_count,
                 "total_ttc": mc.total_ttc,
                 "missing_reason": mc.missing_reason,
+                "energy_kwh": mc.energy_kwh,   # P0-2
+                "pdl_prm": mc.pdl_prm,         # P0-2
             }
             for mc in page
         ],

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -30,7 +30,6 @@ from services.billing_service import (
     shadow_billing_simple,
     BILLING_RULES,
 )
-from services.billing_shadow_v2 import shadow_billing_v2
 from middleware.auth import get_optional_auth, AuthContext
 from services.scope_utils import resolve_org_id
 
@@ -680,6 +679,7 @@ def get_insight_detail(
     # Recalcul V2 à la demande si breakdown absent
     if metrics and metrics.get("expected_ttc") is None and metrics.get("expected_fourniture_ht") is None:
         try:
+            from services.billing_shadow_v2 import shadow_billing_v2
             invoice = db.query(EnergyInvoice).filter(EnergyInvoice.id == insight.invoice_id).first()
             if invoice:
                 lines = db.query(EnergyInvoiceLine).filter(

--- a/backend/routes/ems.py
+++ b/backend/routes/ems.py
@@ -834,3 +834,175 @@ def purge_ems_demo(db: Session = Depends(get_db)):
         "deleted_readings": deleted_readings,
         "deleted_weather": deleted_weather,
     }
+
+
+# -------------------------------------------------------------------
+# P1-1: Reference profile (courbe de référence grand public)
+# -------------------------------------------------------------------
+REFERENCE_PROFILES = {
+    # famille → puissance_class → hourly profile (24 values, kWh)
+    "habitat": {
+        "0-6":   [0.3]*6 + [0.8,1.2,1.5,1.0,0.7,0.5,0.6,0.8,1.0,1.2,1.5,1.8,2.0,1.8,1.3,0.8,0.5,0.4],
+        "6-9":   [0.5]*6 + [1.2,2.0,2.5,1.8,1.2,0.8,1.0,1.4,1.8,2.2,2.8,3.5,3.8,3.2,2.2,1.4,0.8,0.6],
+        "9-12":  [0.8]*6 + [1.8,3.0,3.8,2.8,1.8,1.2,1.5,2.2,2.8,3.5,4.2,5.0,5.5,4.8,3.5,2.0,1.2,0.9],
+        "12-36": [1.2]*6 + [2.5,4.5,5.5,4.0,2.8,2.0,2.5,3.5,4.5,5.5,6.5,7.5,8.0,7.0,5.0,3.2,2.0,1.5],
+        ">36":   [2.0]*6 + [4.0,7.0,8.5,6.5,4.5,3.2,4.0,5.5,7.0,8.5,10.0,12.0,12.5,11.0,8.0,5.0,3.0,2.2],
+    },
+    "petit_tertiaire": {
+        "0-6":   [0.2]*6 + [0.5,1.5,2.5,3.0,3.2,3.0,2.8,3.0,3.2,3.0,2.5,1.5,0.5,0.3,0.2,0.2,0.2,0.2],
+        "6-9":   [0.3]*6 + [0.8,2.5,4.0,5.0,5.5,5.0,4.5,5.0,5.5,5.0,4.0,2.5,0.8,0.5,0.3,0.3,0.3,0.3],
+        "9-12":  [0.5]*6 + [1.2,3.5,6.0,7.5,8.0,7.5,6.8,7.5,8.0,7.5,6.0,3.5,1.2,0.8,0.5,0.5,0.5,0.5],
+        "12-36": [0.8]*6 + [2.0,5.5,9.0,11.0,12.0,11.5,10.0,11.5,12.0,11.0,9.0,5.5,2.0,1.2,0.8,0.8,0.8,0.8],
+        ">36":   [1.5]*6 + [3.5,9.0,14.0,17.0,18.0,17.5,16.0,17.5,18.0,17.0,14.0,9.0,3.5,2.0,1.5,1.5,1.5,1.5],
+    },
+    "entreprise": {
+        "0-6":   [1.0]*6 + [2.0,5.0,8.0,10.0,11.0,11.5,11.0,11.5,11.0,10.0,8.0,5.0,2.0,1.5,1.2,1.0,1.0,1.0],
+        "6-9":   [1.5]*6 + [3.0,7.5,12.0,15.0,16.5,17.0,16.0,17.0,16.5,15.0,12.0,7.5,3.0,2.0,1.8,1.5,1.5,1.5],
+        "9-12":  [2.5]*6 + [5.0,12.0,19.0,24.0,26.0,27.0,25.5,27.0,26.0,24.0,19.0,12.0,5.0,3.5,2.8,2.5,2.5,2.5],
+        "12-36": [4.0]*6 + [8.0,18.0,28.0,35.0,38.0,40.0,38.0,40.0,38.0,35.0,28.0,18.0,8.0,5.0,4.5,4.0,4.0,4.0],
+        ">36":   [6.0]*6 + [12.0,28.0,42.0,52.0,56.0,58.0,55.0,58.0,56.0,52.0,42.0,28.0,12.0,8.0,6.5,6.0,6.0,6.0],
+    },
+}
+
+
+@router.get("/reference_profile")
+def get_reference_profile(
+    site_id: int = Query(...),
+    date_from: str = Query(...),
+    date_to: str = Query(...),
+    famille: str = Query("entreprise", description="habitat | petit_tertiaire | entreprise"),
+    puissance: str = Query("9-12", description="0-6 | 6-9 | 9-12 | 12-36 | >36"),
+    granularity: str = Query("hourly", description="hourly | daily"),
+    db: Session = Depends(get_db),
+):
+    """
+    Generate a reference profile curve for the requested period.
+    Returns a timeseries of expected consumption based on (famille, puissance class).
+    Also returns KPI delta vs actual consumption if site has data.
+    """
+    from datetime import date as date_cls, timedelta
+    from services.ems.timeseries_service import query_timeseries
+
+    df = date_cls.fromisoformat(date_from)
+    dt_to = date_cls.fromisoformat(date_to)
+
+    # Build reference series
+    family_profiles = REFERENCE_PROFILES.get(famille, REFERENCE_PROFILES["entreprise"])
+    hourly_profile = family_profiles.get(puissance, family_profiles["9-12"])
+
+    ref_series = []
+    current = df
+    while current <= dt_to:
+        dow = current.weekday()  # 0=Mon, 6=Sun
+        is_weekend = dow >= 5
+        for hour in range(24):
+            base_kwh = hourly_profile[hour]
+            # Weekend factor: 40% for tertiaire/entreprise, 110% for habitat
+            if is_weekend:
+                factor = 1.1 if famille == "habitat" else 0.4
+                base_kwh = base_kwh * factor
+            ref_series.append({
+                "t": f"{current.isoformat()} {hour:02d}:00:00",
+                "v": round(base_kwh, 2),
+            })
+        current += timedelta(days=1)
+
+    # Aggregate to daily if requested
+    if granularity == "daily":
+        daily = {}
+        for pt in ref_series:
+            day = pt["t"][:10]
+            daily[day] = daily.get(day, 0) + pt["v"]
+        ref_series = [{"t": d, "v": round(v, 1)} for d, v in sorted(daily.items())]
+
+    # Get actual consumption for KPI delta
+    kpi = None
+    try:
+        ts_data = query_timeseries(
+            db, [site_id], None,
+            datetime.combine(df, datetime.min.time()),
+            datetime.combine(dt_to, datetime.min.time()),
+            granularity if granularity != "hourly" else "daily",
+            "aggregate", "kwh",
+        )
+        if ts_data["series"] and ts_data["series"][0]["data"]:
+            actual_total = sum(p["v"] for p in ts_data["series"][0]["data"] if p.get("v"))
+            ref_total = sum(p["v"] for p in ref_series)
+            delta_kwh = actual_total - ref_total
+            delta_pct = round(delta_kwh / ref_total * 100, 1) if ref_total > 0 else 0
+            # Confidence based on actual data coverage
+            n_actual = len([p for p in ts_data["series"][0]["data"] if p.get("v")])
+            n_expected = len(ref_series)
+            coverage = min(100, round(n_actual / max(n_expected, 1) * 100))
+            confidence = "high" if coverage >= 80 else "medium" if coverage >= 50 else "low"
+            kpi = {
+                "actual_kwh": round(actual_total, 1),
+                "reference_kwh": round(ref_total, 1),
+                "delta_kwh": round(delta_kwh, 1),
+                "delta_pct": delta_pct,
+                "coverage_pct": coverage,
+                "confidence": confidence,
+            }
+    except Exception:
+        pass
+
+    return {
+        "famille": famille,
+        "puissance": puissance,
+        "granularity": granularity,
+        "series": ref_series,
+        "kpi": kpi,
+    }
+
+
+# -------------------------------------------------------------------
+# P1-3: Weather sub-hourly UTC (for consumption overlay)
+# -------------------------------------------------------------------
+@router.get("/weather_hourly")
+def get_weather_hourly(
+    site_id: int = Query(...),
+    date_from: str = Query(...),
+    date_to: str = Query(...),
+    db: Session = Depends(get_db),
+):
+    """
+    Returns hourly temperature data in UTC for consumption overlay.
+    Interpolates from daily min/max with sinusoidal intraday pattern.
+    All timestamps are UTC — no DST shifting.
+    """
+    from services.ems.weather_service import get_weather
+    from datetime import date as date_cls, timedelta
+    import math
+
+    df = date_cls.fromisoformat(date_from)
+    dt_to = date_cls.fromisoformat(date_to)
+
+    daily = get_weather(db, site_id, df, dt_to)
+    daily_map = {d["date"]: d for d in daily}
+
+    hours = []
+    current = df
+    while current <= dt_to:
+        day_str = current.isoformat()
+        day_data = daily_map.get(day_str)
+        if not day_data:
+            current += timedelta(days=1)
+            continue
+        t_min = day_data["temp_min_c"]
+        t_max = day_data["temp_max_c"]
+        t_avg = day_data["temp_avg_c"]
+        for h in range(24):
+            # Sinusoidal: min at 5h UTC, max at 15h UTC
+            phase = (h - 5) / 24 * 2 * math.pi
+            temp = t_avg + (t_max - t_min) / 2 * math.sin(phase)
+            hours.append({
+                "t": f"{day_str}T{h:02d}:00:00Z",
+                "temp_c": round(temp, 1),
+            })
+        current += timedelta(days=1)
+
+    return {
+        "site_id": site_id,
+        "timezone": "UTC",
+        "hours": hours,
+    }

--- a/backend/routes/energy.py
+++ b/backend/routes/energy.py
@@ -416,6 +416,10 @@ def generate_demo_data(
         db.commit()
         db.refresh(meter)
 
+    # Purge existing readings to avoid duplicate constraint violation
+    db.query(MeterReading).filter(MeterReading.meter_id == meter.id).delete()
+    db.flush()
+
     # Archetype-based generation profiles
     profiles = {
         "BUREAU_STANDARD": {
@@ -553,8 +557,7 @@ def _import_csv(content: bytes, meter_id: int, frequency: FrequencyType, db: Ses
 
             # Batch commit every 5000 rows
             if len(batch) >= 5000:
-                db.bulk_save_objects(batch)
-                db.flush()
+                _save_readings_ignore_dupes(db, batch)
                 batch = []
 
         except Exception:
@@ -562,8 +565,7 @@ def _import_csv(content: bytes, meter_id: int, frequency: FrequencyType, db: Ses
 
     # Final batch
     if batch:
-        db.bulk_save_objects(batch)
-        db.flush()
+        _save_readings_ignore_dupes(db, batch)
 
     db.commit()
 
@@ -636,6 +638,22 @@ def _import_json(content: bytes, meter_id: int, frequency: FrequencyType, db: Se
     db.commit()
 
     return rows_imported, rows_skipped, rows_errored, (min_date, max_date)
+
+
+def _save_readings_ignore_dupes(db: Session, readings: list):
+    """Save readings, skipping duplicates on (meter_id, timestamp) unique constraint."""
+    try:
+        db.bulk_save_objects(readings)
+        db.flush()
+    except Exception:
+        db.rollback()
+        # Fallback: insert one-by-one, skip duplicates
+        for r in readings:
+            try:
+                db.add(r)
+                db.flush()
+            except Exception:
+                db.rollback()
 
 
 def _parse_timestamp(ts_str: str) -> datetime:

--- a/backend/routes/import_sites.py
+++ b/backend/routes/import_sites.py
@@ -5,6 +5,7 @@ GET  /api/import/template - Retourne la structure CSV attendue
 """
 import io
 import csv
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Request
 from sqlalchemy.orm import Session

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -1,6 +1,7 @@
 """
-PROMEOS — Portfolio Consumption Endpoints (V1)
+PROMEOS — Portfolio Consumption Endpoints (V1.1)
 Aggregated multi-site view: summary + per-site table.
+V1.1: impact_eur_estimated, open_actions_count, with_actions filter, impact sort.
 """
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
@@ -12,6 +13,8 @@ from database import get_db
 from models import Site
 from models.energy_models import Meter, MeterReading, EnergyVector
 from models.consumption_insight import ConsumptionInsight
+from models.action_item import ActionItem
+from models.enums import ActionStatus
 
 router = APIRouter(prefix="/api/portfolio/consumption", tags=["Portfolio Consumption"])
 
@@ -94,6 +97,63 @@ def _confidence_for_readings(n_readings: int, days: int) -> str:
     return "low"
 
 
+def _site_impact_eur(db: Session, site_id: int, dt_from: datetime) -> float:
+    """Sum of estimated_loss_eur from consumption insights for a site."""
+    total = db.query(func.sum(ConsumptionInsight.estimated_loss_eur)).filter(
+        ConsumptionInsight.site_id == site_id,
+        ConsumptionInsight.period_start >= dt_from,
+        ConsumptionInsight.estimated_loss_eur.isnot(None),
+    ).scalar()
+    return round(total, 2) if total else 0.0
+
+
+def _site_open_actions(db: Session, site_id: int) -> int:
+    """Count of open/in_progress actions for a site."""
+    return db.query(func.count(ActionItem.id)).filter(
+        ActionItem.site_id == site_id,
+        ActionItem.status.in_([ActionStatus.OPEN, ActionStatus.IN_PROGRESS]),
+    ).scalar() or 0
+
+
+def _build_site_row(db, site, dt_from, dt_to, days):
+    """Build a single site row dict with all metrics."""
+    conso = _site_consumption(db, site.id, dt_from, dt_to)
+    kwh = conso.kwh or 0
+    n = conso.n_readings or 0
+    last_reading = conso.last_reading
+    has_data = kwh > 0
+    conf = _confidence_for_readings(n, days) if has_data else "low"
+
+    eur = round(kwh * DEFAULT_EUR_KWH, 2)
+    co2 = round(kwh * CO2E_FACTOR, 1)
+
+    diag_count = db.query(func.count(ConsumptionInsight.id)).filter(
+        ConsumptionInsight.site_id == site.id,
+        ConsumptionInsight.period_start >= dt_from,
+    ).scalar() or 0
+
+    peak_kw = _site_peak_kw(db, site.id, dt_from, dt_to) if has_data else None
+    base_night = _base_night_pct(db, site.id, dt_from, dt_to) if has_data else None
+    impact_eur = _site_impact_eur(db, site.id, dt_from)
+    open_actions = _site_open_actions(db, site.id)
+
+    return {
+        "site_id": site.id,
+        "site_name": site.nom,
+        "kwh": round(kwh, 1),
+        "eur": eur,
+        "co2": co2,
+        "base_night_pct": base_night,
+        "peak_kw": round(peak_kw, 1) if peak_kw else None,
+        "diagnostics_count": diag_count,
+        "impact_eur_estimated": impact_eur,
+        "open_actions_count": open_actions,
+        "confidence": conf,
+        "last_reading_date": last_reading.isoformat() if last_reading else None,
+        "n_readings": n,
+    }
+
+
 # -------------------------------------------------------------------
 # GET /api/portfolio/consumption/summary
 # -------------------------------------------------------------------
@@ -127,73 +187,50 @@ def get_portfolio_summary(
     site_rows = []
 
     for site in sites:
-        conso = _site_consumption(db, site.id, dt_from, dt_to)
-        kwh = conso.kwh or 0
-        n = conso.n_readings or 0
-        last_reading = conso.last_reading
-
-        has_data = kwh > 0
-        if has_data:
+        row = _build_site_row(db, site, dt_from, dt_to, days)
+        if row["kwh"] > 0:
             sites_with_data += 1
-
-        conf = _confidence_for_readings(n, days) if has_data else "low"
-        confidence_split[conf] += 1
-
-        eur = round(kwh * DEFAULT_EUR_KWH, 2)
-        co2 = round(kwh * CO2E_FACTOR, 1)
-
-        # Diagnostics count
-        diag_count = db.query(func.count(ConsumptionInsight.id)).filter(
-            ConsumptionInsight.site_id == site.id,
-            ConsumptionInsight.period_start >= dt_from,
-        ).scalar() or 0
-
-        # Peak & base night (only if data)
-        peak_kw = _site_peak_kw(db, site.id, dt_from, dt_to) if has_data else None
-        base_night = _base_night_pct(db, site.id, dt_from, dt_to) if has_data else None
-
-        kwh_total += kwh
-
-        site_rows.append({
-            "site_id": site.id,
-            "site_name": site.nom,
-            "kwh": round(kwh, 1),
-            "eur": eur,
-            "co2": co2,
-            "base_night_pct": base_night,
-            "peak_kw": round(peak_kw, 1) if peak_kw else None,
-            "diagnostics_count": diag_count,
-            "confidence": conf,
-            "last_reading_date": last_reading.isoformat() if last_reading else None,
-            "n_readings": n,
-        })
+        confidence_split[row["confidence"]] += 1
+        kwh_total += row["kwh"]
+        site_rows.append(row)
 
     eur_total = round(kwh_total * DEFAULT_EUR_KWH, 2)
     co2_total = round(kwh_total * CO2E_FACTOR, 1)
+    impact_eur_total = round(sum(r["impact_eur_estimated"] for r in site_rows), 2)
 
     # Build top-lists
     with_data = [r for r in site_rows if r["kwh"] > 0]
 
-    # Top drift: sites with most diagnostics of type "derive"
     top_drift = sorted(
         [r for r in with_data if r["diagnostics_count"] > 0],
         key=lambda r: r["diagnostics_count"],
         reverse=True,
     )[:5]
 
-    # Top base nocturne: highest night/day ratio
     top_base_night = sorted(
         [r for r in with_data if r["base_night_pct"] is not None],
         key=lambda r: r["base_night_pct"],
         reverse=True,
     )[:5]
 
-    # Top peaks: highest peak_kw
     top_peaks = sorted(
         [r for r in with_data if r["peak_kw"] is not None],
         key=lambda r: r["peak_kw"],
         reverse=True,
     )[:5]
+
+    # V1.1: Top impact — sites with highest estimated loss
+    top_impact = sorted(
+        [r for r in with_data if r["impact_eur_estimated"] > 0],
+        key=lambda r: r["impact_eur_estimated"],
+        reverse=True,
+    )[:5]
+
+    def _top_row(r, extra_keys):
+        base = {"site_id": r["site_id"], "site_name": r["site_name"], "kwh": r["kwh"], "confidence": r["confidence"]}
+        for k in extra_keys:
+            base[k] = r[k]
+        return base
 
     return {
         "period": {"from": d_from.isoformat(), "to": d_to.isoformat(), "days": days},
@@ -202,15 +239,17 @@ def get_portfolio_summary(
             "eur_total": eur_total,
             "eur_source": "estime",
             "co2_total": co2_total,
+            "impact_eur_total": impact_eur_total,
         },
         "coverage": {
             "sites_total": sites_total,
             "sites_with_data": sites_with_data,
             "confidence_split": confidence_split,
         },
-        "top_drift": [{"site_id": r["site_id"], "site_name": r["site_name"], "diagnostics_count": r["diagnostics_count"], "kwh": r["kwh"], "confidence": r["confidence"]} for r in top_drift],
-        "top_base_night": [{"site_id": r["site_id"], "site_name": r["site_name"], "base_night_pct": r["base_night_pct"], "kwh": r["kwh"], "confidence": r["confidence"]} for r in top_base_night],
-        "top_peaks": [{"site_id": r["site_id"], "site_name": r["site_name"], "peak_kw": r["peak_kw"], "kwh": r["kwh"], "confidence": r["confidence"]} for r in top_peaks],
+        "top_drift": [_top_row(r, ["diagnostics_count"]) for r in top_drift],
+        "top_base_night": [_top_row(r, ["base_night_pct"]) for r in top_base_night],
+        "top_peaks": [_top_row(r, ["peak_kw"]) for r in top_peaks],
+        "top_impact": [_top_row(r, ["impact_eur_estimated"]) for r in top_impact],
     }
 
 
@@ -221,9 +260,10 @@ def get_portfolio_summary(
 def get_portfolio_sites(
     date_from: Optional[str] = Query(None, alias="from"),
     date_to: Optional[str] = Query(None, alias="to"),
-    sort: str = Query("kwh_desc", description="kwh_desc|kwh_asc|name|peak|base_night|diagnostics"),
+    sort: str = Query("impact_desc", description="impact_desc|kwh_desc|kwh_asc|name|peak|base_night|diagnostics"),
     confidence: Optional[str] = Query(None, description="high|medium|low"),
     with_anomalies: bool = Query(False),
+    with_actions: Optional[str] = Query(None, description="with|without — filter by open actions"),
     search: Optional[str] = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -232,6 +272,7 @@ def get_portfolio_sites(
 ):
     """
     Paginated site-level consumption table for portfolio view.
+    V1.1: impact_eur_estimated, open_actions_count, with_actions filter, impact sort.
     """
     d_from = _parse_date_or_default(date_from, 90)
     d_to = _parse_date_or_default(date_to, 0) if date_to else date_cls.today()
@@ -247,54 +288,28 @@ def get_portfolio_sites(
         q = q.filter(Site.nom.ilike(f"%{search}%"))
     all_sites = q.all()
 
-    rows = []
-    for site in all_sites:
-        conso = _site_consumption(db, site.id, dt_from, dt_to)
-        kwh = conso.kwh or 0
-        n = conso.n_readings or 0
-        last_reading = conso.last_reading
-        has_data = kwh > 0
-        conf = _confidence_for_readings(n, days) if has_data else "low"
-
-        eur = round(kwh * DEFAULT_EUR_KWH, 2)
-        co2 = round(kwh * CO2E_FACTOR, 1)
-
-        diag_count = db.query(func.count(ConsumptionInsight.id)).filter(
-            ConsumptionInsight.site_id == site.id,
-            ConsumptionInsight.period_start >= dt_from,
-        ).scalar() or 0
-
-        peak_kw = _site_peak_kw(db, site.id, dt_from, dt_to) if has_data else None
-        base_night = _base_night_pct(db, site.id, dt_from, dt_to) if has_data else None
-
-        rows.append({
-            "site_id": site.id,
-            "site_name": site.nom,
-            "kwh": round(kwh, 1),
-            "eur": eur,
-            "co2": co2,
-            "base_night_pct": base_night,
-            "peak_kw": round(peak_kw, 1) if peak_kw else None,
-            "diagnostics_count": diag_count,
-            "confidence": conf,
-            "last_reading_date": last_reading.isoformat() if last_reading else None,
-        })
+    rows = [_build_site_row(db, site, dt_from, dt_to, days) for site in all_sites]
 
     # Filters
     if confidence:
         rows = [r for r in rows if r["confidence"] == confidence]
     if with_anomalies:
         rows = [r for r in rows if r["diagnostics_count"] > 0]
+    if with_actions == "with":
+        rows = [r for r in rows if r["open_actions_count"] > 0]
+    elif with_actions == "without":
+        rows = [r for r in rows if r["open_actions_count"] == 0]
 
     # Sort
     sort_key = {
+        "impact_desc": lambda r: -(r["impact_eur_estimated"] or 0),
         "kwh_desc": lambda r: -(r["kwh"] or 0),
         "kwh_asc": lambda r: r["kwh"] or 0,
         "name": lambda r: (r["site_name"] or "").lower(),
         "peak": lambda r: -(r["peak_kw"] or 0),
         "base_night": lambda r: -(r["base_night_pct"] or 0),
         "diagnostics": lambda r: -(r["diagnostics_count"] or 0),
-    }.get(sort, lambda r: -(r["kwh"] or 0))
+    }.get(sort, lambda r: -(r["impact_eur_estimated"] or 0))
     rows.sort(key=sort_key)
 
     total = len(rows)

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -1,0 +1,308 @@
+"""
+PROMEOS — Portfolio Consumption Endpoints (V1)
+Aggregated multi-site view: summary + per-site table.
+"""
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import func, case, and_
+from datetime import datetime, date as date_cls, timedelta
+from typing import Optional, List
+
+from database import get_db
+from models import Site
+from models.energy_models import Meter, MeterReading, EnergyVector
+from models.consumption_insight import ConsumptionInsight
+
+router = APIRouter(prefix="/api/portfolio/consumption", tags=["Portfolio Consumption"])
+
+# Default kWh→EUR estimation (used when no contract price available)
+DEFAULT_EUR_KWH = 0.18
+CO2E_FACTOR = 0.052  # kgCO2e/kWh ADEME 2024
+
+
+def _parse_date_or_default(val: Optional[str], default_days_ago: int = 90) -> date_cls:
+    if val:
+        return date_cls.fromisoformat(val)
+    return date_cls.today() - timedelta(days=default_days_ago)
+
+
+def _site_consumption(db: Session, site_id: int, dt_from: datetime, dt_to: datetime):
+    """Get aggregated consumption for a single site in the period."""
+    row = db.query(
+        func.sum(MeterReading.value_kwh).label("kwh"),
+        func.count(MeterReading.id).label("n_readings"),
+        func.max(MeterReading.timestamp).label("last_reading"),
+    ).join(Meter, MeterReading.meter_id == Meter.id).filter(
+        Meter.site_id == site_id,
+        Meter.energy_vector == EnergyVector.ELECTRICITY,
+        MeterReading.timestamp >= dt_from,
+        MeterReading.timestamp < dt_to,
+    ).first()
+    return row
+
+
+def _site_peak_kw(db: Session, site_id: int, dt_from: datetime, dt_to: datetime):
+    """P95 approximation: max hourly kWh reading (proxy for kW peak)."""
+    row = db.query(
+        func.max(MeterReading.value_kwh).label("peak"),
+    ).join(Meter, MeterReading.meter_id == Meter.id).filter(
+        Meter.site_id == site_id,
+        Meter.energy_vector == EnergyVector.ELECTRICITY,
+        MeterReading.timestamp >= dt_from,
+        MeterReading.timestamp < dt_to,
+    ).first()
+    return row.peak if row and row.peak else None
+
+
+def _base_night_pct(db: Session, site_id: int, dt_from: datetime, dt_to: datetime):
+    """Base nocturne %: ratio night (22h-6h) vs day (6h-22h) avg kWh."""
+    from sqlalchemy import extract
+    night_avg = db.query(func.avg(MeterReading.value_kwh)).join(
+        Meter, MeterReading.meter_id == Meter.id
+    ).filter(
+        Meter.site_id == site_id,
+        Meter.energy_vector == EnergyVector.ELECTRICITY,
+        MeterReading.timestamp >= dt_from,
+        MeterReading.timestamp < dt_to,
+        ((extract("hour", MeterReading.timestamp) < 6) |
+         (extract("hour", MeterReading.timestamp) >= 22)),
+    ).scalar()
+
+    day_avg = db.query(func.avg(MeterReading.value_kwh)).join(
+        Meter, MeterReading.meter_id == Meter.id
+    ).filter(
+        Meter.site_id == site_id,
+        Meter.energy_vector == EnergyVector.ELECTRICITY,
+        MeterReading.timestamp >= dt_from,
+        MeterReading.timestamp < dt_to,
+        extract("hour", MeterReading.timestamp) >= 6,
+        extract("hour", MeterReading.timestamp) < 22,
+    ).scalar()
+
+    if not day_avg or day_avg == 0:
+        return None
+    return round((night_avg or 0) / day_avg * 100)
+
+
+def _confidence_for_readings(n_readings: int, days: int) -> str:
+    """Heuristic confidence from reading density."""
+    expected = days * 24  # hourly
+    if n_readings >= expected * 0.8:
+        return "high"
+    if n_readings >= expected * 0.3:
+        return "medium"
+    return "low"
+
+
+# -------------------------------------------------------------------
+# GET /api/portfolio/consumption/summary
+# -------------------------------------------------------------------
+@router.get("/summary")
+def get_portfolio_summary(
+    date_from: Optional[str] = Query(None, alias="from"),
+    date_to: Optional[str] = Query(None, alias="to"),
+    site_ids: Optional[str] = Query(None, description="Comma-separated site IDs"),
+    db: Session = Depends(get_db),
+):
+    """
+    Aggregated portfolio KPIs + top-lists for multi-site consumption view.
+    """
+    d_from = _parse_date_or_default(date_from, 90)
+    d_to = _parse_date_or_default(date_to, 0) if date_to else date_cls.today()
+    dt_from = datetime.combine(d_from, datetime.min.time())
+    dt_to = datetime.combine(d_to + timedelta(days=1), datetime.min.time())
+    days = (d_to - d_from).days or 1
+
+    # Resolve sites
+    q = db.query(Site).filter(Site.actif == True)
+    if site_ids:
+        ids = [int(x) for x in site_ids.split(",") if x.strip()]
+        q = q.filter(Site.id.in_(ids))
+    sites = q.all()
+
+    kwh_total = 0.0
+    sites_total = len(sites)
+    sites_with_data = 0
+    confidence_split = {"high": 0, "medium": 0, "low": 0}
+    site_rows = []
+
+    for site in sites:
+        conso = _site_consumption(db, site.id, dt_from, dt_to)
+        kwh = conso.kwh or 0
+        n = conso.n_readings or 0
+        last_reading = conso.last_reading
+
+        has_data = kwh > 0
+        if has_data:
+            sites_with_data += 1
+
+        conf = _confidence_for_readings(n, days) if has_data else "low"
+        confidence_split[conf] += 1
+
+        eur = round(kwh * DEFAULT_EUR_KWH, 2)
+        co2 = round(kwh * CO2E_FACTOR, 1)
+
+        # Diagnostics count
+        diag_count = db.query(func.count(ConsumptionInsight.id)).filter(
+            ConsumptionInsight.site_id == site.id,
+            ConsumptionInsight.period_start >= dt_from,
+        ).scalar() or 0
+
+        # Peak & base night (only if data)
+        peak_kw = _site_peak_kw(db, site.id, dt_from, dt_to) if has_data else None
+        base_night = _base_night_pct(db, site.id, dt_from, dt_to) if has_data else None
+
+        kwh_total += kwh
+
+        site_rows.append({
+            "site_id": site.id,
+            "site_name": site.nom,
+            "kwh": round(kwh, 1),
+            "eur": eur,
+            "co2": co2,
+            "base_night_pct": base_night,
+            "peak_kw": round(peak_kw, 1) if peak_kw else None,
+            "diagnostics_count": diag_count,
+            "confidence": conf,
+            "last_reading_date": last_reading.isoformat() if last_reading else None,
+            "n_readings": n,
+        })
+
+    eur_total = round(kwh_total * DEFAULT_EUR_KWH, 2)
+    co2_total = round(kwh_total * CO2E_FACTOR, 1)
+
+    # Build top-lists
+    with_data = [r for r in site_rows if r["kwh"] > 0]
+
+    # Top drift: sites with most diagnostics of type "derive"
+    top_drift = sorted(
+        [r for r in with_data if r["diagnostics_count"] > 0],
+        key=lambda r: r["diagnostics_count"],
+        reverse=True,
+    )[:5]
+
+    # Top base nocturne: highest night/day ratio
+    top_base_night = sorted(
+        [r for r in with_data if r["base_night_pct"] is not None],
+        key=lambda r: r["base_night_pct"],
+        reverse=True,
+    )[:5]
+
+    # Top peaks: highest peak_kw
+    top_peaks = sorted(
+        [r for r in with_data if r["peak_kw"] is not None],
+        key=lambda r: r["peak_kw"],
+        reverse=True,
+    )[:5]
+
+    return {
+        "period": {"from": d_from.isoformat(), "to": d_to.isoformat(), "days": days},
+        "totals": {
+            "kwh_total": round(kwh_total, 1),
+            "eur_total": eur_total,
+            "eur_source": "estime",
+            "co2_total": co2_total,
+        },
+        "coverage": {
+            "sites_total": sites_total,
+            "sites_with_data": sites_with_data,
+            "confidence_split": confidence_split,
+        },
+        "top_drift": [{"site_id": r["site_id"], "site_name": r["site_name"], "diagnostics_count": r["diagnostics_count"], "kwh": r["kwh"], "confidence": r["confidence"]} for r in top_drift],
+        "top_base_night": [{"site_id": r["site_id"], "site_name": r["site_name"], "base_night_pct": r["base_night_pct"], "kwh": r["kwh"], "confidence": r["confidence"]} for r in top_base_night],
+        "top_peaks": [{"site_id": r["site_id"], "site_name": r["site_name"], "peak_kw": r["peak_kw"], "kwh": r["kwh"], "confidence": r["confidence"]} for r in top_peaks],
+    }
+
+
+# -------------------------------------------------------------------
+# GET /api/portfolio/consumption/sites
+# -------------------------------------------------------------------
+@router.get("/sites")
+def get_portfolio_sites(
+    date_from: Optional[str] = Query(None, alias="from"),
+    date_to: Optional[str] = Query(None, alias="to"),
+    sort: str = Query("kwh_desc", description="kwh_desc|kwh_asc|name|peak|base_night|diagnostics"),
+    confidence: Optional[str] = Query(None, description="high|medium|low"),
+    with_anomalies: bool = Query(False),
+    search: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    site_ids: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+):
+    """
+    Paginated site-level consumption table for portfolio view.
+    """
+    d_from = _parse_date_or_default(date_from, 90)
+    d_to = _parse_date_or_default(date_to, 0) if date_to else date_cls.today()
+    dt_from = datetime.combine(d_from, datetime.min.time())
+    dt_to = datetime.combine(d_to + timedelta(days=1), datetime.min.time())
+    days = (d_to - d_from).days or 1
+
+    q = db.query(Site).filter(Site.actif == True)
+    if site_ids:
+        ids = [int(x) for x in site_ids.split(",") if x.strip()]
+        q = q.filter(Site.id.in_(ids))
+    if search:
+        q = q.filter(Site.nom.ilike(f"%{search}%"))
+    all_sites = q.all()
+
+    rows = []
+    for site in all_sites:
+        conso = _site_consumption(db, site.id, dt_from, dt_to)
+        kwh = conso.kwh or 0
+        n = conso.n_readings or 0
+        last_reading = conso.last_reading
+        has_data = kwh > 0
+        conf = _confidence_for_readings(n, days) if has_data else "low"
+
+        eur = round(kwh * DEFAULT_EUR_KWH, 2)
+        co2 = round(kwh * CO2E_FACTOR, 1)
+
+        diag_count = db.query(func.count(ConsumptionInsight.id)).filter(
+            ConsumptionInsight.site_id == site.id,
+            ConsumptionInsight.period_start >= dt_from,
+        ).scalar() or 0
+
+        peak_kw = _site_peak_kw(db, site.id, dt_from, dt_to) if has_data else None
+        base_night = _base_night_pct(db, site.id, dt_from, dt_to) if has_data else None
+
+        rows.append({
+            "site_id": site.id,
+            "site_name": site.nom,
+            "kwh": round(kwh, 1),
+            "eur": eur,
+            "co2": co2,
+            "base_night_pct": base_night,
+            "peak_kw": round(peak_kw, 1) if peak_kw else None,
+            "diagnostics_count": diag_count,
+            "confidence": conf,
+            "last_reading_date": last_reading.isoformat() if last_reading else None,
+        })
+
+    # Filters
+    if confidence:
+        rows = [r for r in rows if r["confidence"] == confidence]
+    if with_anomalies:
+        rows = [r for r in rows if r["diagnostics_count"] > 0]
+
+    # Sort
+    sort_key = {
+        "kwh_desc": lambda r: -(r["kwh"] or 0),
+        "kwh_asc": lambda r: r["kwh"] or 0,
+        "name": lambda r: (r["site_name"] or "").lower(),
+        "peak": lambda r: -(r["peak_kw"] or 0),
+        "base_night": lambda r: -(r["base_night_pct"] or 0),
+        "diagnostics": lambda r: -(r["diagnostics_count"] or 0),
+    }.get(sort, lambda r: -(r["kwh"] or 0))
+    rows.sort(key=sort_key)
+
+    total = len(rows)
+    page = rows[offset:offset + limit]
+
+    return {
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "rows": page,
+    }

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -1,7 +1,8 @@
 """
-PROMEOS — Portfolio Consumption Endpoints (V1.1)
+PROMEOS — Portfolio Consumption Endpoints (V2)
 Aggregated multi-site view: summary + per-site table.
-V1.1: impact_eur_estimated, open_actions_count, with_actions filter, impact sort.
+V2: patrimoine-first — all sites shown, data_status badge, coverage_pct per site,
+    without_data filter, coverage sort.
 """
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
@@ -116,13 +117,25 @@ def _site_open_actions(db: Session, site_id: int) -> int:
 
 
 def _build_site_row(db, site, dt_from, dt_to, days):
-    """Build a single site row dict with all metrics."""
+    """Build a single site row dict with all metrics (patrimoine-first)."""
     conso = _site_consumption(db, site.id, dt_from, dt_to)
     kwh = conso.kwh or 0
     n = conso.n_readings or 0
     last_reading = conso.last_reading
     has_data = kwh > 0
     conf = _confidence_for_readings(n, days) if has_data else "low"
+
+    # V2: coverage_pct per site + data_status badge
+    expected = days * 24  # hourly readings expected
+    coverage_pct = round(n / expected * 100) if expected > 0 else 0
+    if coverage_pct > 100:
+        coverage_pct = 100
+    if not has_data:
+        data_status = "none"       # Aucune donnee
+    elif coverage_pct >= 80:
+        data_status = "ok"         # Donnees completes
+    else:
+        data_status = "partial"    # Donnees partielles
 
     eur = round(kwh * DEFAULT_EUR_KWH, 2)
     co2 = round(kwh * CO2E_FACTOR, 1)
@@ -149,6 +162,8 @@ def _build_site_row(db, site, dt_from, dt_to, days):
         "impact_eur_estimated": impact_eur,
         "open_actions_count": open_actions,
         "confidence": conf,
+        "data_status": data_status,
+        "coverage_pct": coverage_pct,
         "last_reading_date": last_reading.isoformat() if last_reading else None,
         "n_readings": n,
     }
@@ -244,6 +259,7 @@ def get_portfolio_summary(
         "coverage": {
             "sites_total": sites_total,
             "sites_with_data": sites_with_data,
+            "sites_without_data": sites_total - sites_with_data,
             "confidence_split": confidence_split,
         },
         "top_drift": [_top_row(r, ["diagnostics_count"]) for r in top_drift],
@@ -260,10 +276,11 @@ def get_portfolio_summary(
 def get_portfolio_sites(
     date_from: Optional[str] = Query(None, alias="from"),
     date_to: Optional[str] = Query(None, alias="to"),
-    sort: str = Query("impact_desc", description="impact_desc|kwh_desc|kwh_asc|name|peak|base_night|diagnostics"),
+    sort: str = Query("impact_desc", description="impact_desc|kwh_desc|kwh_asc|name|peak|base_night|diagnostics|coverage"),
     confidence: Optional[str] = Query(None, description="high|medium|low"),
     with_anomalies: bool = Query(False),
     with_actions: Optional[str] = Query(None, description="with|without — filter by open actions"),
+    without_data: bool = Query(False, description="Show only sites without consumption data"),
     search: Optional[str] = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -299,6 +316,8 @@ def get_portfolio_sites(
         rows = [r for r in rows if r["open_actions_count"] > 0]
     elif with_actions == "without":
         rows = [r for r in rows if r["open_actions_count"] == 0]
+    if without_data:
+        rows = [r for r in rows if r["data_status"] == "none"]
 
     # Sort
     sort_key = {
@@ -309,6 +328,7 @@ def get_portfolio_sites(
         "peak": lambda r: -(r["peak_kw"] or 0),
         "base_night": lambda r: -(r["base_night_pct"] or 0),
         "diagnostics": lambda r: -(r["diagnostics_count"] or 0),
+        "coverage": lambda r: -(r["coverage_pct"] or 0),
     }.get(sort, lambda r: -(r["impact_eur_estimated"] or 0))
     rows.sort(key=sort_key)
 

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -1119,6 +1119,16 @@ def main():
         patrimoine_result = seed_patrimoine_demo(db)
         db.commit()
 
+        # V68: Billing demo 36 mois
+        from services.billing_seed import seed_billing_demo
+        billing_result = seed_billing_demo(db)
+        if "error" in billing_result:
+            print(f"  ⚠ Billing seed skipped: {billing_result['error']}")
+        elif billing_result.get("skipped"):
+            print(f"  ⚠ Billing seed skipped: {billing_result.get('reason')}")
+        else:
+            print(f"  ✓ Billing demo seeded ({billing_result.get('invoices_created')} factures, 36 mois, 2 sites)")
+
         print("\n" + "=" * 70)
         print("SEED TERMINE AVEC SUCCES !")
         print("=" * 70)

--- a/backend/services/billing_coverage.py
+++ b/backend/services/billing_coverage.py
@@ -14,8 +14,9 @@ Règles:
 """
 from __future__ import annotations
 
+import json
 from calendar import monthrange
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import List, Optional, Tuple
 
@@ -33,6 +34,8 @@ class MonthCoverage:
     invoices_count: int      # toutes factures incl. avoirs
     total_ttc: Optional[float]  # somme total_eur (incl. avoirs) ou None si vide
     missing_reason: Optional[str]
+    energy_kwh: Optional[float] = field(default=None)   # P0-2: somme kWh factures positives
+    pdl_prm: Optional[str] = field(default=None)         # P0-2: PDL/PRM depuis raw_json
 
 
 def _invoice_period(inv) -> Tuple[Optional[date], Optional[date]]:
@@ -94,6 +97,8 @@ def compute_coverage(invoices: list, range_start: date, range_end: date) -> List
         covered_days: set[date] = set()
         inv_in_month: list = []
         total_ttc = 0.0
+        total_kwh = 0.0           # P0-2
+        pdl_found: Optional[str] = None  # P0-2
 
         for inv in invoices:
             ps, pe = _invoice_period(inv)
@@ -111,6 +116,15 @@ def compute_coverage(invoices: list, range_start: date, range_end: date) -> List
 
             # Avoirs (total_eur <= 0) ne contribuent pas à la couverture
             if (inv.total_eur or 0.0) > 0:
+                total_kwh += (getattr(inv, "energy_kwh", None) or 0.0)  # P0-2: accumuler kWh
+                # P0-2: extraire PDL depuis raw_json si pas encore trouvé
+                if pdl_found is None:
+                    try:
+                        raw = json.loads(getattr(inv, "raw_json", None) or "{}")
+                        if raw.get("pdl_prm"):
+                            pdl_found = raw["pdl_prm"]
+                    except Exception:
+                        pass
                 d = overlap_start
                 while d <= overlap_end:
                     covered_days.add(d)
@@ -140,6 +154,8 @@ def compute_coverage(invoices: list, range_start: date, range_end: date) -> List
             invoices_count=len(inv_in_month),
             total_ttc=round(total_ttc, 2) if inv_in_month else None,
             missing_reason=reason,
+            energy_kwh=round(total_kwh, 1) if inv_in_month else None,  # P0-2
+            pdl_prm=pdl_found,                                          # P0-2
         ))
 
     return results

--- a/backend/services/billing_coverage.py
+++ b/backend/services/billing_coverage.py
@@ -1,0 +1,185 @@
+"""
+PROMEOS — Billing Coverage Engine (V67)
+Calcule la couverture mensuelle à partir des factures importées.
+
+SoT période:
+  1. period_start + period_end si disponibles
+  2. Fallback sur issue_date → mois entier (1er→dernier du mois)
+  3. Facture sans aucune date → ignorée pour la couverture (R4 l'a signalée)
+
+Règles:
+  - Avoirs (total_eur <= 0) exclus du calcul de couverture (inclus dans totaux)
+  - Chevauchements gérés par set() de jours → pas de double-comptage
+  - COVERAGE_THRESHOLD = 0.80 (configurable)
+"""
+from __future__ import annotations
+
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import List, Optional, Tuple
+
+
+COVERAGE_THRESHOLD = 0.80  # 80% des jours du mois = "covered"
+
+
+@dataclass
+class MonthCoverage:
+    month_key: str           # "YYYY-MM"
+    month_start: date
+    month_end: date
+    coverage_status: str     # "covered" | "partial" | "missing"
+    coverage_ratio: float    # 0.0 → 1.0
+    invoices_count: int      # toutes factures incl. avoirs
+    total_ttc: Optional[float]  # somme total_eur (incl. avoirs) ou None si vide
+    missing_reason: Optional[str]
+
+
+def _invoice_period(inv) -> Tuple[Optional[date], Optional[date]]:
+    """
+    Source-of-Truth pour la période d'une facture.
+    Priorité: period_start/end → fallback issue_date (mois entier) → None/None.
+    """
+    if inv.period_start and inv.period_end:
+        return inv.period_start, inv.period_end
+    if inv.issue_date:
+        d = inv.issue_date
+        _, last_day = monthrange(d.year, d.month)
+        return date(d.year, d.month, 1), date(d.year, d.month, last_day)
+    return None, None
+
+
+def _month_bounds(year: int, month: int) -> Tuple[date, date]:
+    _, last_day = monthrange(year, month)
+    return date(year, month, 1), date(year, month, last_day)
+
+
+def _iter_months(start: date, end: date):
+    """Génère (year, month) pour chaque mois de [start, end] inclus."""
+    y, m = start.year, start.month
+    while (y, m) <= (end.year, end.month):
+        yield y, m
+        m += 1
+        if m > 12:
+            m, y = 1, y + 1
+
+
+def compute_range(invoices: list) -> Tuple[Optional[date], Optional[date]]:
+    """Calcule le range min/max des périodes effectives sur toutes les factures."""
+    starts: list[date] = []
+    ends: list[date] = []
+    for inv in invoices:
+        ps, pe = _invoice_period(inv)
+        if ps:
+            starts.append(ps)
+        if pe:
+            ends.append(pe)
+    if not starts:
+        return None, None
+    return min(starts), max(ends)
+
+
+def compute_coverage(invoices: list, range_start: date, range_end: date) -> List[MonthCoverage]:
+    """
+    Pour chaque mois dans [range_start, range_end] :
+    - Compte les jours couverts (factures non-avoir avec période valide)
+    - Détermine status et missing_reason
+    Retourne la liste de MonthCoverage (du plus ancien au plus récent).
+    """
+    results: List[MonthCoverage] = []
+
+    for y, m in _iter_months(range_start, range_end):
+        ms, me = _month_bounds(y, m)
+        nb_days = (me - ms).days + 1
+        covered_days: set[date] = set()
+        inv_in_month: list = []
+        total_ttc = 0.0
+
+        for inv in invoices:
+            ps, pe = _invoice_period(inv)
+            if ps is None:
+                continue  # pas de période utilisable
+
+            # Intersection avec le mois
+            overlap_start = max(ps, ms)
+            overlap_end = min(pe, me)
+            if overlap_start > overlap_end:
+                continue  # facture hors du mois
+
+            inv_in_month.append(inv)
+            total_ttc += (inv.total_eur or 0.0)
+
+            # Avoirs (total_eur <= 0) ne contribuent pas à la couverture
+            if (inv.total_eur or 0.0) > 0:
+                d = overlap_start
+                while d <= overlap_end:
+                    covered_days.add(d)
+                    d += timedelta(days=1)
+
+        ratio = len(covered_days) / nb_days if nb_days > 0 else 0.0
+
+        if ratio >= COVERAGE_THRESHOLD:
+            status = "covered"
+            reason = None
+        elif ratio > 0:
+            status = "partial"
+            reason = f"Couverture {ratio:.0%} ({len(covered_days)}/{nb_days} jours)"
+        else:
+            status = "missing"
+            if not inv_in_month:
+                reason = "Aucune facture importée pour ce mois"
+            else:
+                reason = "Factures présentes mais sans dates valides (vérifier R4)"
+
+        results.append(MonthCoverage(
+            month_key=f"{y:04d}-{m:02d}",
+            month_start=ms,
+            month_end=me,
+            coverage_status=status,
+            coverage_ratio=round(ratio, 4),
+            invoices_count=len(inv_in_month),
+            total_ttc=round(total_ttc, 2) if inv_in_month else None,
+            missing_reason=reason,
+        ))
+
+    return results
+
+
+def compute_top_sites_missing(db, effective_org_id: int, site_id_filter: Optional[int] = None) -> list:
+    """
+    Calcule le top 10 des sites avec le plus de mois manquants/partiels.
+    Retourne: [{"site_id": int, "site_name": str, "missing_months_count": int}]
+    """
+    from models.billing_models import EnergyInvoice
+    from models import Portefeuille, Site, EntiteJuridique
+
+    # Récupérer tous les sites de l'org
+    q = (
+        db.query(Site)
+        .join(Portefeuille, Portefeuille.id == Site.portefeuille_id)
+        .join(EntiteJuridique, EntiteJuridique.id == Portefeuille.entite_juridique_id)
+        .filter(EntiteJuridique.organisation_id == effective_org_id)
+    )
+    if site_id_filter:
+        q = q.filter(Site.id == site_id_filter)
+    sites = q.all()
+
+    site_missing: list = []
+    for site in sites:
+        invs = db.query(EnergyInvoice).filter(EnergyInvoice.site_id == site.id).all()
+        if not invs:
+            continue
+        rstart, rend = compute_range(invs)
+        if not rstart:
+            continue
+        months = compute_coverage(invs, rstart, rend)
+        missing_count = sum(1 for mc in months if mc.coverage_status != "covered")
+        if missing_count > 0:
+            site_missing.append({
+                "site_id": site.id,
+                "site_name": site.nom,
+                "missing_months_count": missing_count,
+            })
+
+    site_missing.sort(key=lambda x: x["missing_months_count"], reverse=True)
+    return site_missing[:10]

--- a/backend/services/billing_coverage.py
+++ b/backend/services/billing_coverage.py
@@ -36,6 +36,7 @@ class MonthCoverage:
     missing_reason: Optional[str]
     energy_kwh: Optional[float] = field(default=None)   # P0-2: somme kWh factures positives
     pdl_prm: Optional[str] = field(default=None)         # P0-2: PDL/PRM depuis raw_json
+    invoice_ids: List[int] = field(default_factory=list)  # V70: IDs factures du mois
 
 
 def _invoice_period(inv) -> Tuple[Optional[date], Optional[date]]:
@@ -156,6 +157,7 @@ def compute_coverage(invoices: list, range_start: date, range_end: date) -> List
             missing_reason=reason,
             energy_kwh=round(total_kwh, 1) if inv_in_month else None,  # P0-2
             pdl_prm=pdl_found,                                          # P0-2
+            invoice_ids=[inv.id for inv in inv_in_month],               # V70
         ))
 
     return results

--- a/backend/services/billing_normalization.py
+++ b/backend/services/billing_normalization.py
@@ -1,0 +1,83 @@
+"""
+PROMEOS — Billing Normalization (V68)
+InvoiceNormalized Pydantic schema + normalize_invoice() helper.
+Calcule ht/tva/fournisseur/energie à la volée depuis lignes + contrat.
+Pas de migration DB — view layer uniquement.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class InvoiceNormalized(BaseModel):
+    id: int
+    org_id: int
+    site_id: int
+    fournisseur: Optional[str]       # EnergyContract.supplier_name
+    energie: Optional[str]           # "ELEC" | "GAZ"
+    period_start: Optional[date]
+    period_end: Optional[date]
+    issue_date: Optional[date]
+    month_key: Optional[str]         # YYYY-MM dérivé de period_start (ou issue_date)
+    ttc: Optional[float]             # = total_eur
+    ht: Optional[float]              # sum(ENERGY + NETWORK lines)
+    tva: Optional[float]             # sum(TAX lines)
+    ht_fourniture: Optional[float]   # sum(ENERGY lines)
+    ht_reseau: Optional[float]       # sum(NETWORK lines)
+    kwh: Optional[float]
+    invoice_number: str
+    status: str
+    pdf_doc_id: Optional[str]
+
+
+def normalize_invoice(inv, lines: list, contract, org_id: int) -> InvoiceNormalized:
+    """
+    Construit InvoiceNormalized depuis un EnergyInvoice + ses lignes + contrat.
+    org_id doit être résolu en amont via _resolve_invoice_org_id ou effective_org_id.
+    """
+    ht_fourniture = sum(
+        l.amount_eur or 0 for l in lines if l.line_type.value == "energy"
+    )
+    ht_reseau = sum(
+        l.amount_eur or 0 for l in lines if l.line_type.value == "network"
+    )
+    tva = sum(
+        l.amount_eur or 0 for l in lines if l.line_type.value == "tax"
+    )
+
+    month_key = None
+    if inv.period_start:
+        month_key = inv.period_start.strftime("%Y-%m")
+    elif inv.issue_date:
+        month_key = inv.issue_date.strftime("%Y-%m")
+
+    raw: dict = {}
+    try:
+        raw = json.loads(inv.raw_json or "{}")
+    except Exception:
+        pass
+
+    return InvoiceNormalized(
+        id=inv.id,
+        org_id=org_id,
+        site_id=inv.site_id,
+        fournisseur=getattr(contract, "supplier_name", None),
+        energie=contract.energy_type.value.upper() if contract else None,
+        period_start=inv.period_start,
+        period_end=inv.period_end,
+        issue_date=inv.issue_date,
+        month_key=month_key,
+        ttc=inv.total_eur,
+        ht=round(ht_fourniture + ht_reseau, 2),
+        tva=round(tva, 2),
+        ht_fourniture=round(ht_fourniture, 2),
+        ht_reseau=round(ht_reseau, 2),
+        kwh=inv.energy_kwh,
+        invoice_number=inv.invoice_number,
+        status=inv.status.value if inv.status else "imported",
+        pdf_doc_id=raw.get("pdf_doc_id"),
+    )

--- a/backend/services/billing_seed.py
+++ b/backend/services/billing_seed.py
@@ -1,7 +1,10 @@
 """
-PROMEOS — Bill Intelligence Seed Demo
-3 good invoices + 2 bad (anomalous) invoices.
+PROMEOS — Bill Intelligence Seed Demo (V68)
+36 mois (Jan 2023 – Déc 2025) × 2 sites (elec + gaz).
+3 trous + 2 partiels + 3 anomalies contrôlées.
+Idempotent via source tag "seed_36m".
 """
+import calendar
 from datetime import date
 from sqlalchemy.orm import Session
 
@@ -10,186 +13,234 @@ from models import (
     BillingEnergyType, InvoiceLineType, BillingInvoiceStatus,
 )
 
+# ── Constantes seed ──
+SOURCE_TAG     = "seed_36m"
+START_YEAR     = 2023
+START_MONTH    = 1
+MONTHS_COUNT   = 36   # Jan 2023 → Déc 2025
+KWH_ELEC       = 9000
+KWH_GAZ        = 6000
+PRICE_REF_ELEC = 0.18   # EUR/kWh all-in (TTC / kWh dans ce modèle simplifié)
+PRICE_REF_GAZ  = 0.09
+
+# Montants ligne "normaux" pour 9000 kWh elec (total = 1620)
+ELEC_ENERGY_AMT  = 1020.0   # fourniture
+ELEC_NETWORK_AMT = 400.0    # réseau (attendu TURPE ≈ 407.70 → delta < 2%)
+ELEC_TAX_AMT     = 200.0    # taxes (attendu CSPE ≈ 202.50 → delta < 1%)
+
+# Montants ligne "normaux" pour 6000 kWh gaz (total = 540)
+GAZ_ENERGY_AMT  = 192.0     # fourniture
+GAZ_NETWORK_AMT = 220.0     # réseau (attendu ATRD+ATRT ≈ 222 → delta < 1%)
+GAZ_TAX_AMT     = 128.0     # taxes (attendu TICGN ≈ 130.20 → delta < 2%)
+
+# ── Trous contrôlés ──
+GAPS_SITE_A = {
+    (2023, 3): "missing",
+    (2024, 9): "missing",
+}
+PARTIALS_SITE_A = {
+    (2023, 6): 15,   # 15 jours → couverture partielle
+    (2024, 1): 20,   # 20 jours/31 → couverture partielle
+}
+GAPS_SITE_B = {
+    (2025, 2): "missing",
+}
+
+# ── Anomalies contrôlées ──
+ANOMALY_SHADOW_GAP    = (2024, 7)   # R1 : total_eur = shadow × 1.45
+ANOMALY_RESEAU_MISMATCH = (2024, 11)  # R13: NETWORK line = TURPE × 2.3
+ANOMALY_TAXES_MISMATCH  = (2025, 1)   # R14: TAX line = CSPE × 1.08
+
+
+def _iter_months(start_year: int, start_month: int, count: int):
+    """Génère (year, month) pour `count` mois consécutifs."""
+    y, m = start_year, start_month
+    for _ in range(count):
+        yield y, m
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+
+
+def _add_elec_invoice(db: Session, site_id: int, contract_id: int, y: int, m: int) -> None:
+    """Crée une facture elec pour le mois (y, m), avec anomalies contrôlées."""
+    # Trou → skip
+    if (y, m) in GAPS_SITE_A:
+        return
+
+    # Période
+    days_in_month = calendar.monthrange(y, m)[1]
+    period_start = date(y, m, 1)
+
+    if (y, m) in PARTIALS_SITE_A:
+        period_end = date(y, m, PARTIALS_SITE_A[(y, m)])
+    else:
+        period_end = date(y, m, days_in_month)
+
+    issue_date = date(y, m + 1 if m < 12 else 1, 5)
+    if m == 12:
+        issue_date = date(y + 1, 1, 5)
+
+    energy_line = ELEC_ENERGY_AMT
+    network_line = ELEC_NETWORK_AMT
+    tax_line = ELEC_TAX_AMT
+
+    # Anomalie R13 : réseau × 2.3
+    if (y, m) == ANOMALY_RESEAU_MISMATCH:
+        network_line = round(9000 * 0.0453 * 2.3, 2)  # 937.71
+
+    # Anomalie R14 : taxes × 1.08
+    if (y, m) == ANOMALY_TAXES_MISMATCH:
+        tax_line = round(9000 * 0.0225 * 1.08, 2)  # 218.70
+
+    total_eur = round(energy_line + network_line + tax_line, 2)
+
+    # Anomalie R1 : surcharge 45%
+    if (y, m) == ANOMALY_SHADOW_GAP:
+        total_eur = round(KWH_ELEC * PRICE_REF_ELEC * 1.45, 2)  # 2349.00
+        energy_line = round(total_eur - network_line - tax_line, 2)
+
+    inv = EnergyInvoice(
+        site_id=site_id,
+        contract_id=contract_id,
+        invoice_number=f"EDF-{y}-{m:02d}",
+        period_start=period_start,
+        period_end=period_end,
+        issue_date=issue_date,
+        total_eur=total_eur,
+        energy_kwh=KWH_ELEC,
+        status=BillingInvoiceStatus.IMPORTED,
+        source=SOURCE_TAG,
+    )
+    db.add(inv)
+    db.flush()
+
+    for lt, label, qty, unit, up, amt in [
+        (InvoiceLineType.ENERGY,  "Consommation elec",  KWH_ELEC, "kWh", round(energy_line / KWH_ELEC, 4), energy_line),
+        (InvoiceLineType.NETWORK, "Acheminement TURPE",     None,  None,  None, network_line),
+        (InvoiceLineType.TAX,     "CSPE / Accise elec",     None,  None,  None, tax_line),
+    ]:
+        db.add(EnergyInvoiceLine(
+            invoice_id=inv.id, line_type=lt, label=label,
+            qty=qty, unit=unit, unit_price=up, amount_eur=amt,
+        ))
+
+
+def _add_gaz_invoice(db: Session, site_id: int, contract_id: int, y: int, m: int) -> None:
+    """Crée une facture gaz pour le mois (y, m)."""
+    if (y, m) in GAPS_SITE_B:
+        return
+
+    days_in_month = calendar.monthrange(y, m)[1]
+    period_start = date(y, m, 1)
+    period_end = date(y, m, days_in_month)
+    issue_date = date(y, m + 1 if m < 12 else 1, 10)
+    if m == 12:
+        issue_date = date(y + 1, 1, 10)
+
+    total_eur = round(GAZ_ENERGY_AMT + GAZ_NETWORK_AMT + GAZ_TAX_AMT, 2)
+
+    inv = EnergyInvoice(
+        site_id=site_id,
+        contract_id=contract_id,
+        invoice_number=f"ENGIE-{y}-{m:02d}",
+        period_start=period_start,
+        period_end=period_end,
+        issue_date=issue_date,
+        total_eur=total_eur,
+        energy_kwh=KWH_GAZ,
+        status=BillingInvoiceStatus.IMPORTED,
+        source=SOURCE_TAG,
+    )
+    db.add(inv)
+    db.flush()
+
+    for lt, label, qty, unit, up, amt in [
+        (InvoiceLineType.ENERGY,  "Terme variable gaz",    KWH_GAZ, "kWh", round(GAZ_ENERGY_AMT / KWH_GAZ, 4), GAZ_ENERGY_AMT),
+        (InvoiceLineType.NETWORK, "Acheminement gaz (ATRD+ATRT)", None, None, None, GAZ_NETWORK_AMT),
+        (InvoiceLineType.TAX,     "TICGN",                  None,  None,  None, GAZ_TAX_AMT),
+    ]:
+        db.add(EnergyInvoiceLine(
+            invoice_id=inv.id, line_type=lt, label=label,
+            qty=qty, unit=unit, unit_price=up, amount_eur=amt,
+        ))
+
 
 def seed_billing_demo(db: Session) -> dict:
     """
-    Seed 2 contracts + 5 invoices (3 clean, 2 anomalous) for existing sites.
-    Returns summary.
+    Seed 36 mois (Jan 2023 – Déc 2025) × 2 sites (elec + gaz).
+    Trous contrôlés : 2023-03, 2024-09 (site_a); 2025-02 (site_b).
+    Partiels : 2023-06 (15j), 2024-01 (20j/31) sur site_a.
+    Anomalies : 2024-07 R1 shadow_gap, 2024-11 R13 reseau, 2025-01 R14 taxes.
+    Idempotent via source="seed_36m".
     """
-    # Get first 3 sites
+    # Idempotency check
+    existing = db.query(EnergyInvoice).filter(
+        EnergyInvoice.source == SOURCE_TAG
+    ).count()
+    if existing > 0:
+        return {"skipped": True, "reason": "already seeded (seed_36m)", "existing": existing}
+
+    # Récupérer les 2 premiers sites
     sites = db.query(Site).limit(3).all()
     if len(sites) < 2:
         return {"error": "Need at least 2 sites to seed billing demo"}
 
-    site_a = sites[0]  # Main site
-    site_b = sites[1]  # Secondary site
+    site_a = sites[0]
+    site_b = sites[1]
 
-    # ── Contract 1: elec for site_a ──
+    # ── Contrats ──
     contract_elec = EnergyContract(
         site_id=site_a.id,
         energy_type=BillingEnergyType.ELEC,
-        supplier_name="EDF Entreprises",
-        start_date=date(2024, 1, 1),
+        supplier_name="EDF ENR",
+        start_date=date(2022, 12, 1),
         end_date=date(2026, 12, 31),
-        price_ref_eur_per_kwh=0.18,
+        price_ref_eur_per_kwh=PRICE_REF_ELEC,
         fixed_fee_eur_per_month=45.0,
     )
     db.add(contract_elec)
 
-    # ── Contract 2: gaz for site_b ──
     contract_gaz = EnergyContract(
         site_id=site_b.id,
         energy_type=BillingEnergyType.GAZ,
         supplier_name="Engie Pro",
-        start_date=date(2024, 1, 1),
+        start_date=date(2022, 12, 1),
         end_date=date(2025, 12, 31),
-        price_ref_eur_per_kwh=0.09,
+        price_ref_eur_per_kwh=PRICE_REF_GAZ,
         fixed_fee_eur_per_month=30.0,
     )
     db.add(contract_gaz)
     db.flush()
 
-    invoices_created = []
+    # ── 36 mois site_a (elec) ──
+    for y, m in _iter_months(START_YEAR, START_MONTH, MONTHS_COUNT):
+        _add_elec_invoice(db, site_a.id, contract_elec.id, y, m)
 
-    # ── Invoice 1: GOOD — site_a elec jan 2025 ──
-    inv1 = EnergyInvoice(
-        site_id=site_a.id,
-        contract_id=contract_elec.id,
-        invoice_number="EDF-2025-001",
-        period_start=date(2025, 1, 1),
-        period_end=date(2025, 1, 31),
-        issue_date=date(2025, 2, 5),
-        total_eur=1620.00,
-        energy_kwh=9000,
-        status=BillingInvoiceStatus.IMPORTED,
-        source="seed",
-    )
-    db.add(inv1)
-    db.flush()
-    # Lines
-    for lt, label, qty, unit, up, amt in [
-        (InvoiceLineType.ENERGY, "Consommation HP", 5400, "kWh", 0.20, 1080.00),
-        (InvoiceLineType.ENERGY, "Consommation HC", 3600, "kWh", 0.14, 504.00),
-        (InvoiceLineType.TAX, "CSPE + ACCISE", None, None, None, 36.00),
-    ]:
-        db.add(EnergyInvoiceLine(
-            invoice_id=inv1.id, line_type=lt, label=label,
-            qty=qty, unit=unit, unit_price=up, amount_eur=amt,
-        ))
-    invoices_created.append(inv1)
-
-    # ── Invoice 2: GOOD — site_a elec feb 2025 ──
-    inv2 = EnergyInvoice(
-        site_id=site_a.id,
-        contract_id=contract_elec.id,
-        invoice_number="EDF-2025-002",
-        period_start=date(2025, 2, 1),
-        period_end=date(2025, 2, 28),
-        issue_date=date(2025, 3, 5),
-        total_eur=1530.00,
-        energy_kwh=8500,
-        status=BillingInvoiceStatus.IMPORTED,
-        source="seed",
-    )
-    db.add(inv2)
-    db.flush()
-    for lt, label, qty, unit, up, amt in [
-        (InvoiceLineType.ENERGY, "Consommation HP", 5100, "kWh", 0.20, 1020.00),
-        (InvoiceLineType.ENERGY, "Consommation HC", 3400, "kWh", 0.14, 476.00),
-        (InvoiceLineType.TAX, "CSPE + ACCISE", None, None, None, 34.00),
-    ]:
-        db.add(EnergyInvoiceLine(
-            invoice_id=inv2.id, line_type=lt, label=label,
-            qty=qty, unit=unit, unit_price=up, amount_eur=amt,
-        ))
-    invoices_created.append(inv2)
-
-    # ── Invoice 3: GOOD — site_b gaz jan 2025 ──
-    inv3 = EnergyInvoice(
-        site_id=site_b.id,
-        contract_id=contract_gaz.id,
-        invoice_number="ENGIE-2025-001",
-        period_start=date(2025, 1, 1),
-        period_end=date(2025, 1, 31),
-        issue_date=date(2025, 2, 10),
-        total_eur=540.00,
-        energy_kwh=6000,
-        status=BillingInvoiceStatus.IMPORTED,
-        source="seed",
-    )
-    db.add(inv3)
-    db.flush()
-    for lt, label, qty, unit, up, amt in [
-        (InvoiceLineType.ENERGY, "Terme variable gaz", 6000, "kWh", 0.08, 480.00),
-        (InvoiceLineType.NETWORK, "Abonnement distribution", 1, "mois", 30.0, 30.00),
-        (InvoiceLineType.TAX, "TICGN", None, None, None, 30.00),
-    ]:
-        db.add(EnergyInvoiceLine(
-            invoice_id=inv3.id, line_type=lt, label=label,
-            qty=qty, unit=unit, unit_price=up, amount_eur=amt,
-        ))
-    invoices_created.append(inv3)
-
-    # ── Invoice 4: BAD — site_a elec overcharge (shadow gap > 20%) ──
-    inv4 = EnergyInvoice(
-        site_id=site_a.id,
-        contract_id=contract_elec.id,
-        invoice_number="EDF-2025-003",
-        period_start=date(2025, 3, 1),
-        period_end=date(2025, 3, 31),
-        issue_date=date(2025, 4, 5),
-        total_eur=2800.00,  # Should be ~1620 for 9000 kWh → overcharge
-        energy_kwh=9000,
-        status=BillingInvoiceStatus.IMPORTED,
-        source="seed",
-    )
-    db.add(inv4)
-    db.flush()
-    # Lines don't match total (lines_sum_mismatch)
-    for lt, label, qty, unit, up, amt in [
-        (InvoiceLineType.ENERGY, "Consommation HP", 5400, "kWh", 0.20, 1080.00),
-        (InvoiceLineType.ENERGY, "Consommation HC", 3600, "kWh", 0.14, 504.00),
-        (InvoiceLineType.OTHER, "Frais supplementaires", None, None, None, 800.00),
-        (InvoiceLineType.TAX, "CSPE + ACCISE", None, None, None, 36.00),
-    ]:
-        db.add(EnergyInvoiceLine(
-            invoice_id=inv4.id, line_type=lt, label=label,
-            qty=qty, unit=unit, unit_price=up, amount_eur=amt,
-        ))
-    invoices_created.append(inv4)
-
-    # ── Invoice 5: BAD — site_b gaz consumption spike + period too long ──
-    inv5 = EnergyInvoice(
-        site_id=site_b.id,
-        contract_id=contract_gaz.id,
-        invoice_number="ENGIE-2025-002",
-        period_start=date(2025, 2, 1),
-        period_end=date(2025, 5, 30),  # 119 days — period_too_long
-        issue_date=date(2025, 6, 10),
-        total_eur=2700.00,
-        energy_kwh=30000,  # 5x normal → consumption_spike
-        status=BillingInvoiceStatus.IMPORTED,
-        source="seed",
-    )
-    db.add(inv5)
-    db.flush()
-    for lt, label, qty, unit, up, amt in [
-        (InvoiceLineType.ENERGY, "Terme variable gaz", 30000, "kWh", 0.08, 2400.00),
-        (InvoiceLineType.NETWORK, "Abonnement distribution", 4, "mois", 30.0, 120.00),
-        (InvoiceLineType.TAX, "TICGN", None, None, None, 180.00),
-    ]:
-        db.add(EnergyInvoiceLine(
-            invoice_id=inv5.id, line_type=lt, label=label,
-            qty=qty, unit=unit, unit_price=up, amount_eur=amt,
-        ))
-    invoices_created.append(inv5)
+    # ── 36 mois site_b (gaz) ──
+    for y, m in _iter_months(START_YEAR, START_MONTH, MONTHS_COUNT):
+        _add_gaz_invoice(db, site_b.id, contract_gaz.id, y, m)
 
     db.commit()
 
+    # Compter
+    n_elec = db.query(EnergyInvoice).filter(
+        EnergyInvoice.site_id == site_a.id,
+        EnergyInvoice.source == SOURCE_TAG,
+    ).count()
+    n_gaz = db.query(EnergyInvoice).filter(
+        EnergyInvoice.site_id == site_b.id,
+        EnergyInvoice.source == SOURCE_TAG,
+    ).count()
+
     return {
         "contracts_created": 2,
-        "invoices_created": len(invoices_created),
-        "good_invoices": 3,
-        "bad_invoices": 2,
+        "invoices_created": n_elec + n_gaz,
+        "elec_invoices": n_elec,
+        "gaz_invoices": n_gaz,
         "sites_used": [site_a.id, site_b.id],
+        "months_range": f"{START_YEAR}-{START_MONTH:02d} → 2025-12",
+        "controlled_gaps": 3,
+        "controlled_anomalies": 3,
     }

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -16,7 +16,9 @@ from models import (
     Site, EnergyContract, EnergyInvoice, EnergyInvoiceLine, BillingInsight,
     BillingEnergyType, InvoiceLineType, BillingInvoiceStatus,
     SiteTariffProfile, InsightStatus,
+    ActionItem, Portefeuille, EntiteJuridique,
 )
+from models.enums import ActionSourceType, ActionStatus
 
 
 # ========================================
@@ -401,6 +403,72 @@ def _energy_type(invoice: EnergyInvoice, contract: Optional[EnergyContract]) -> 
     return "elec"  # default
 
 
+# ========================================
+# R11 — TTC Coherence (V66)
+# ========================================
+
+def _rule_ttc_coherence(invoice: EnergyInvoice, contract: Optional[EnergyContract], lines: List[EnergyInvoiceLine]) -> Optional[Dict]:
+    """R11: TTC facturé incohérent avec HT+TVA (tolérance 2%)."""
+    if not invoice.total_eur or not lines:
+        return None
+    sum_ht = sum(l.amount_eur or 0 for l in lines if l.line_type != InvoiceLineType.TAX)
+    sum_tva = sum(l.amount_eur or 0 for l in lines if l.line_type == InvoiceLineType.TAX)
+    expected = sum_ht + sum_tva
+    if expected == 0:
+        return None
+    delta = abs(expected - invoice.total_eur)
+    if delta / max(invoice.total_eur, 1) > 0.02:
+        return {
+            "type": "ttc_mismatch",
+            "severity": "high",
+            "message": f"TTC facturé {invoice.total_eur:.2f}€ ≠ HT+TVA {expected:.2f}€ (écart {delta:.2f}€)",
+            "metrics": {
+                "total_eur_facture": invoice.total_eur,
+                "total_eur_calcule": round(expected, 2),
+                "delta_eur": round(delta, 2),
+                "tolerance_pct": 2,
+            },
+            "estimated_loss_eur": round(delta, 2),
+        }
+    return None
+
+
+# ========================================
+# R12 — Contract Expiry (V66)
+# ========================================
+
+def _rule_contract_expiry(invoice: EnergyInvoice, contract: Optional[EnergyContract], lines: List[EnergyInvoiceLine]) -> Optional[Dict]:
+    """R12: Contrat expiré ou expire bientôt (< 90 jours)."""
+    if not contract or not contract.end_date:
+        return None
+    days_left = (contract.end_date - date.today()).days
+    if days_left < 0:
+        return {
+            "type": "contract_expired",
+            "severity": "critical",
+            "message": f"Contrat {contract.supplier_name} expiré le {contract.end_date} ({abs(days_left)}j)",
+            "metrics": {
+                "end_date": str(contract.end_date),
+                "days_overdue": abs(days_left),
+                "supplier": contract.supplier_name,
+            },
+            "estimated_loss_eur": round((invoice.total_eur or 0) * 0.1, 2),
+        }
+    elif days_left <= 90:
+        return {
+            "type": "contract_expiry_soon",
+            "severity": "high",
+            "message": f"Contrat {contract.supplier_name} expire dans {days_left}j (le {contract.end_date})",
+            "metrics": {
+                "end_date": str(contract.end_date),
+                "days_left": days_left,
+                "supplier": contract.supplier_name,
+            },
+            "estimated_loss_eur": 0,
+        }
+    return None
+
+
 # All rules
 BILLING_RULES = [
     ("R1", "Shadow gap", _rule_shadow_gap),
@@ -413,6 +481,8 @@ BILLING_RULES = [
     ("R8", "Lines sum mismatch", _rule_lines_sum_mismatch),
     ("R9", "Consumption spike", _rule_consumption_spike),
     ("R10", "Price drift", _rule_price_drift),
+    ("R11", "TTC coherence", _rule_ttc_coherence),
+    ("R12", "Contract expiry", _rule_contract_expiry),
 ]
 
 
@@ -441,14 +511,30 @@ def run_anomaly_engine(
     return anomalies
 
 
+def _resolve_invoice_org_id(db: Session, invoice: EnergyInvoice) -> Optional[int]:
+    """Walk site→portefeuille→entite_juridique→org to resolve org_id for an invoice."""
+    try:
+        site = db.query(Site).filter(Site.id == invoice.site_id).first()
+        if not site or not site.portefeuille_id:
+            return None
+        port = db.query(Portefeuille).filter(Portefeuille.id == site.portefeuille_id).first()
+        if not port or not port.entite_juridique_id:
+            return None
+        entite = db.query(EntiteJuridique).filter(EntiteJuridique.id == port.entite_juridique_id).first()
+        return entite.organisation_id if entite else None
+    except Exception:
+        return None
+
+
 def persist_insights(
     db: Session,
     invoice: EnergyInvoice,
     anomalies: List[Dict[str, Any]],
 ) -> List[BillingInsight]:
-    """Persist anomaly results as BillingInsight rows."""
+    """Persist anomaly results as BillingInsight rows + idempotent ActionItem bridge."""
     db.query(BillingInsight).filter(BillingInsight.invoice_id == invoice.id).delete()
 
+    org_id = _resolve_invoice_org_id(db, invoice)
     insights = []
     for a in anomalies:
         insight = BillingInsight(
@@ -463,6 +549,32 @@ def persist_insights(
             insight_status=InsightStatus.OPEN,
         )
         db.add(insight)
+        db.flush()  # get insight.id for idempotency_key
+
+        # V66 P2.4 — Bridge billing anomaly → ActionItem (idempotent)
+        if org_id:
+            idem_key = f"billing:{invoice.id}:{a['type']}"
+            existing_action = db.query(ActionItem).filter(
+                ActionItem.idempotency_key == idem_key
+            ).first()
+            if not existing_action:
+                sev = a.get("severity", "medium").lower()
+                priority = 1 if sev == "critical" else 2 if sev == "high" else 3
+                db.add(ActionItem(
+                    org_id=org_id,
+                    site_id=invoice.site_id,
+                    source_type=ActionSourceType.BILLING,
+                    source_id=str(insight.id),
+                    source_key=f"billing:{invoice.id}:{a['type']}",
+                    idempotency_key=idem_key,
+                    title=a.get("message", a["type"]),
+                    rationale=json.dumps(a.get("metrics", {})),
+                    priority=priority,
+                    severity=sev,
+                    estimated_gain_eur=a.get("estimated_loss_eur"),
+                    status=ActionStatus.OPEN,
+                ))
+
         insights.append(insight)
 
     if anomalies:

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -162,16 +162,30 @@ def _rule_shadow_gap(invoice: EnergyInvoice, contract: Optional[EnergyContract],
     """R1: Ecart shadow billing > 10%."""
     shadow = shadow_billing_simple(invoice, contract)
     if shadow["delta_pct"] is not None and abs(shadow["delta_pct"]) > 10:
+        metrics = {
+            **shadow,
+            "inputs": _build_inputs(invoice, shadow.get("price_ref_eur_kwh")),
+            "threshold_pct": 10,
+            "delta_calculated_pct": shadow["delta_pct"],
+            "confidence": "medium",
+            "assumptions": [
+                f"Prix ref: {shadow.get('ref_price_source', 'défaut')}",
+                "Tarifs réseau/taxes POC 2025 simplifiés",
+            ],
+        }
+        # Enrich with V2 4-component breakdown when lines available
+        if lines:
+            try:
+                from services.billing_shadow_v2 import shadow_billing_v2
+                v2 = shadow_billing_v2(invoice, lines, contract)
+                metrics.update(v2)
+            except Exception:
+                pass
         return {
             "type": "shadow_gap",
             "severity": "high" if abs(shadow["delta_pct"]) > 20 else "medium",
             "message": f"Ecart shadow billing de {shadow['delta_pct']:+.1f}% ({shadow['delta_eur']:+.2f} EUR)",
-            "metrics": {
-                **shadow,
-                "inputs": _build_inputs(invoice, shadow.get("price_ref_eur_kwh")),
-                "threshold_pct": 10,
-                "delta_calculated_pct": shadow["delta_pct"],
-            },
+            "metrics": metrics,
             "estimated_loss_eur": abs(shadow["delta_eur"]) if shadow["delta_eur"] and shadow["delta_eur"] > 0 else 0,
         }
     return None
@@ -193,6 +207,8 @@ def _rule_unit_price_high(invoice: EnergyInvoice, contract: Optional[EnergyContr
                 "threshold": threshold,
                 "inputs": _build_inputs(invoice, threshold),
                 "delta_calculated": round(unit_price - threshold, 4),
+                "confidence": "high",
+                "assumptions": [f"Seuil: {threshold} €/kWh"],
             },
             "estimated_loss_eur": round((unit_price - threshold) * invoice.energy_kwh, 2),
         }
@@ -218,6 +234,8 @@ def _rule_duplicate_invoice(invoice: EnergyInvoice, contract: Optional[EnergyCon
             "metrics": {
                 "duplicates_count": dupes,
                 "inputs": _build_inputs(invoice),
+                "confidence": "high",
+                "assumptions": ["Même site, période et montant"],
             },
             "estimated_loss_eur": invoice.total_eur or 0,
         }
@@ -235,6 +253,8 @@ def _rule_missing_period(invoice: EnergyInvoice, contract: Optional[EnergyContra
                 "has_start": invoice.period_start is not None,
                 "has_end": invoice.period_end is not None,
                 "inputs": _build_inputs(invoice),
+                "confidence": "high",
+                "assumptions": ["Champs période absents"],
             },
             "estimated_loss_eur": 0,
         }
@@ -256,6 +276,8 @@ def _rule_period_too_long(invoice: EnergyInvoice, contract: Optional[EnergyContr
                 "threshold_days": 62,
                 "delta_calculated_days": days - 62,
                 "inputs": _build_inputs(invoice),
+                "confidence": "high",
+                "assumptions": ["Seuil: 62 jours"],
             },
             "estimated_loss_eur": 0,
         }
@@ -272,6 +294,8 @@ def _rule_negative_kwh(invoice: EnergyInvoice, contract: Optional[EnergyContract
             "metrics": {
                 "energy_kwh": invoice.energy_kwh,
                 "inputs": _build_inputs(invoice),
+                "confidence": "high",
+                "assumptions": ["Relevé négatif"],
             },
             "estimated_loss_eur": 0,
         }
@@ -290,6 +314,8 @@ def _rule_zero_amount(invoice: EnergyInvoice, contract: Optional[EnergyContract]
                 "total_eur": invoice.total_eur,
                 "energy_kwh": invoice.energy_kwh,
                 "inputs": _build_inputs(invoice),
+                "confidence": "high",
+                "assumptions": ["Montant nul avec consommation > 0"],
             },
             "estimated_loss_eur": 0,
         }
@@ -318,6 +344,8 @@ def _rule_lines_sum_mismatch(invoice: EnergyInvoice, contract: Optional[EnergyCo
                 "threshold_pct": 2,
                 "delta_calculated_pct": round(pct, 1),
                 "inputs": _build_inputs(invoice),
+                "confidence": "high",
+                "assumptions": ["Tolérance: 2%"],
             },
             "estimated_loss_eur": round(diff, 2) if diff > 1 else 0,
         }
@@ -346,6 +374,8 @@ def _rule_consumption_spike(invoice: EnergyInvoice, contract: Optional[EnergyCon
                 "threshold_ratio": 2.0,
                 "delta_calculated_ratio": ratio,
                 "inputs": _build_inputs(invoice),
+                "confidence": "medium",
+                "assumptions": ["Moyenne 6 mois glissants", "Seuil: ×2"],
                 "cross_link": {
                     "module": "diagnostic-conso",
                     "site_id": invoice.site_id,
@@ -389,6 +419,8 @@ def _rule_price_drift(invoice: EnergyInvoice, contract: Optional[EnergyContract]
                 "threshold_pct": 15,
                 "delta_calculated_pct": round(drift_pct, 1),
                 "inputs": _build_inputs(invoice, ref),
+                "confidence": "high",
+                "assumptions": ["Comparaison avec prix contrat"],
             },
             "estimated_loss_eur": loss,
         }
@@ -427,6 +459,8 @@ def _rule_ttc_coherence(invoice: EnergyInvoice, contract: Optional[EnergyContrac
                 "total_eur_calcule": round(expected, 2),
                 "delta_eur": round(delta, 2),
                 "tolerance_pct": 2,
+                "confidence": "high",
+                "assumptions": ["Tolérance: 2%"],
             },
             "estimated_loss_eur": round(delta, 2),
         }
@@ -451,6 +485,8 @@ def _rule_contract_expiry(invoice: EnergyInvoice, contract: Optional[EnergyContr
                 "end_date": str(contract.end_date),
                 "days_overdue": abs(days_left),
                 "supplier": contract.supplier_name,
+                "confidence": "high",
+                "assumptions": [f"Date fin contrat: {contract.end_date}"],
             },
             "estimated_loss_eur": round((invoice.total_eur or 0) * 0.1, 2),
         }
@@ -463,6 +499,8 @@ def _rule_contract_expiry(invoice: EnergyInvoice, contract: Optional[EnergyContr
                 "end_date": str(contract.end_date),
                 "days_left": days_left,
                 "supplier": contract.supplier_name,
+                "confidence": "high",
+                "assumptions": [f"Date fin contrat: {contract.end_date}"],
             },
             "estimated_loss_eur": 0,
         }
@@ -492,10 +530,10 @@ def _rule_reseau_mismatch(invoice: EnergyInvoice, contract: Optional[EnergyContr
                 f"{res['expected_reseau_ht']:.2f}€ (Δ {pct:.0f}%)"
             ),
             "metrics": {
-                "actual_reseau_ht": res["actual_reseau_ht"],
-                "expected_reseau_ht": res["expected_reseau_ht"],
+                **res,
                 "delta_pct": round(pct, 1),
-                "energy_type": res["energy_type"],
+                "confidence": "medium",
+                "assumptions": ["Tarif TURPE simplifié (C5 BT ≤ 36kVA)"],
             },
             "estimated_loss_eur": round(abs(res["delta_reseau"]), 2),
         }
@@ -524,10 +562,10 @@ def _rule_taxes_mismatch(invoice: EnergyInvoice, contract: Optional[EnergyContra
                 f"{res['expected_taxes_ht']:.2f}€ (Δ {pct:.0f}%)"
             ),
             "metrics": {
-                "actual_taxes_ht": res["actual_taxes_ht"],
-                "expected_taxes_ht": res["expected_taxes_ht"],
+                **res,
                 "delta_pct": round(pct, 1),
-                "energy_type": res["energy_type"],
+                "confidence": "medium",
+                "assumptions": ["Taux CSPE/TICGN 2025 simplifiés"],
             },
             "estimated_loss_eur": round(abs(res["delta_taxes"]), 2),
         }
@@ -572,6 +610,9 @@ def run_anomaly_engine(
             if result:
                 result["rule_id"] = rule_id
                 result["rule_name"] = rule_name
+                if "metrics" in result:
+                    result["metrics"]["rule_id"] = rule_id
+                    result["metrics"]["rule_name"] = rule_name
                 anomalies.append(result)
         except Exception:
             pass

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -469,20 +469,87 @@ def _rule_contract_expiry(invoice: EnergyInvoice, contract: Optional[EnergyContr
     return None
 
 
+# ========================================
+# R13 — Réseau / TURPE mismatch (V68)
+# ========================================
+
+def _rule_reseau_mismatch(invoice: EnergyInvoice, contract: Optional[EnergyContract], lines: List[EnergyInvoiceLine]) -> Optional[Dict]:
+    """R13: Coût réseau/TURPE facturé ≠ attendu > 10%."""
+    if not lines:
+        return None
+    from services.billing_shadow_v2 import shadow_billing_v2
+    res = shadow_billing_v2(invoice, lines, contract)
+    if res["expected_reseau_ht"] == 0:
+        return None
+    pct = abs(res["delta_reseau"] / res["expected_reseau_ht"] * 100)
+    if pct > 10:
+        sev = "high" if pct > 20 else "medium"
+        return {
+            "type": "reseau_mismatch",
+            "severity": sev,
+            "message": (
+                f"Coût réseau {res['actual_reseau_ht']:.2f}€ vs attendu "
+                f"{res['expected_reseau_ht']:.2f}€ (Δ {pct:.0f}%)"
+            ),
+            "metrics": {
+                "actual_reseau_ht": res["actual_reseau_ht"],
+                "expected_reseau_ht": res["expected_reseau_ht"],
+                "delta_pct": round(pct, 1),
+                "energy_type": res["energy_type"],
+            },
+            "estimated_loss_eur": round(abs(res["delta_reseau"]), 2),
+        }
+    return None
+
+
+# ========================================
+# R14 — Taxes / CSPE mismatch (V68)
+# ========================================
+
+def _rule_taxes_mismatch(invoice: EnergyInvoice, contract: Optional[EnergyContract], lines: List[EnergyInvoiceLine]) -> Optional[Dict]:
+    """R14: Taxes (CSPE/TICGN) facturées ≠ attendu > 5%."""
+    if not lines:
+        return None
+    from services.billing_shadow_v2 import shadow_billing_v2
+    res = shadow_billing_v2(invoice, lines, contract)
+    if res["expected_taxes_ht"] == 0:
+        return None
+    pct = abs(res["delta_taxes"] / res["expected_taxes_ht"] * 100)
+    if pct > 5:
+        return {
+            "type": "taxes_mismatch",
+            "severity": "medium",
+            "message": (
+                f"Taxes {res['actual_taxes_ht']:.2f}€ vs attendu "
+                f"{res['expected_taxes_ht']:.2f}€ (Δ {pct:.0f}%)"
+            ),
+            "metrics": {
+                "actual_taxes_ht": res["actual_taxes_ht"],
+                "expected_taxes_ht": res["expected_taxes_ht"],
+                "delta_pct": round(pct, 1),
+                "energy_type": res["energy_type"],
+            },
+            "estimated_loss_eur": round(abs(res["delta_taxes"]), 2),
+        }
+    return None
+
+
 # All rules
 BILLING_RULES = [
-    ("R1", "Shadow gap", _rule_shadow_gap),
-    ("R2", "Unit price high", _rule_unit_price_high),
-    ("R3", "Duplicate invoice", _rule_duplicate_invoice),
-    ("R4", "Missing period", _rule_missing_period),
-    ("R5", "Period too long", _rule_period_too_long),
-    ("R6", "Negative kWh", _rule_negative_kwh),
-    ("R7", "Zero amount", _rule_zero_amount),
-    ("R8", "Lines sum mismatch", _rule_lines_sum_mismatch),
-    ("R9", "Consumption spike", _rule_consumption_spike),
-    ("R10", "Price drift", _rule_price_drift),
-    ("R11", "TTC coherence", _rule_ttc_coherence),
-    ("R12", "Contract expiry", _rule_contract_expiry),
+    ("R1",  "Shadow gap",         _rule_shadow_gap),
+    ("R2",  "Unit price high",    _rule_unit_price_high),
+    ("R3",  "Duplicate invoice",  _rule_duplicate_invoice),
+    ("R4",  "Missing period",     _rule_missing_period),
+    ("R5",  "Period too long",    _rule_period_too_long),
+    ("R6",  "Negative kWh",       _rule_negative_kwh),
+    ("R7",  "Zero amount",        _rule_zero_amount),
+    ("R8",  "Lines sum mismatch", _rule_lines_sum_mismatch),
+    ("R9",  "Consumption spike",  _rule_consumption_spike),
+    ("R10", "Price drift",        _rule_price_drift),
+    ("R11", "TTC coherence",      _rule_ttc_coherence),
+    ("R12", "Contract expiry",    _rule_contract_expiry),
+    ("R13", "Réseau / TURPE mismatch", _rule_reseau_mismatch),
+    ("R14", "Taxes / CSPE mismatch",   _rule_taxes_mismatch),
 ]
 
 

--- a/backend/services/billing_shadow_v2.py
+++ b/backend/services/billing_shadow_v2.py
@@ -1,0 +1,84 @@
+"""
+PROMEOS — Shadow Billing V2 (V68)
+Décomposition 4 composantes : fourniture_ht, reseau_ht, taxes_ht, tva.
+Tarifs POC France 2025 simplifiés (constantes publiques).
+Comparaison vs lignes réelles → deltas pour R13/R14.
+"""
+
+# ── Tarifs POC France 2025 (simplifiés, source CRE / DGFiP publique) ──
+TURPE_EUR_KWH_ELEC = 0.0453    # C5 BT <= 36 kVA (grille TURPE 7)
+ATRD_EUR_KWH_GAZ   = 0.025     # Distribution gaz (ATRD moyen)
+ATRT_EUR_KWH_GAZ   = 0.012     # Transport gaz (ATRT moyen)
+CSPE_EUR_KWH_ELEC  = 0.0225    # TIEE / Accise énergie électrique 2025
+TICGN_EUR_KWH_GAZ  = 0.0217    # Accise gaz naturel (TICGN 2025)
+TVA_RATE_20        = 0.20
+
+
+def shadow_billing_v2(invoice, lines: list, contract) -> dict:
+    """
+    Calcule la facture attendue sur 4 composantes et les deltas vs facturé.
+
+    Args:
+        invoice: EnergyInvoice (energy_kwh, total_eur, ...)
+        lines:   liste d'EnergyInvoiceLine (line_type, amount_eur)
+        contract: EnergyContract ou None
+
+    Returns:
+        dict avec expected_* + actual_* + delta_* + meta (energy_type, kwh, method)
+    """
+    kwh = invoice.energy_kwh or 0.0
+    is_elec = (contract.energy_type.value == "elec") if contract else True
+    price_ref = (
+        contract.price_ref_eur_per_kwh
+        if (contract and contract.price_ref_eur_per_kwh)
+        else (0.18 if is_elec else 0.09)
+    )
+
+    # ── Valeurs attendues (shadow) ──
+    exp_fourniture = kwh * price_ref
+    exp_reseau = kwh * (
+        TURPE_EUR_KWH_ELEC if is_elec else ATRD_EUR_KWH_GAZ + ATRT_EUR_KWH_GAZ
+    )
+    exp_taxes = kwh * (CSPE_EUR_KWH_ELEC if is_elec else TICGN_EUR_KWH_GAZ)
+    exp_tva   = (exp_fourniture + exp_reseau) * TVA_RATE_20
+    exp_ttc   = exp_fourniture + exp_reseau + exp_taxes + exp_tva
+
+    # ── Valeurs réelles (depuis lignes) ──
+    act_fourniture = sum(
+        l.amount_eur or 0 for l in lines if l.line_type.value == "energy"
+    )
+    act_reseau = sum(
+        l.amount_eur or 0 for l in lines if l.line_type.value == "network"
+    )
+    act_taxes = sum(
+        l.amount_eur or 0 for l in lines if l.line_type.value == "tax"
+    )
+    act_ttc = invoice.total_eur or 0.0
+
+    # ── Deltas ──
+    delta_fourniture = act_fourniture - exp_fourniture
+    delta_reseau     = act_reseau - exp_reseau
+    delta_taxes      = act_taxes - exp_taxes
+    delta_ttc        = act_ttc - exp_ttc
+    delta_pct        = (delta_ttc / exp_ttc * 100) if exp_ttc else 0.0
+
+    return {
+        "expected_fourniture_ht": round(exp_fourniture, 2),
+        "expected_reseau_ht":     round(exp_reseau, 2),
+        "expected_taxes_ht":      round(exp_taxes, 2),
+        "expected_tva":           round(exp_tva, 2),
+        "expected_ttc":           round(exp_ttc, 2),
+        "actual_fourniture_ht":   round(act_fourniture, 2),
+        "actual_reseau_ht":       round(act_reseau, 2),
+        "actual_taxes_ht":        round(act_taxes, 2),
+        "actual_ttc":             round(act_ttc, 2),
+        "delta_fourniture":       round(delta_fourniture, 2),
+        "delta_reseau":           round(delta_reseau, 2),
+        "delta_taxes":            round(delta_taxes, 2),
+        "delta_ttc":              round(delta_ttc, 2),
+        "delta_pct":              round(delta_pct, 2),
+        "energy_type":            "ELEC" if is_elec else "GAZ",
+        "kwh":                    kwh,
+        "price_ref":              round(price_ref, 4),
+        "method":                 "shadow_v2_simplified",
+    }

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -546,7 +546,7 @@ class TestBillingAPI:
     def test_list_rules(self, client):
         r = client.get("/api/billing/rules")
         assert r.status_code == 200
-        assert r.json()["count"] == 12  # V66: +2 rules (R11 TTC coherence, R12 contract expiry)
+        assert r.json()["count"] == 14  # V68: +2 rules (R13 réseau mismatch, R14 taxes mismatch)
 
     def test_csv_import(self, client, db_session):
         _, site = _create_org_site(db_session)
@@ -599,9 +599,10 @@ class TestBillingAPI:
         r = client.post("/api/billing/seed-demo")
         assert r.status_code == 200
         data = r.json()
-        assert data["invoices_created"] == 5
-        assert data["good_invoices"] == 3
-        assert data["bad_invoices"] == 2
+        assert data["invoices_created"] == 69   # V68: 34 elec + 35 gaz (36 mois - 3 trous)
+        assert data["contracts_created"] == 2
+        assert data["controlled_gaps"] == 3
+        assert data["controlled_anomalies"] == 3
 
     def test_seed_then_audit_then_summary(self, client, db_session):
         """Integration: seed → audit-all → verify insights created."""
@@ -626,7 +627,7 @@ class TestBillingAPI:
         r = client.get("/api/billing/summary")
         assert r.status_code == 200
         s = r.json()
-        assert s["total_invoices"] == 5
+        assert s["total_invoices"] == 69   # V68: 36 mois × 2 sites - 3 trous
         assert s["total_insights"] > 0
         assert s["total_estimated_loss_eur"] > 0
 
@@ -743,4 +744,4 @@ class TestBillingAPI:
         assert r.status_code == 200
         data = r.json()
         assert "billing" in data
-        assert data["billing"]["total_invoices"] == 5
+        assert data["billing"]["total_invoices"] == 69  # V68: 36 mois × 2 sites - 3 trous

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -546,7 +546,7 @@ class TestBillingAPI:
     def test_list_rules(self, client):
         r = client.get("/api/billing/rules")
         assert r.status_code == 200
-        assert r.json()["count"] == 10
+        assert r.json()["count"] == 12  # V66: +2 rules (R11 TTC coherence, R12 contract expiry)
 
     def test_csv_import(self, client, db_session):
         _, site = _create_org_site(db_session)

--- a/backend/tests/test_billing_v66_checks.py
+++ b/backend/tests/test_billing_v66_checks.py
@@ -1,0 +1,250 @@
+"""
+PROMEOS — V66 Billing Rules R11+R12 + ActionItem Bridge Tests
+Tests for: R11 TTC coherence, R12 contract expiry, persist_insights ActionItem bridge.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import date, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import (
+    Base, Organisation, EntiteJuridique, Portefeuille,
+    Site, TypeSite, EnergyContract, EnergyInvoice, EnergyInvoiceLine,
+    BillingInsight, BillingInvoiceStatus, BillingImportBatch, InsightStatus,
+    ActionItem,
+)
+from models.billing_models import BillingEnergyType, InvoiceLineType
+from models.enums import ActionSourceType
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+def _make_site(db):
+    """Create minimal org→EJ→Portefeuille→Site; returns site."""
+    org = Organisation(nom="Checks Org", type_client="bureau", actif=True, siren="500000001")
+    db.add(org)
+    db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom="EJ Checks", siren="500000001")
+    db.add(ej)
+    db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom="PF Checks")
+    db.add(pf)
+    db.flush()
+    site = Site(
+        portefeuille_id=pf.id, nom="Site Checks", type=TypeSite.BUREAU,
+        adresse="1 rue Checks", code_postal="75001", ville="Paris",
+        surface_m2=100, actif=True,
+    )
+    db.add(site)
+    db.commit()
+    return site
+
+
+# ========================================
+# R11 — TTC Coherence
+# ========================================
+
+class TestR11TtcCoherence:
+
+    def _make_invoice_with_lines(self, db, site_id, total_eur, ht_amount, tva_amount):
+        inv = EnergyInvoice(
+            site_id=site_id, invoice_number=f"INV-R11-{id(total_eur)}",
+            total_eur=total_eur, energy_kwh=5000.0,
+            status=BillingInvoiceStatus.IMPORTED, source="csv",
+        )
+        db.add(inv)
+        db.flush()
+        db.add(EnergyInvoiceLine(
+            invoice_id=inv.id, line_type=InvoiceLineType.ENERGY,
+            label="HT", amount_eur=ht_amount,
+        ))
+        db.add(EnergyInvoiceLine(
+            invoice_id=inv.id, line_type=InvoiceLineType.TAX,
+            label="TVA", amount_eur=tva_amount,
+        ))
+        db.flush()
+        return inv
+
+    def test_ttc_mismatch_above_2pct_generates_anomaly(self, db):
+        """R11: TTC facturé 1000 vs HT(900)+TVA(50)=950 → delta 5% → anomalie."""
+        from services.billing_service import _rule_ttc_coherence
+        site = _make_site(db)
+        inv = self._make_invoice_with_lines(db, site.id, 1000.0, 900.0, 50.0)
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = _rule_ttc_coherence(inv, None, lines)
+        assert result is not None
+        assert result["type"] == "ttc_mismatch"
+        assert result["severity"] == "high"
+        assert result["estimated_loss_eur"] > 0
+
+    def test_ttc_coherent_within_2pct_no_anomaly(self, db):
+        """R11: TTC 1000 vs HT(900)+TVA(100)=1000 → no anomalie."""
+        from services.billing_service import _rule_ttc_coherence
+        site = _make_site(db)
+        inv = self._make_invoice_with_lines(db, site.id, 1000.0, 900.0, 100.0)
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = _rule_ttc_coherence(inv, None, lines)
+        assert result is None
+
+    def test_ttc_no_lines_no_anomaly(self, db):
+        """R11: no lines → skip rule."""
+        from services.billing_service import _rule_ttc_coherence
+        site = _make_site(db)
+        inv = EnergyInvoice(
+            site_id=site.id, invoice_number="INV-NOLINES",
+            total_eur=1000.0, status=BillingInvoiceStatus.IMPORTED, source="csv",
+        )
+        db.add(inv)
+        db.flush()
+        result = _rule_ttc_coherence(inv, None, [])
+        assert result is None
+
+
+# ========================================
+# R12 — Contract Expiry
+# ========================================
+
+class TestR12ContractExpiry:
+
+    def _make_contract(self, db, site_id, end_date):
+        contract = EnergyContract(
+            site_id=site_id, supplier_name="EDF Test",
+            energy_type=BillingEnergyType.ELEC,
+            end_date=end_date,
+        )
+        db.add(contract)
+        db.flush()
+        return contract
+
+    def _make_invoice(self, db, site_id, contract_id=None):
+        inv = EnergyInvoice(
+            site_id=site_id, invoice_number=f"INV-R12-{id(site_id)}",
+            total_eur=500.0, status=BillingInvoiceStatus.IMPORTED, source="csv",
+        )
+        if contract_id:
+            inv.contract_id = contract_id
+        db.add(inv)
+        db.flush()
+        return inv
+
+    def test_expired_contract_generates_critical(self, db):
+        """R12: contrat expiré hier → CRITICAL."""
+        from services.billing_service import _rule_contract_expiry
+        site = _make_site(db)
+        yesterday = date.today() - timedelta(days=1)
+        contract = self._make_contract(db, site.id, yesterday)
+        inv = self._make_invoice(db, site.id, contract.id)
+        result = _rule_contract_expiry(inv, contract, [])
+        assert result is not None
+        assert result["type"] == "contract_expired"
+        assert result["severity"] == "critical"
+
+    def test_contract_expiry_soon_generates_high(self, db):
+        """R12: contrat expire dans 30 jours → HIGH."""
+        from services.billing_service import _rule_contract_expiry
+        site = _make_site(db)
+        soon = date.today() + timedelta(days=30)
+        contract = self._make_contract(db, site.id, soon)
+        inv = self._make_invoice(db, site.id, contract.id)
+        result = _rule_contract_expiry(inv, contract, [])
+        assert result is not None
+        assert result["type"] == "contract_expiry_soon"
+        assert result["severity"] == "high"
+
+    def test_valid_contract_no_anomaly(self, db):
+        """R12: contrat expire dans 200 jours → pas d'anomalie."""
+        from services.billing_service import _rule_contract_expiry
+        site = _make_site(db)
+        future = date.today() + timedelta(days=200)
+        contract = self._make_contract(db, site.id, future)
+        inv = self._make_invoice(db, site.id, contract.id)
+        result = _rule_contract_expiry(inv, contract, [])
+        assert result is None
+
+    def test_no_contract_no_anomaly(self, db):
+        """R12: pas de contrat → skip rule."""
+        from services.billing_service import _rule_contract_expiry
+        site = _make_site(db)
+        inv = self._make_invoice(db, site.id)
+        result = _rule_contract_expiry(inv, None, [])
+        assert result is None
+
+
+# ========================================
+# ActionItem Bridge
+# ========================================
+
+class TestActionItemBridge:
+
+    def test_persist_insights_creates_action_item(self, db):
+        """persist_insights creates ActionItem for each anomaly (idempotent)."""
+        from services.billing_service import persist_insights
+        site = _make_site(db)
+        inv = EnergyInvoice(
+            site_id=site.id, invoice_number="INV-ACTION-001",
+            total_eur=1000.0, status=BillingInvoiceStatus.IMPORTED, source="csv",
+        )
+        db.add(inv)
+        db.flush()
+
+        anomalies = [{
+            "type": "shadow_gap",
+            "severity": "high",
+            "message": "Test anomaly for bridge",
+            "estimated_loss_eur": 150.0,
+            "metrics": {},
+        }]
+
+        persist_insights(db, inv, anomalies)
+
+        # Verify ActionItem was created
+        actions = db.query(ActionItem).filter(
+            ActionItem.source_type == ActionSourceType.BILLING
+        ).all()
+        assert len(actions) == 1
+        assert actions[0].idempotency_key == f"billing:{inv.id}:shadow_gap"
+
+    def test_persist_insights_idempotent_no_duplicate(self, db):
+        """Calling persist_insights twice does not create duplicate ActionItems."""
+        from services.billing_service import persist_insights
+        site = _make_site(db)
+        inv = EnergyInvoice(
+            site_id=site.id, invoice_number="INV-ACTION-002",
+            total_eur=1000.0, status=BillingInvoiceStatus.IMPORTED, source="csv",
+        )
+        db.add(inv)
+        db.flush()
+
+        anomalies = [{
+            "type": "unit_price_high",
+            "severity": "high",
+            "message": "Prix unitaire eleve",
+            "estimated_loss_eur": 80.0,
+            "metrics": {},
+        }]
+
+        persist_insights(db, inv, anomalies)
+        persist_insights(db, inv, anomalies)
+
+        # Should still be only 1 action (idempotency_key dedup)
+        actions = db.query(ActionItem).filter(
+            ActionItem.idempotency_key == f"billing:{inv.id}:unit_price_high"
+        ).all()
+        assert len(actions) == 1

--- a/backend/tests/test_billing_v66_pdf.py
+++ b/backend/tests/test_billing_v66_pdf.py
@@ -1,0 +1,197 @@
+"""
+PROMEOS — V66 Billing PDF Parser Tests
+Tests for: extract_text_with_fitz, parse_pdf_bytes, POST /import-pdf.
+Uses a minimal valid PDF (created in-memory) to avoid storing binary files.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+import io
+
+
+def _minimal_pdf_bytes() -> bytes:
+    """Create a minimal valid PDF in-memory (no external files needed)."""
+    # Minimal PDF 1.4 with one page containing the word "EDF"
+    content = b"""%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /MediaBox [0 0 612 792] /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT /F1 12 Tf 100 700 Td (EDF FACTURE 2024-01) Tj ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000266 00000 n
+0000000346 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+440
+%%EOF"""
+    return content
+
+
+# ========================================
+# Unit tests — pdf_parser module
+# ========================================
+
+class TestPdfParserUnit:
+
+    def test_extract_text_with_fitz_returns_string(self):
+        """extract_text_with_fitz runs on minimal PDF without error."""
+        from app.bill_intelligence.parsers.pdf_parser import extract_text_with_fitz
+        pdf_bytes = _minimal_pdf_bytes()
+        try:
+            text = extract_text_with_fitz(pdf_bytes)
+            assert isinstance(text, str)
+        except Exception as e:
+            # If fitz not available in test env, skip rather than fail
+            pytest.skip(f"fitz (pymupdf) not available: {e}")
+
+    def test_parse_pdf_bytes_returns_none_or_invoice(self):
+        """parse_pdf_bytes on minimal PDF returns None or InvoiceDomain (no crash)."""
+        from app.bill_intelligence.parsers.pdf_parser import parse_pdf_bytes
+        pdf_bytes = _minimal_pdf_bytes()
+        try:
+            result = parse_pdf_bytes(pdf_bytes, "test.pdf")
+            # May be None (low confidence) or an invoice object — both are valid
+            assert result is None or hasattr(result, "confidence")
+        except Exception as e:
+            pytest.skip(f"fitz (pymupdf) not available: {e}")
+
+    def test_parse_pdf_bytes_low_confidence_text(self):
+        """parse_pdf_text on garbage text returns None, low confidence, or raises ValueError."""
+        from app.bill_intelligence.parsers.pdf_parser import parse_pdf_text
+        # pass garbage text directly (no fitz needed)
+        try:
+            result = parse_pdf_text("gibberish text no supplier match", "test.pdf")
+            # If it returns a result, confidence should be low or None
+            if result is not None:
+                assert result.confidence < 0.5
+            # None return is also valid
+        except (ValueError, Exception):
+            # No template match → expected for garbage text
+            pass
+
+    def test_parse_pdf_text_edf_template_detection(self):
+        """parse_pdf_text recognises EDF template from supplier keyword."""
+        from app.bill_intelligence.parsers.pdf_parser import parse_pdf_text
+        text = "EDF SA\nFacture n°F-2024-001\nMontant TTC: 1 234,56 €\nPeriode: 01/01/2024 au 31/01/2024"
+        result = parse_pdf_text(text, "edf_test.pdf")
+        # If parsing succeeds, supplier should contain EDF
+        if result is not None:
+            assert "edf" in (result.supplier or "").lower() or result.confidence >= 0
+
+
+# ========================================
+# Integration test — POST /import-pdf
+# ========================================
+
+@pytest.fixture
+def db():
+    from models import Base
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def client(db):
+    from database import get_db
+    from main import app
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _seed_site(db):
+    """Create minimal org→EJ→Portefeuille→Site chain for billing tests."""
+    from models import Organisation, EntiteJuridique, Portefeuille, Site, TypeSite
+    org = Organisation(nom="PDF Test Org", type_client="bureau", actif=True, siren="400000001")
+    db.add(org)
+    db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom="EJ PDF", siren="400000001")
+    db.add(ej)
+    db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom="PF PDF")
+    db.add(pf)
+    db.flush()
+    site = Site(
+        portefeuille_id=pf.id, nom="Site PDF", type=TypeSite.BUREAU,
+        adresse="1 rue Test", code_postal="75001", ville="Paris",
+        surface_m2=200, actif=True,
+    )
+    db.add(site)
+    db.commit()
+    return {"org": org, "site": site}
+
+
+class TestImportPdfEndpoint:
+
+    def test_import_pdf_low_confidence_returns_422(self, client, db):
+        """POST /import-pdf with a PDF that parses with confidence < 0.5 → 422."""
+        d = _seed_site(db)
+        org_id = d["org"].id
+        site_id = d["site"].id
+
+        # Minimal PDF with no EDF/Engie content → low confidence
+        pdf_content = _minimal_pdf_bytes()
+        try:
+            r = client.post(
+                f"/api/billing/import-pdf?site_id={site_id}&run_audit=false",
+                files={"file": ("test.pdf", io.BytesIO(pdf_content), "application/pdf")},
+                headers={"X-Org-Id": str(org_id)},
+            )
+            # Either 422 (confidence < 0.5) or 200 if fitz parses successfully
+            assert r.status_code in (200, 422)
+        except Exception:
+            pytest.skip("fitz not available in test environment")
+
+    def test_import_pdf_wrong_site_org_returns_404(self, client, db):
+        """POST /import-pdf for site not belonging to org → 404."""
+        d = _seed_site(db)
+        # Use a non-existent site_id (9999)
+        pdf_content = _minimal_pdf_bytes()
+        try:
+            r = client.post(
+                "/api/billing/import-pdf?site_id=9999&run_audit=false",
+                files={"file": ("test.pdf", io.BytesIO(pdf_content), "application/pdf")},
+                headers={"X-Org-Id": str(d["org"].id)},
+            )
+            assert r.status_code == 404
+        except Exception:
+            pytest.skip("fitz not available in test environment")

--- a/backend/tests/test_billing_v66_scoping.py
+++ b/backend/tests/test_billing_v66_scoping.py
@@ -1,0 +1,178 @@
+"""
+PROMEOS — V66 Billing Org Scoping Tests
+Proves: resolve_org_id added to billing routes — no cross-org data leakage.
+
+Setup: 2 orgs (Alpha, Bravo), each with EJ → Portefeuille → Site.
+Alpha has invoices and insights; Bravo has none.
+All tests use X-Org-Id header to simulate org context.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import (
+    Base, Organisation, EntiteJuridique, Portefeuille,
+    Site, TypeSite, EnergyInvoice, EnergyContract,
+    BillingInsight, BillingInvoiceStatus, InsightStatus, BillingImportBatch,
+)
+from models.billing_models import BillingEnergyType
+from database import get_db
+from main import app
+
+
+# ========================================
+# Fixtures
+# ========================================
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def client(db):
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _create_two_orgs_with_billing(db):
+    """Create 2 org hierarchies; Alpha has invoices + insights, Bravo is empty."""
+    # ── Org Alpha ──
+    org_a = Organisation(nom="Billing Alpha", type_client="bureau", actif=True, siren="300000001")
+    db.add(org_a)
+    db.flush()
+    ej_a = EntiteJuridique(organisation_id=org_a.id, nom="EJ Alpha", siren="300000001")
+    db.add(ej_a)
+    db.flush()
+    pf_a = Portefeuille(entite_juridique_id=ej_a.id, nom="PF Alpha")
+    db.add(pf_a)
+    db.flush()
+    site_a = Site(
+        portefeuille_id=pf_a.id, nom="Site Alpha", type=TypeSite.BUREAU,
+        adresse="1 rue Alpha", code_postal="75001", ville="Paris",
+        surface_m2=500, actif=True,
+    )
+    db.add(site_a)
+    db.flush()
+
+    # Alpha's invoice + insight
+    inv_a = EnergyInvoice(
+        site_id=site_a.id, invoice_number="FA-ALPHA-001",
+        total_eur=1200.0, energy_kwh=5000.0,
+        status=BillingInvoiceStatus.ANOMALY, source="csv",
+    )
+    db.add(inv_a)
+    db.flush()
+    insight_a = BillingInsight(
+        site_id=site_a.id, invoice_id=inv_a.id,
+        type="shadow_gap", severity="high",
+        message="Ecart alpha test",
+        insight_status=InsightStatus.OPEN,
+    )
+    db.add(insight_a)
+
+    # ── Org Bravo ──
+    org_b = Organisation(nom="Billing Bravo", type_client="industrie", actif=True, siren="300000002")
+    db.add(org_b)
+    db.flush()
+    ej_b = EntiteJuridique(organisation_id=org_b.id, nom="EJ Bravo", siren="300000002")
+    db.add(ej_b)
+    db.flush()
+    pf_b = Portefeuille(entite_juridique_id=ej_b.id, nom="PF Bravo")
+    db.add(pf_b)
+    db.flush()
+    site_b = Site(
+        portefeuille_id=pf_b.id, nom="Site Bravo", type=TypeSite.BUREAU,
+        adresse="2 rue Bravo", code_postal="69001", ville="Lyon",
+        surface_m2=400, actif=True,
+    )
+    db.add(site_b)
+    db.flush()
+
+    db.commit()
+    return {
+        "org_a": org_a, "site_a": site_a, "inv_a": inv_a, "insight_a": insight_a,
+        "org_b": org_b, "site_b": site_b,
+    }
+
+
+def _h(org_id: int) -> dict:
+    return {"X-Org-Id": str(org_id)}
+
+
+# ========================================
+# Tests
+# ========================================
+
+class TestBillingOrgScoping:
+
+    def test_invoices_only_return_own_org(self, client, db):
+        """GET /invoices scoped to org_a returns Alpha's invoices only."""
+        d = _create_two_orgs_with_billing(db)
+        r = client.get("/api/billing/invoices", headers=_h(d["org_a"].id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["count"] >= 1
+        for inv in data["invoices"]:
+            assert inv["site_id"] == d["site_a"].id
+
+    def test_invoices_cross_org_returns_empty(self, client, db):
+        """GET /invoices scoped to org_b returns empty list (Alpha's data invisible)."""
+        d = _create_two_orgs_with_billing(db)
+        r = client.get("/api/billing/invoices", headers=_h(d["org_b"].id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["count"] == 0
+        assert data["invoices"] == []
+
+    def test_insights_cross_org_returns_empty(self, client, db):
+        """GET /insights scoped to org_b returns empty list."""
+        d = _create_two_orgs_with_billing(db)
+        r = client.get("/api/billing/insights", headers=_h(d["org_b"].id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["count"] == 0
+
+    def test_summary_shows_own_org_data(self, client, db):
+        """GET /summary scoped to org_a returns non-zero counts."""
+        d = _create_two_orgs_with_billing(db)
+        r_a = client.get("/api/billing/summary", headers=_h(d["org_a"].id))
+        assert r_a.status_code == 200
+        data_a = r_a.json()
+        assert data_a["total_invoices"] >= 1
+
+        # Org_b sees nothing
+        r_b = client.get("/api/billing/summary", headers=_h(d["org_b"].id))
+        assert r_b.status_code == 200
+        data_b = r_b.json()
+        assert data_b["total_invoices"] == 0
+
+    def test_site_billing_cross_org_returns_404(self, client, db):
+        """GET /site/{site_id} for a site belonging to org_a, accessed via org_b → 404."""
+        d = _create_two_orgs_with_billing(db)
+        r = client.get(
+            f"/api/billing/site/{d['site_a'].id}",
+            headers=_h(d["org_b"].id),
+        )
+        assert r.status_code == 404

--- a/backend/tests/test_billing_v67_coverage.py
+++ b/backend/tests/test_billing_v67_coverage.py
@@ -1,0 +1,318 @@
+"""
+PROMEOS — V67 Billing Coverage Tests
+Tests pour: compute_coverage, compute_range, endpoints /periods /coverage-summary /missing-periods.
+Couvre: covered/partial/missing, avoirs, fallback issue_date, chevauchements, multi-org, pagination.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import date, timedelta
+from calendar import monthrange
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from models import (
+    Base, Organisation, EntiteJuridique, Portefeuille,
+    Site, TypeSite, EnergyInvoice, BillingInvoiceStatus,
+)
+from database import get_db
+from main import app
+
+
+# ========================================
+# Fixtures
+# ========================================
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def client(db):
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _make_org_site(db, nom="Org Test", siren="600000001"):
+    org = Organisation(nom=nom, type_client="bureau", actif=True, siren=siren)
+    db.add(org)
+    db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom=f"EJ {nom}", siren=siren)
+    db.add(ej)
+    db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom=f"PF {nom}")
+    db.add(pf)
+    db.flush()
+    site = Site(
+        portefeuille_id=pf.id, nom=f"Site {nom}", type=TypeSite.BUREAU,
+        adresse="1 rue Test", code_postal="75001", ville="Paris",
+        surface_m2=200, actif=True,
+    )
+    db.add(site)
+    db.commit()
+    return org, site
+
+
+def _make_invoice(db, site_id, period_start=None, period_end=None, issue_date=None,
+                  total_eur=1000.0, number=None):
+    import random
+    num = number or f"INV-COV-{random.randint(10000, 99999)}"
+    inv = EnergyInvoice(
+        site_id=site_id,
+        invoice_number=num,
+        period_start=period_start,
+        period_end=period_end,
+        issue_date=issue_date,
+        total_eur=total_eur,
+        status=BillingInvoiceStatus.IMPORTED,
+        source="csv",
+    )
+    db.add(inv)
+    db.flush()
+    return inv
+
+
+def _h(org_id):
+    return {"X-Org-Id": str(org_id)}
+
+
+# ========================================
+# Unit tests — Coverage Engine
+# ========================================
+
+class TestCoverageEngine:
+
+    def test_covered_month_full(self):
+        """Facture couvrant tout janvier → 'covered'."""
+        from services.billing_coverage import compute_coverage
+
+        class FakeInv:
+            period_start = date(2024, 1, 1)
+            period_end = date(2024, 1, 31)
+            issue_date = None
+            total_eur = 1000.0
+
+        months = compute_coverage([FakeInv()], date(2024, 1, 1), date(2024, 1, 31))
+        assert len(months) == 1
+        assert months[0].coverage_status == "covered"
+        assert months[0].coverage_ratio == 1.0
+        assert months[0].invoices_count == 1
+        assert months[0].total_ttc == 1000.0
+
+    def test_partial_month_below_threshold(self):
+        """Facture couvrant 10/31 jours → 'partial'."""
+        from services.billing_coverage import compute_coverage
+
+        class FakeInv:
+            period_start = date(2024, 1, 1)
+            period_end = date(2024, 1, 10)
+            issue_date = None
+            total_eur = 500.0
+
+        months = compute_coverage([FakeInv()], date(2024, 1, 1), date(2024, 1, 31))
+        assert months[0].coverage_status == "partial"
+        assert months[0].coverage_ratio < 0.80
+
+    def test_missing_month_no_invoices(self):
+        """Aucune facture pour un mois → 'missing'."""
+        from services.billing_coverage import compute_coverage
+
+        months = compute_coverage([], date(2024, 3, 1), date(2024, 3, 31))
+        assert len(months) == 1
+        assert months[0].coverage_status == "missing"
+        assert months[0].invoices_count == 0
+        assert months[0].missing_reason is not None
+
+    def test_avoir_excluded_from_coverage(self):
+        """Avoir (total_eur <= 0) ne contribue pas à la couverture."""
+        from services.billing_coverage import compute_coverage
+
+        class AvoirInv:
+            period_start = date(2024, 2, 1)
+            period_end = date(2024, 2, 29)
+            issue_date = None
+            total_eur = -200.0  # Avoir
+
+        months = compute_coverage([AvoirInv()], date(2024, 2, 1), date(2024, 2, 29))
+        assert months[0].coverage_status == "missing"  # Avoir n'apporte pas de couverture
+        assert months[0].invoices_count == 1  # Mais compté dans les factures
+        assert months[0].total_ttc == -200.0  # Et dans les totaux
+
+    def test_fallback_to_issue_date(self):
+        """Sans period_start/end, issue_date → mois entier utilisé."""
+        from services.billing_coverage import compute_coverage
+
+        class NoDateInv:
+            period_start = None
+            period_end = None
+            issue_date = date(2024, 5, 15)  # Milieu du mois
+            total_eur = 800.0
+
+        months = compute_coverage([NoDateInv()], date(2024, 5, 1), date(2024, 5, 31))
+        # Issue_date → couvre tout le mois de mai → covered
+        assert months[0].coverage_status == "covered"
+
+    def test_overlapping_invoices_no_double_count(self):
+        """2 factures qui se chevauchent → pas de double-comptage des jours."""
+        from services.billing_coverage import compute_coverage
+
+        class Inv1:
+            period_start = date(2024, 6, 1)
+            period_end = date(2024, 6, 20)
+            issue_date = None
+            total_eur = 600.0
+
+        class Inv2:
+            period_start = date(2024, 6, 10)  # Chevauchement avec Inv1
+            period_end = date(2024, 6, 30)
+            issue_date = None
+            total_eur = 400.0
+
+        months = compute_coverage([Inv1(), Inv2()], date(2024, 6, 1), date(2024, 6, 30))
+        assert months[0].coverage_status == "covered"
+        assert months[0].coverage_ratio == 1.0  # Tout le mois couvert, sans double-comptage
+
+    def test_multimonth_invoice_covers_three_months(self):
+        """1 facture sur 3 mois → 3 mois couverts."""
+        from services.billing_coverage import compute_coverage
+
+        class LongInv:
+            period_start = date(2024, 1, 1)
+            period_end = date(2024, 3, 31)
+            issue_date = None
+            total_eur = 3000.0
+
+        months = compute_coverage([LongInv()], date(2024, 1, 1), date(2024, 3, 31))
+        assert len(months) == 3
+        assert all(mc.coverage_status == "covered" for mc in months)
+
+    def test_missing_reason_text(self):
+        """missing_reason est une chaîne explicite pour les cas 'missing'."""
+        from services.billing_coverage import compute_coverage
+
+        months = compute_coverage([], date(2024, 7, 1), date(2024, 7, 31))
+        assert months[0].missing_reason is not None
+        assert len(months[0].missing_reason) > 5
+
+
+# ========================================
+# Integration tests — Endpoints
+# ========================================
+
+class TestCoverageEndpoints:
+
+    def test_periods_empty_returns_empty(self, client, db):
+        """GET /periods sans factures → periods=[], total=0."""
+        org, site = _make_org_site(db, "Org Periods Empty", "600000010")
+        r = client.get("/api/billing/periods", headers=_h(org.id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["periods"] == []
+        assert data["total"] == 0
+
+    def test_periods_with_invoices_returns_months(self, client, db):
+        """GET /periods avec 2 factures → liste de mois couverts."""
+        org, site = _make_org_site(db, "Org Periods OK", "600000011")
+        _make_invoice(db, site.id, period_start=date(2024, 1, 1), period_end=date(2024, 1, 31), number="INV-P001")
+        _make_invoice(db, site.id, period_start=date(2024, 2, 1), period_end=date(2024, 2, 29), number="INV-P002")
+        db.commit()
+
+        r = client.get("/api/billing/periods", headers=_h(org.id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] >= 2
+        assert len(data["periods"]) >= 1
+        # Chaque période a les champs requis
+        for p in data["periods"]:
+            assert "month_key" in p
+            assert "coverage_status" in p
+            assert p["coverage_status"] in ("covered", "partial", "missing")
+
+    def test_periods_pagination(self, client, db):
+        """GET /periods avec limit=1&offset=0 vs offset=1 → slices différents."""
+        org, site = _make_org_site(db, "Org Paginate", "600000012")
+        _make_invoice(db, site.id, period_start=date(2024, 1, 1), period_end=date(2024, 1, 31), number="INV-PG1")
+        _make_invoice(db, site.id, period_start=date(2024, 2, 1), period_end=date(2024, 2, 29), number="INV-PG2")
+        _make_invoice(db, site.id, period_start=date(2024, 3, 1), period_end=date(2024, 3, 31), number="INV-PG3")
+        db.commit()
+
+        r1 = client.get("/api/billing/periods?limit=1&offset=0", headers=_h(org.id))
+        r2 = client.get("/api/billing/periods?limit=1&offset=1", headers=_h(org.id))
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        d1, d2 = r1.json(), r2.json()
+        assert len(d1["periods"]) == 1
+        assert len(d2["periods"]) == 1
+        assert d1["periods"][0]["month_key"] != d2["periods"][0]["month_key"]
+
+    def test_coverage_summary_org_a_vs_b(self, client, db):
+        """GET /coverage-summary : org_a voit ses données, org_b voit zéro."""
+        org_a, site_a = _make_org_site(db, "Org Summary A", "600000020")
+        org_b, site_b = _make_org_site(db, "Org Summary B", "600000021")
+
+        _make_invoice(db, site_a.id, period_start=date(2024, 1, 1), period_end=date(2024, 1, 31), number="INV-SUM-A1")
+        _make_invoice(db, site_a.id, period_start=date(2024, 3, 1), period_end=date(2024, 3, 31), number="INV-SUM-A2")
+        db.commit()
+
+        r_a = client.get("/api/billing/coverage-summary", headers=_h(org_a.id))
+        r_b = client.get("/api/billing/coverage-summary", headers=_h(org_b.id))
+
+        assert r_a.status_code == 200
+        assert r_b.status_code == 200
+
+        data_a = r_a.json()
+        data_b = r_b.json()
+
+        assert data_a["months_total"] >= 2  # Janv + Fév (manquant) + Mars au moins
+        assert data_b["months_total"] == 0  # Org_b n'a aucune facture
+        assert data_b["range"] is None
+
+    def test_missing_periods_cross_org_empty(self, client, db):
+        """GET /missing-periods pour org sans factures → items=[]."""
+        org, site = _make_org_site(db, "Org Missing Empty", "600000030")
+        r = client.get("/api/billing/missing-periods", headers=_h(org.id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+
+    def test_missing_periods_detects_gap(self, client, db):
+        """GET /missing-periods détecte un trou entre 2 factures."""
+        org, site = _make_org_site(db, "Org Gap", "600000031")
+        # Janv + Mars couverts, Fév manquant
+        _make_invoice(db, site.id, period_start=date(2024, 1, 1), period_end=date(2024, 1, 31), number="INV-GAP1")
+        _make_invoice(db, site.id, period_start=date(2024, 3, 1), period_end=date(2024, 3, 31), number="INV-GAP3")
+        db.commit()
+
+        r = client.get("/api/billing/missing-periods", headers=_h(org.id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] >= 1
+        month_keys = [item["month_key"] for item in data["items"]]
+        assert "2024-02" in month_keys
+        # Chaque item a les champs requis
+        for item in data["items"]:
+            assert "site_id" in item
+            assert "cta_url" in item
+            assert "regulatory_impact" in item
+            assert item["regulatory_impact"]["framework"] == "FACTURATION"

--- a/backend/tests/test_billing_v68.py
+++ b/backend/tests/test_billing_v68.py
@@ -591,3 +591,37 @@ class TestPDFImportDoD:
         assert data["kb_updated"] is True
         assert "kb_rules_applied" in data
         assert isinstance(data["kb_rules_applied"], list)
+
+
+# ========================================
+# TestTimelineAllSites
+# ========================================
+
+class TestTimelineAllSites:
+
+    def test_billing_periods_no_site_id_returns_data(self, client, db):
+        """GET /billing/periods sans site_id retourne des périodes quand des factures existent."""
+        org, site = _make_org_site(db, "OrgTimeline1", "600007001")
+        inv = EnergyInvoice(
+            site_id=site.id,
+            invoice_number="TIMELINE-TEST-001",
+            period_start=date(2024, 3, 1),
+            period_end=date(2024, 3, 31),
+            issue_date=date(2024, 4, 5),
+            total_eur=800.0,
+            energy_kwh=3200.0,
+            status=BillingInvoiceStatus.IMPORTED,
+            source="test",
+        )
+        db.add(inv)
+        db.commit()
+
+        # Sans site_id → agrégation all-org (root cause fix : front ne doit plus envoyer site_id=None)
+        r = client.get("/api/billing/periods", headers=_h(org.id))
+        assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+        data = r.json()
+        assert "periods" in data, "Champ 'periods' absent de la réponse"
+        assert data["total"] >= 1, "Aucune période retournée alors qu'une facture existe"
+        # Vérifier que les champs DoD sont présents
+        period = data["periods"][0]
+        assert "energy_kwh" in period, "Champ energy_kwh absent de la période"

--- a/backend/tests/test_billing_v68.py
+++ b/backend/tests/test_billing_v68.py
@@ -461,3 +461,133 @@ class TestSeedAndCoverage:
         data = r.json()
         assert data["invoices"] == []
         assert data["total"] == 0
+
+
+# ========================================
+# TestPDFImportDoD — 3 smoke tests E2E
+# ========================================
+
+class TestPDFImportDoD:
+    """DoD P0 smoke tests — vérifie le flux PDF import complet."""
+
+    def _fake_invoice_domain(self):
+        """Construit un faux Invoice domain avec 2 composantes (CONSO_BASE + TURPE_FIXE)."""
+        from app.bill_intelligence.domain import (
+            Invoice, InvoiceComponent, InvoiceStatus,
+            EnergyType, ComponentType,
+        )
+        from datetime import date
+        comp1 = InvoiceComponent(
+            component_type=ComponentType.CONSO_BASE,
+            label="Energie base",
+            quantity=4500.0, unit="kWh", unit_price=0.18,
+            amount_ht=810.0, tva_rate=20.0,
+        )
+        comp2 = InvoiceComponent(
+            component_type=ComponentType.TURPE_FIXE,
+            label="TURPE gestion",
+            amount_ht=150.0, tva_rate=5.5,
+        )
+        comp3 = InvoiceComponent(
+            component_type=ComponentType.ACCISE,
+            label="Accise electricite",
+            amount_ht=101.25, tva_rate=20.0,
+        )
+        return Invoice(
+            invoice_id="TEST-2024-01",
+            energy_type=EnergyType.ELEC,
+            supplier="EDF Test",
+            pdl_pce="12345678901234",
+            period_start=date(2024, 1, 1),
+            period_end=date(2024, 1, 31),
+            invoice_date=date(2024, 2, 5),
+            total_ht=1061.25,
+            total_ttc=1291.25,
+            conso_kwh=4500.0,
+            components=[comp1, comp2, comp3],
+            status=InvoiceStatus.PARSED,
+            parsing_confidence=0.92,
+        )
+
+    def test_pdf_import_creates_invoice_lines(self, client, db):
+        """P0-1 : POST /billing/import-pdf crée des EnergyInvoiceLine depuis les composantes."""
+        from unittest.mock import patch, MagicMock
+        org, site = _make_org_site(db, "OrgPDF1", "600006001")
+        fake_domain = self._fake_invoice_domain()
+
+        fake_bytes = b"%PDF-1.4 fake"
+        with patch(
+            "app.bill_intelligence.parsers.pdf_parser.parse_pdf_bytes",
+            return_value=fake_domain,
+        ):
+            r = client.post(
+                f"/api/billing/import-pdf?site_id={site.id}",
+                files={"file": ("facture.pdf", fake_bytes, "application/pdf")},
+                headers=_h(org.id),
+            )
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["status"] == "imported"
+        invoice_id = data["invoice_id"]
+
+        # Vérifier que les lignes ont été créées (P0-1)
+        lines = db.query(EnergyInvoiceLine).filter(
+            EnergyInvoiceLine.invoice_id == invoice_id
+        ).all()
+        assert len(lines) == 3, f"Attendu 3 lignes, eu {len(lines)}"
+
+        line_types = {l.line_type for l in lines}
+        assert InvoiceLineType.ENERGY in line_types
+        assert InvoiceLineType.NETWORK in line_types
+        assert InvoiceLineType.TAX in line_types
+
+    def test_billing_periods_returns_kwh(self, client, db):
+        """P0-2 : GET /billing/periods retourne energy_kwh pour chaque période."""
+        org, site = _make_org_site(db, "OrgPDF2", "600006002")
+        # Créer une facture avec kWh
+        inv = EnergyInvoice(
+            site_id=site.id,
+            invoice_number="TEST-KWH-2024-01",
+            period_start=date(2024, 1, 1),
+            period_end=date(2024, 1, 31),
+            issue_date=date(2024, 2, 5),
+            total_eur=1291.25,
+            energy_kwh=4500.0,
+            status=BillingInvoiceStatus.IMPORTED,
+            source="test",
+        )
+        db.add(inv)
+        db.commit()
+
+        r = client.get(f"/api/billing/periods?site_id={site.id}", headers=_h(org.id))
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["total"] >= 1
+        period = data["periods"][0]
+        assert "energy_kwh" in period, "Champ energy_kwh manquant dans /billing/periods"
+        assert period["energy_kwh"] == 4500.0
+
+    def test_pdf_import_kb_updated_flag(self, client, db):
+        """P0-5 : POST /billing/import-pdf retourne kb_updated=True si run_audit=True."""
+        from unittest.mock import patch
+        org, site = _make_org_site(db, "OrgPDF3", "600006003")
+        fake_domain = self._fake_invoice_domain()
+
+        fake_bytes = b"%PDF-1.4 fake"
+        with patch(
+            "app.bill_intelligence.parsers.pdf_parser.parse_pdf_bytes",
+            return_value=fake_domain,
+        ):
+            r = client.post(
+                f"/api/billing/import-pdf?site_id={site.id}&run_audit=true",
+                files={"file": ("facture.pdf", fake_bytes, "application/pdf")},
+                headers=_h(org.id),
+            )
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert "kb_updated" in data, "Champ kb_updated manquant dans la réponse import-pdf"
+        assert data["kb_updated"] is True
+        assert "kb_rules_applied" in data
+        assert isinstance(data["kb_rules_applied"], list)

--- a/backend/tests/test_billing_v68.py
+++ b/backend/tests/test_billing_v68.py
@@ -1,0 +1,463 @@
+"""
+PROMEOS — V68 Billing Unified Tests
+Couvre: InvoiceNormalized, Shadow V2, R13/R14, Seed 36 mois, endpoint /invoices/normalized.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import date
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from models import (
+    Base, Organisation, EntiteJuridique, Portefeuille,
+    Site, TypeSite, EnergyInvoice, EnergyInvoiceLine,
+    EnergyContract, BillingEnergyType, InvoiceLineType, BillingInvoiceStatus,
+)
+from database import get_db
+from main import app
+
+
+# ========================================
+# Fixtures
+# ========================================
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def client(db):
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _make_org_site(db, nom="OrgTest", siren="600000001"):
+    org = Organisation(nom=nom, type_client="bureau", actif=True, siren=siren)
+    db.add(org); db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom=f"EJ {nom}", siren=siren)
+    db.add(ej); db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom=f"PF {nom}")
+    db.add(pf); db.flush()
+    site = Site(
+        portefeuille_id=pf.id, nom=f"Site {nom}", type=TypeSite.BUREAU,
+        adresse="1 rue Test", code_postal="75001", ville="Paris",
+        surface_m2=200, actif=True,
+    )
+    db.add(site); db.commit()
+    return org, site
+
+
+def _make_contract(db, site_id, energy_type=BillingEnergyType.ELEC,
+                   supplier="EDF Test", price_ref=0.18):
+    c = EnergyContract(
+        site_id=site_id, energy_type=energy_type,
+        supplier_name=supplier, price_ref_eur_per_kwh=price_ref,
+    )
+    db.add(c); db.flush()
+    return c
+
+
+def _make_invoice_with_lines(db, site_id, contract_id=None,
+                              period_start=date(2024, 1, 1),
+                              period_end=date(2024, 1, 31),
+                              total_eur=1620.0, kwh=9000,
+                              energy_amt=1020.0, network_amt=400.0, tax_amt=200.0,
+                              number=None):
+    import random
+    inv = EnergyInvoice(
+        site_id=site_id,
+        contract_id=contract_id,
+        invoice_number=number or f"INV-{random.randint(10000, 99999)}",
+        period_start=period_start,
+        period_end=period_end,
+        issue_date=date(2024, 2, 5),
+        total_eur=total_eur,
+        energy_kwh=kwh,
+        status=BillingInvoiceStatus.IMPORTED,
+        source="test",
+    )
+    db.add(inv); db.flush()
+    db.add(EnergyInvoiceLine(invoice_id=inv.id, line_type=InvoiceLineType.ENERGY,
+                              label="Energie", amount_eur=energy_amt))
+    db.add(EnergyInvoiceLine(invoice_id=inv.id, line_type=InvoiceLineType.NETWORK,
+                              label="Réseau", amount_eur=network_amt))
+    db.add(EnergyInvoiceLine(invoice_id=inv.id, line_type=InvoiceLineType.TAX,
+                              label="Taxes", amount_eur=tax_amt))
+    db.flush()
+    return inv
+
+
+def _h(org_id):
+    return {"X-Org-Id": str(org_id)}
+
+
+# ========================================
+# TestInvoiceNormalized
+# ========================================
+
+class TestInvoiceNormalized:
+
+    def test_normalize_with_lines(self, db):
+        """ht/tva/fournisseur/energie calculés correctement."""
+        from services.billing_normalization import normalize_invoice
+        org, site = _make_org_site(db, "OrgNorm", "600001001")
+        contract = _make_contract(db, site.id, supplier="EDF ENR", price_ref=0.18)
+        inv = _make_invoice_with_lines(db, site.id, contract.id,
+                                       energy_amt=1020.0, network_amt=400.0, tax_amt=200.0,
+                                       total_eur=1620.0, kwh=9000)
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = normalize_invoice(inv, lines, contract, org.id)
+        assert result.ht == 1420.0          # 1020 + 400
+        assert result.tva == 200.0
+        assert result.ht_fourniture == 1020.0
+        assert result.ht_reseau == 400.0
+        assert result.ttc == 1620.0
+        assert result.fournisseur == "EDF ENR"
+        assert result.energie == "ELEC"
+        assert result.org_id == org.id
+
+    def test_normalize_no_contract(self, db):
+        """Fournisseur=None, energie=None si pas de contrat."""
+        from services.billing_normalization import normalize_invoice
+        org, site = _make_org_site(db, "OrgNoContract", "600001002")
+        inv = _make_invoice_with_lines(db, site.id)
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = normalize_invoice(inv, lines, None, org.id)
+        assert result.fournisseur is None
+        assert result.energie is None
+        assert result.ht == 1420.0
+
+    def test_normalize_month_key_from_period(self, db):
+        """month_key dérivé de period_start."""
+        from services.billing_normalization import normalize_invoice
+        org, site = _make_org_site(db, "OrgMK1", "600001003")
+        inv = _make_invoice_with_lines(db, site.id, period_start=date(2024, 3, 1),
+                                       period_end=date(2024, 3, 31))
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = normalize_invoice(inv, lines, None, org.id)
+        assert result.month_key == "2024-03"
+
+    def test_normalize_month_key_fallback(self, db):
+        """month_key utilise issue_date si period_start absent."""
+        from services.billing_normalization import normalize_invoice
+        org, site = _make_org_site(db, "OrgMK2", "600001004")
+        inv = EnergyInvoice(
+            site_id=site.id, invoice_number="INV-MK-001",
+            period_start=None, period_end=None,
+            issue_date=date(2024, 5, 10),
+            total_eur=100.0, status=BillingInvoiceStatus.IMPORTED, source="test",
+        )
+        db.add(inv); db.flush()
+        result = normalize_invoice(inv, [], None, org.id)
+        assert result.month_key == "2024-05"
+
+    def test_endpoint_org_scoped(self, client, db):
+        """org_a voit ses factures, org_b ne voit rien."""
+        org_a, site_a = _make_org_site(db, "OrgA", "600002001")
+        org_b, site_b = _make_org_site(db, "OrgB", "600002002")
+        _make_invoice_with_lines(db, site_a.id)
+        _make_invoice_with_lines(db, site_b.id)
+
+        r_a = client.get("/api/billing/invoices/normalized", headers=_h(org_a.id))
+        r_b = client.get("/api/billing/invoices/normalized", headers=_h(org_b.id))
+        assert r_a.status_code == 200
+        assert r_b.status_code == 200
+        assert len(r_a.json()["invoices"]) == 1
+        assert len(r_b.json()["invoices"]) == 1
+        assert r_a.json()["invoices"][0]["org_id"] == org_a.id
+
+    def test_endpoint_month_key_filter(self, client, db):
+        """?month_key=2024-01 filtre correctement."""
+        org, site = _make_org_site(db, "OrgMKF", "600002003")
+        _make_invoice_with_lines(db, site.id, period_start=date(2024, 1, 1), period_end=date(2024, 1, 31))
+        _make_invoice_with_lines(db, site.id, period_start=date(2024, 2, 1), period_end=date(2024, 2, 28))
+
+        r = client.get("/api/billing/invoices/normalized?month_key=2024-01", headers=_h(org.id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 1
+        assert data["invoices"][0]["month_key"] == "2024-01"
+
+
+# ========================================
+# TestShadowBillingV2
+# ========================================
+
+class TestShadowBillingV2:
+
+    def _fake_inv(self, kwh=9000, total_eur=1620.0):
+        class Inv:
+            pass
+        Inv.energy_kwh = kwh
+        Inv.total_eur = total_eur
+        return Inv()
+
+    def _fake_contract(self, energy_type="elec", price_ref=0.18):
+        """energy_type must use lowercase enum value: 'elec' or 'gaz'."""
+        class C:
+            pass
+        c = C()
+        c.price_ref_eur_per_kwh = price_ref
+
+        class ET:
+            value = energy_type
+        c.energy_type = ET()
+        return c
+
+    def _fake_lines(self, energy=1020.0, network=400.0, tax=200.0):
+        """line_type values must use lowercase enum values: 'energy', 'network', 'tax'."""
+        lines = []
+        for lt_val, amt in [("energy", energy), ("network", network), ("tax", tax)]:
+            class L:
+                pass
+            l = L()
+            l.amount_eur = amt
+
+            class LT:
+                value = lt_val
+            l.line_type = LT()
+            lines.append(l)
+        return lines
+
+    def test_shadow_v2_elec_components(self):
+        """TURPE + CSPE + TVA calculés correctement pour elec."""
+        from services.billing_shadow_v2 import shadow_billing_v2, TURPE_EUR_KWH_ELEC, CSPE_EUR_KWH_ELEC
+        inv = self._fake_inv(kwh=9000, total_eur=1620.0)
+        contract = self._fake_contract("elec", 0.18)
+        lines = self._fake_lines(1020.0, 400.0, 200.0)
+        res = shadow_billing_v2(inv, lines, contract)
+        assert res["energy_type"] == "ELEC"
+        assert res["expected_fourniture_ht"] == round(9000 * 0.18, 2)
+        assert res["expected_reseau_ht"] == round(9000 * TURPE_EUR_KWH_ELEC, 2)
+        assert res["expected_taxes_ht"] == round(9000 * CSPE_EUR_KWH_ELEC, 2)
+        assert res["method"] == "shadow_v2_simplified"
+
+    def test_shadow_v2_gaz_components(self):
+        """ATRD + ATRT + TICGN calculés correctement pour gaz."""
+        from services.billing_shadow_v2 import shadow_billing_v2, ATRD_EUR_KWH_GAZ, ATRT_EUR_KWH_GAZ, TICGN_EUR_KWH_GAZ
+        inv = self._fake_inv(kwh=6000, total_eur=540.0)
+        contract = self._fake_contract("gaz", 0.09)
+        lines = self._fake_lines(192.0, 220.0, 128.0)
+        res = shadow_billing_v2(inv, lines, contract)
+        assert res["energy_type"] == "GAZ"
+        assert res["expected_reseau_ht"] == round(6000 * (ATRD_EUR_KWH_GAZ + ATRT_EUR_KWH_GAZ), 2)
+        assert res["expected_taxes_ht"] == round(6000 * TICGN_EUR_KWH_GAZ, 2)
+
+    def test_shadow_v2_delta_reseau_above_threshold(self):
+        """delta_reseau significatif quand NETWORK ligne inflée × 2.3."""
+        from services.billing_shadow_v2 import shadow_billing_v2, TURPE_EUR_KWH_ELEC
+        inv = self._fake_inv(kwh=9000, total_eur=2600.0)
+        contract = self._fake_contract("elec", 0.18)
+        inflated_network = round(9000 * TURPE_EUR_KWH_ELEC * 2.3, 2)
+        lines = self._fake_lines(energy=1020.0, network=inflated_network, tax=200.0)
+        res = shadow_billing_v2(inv, lines, contract)
+        pct = abs(res["delta_reseau"] / res["expected_reseau_ht"] * 100)
+        assert pct > 20  # doit déclencher R13 HIGH
+
+    def test_shadow_v2_delta_taxes_above_threshold(self):
+        """delta_taxes > 5% quand TAX ligne = CSPE × 1.08."""
+        from services.billing_shadow_v2 import shadow_billing_v2, CSPE_EUR_KWH_ELEC
+        inv = self._fake_inv(kwh=9000, total_eur=1639.0)
+        contract = self._fake_contract("elec", 0.18)
+        inflated_tax = round(9000 * CSPE_EUR_KWH_ELEC * 1.08, 2)
+        lines = self._fake_lines(energy=1020.0, network=400.0, tax=inflated_tax)
+        res = shadow_billing_v2(inv, lines, contract)
+        pct = abs(res["delta_taxes"] / res["expected_taxes_ht"] * 100)
+        assert pct > 5  # doit déclencher R14
+
+    def test_shadow_v2_no_anomaly_within_threshold(self):
+        """Pas d'anomalie réseau/taxes dans les seuils normaux."""
+        from services.billing_shadow_v2 import shadow_billing_v2, TURPE_EUR_KWH_ELEC, CSPE_EUR_KWH_ELEC
+        inv = self._fake_inv(kwh=9000, total_eur=1620.0)
+        contract = self._fake_contract("elec", 0.18)
+        # Normal lines (within 2% of expected)
+        lines = self._fake_lines(
+            energy=1020.0,
+            network=round(9000 * TURPE_EUR_KWH_ELEC * 0.99, 2),
+            tax=round(9000 * CSPE_EUR_KWH_ELEC * 0.99, 2),
+        )
+        res = shadow_billing_v2(inv, lines, contract)
+        pct_reseau = abs(res["delta_reseau"] / res["expected_reseau_ht"] * 100)
+        pct_taxes = abs(res["delta_taxes"] / res["expected_taxes_ht"] * 100)
+        assert pct_reseau < 10
+        assert pct_taxes < 5
+
+
+# ========================================
+# TestR13R14
+# ========================================
+
+class TestR13R14:
+
+    def _make_full_invoice(self, db, site_id, contract_id,
+                           energy_amt, network_amt, tax_amt, total_eur, kwh=9000):
+        inv = EnergyInvoice(
+            site_id=site_id, contract_id=contract_id,
+            invoice_number=f"R13R14-{network_amt:.0f}",
+            period_start=date(2024, 4, 1), period_end=date(2024, 4, 30),
+            total_eur=total_eur, energy_kwh=kwh,
+            status=BillingInvoiceStatus.IMPORTED, source="test",
+        )
+        db.add(inv); db.flush()
+        for lt, lbl, amt in [(InvoiceLineType.ENERGY, "Energie", energy_amt),
+                             (InvoiceLineType.NETWORK, "Réseau", network_amt),
+                             (InvoiceLineType.TAX, "Taxes", tax_amt)]:
+            db.add(EnergyInvoiceLine(invoice_id=inv.id, line_type=lt, label=lbl, amount_eur=amt))
+        db.flush()
+        return inv
+
+    def test_r13_high_above_20pct(self, db):
+        """R13 HIGH quand réseau > 20% au-dessus attendu."""
+        from services.billing_service import _rule_reseau_mismatch
+        from services.billing_shadow_v2 import TURPE_EUR_KWH_ELEC
+        org, site = _make_org_site(db, "OrgR13H", "600003001")
+        contract = _make_contract(db, site.id)
+        inflated_network = round(9000 * TURPE_EUR_KWH_ELEC * 2.3, 2)
+        total = round(1020 + inflated_network + 200, 2)
+        inv = self._make_full_invoice(db, site.id, contract.id,
+                                      energy_amt=1020, network_amt=inflated_network,
+                                      tax_amt=200, total_eur=total)
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = _rule_reseau_mismatch(inv, contract, lines)
+        assert result is not None
+        assert result["type"] == "reseau_mismatch"
+        assert result["severity"] == "high"
+
+    def test_r13_medium_10_to_20pct(self, db):
+        """R13 MEDIUM quand réseau entre 10% et 20% au-dessus attendu."""
+        from services.billing_service import _rule_reseau_mismatch
+        from services.billing_shadow_v2 import TURPE_EUR_KWH_ELEC
+        org, site = _make_org_site(db, "OrgR13M", "600003002")
+        contract = _make_contract(db, site.id)
+        # 15% above expected
+        network = round(9000 * TURPE_EUR_KWH_ELEC * 1.15, 2)
+        total = round(1020 + network + 200, 2)
+        inv = self._make_full_invoice(db, site.id, contract.id,
+                                      energy_amt=1020, network_amt=network,
+                                      tax_amt=200, total_eur=total)
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = _rule_reseau_mismatch(inv, contract, lines)
+        assert result is not None
+        assert result["severity"] == "medium"
+
+    def test_r13_no_anomaly_below_10pct(self, db):
+        """R13 = None quand réseau dans seuil (< 10%)."""
+        from services.billing_service import _rule_reseau_mismatch
+        from services.billing_shadow_v2 import TURPE_EUR_KWH_ELEC
+        org, site = _make_org_site(db, "OrgR13N", "600003003")
+        contract = _make_contract(db, site.id)
+        # 2% above expected (normal)
+        network = round(9000 * TURPE_EUR_KWH_ELEC * 1.02, 2)
+        total = round(1020 + network + 200, 2)
+        inv = self._make_full_invoice(db, site.id, contract.id,
+                                      energy_amt=1020, network_amt=network,
+                                      tax_amt=200, total_eur=total)
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = _rule_reseau_mismatch(inv, contract, lines)
+        assert result is None
+
+    def test_r14_medium_above_5pct(self, db):
+        """R14 MEDIUM quand taxes > 5% au-dessus attendu."""
+        from services.billing_service import _rule_taxes_mismatch
+        from services.billing_shadow_v2 import CSPE_EUR_KWH_ELEC
+        org, site = _make_org_site(db, "OrgR14M", "600003004")
+        contract = _make_contract(db, site.id)
+        # 8% above expected CSPE
+        tax = round(9000 * CSPE_EUR_KWH_ELEC * 1.08, 2)
+        total = round(1020 + 400 + tax, 2)
+        inv = self._make_full_invoice(db, site.id, contract.id,
+                                      energy_amt=1020, network_amt=400,
+                                      tax_amt=tax, total_eur=total)
+        lines = db.query(EnergyInvoiceLine).filter(EnergyInvoiceLine.invoice_id == inv.id).all()
+        result = _rule_taxes_mismatch(inv, contract, lines)
+        assert result is not None
+        assert result["type"] == "taxes_mismatch"
+        assert result["severity"] == "medium"
+
+
+# ========================================
+# TestSeedAndCoverage
+# ========================================
+
+class TestSeedAndCoverage:
+
+    def test_seed_creates_expected_invoices(self, db):
+        """Seed 36 mois crée ~67 factures (36 elec - 3 gaps + 36 gaz - 1 gap = 68)."""
+        from services.billing_seed import seed_billing_demo
+        # Need 2+ sites
+        _, site_a = _make_org_site(db, "SeedOrg", "600004001")
+        _, site_b = _make_org_site(db, "SeedOrg2", "600004002")
+        result = seed_billing_demo(db)
+        assert "error" not in result
+        assert result.get("invoices_created", 0) > 0
+        assert result.get("contracts_created") == 2
+
+    def test_seed_is_idempotent(self, db):
+        """Appeler seed_billing_demo deux fois → skip au second appel."""
+        from services.billing_seed import seed_billing_demo
+        _make_org_site(db, "SeedIdmp1", "600004010")
+        _make_org_site(db, "SeedIdmp2", "600004011")
+        r1 = seed_billing_demo(db)
+        r2 = seed_billing_demo(db)
+        assert "error" not in r1
+        assert r2.get("skipped") is True
+
+    def test_seed_has_controlled_gaps(self, db):
+        """2023-03 et 2024-09 manquants pour site_a."""
+        from services.billing_seed import seed_billing_demo, SOURCE_TAG
+        _make_org_site(db, "SeedGap1", "600004020")
+        _make_org_site(db, "SeedGap2", "600004021")
+        seed_billing_demo(db)
+        gap_mar = db.query(EnergyInvoice).filter(
+            EnergyInvoice.source == SOURCE_TAG,
+            EnergyInvoice.invoice_number == "EDF-2023-03",
+        ).count()
+        gap_sep = db.query(EnergyInvoice).filter(
+            EnergyInvoice.source == SOURCE_TAG,
+            EnergyInvoice.invoice_number == "EDF-2024-09",
+        ).count()
+        assert gap_mar == 0
+        assert gap_sep == 0
+
+    def test_seed_has_partial_months(self, db):
+        """2023-06 → facture partielle (period_end = 15)."""
+        from services.billing_seed import seed_billing_demo, SOURCE_TAG
+        _make_org_site(db, "SeedPart1", "600004030")
+        _make_org_site(db, "SeedPart2", "600004031")
+        seed_billing_demo(db)
+        inv = db.query(EnergyInvoice).filter(
+            EnergyInvoice.source == SOURCE_TAG,
+            EnergyInvoice.invoice_number == "EDF-2023-06",
+        ).first()
+        assert inv is not None
+        assert inv.period_end.day == 15
+
+    def test_empty_org_returns_200_not_error(self, client, db):
+        """Org sans factures → /invoices/normalized retourne 200 + empty, pas d'erreur."""
+        org, _ = _make_org_site(db, "OrgEmpty", "600005001")
+        r = client.get("/api/billing/invoices/normalized", headers=_h(org.id))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["invoices"] == []
+        assert data["total"] == 0

--- a/backend/tests/test_billing_v69.py
+++ b/backend/tests/test_billing_v69.py
@@ -1,0 +1,72 @@
+"""
+PROMEOS — V69 Meta Version Tests
+Couvre: GET /api/meta/version — sha + branch.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from models import Base
+from database import get_db
+from main import app
+
+
+# ========================================
+# Fixtures
+# ========================================
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def client(db):
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+# ========================================
+# Tests GET /api/meta/version
+# ========================================
+
+def test_meta_version_returns_sha(client):
+    """GET /api/meta/version retourne sha + branch + build_time."""
+    r = client.get("/api/meta/version")
+    assert r.status_code == 200
+    data = r.json()
+    assert "sha" in data
+    assert "branch" in data
+    assert "build_time" in data
+    assert "version" in data
+    assert data["version"] == "1.0.0"
+
+
+def test_meta_version_sha_nonempty(client):
+    """sha et branch doivent être non-vides (git disponible en dev)."""
+    r = client.get("/api/meta/version")
+    data = r.json()
+    # Si git est absent, sha = 'unknown' — on accepte les deux cas
+    assert isinstance(data["sha"], str)
+    assert len(data["sha"]) > 0

--- a/backend/tests/test_billing_v69.py
+++ b/backend/tests/test_billing_v69.py
@@ -1,6 +1,7 @@
 """
-PROMEOS — V69 Meta Version Tests
+PROMEOS — V69 Meta Version + Coverage Summary Tests
 Couvre: GET /api/meta/version — sha + branch.
+        GET /api/billing/coverage-summary — smoke (empty DB → 200 + keys).
 """
 import sys
 import os
@@ -12,7 +13,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from fastapi.testclient import TestClient
 
-from models import Base
+from models import Base, Organisation
 from database import get_db
 from main import app
 
@@ -70,3 +71,21 @@ def test_meta_version_sha_nonempty(client):
     # Si git est absent, sha = 'unknown' — on accepte les deux cas
     assert isinstance(data["sha"], str)
     assert len(data["sha"]) > 0
+
+
+# ========================================
+# Tests GET /api/billing/coverage-summary
+# ========================================
+
+def test_coverage_summary_empty_db(client, db):
+    """GET /api/billing/coverage-summary retourne 200 même sans factures."""
+    org = Organisation(nom="OrgCov", type_client="bureau", actif=True, siren="600099001")
+    db.add(org)
+    db.commit()
+    r = client.get("/api/billing/coverage-summary", headers={"X-Org-Id": str(org.id)})
+    assert r.status_code == 200
+    data = r.json()
+    assert "months_total" in data
+    assert "covered" in data
+    assert "missing" in data
+    assert data["months_total"] == 0

--- a/backend/tests/test_billing_v69.py
+++ b/backend/tests/test_billing_v69.py
@@ -89,3 +89,50 @@ def test_coverage_summary_empty_db(client, db):
     assert "covered" in data
     assert "missing" in data
     assert data["months_total"] == 0
+
+
+# ========================================
+# Tests GET /api/billing/periods
+# ========================================
+
+def test_periods_empty_db(client, db):
+    """GET /api/billing/periods retourne 200 + liste vide sans factures."""
+    org = Organisation(nom="OrgPeriods", type_client="bureau", actif=True, siren="600099002")
+    db.add(org)
+    db.commit()
+    r = client.get("/api/billing/periods", headers={"X-Org-Id": str(org.id)})
+    assert r.status_code == 200
+    data = r.json()
+    assert "periods" in data
+    assert "total" in data
+    assert data["total"] == 0
+    assert data["periods"] == []
+
+
+def test_missing_periods_empty_db(client, db):
+    """GET /api/billing/missing-periods retourne 200 + items vide sans factures."""
+    org = Organisation(nom="OrgMissing", type_client="bureau", actif=True, siren="600099003")
+    db.add(org)
+    db.commit()
+    r = client.get("/api/billing/missing-periods", headers={"X-Org-Id": str(org.id)})
+    assert r.status_code == 200
+    data = r.json()
+    assert "items" in data
+    assert "total" in data
+    assert data["total"] == 0
+
+
+# ========================================
+# Tests route registration (V67 critical)
+# ========================================
+
+def test_v67_billing_routes_registered():
+    """Critical V67 routes must be present in app.routes."""
+    registered = {r.path for r in app.routes}
+    required = [
+        "/api/billing/periods",
+        "/api/billing/coverage-summary",
+        "/api/billing/missing-periods",
+    ]
+    for route in required:
+        assert route in registered, f"Route {route} not registered — restart uvicorn"

--- a/backend/tests/test_conso_smoke.py
+++ b/backend/tests/test_conso_smoke.py
@@ -1,0 +1,208 @@
+"""
+PROMEOS - Consumption / Performance / Diagnostic — Smoke Tests
+Verify core conso endpoints respond 200, granularity works,
+empty states don't crash, and at least 1 diagnostic returns a result.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# =============================================
+# 1. Consumption endpoints return 200
+# =============================================
+class TestConsoEndpoints200:
+    """All consumption/EMS/monitoring endpoints must respond, even with no data."""
+
+    def test_consumption_availability(self, client):
+        r = client.get("/api/consumption/availability?site_id=1&energy_type=electricity")
+        assert r.status_code == 200
+        data = r.json()
+        assert "has_data" in data
+
+    def test_consumption_tunnel_v2(self, client):
+        r = client.get("/api/consumption/tunnel_v2?site_id=1&days=90&energy_type=electricity")
+        assert r.status_code == 200
+
+    def test_consumption_targets(self, client):
+        r = client.get("/api/consumption/targets?site_id=1&energy_type=electricity")
+        assert r.status_code == 200
+        assert isinstance(r.json(), list)
+
+    def test_consumption_targets_progress_v2(self, client):
+        r = client.get("/api/consumption/targets/progress_v2?site_id=1&energy_type=electricity")
+        assert r.status_code == 200
+
+    def test_consumption_hphc_breakdown_v2(self, client):
+        r = client.get("/api/consumption/hphc_breakdown_v2?site_id=1&days=30")
+        assert r.status_code == 200
+
+    def test_consumption_gas_summary(self, client):
+        r = client.get("/api/consumption/gas/summary?site_id=1&days=90")
+        assert r.status_code == 200
+
+    def test_consumption_gas_weather_normalized(self, client):
+        r = client.get("/api/consumption/gas/weather_normalized?site_id=1&days=90")
+        assert r.status_code == 200
+
+    def test_consumption_insights(self, client):
+        r = client.get("/api/consumption/insights")
+        assert r.status_code == 200
+
+    def test_consumption_tou_schedules(self, client):
+        r = client.get("/api/consumption/tou_schedules?site_id=1")
+        assert r.status_code == 200
+
+
+# =============================================
+# 2. EMS / Timeseries endpoints
+# =============================================
+class TestEmsEndpoints:
+    """EMS Explorer endpoints must respond without errors."""
+
+    def test_ems_health(self, client):
+        r = client.get("/api/ems/health")
+        assert r.status_code == 200
+        assert r.json()["status"] == "ok"
+
+    def test_ems_timeseries_suggest(self, client):
+        r = client.get("/api/ems/timeseries/suggest?date_from=2025-01-01T00:00:00Z&date_to=2025-03-01T00:00:00Z")
+        assert r.status_code == 200
+        data = r.json()
+        assert "granularity" in data
+
+    def test_ems_usage_suggest(self, client):
+        r = client.get("/api/ems/usage_suggest?site_id=1")
+        assert r.status_code == 200
+        data = r.json()
+        assert "archetype_code" in data
+
+    def test_ems_schedule_suggest(self, client):
+        r = client.get("/api/ems/schedule_suggest?site_id=1&days=90")
+        assert r.status_code == 200
+
+    def test_ems_benchmark(self, client):
+        r = client.get("/api/ems/benchmark?site_id=1")
+        assert r.status_code == 200
+
+    def test_ems_collections(self, client):
+        r = client.get("/api/ems/collections")
+        assert r.status_code == 200
+        assert isinstance(r.json(), list)
+
+    def test_ems_views(self, client):
+        r = client.get("/api/ems/views")
+        assert r.status_code == 200
+        assert isinstance(r.json(), list)
+
+
+# =============================================
+# 3. Monitoring / Performance endpoints
+# =============================================
+class TestMonitoringEndpoints:
+    """Monitoring endpoints for Performance page."""
+
+    def test_monitoring_alerts(self, client):
+        r = client.get("/api/monitoring/alerts")
+        assert r.status_code == 200
+        assert isinstance(r.json(), list)
+
+    def test_monitoring_snapshots(self, client):
+        r = client.get("/api/monitoring/snapshots?site_id=1")
+        assert r.status_code == 200
+
+    def test_monitoring_emissions(self, client):
+        r = client.get("/api/monitoring/emissions?site_id=1")
+        # 200 if snapshot exists, 404 if no snapshot for this site
+        assert r.status_code in (200, 404)
+
+    def test_monitoring_emission_factors(self, client):
+        r = client.get("/api/monitoring/emission-factors")
+        assert r.status_code == 200
+
+
+# =============================================
+# 4. Granularity validation
+# =============================================
+class TestGranularity:
+    """Verify multi-granularity support in timeseries API."""
+
+    @pytest.mark.parametrize("gran", ["hourly", "daily", "monthly"])
+    def test_timeseries_granularity(self, client, gran):
+        r = client.get(
+            f"/api/ems/timeseries?site_ids=1&date_from=2025-01-01T00:00:00Z"
+            f"&date_to=2025-04-01T00:00:00Z&granularity={gran}"
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert "series" in data or "meta" in data or isinstance(data, dict)
+
+    def test_timeseries_auto_granularity(self, client):
+        """Auto granularity should default to a valid value."""
+        r = client.get(
+            "/api/ems/timeseries?site_ids=1"
+            "&date_from=2025-01-01T00:00:00Z&date_to=2025-02-01T00:00:00Z"
+            "&granularity=auto"
+        )
+        assert r.status_code == 200
+
+
+# =============================================
+# 5. Empty state resilience
+# =============================================
+class TestEmptyStateResilience:
+    """Endpoints must not crash on empty or edge-case inputs."""
+
+    def test_availability_unknown_site(self, client):
+        """Non-existent site should return has_data=false, not 500."""
+        r = client.get("/api/consumption/availability?site_id=999999&energy_type=electricity")
+        assert r.status_code == 200
+        assert r.json()["has_data"] is False
+
+    def test_tunnel_no_data(self, client):
+        """Tunnel for site with no hourly data should not 500."""
+        r = client.get("/api/consumption/tunnel_v2?site_id=999999&days=30")
+        assert r.status_code in (200, 404)
+
+    def test_insights_empty_org(self, client):
+        """Insights with no org context should still respond."""
+        r = client.get("/api/consumption/insights")
+        assert r.status_code == 200
+
+    def test_gas_summary_no_gas_data(self, client):
+        """Gas summary for electricity-only site should not crash."""
+        r = client.get("/api/consumption/gas/summary?site_id=1&days=90")
+        assert r.status_code == 200
+
+
+# =============================================
+# 6. Diagnostic produces results (if data exists)
+# =============================================
+class TestDiagnosticRun:
+    """Verify diagnostic engine can run and return structured results."""
+
+    def test_diagnose_returns_structured(self, client):
+        """POST /consumption/diagnose should return status + analysis info."""
+        r = client.post("/api/consumption/diagnose?days=30")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "ok"
+        assert "sites_analyzed" in data or "results" in data or "total" in data
+
+    def test_consumption_site_detail(self, client):
+        """GET /consumption/site/{id} should return site-level insights."""
+        r = client.get("/api/consumption/site/1")
+        assert r.status_code == 200
+        data = r.json()
+        assert "site_id" in data
+        assert "insights" in data
+        assert isinstance(data["insights"], list)

--- a/backend/tests/test_ems_p1.py
+++ b/backend/tests/test_ems_p1.py
@@ -1,0 +1,206 @@
+"""
+PROMEOS — P1 Backend Tests
+Tests for reference_profile and weather_hourly endpoints.
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from main import app
+from models import Base, Site, TypeSite, Meter, MeterReading
+from models.energy_models import EnergyVector, FrequencyType
+from database import get_db
+
+
+@pytest.fixture
+def env():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    def _override():
+        try:
+            yield session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    client = TestClient(app)
+
+    # Seed a site + meter + 30 days of readings
+    site = Site(nom="P1 Test Site", type=TypeSite.BUREAU, latitude=48.86, longitude=2.35)
+    session.add(site)
+    session.flush()
+
+    m = Meter(meter_id="PRM-P1-01", name="P1 Meter", site_id=site.id, energy_vector=EnergyVector.ELECTRICITY)
+    session.add(m)
+    session.flush()
+
+    for d in range(30):
+        dt = datetime(2025, 3, 1) + timedelta(days=d)
+        for h in range(24):
+            session.add(MeterReading(
+                meter_id=m.id,
+                timestamp=dt.replace(hour=h),
+                frequency=FrequencyType.HOURLY,
+                value_kwh=10 + h * 0.5,
+            ))
+    session.flush()
+
+    yield client, session, site
+    app.dependency_overrides.clear()
+    session.close()
+
+
+class TestReferenceProfile:
+    """P1-1: /api/ems/reference_profile endpoint."""
+
+    def test_returns_200(self, env):
+        client, _, site = env
+        r = client.get("/api/ems/reference_profile", params={
+            "site_id": site.id,
+            "date_from": "2025-03-01",
+            "date_to": "2025-03-10",
+            "famille": "entreprise",
+            "puissance": "9-12",
+        })
+        assert r.status_code == 200
+
+    def test_returns_series(self, env):
+        client, _, site = env
+        r = client.get("/api/ems/reference_profile", params={
+            "site_id": site.id,
+            "date_from": "2025-03-01",
+            "date_to": "2025-03-05",
+            "famille": "habitat",
+            "puissance": "6-9",
+            "granularity": "daily",
+        })
+        data = r.json()
+        assert "series" in data
+        assert len(data["series"]) == 5  # 5 days
+        assert data["famille"] == "habitat"
+        assert data["puissance"] == "6-9"
+
+    def test_returns_kpi_delta(self, env):
+        client, _, site = env
+        r = client.get("/api/ems/reference_profile", params={
+            "site_id": site.id,
+            "date_from": "2025-03-01",
+            "date_to": "2025-03-15",
+            "famille": "entreprise",
+            "puissance": "9-12",
+            "granularity": "daily",
+        })
+        data = r.json()
+        kpi = data.get("kpi")
+        assert kpi is not None
+        assert "actual_kwh" in kpi
+        assert "reference_kwh" in kpi
+        assert "delta_pct" in kpi
+        assert "coverage_pct" in kpi
+        assert "confidence" in kpi
+
+    def test_hourly_granularity(self, env):
+        client, _, site = env
+        r = client.get("/api/ems/reference_profile", params={
+            "site_id": site.id,
+            "date_from": "2025-03-01",
+            "date_to": "2025-03-02",
+            "famille": "entreprise",
+            "puissance": "9-12",
+            "granularity": "hourly",
+        })
+        data = r.json()
+        # 2 days * 24h = 48 hourly points
+        assert len(data["series"]) == 48
+
+    def test_weekend_factor_applied(self, env):
+        client, _, site = env
+        # 2025-03-01 is Saturday, 2025-03-03 is Monday
+        r = client.get("/api/ems/reference_profile", params={
+            "site_id": site.id,
+            "date_from": "2025-03-01",
+            "date_to": "2025-03-03",
+            "famille": "entreprise",
+            "puissance": "9-12",
+            "granularity": "daily",
+        })
+        data = r.json()
+        # Weekend (Saturday) daily total should be less than weekday (Monday)
+        # for entreprise (factor=0.4)
+        series = data["series"]
+        sat = next(p for p in series if p["t"].startswith("2025-03-01"))
+        mon = next(p for p in series if p["t"].startswith("2025-03-03"))
+        assert sat["v"] < mon["v"]
+
+
+class TestWeatherHourly:
+    """P1-3: /api/ems/weather_hourly endpoint."""
+
+    def test_returns_200(self, env):
+        client, _, site = env
+        r = client.get("/api/ems/weather_hourly", params={
+            "site_id": site.id,
+            "date_from": "2025-03-01",
+            "date_to": "2025-03-05",
+        })
+        assert r.status_code == 200
+
+    def test_returns_utc_timezone(self, env):
+        client, _, site = env
+        r = client.get("/api/ems/weather_hourly", params={
+            "site_id": site.id,
+            "date_from": "2025-03-01",
+            "date_to": "2025-03-03",
+        })
+        data = r.json()
+        assert data["timezone"] == "UTC"
+
+    def test_timestamps_end_with_z(self, env):
+        client, _, site = env
+        r = client.get("/api/ems/weather_hourly", params={
+            "site_id": site.id,
+            "date_from": "2025-03-01",
+            "date_to": "2025-03-02",
+        })
+        data = r.json()
+        hours = data.get("hours", [])
+        assert len(hours) > 0
+        for h in hours:
+            assert h["t"].endswith("Z"), f"Timestamp {h['t']} should end with Z"
+
+    def test_24_hours_per_day(self, env):
+        client, _, site = env
+        r = client.get("/api/ems/weather_hourly", params={
+            "site_id": site.id,
+            "date_from": "2025-06-15",
+            "date_to": "2025-06-15",
+        })
+        data = r.json()
+        hours = data.get("hours", [])
+        assert len(hours) == 24
+
+    def test_sinusoidal_intraday_pattern(self, env):
+        """Min near 5h UTC, max near 15h UTC (sinusoidal)."""
+        client, _, site = env
+        r = client.get("/api/ems/weather_hourly", params={
+            "site_id": site.id,
+            "date_from": "2025-07-15",
+            "date_to": "2025-07-15",
+        })
+        data = r.json()
+        hours = data.get("hours", [])
+        if len(hours) == 24:
+            # Temperature at 15h should be warmer than at 5h
+            t5 = hours[5]["temp_c"]
+            t15 = hours[15]["temp_c"]
+            assert t15 > t5

--- a/backend/tests/test_portfolio.py
+++ b/backend/tests/test_portfolio.py
@@ -103,6 +103,7 @@ class TestPortfolioSummary:
         assert "top_drift" in data
         assert "top_base_night" in data
         assert "top_peaks" in data
+        assert "top_impact" in data
 
     def test_totals_kwh_positive(self, env):
         client, _, _ = env
@@ -184,7 +185,8 @@ class TestPortfolioSites:
         data = r.json()
         row = data["rows"][0]
         for key in ["site_id", "site_name", "kwh", "eur", "co2", "confidence",
-                     "peak_kw", "base_night_pct", "diagnostics_count"]:
+                     "peak_kw", "base_night_pct", "diagnostics_count",
+                     "impact_eur_estimated", "open_actions_count"]:
             assert key in row, f"Missing key: {key}"
 
     def test_sort_kwh_desc(self, env):
@@ -244,3 +246,68 @@ class TestPortfolioSites:
         })
         data2 = r2.json()
         assert len(data2["rows"]) == 1
+
+
+class TestPortfolioV11:
+    """V1.1: impact_eur_estimated, open_actions_count, with_actions filter, impact sort."""
+
+    def test_impact_eur_in_summary_totals(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        assert "impact_eur_total" in data["totals"]
+        # Site Alpha has insight with estimated_loss_eur=90
+        assert data["totals"]["impact_eur_total"] >= 90
+
+    def test_top_impact_list(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        assert len(data["top_impact"]) >= 1
+        assert data["top_impact"][0]["impact_eur_estimated"] >= 90
+
+    def test_impact_eur_in_site_row(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "search": "Alpha",
+        })
+        data = r.json()
+        row = data["rows"][0]
+        assert row["impact_eur_estimated"] >= 90
+
+    def test_sort_impact_desc(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "sort": "impact_desc",
+        })
+        data = r.json()
+        impacts = [r["impact_eur_estimated"] for r in data["rows"]]
+        assert impacts == sorted(impacts, reverse=True)
+
+    def test_filter_with_actions_without(self, env):
+        """No actions seeded → with_actions='without' should return all sites."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "with_actions": "without",
+        })
+        data = r.json()
+        assert data["total"] == 3  # All sites have 0 open actions
+        for row in data["rows"]:
+            assert row["open_actions_count"] == 0
+
+    def test_filter_with_actions_with(self, env):
+        """No actions seeded → with_actions='with' should return 0 sites."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "with_actions": "with",
+        })
+        data = r.json()
+        assert data["total"] == 0

--- a/backend/tests/test_portfolio.py
+++ b/backend/tests/test_portfolio.py
@@ -354,3 +354,37 @@ class TestPortfolioV13:
         data = r.json()
         assert data["totals"]["kwh_total"] == 0
         assert data["coverage"]["sites_with_data"] == 0
+
+
+class TestPortfolioScopeHeader:
+    """X-Site-Id header must NOT filter portfolio results (defense-in-depth)."""
+
+    def test_summary_ignores_x_site_id(self, env):
+        """Sending X-Site-Id should not change summary results."""
+        client, _, sites = env
+        params = {"from": "2025-03-01", "to": "2025-03-31"}
+        r_no_header = client.get("/api/portfolio/consumption/summary", params=params)
+        r_with_header = client.get(
+            "/api/portfolio/consumption/summary",
+            params=params,
+            headers={"X-Site-Id": str(sites[0].id)},
+        )
+        assert r_no_header.status_code == 200
+        assert r_with_header.status_code == 200
+        assert r_no_header.json()["coverage"]["sites_total"] == r_with_header.json()["coverage"]["sites_total"]
+        assert r_no_header.json()["totals"]["kwh_total"] == r_with_header.json()["totals"]["kwh_total"]
+
+    def test_sites_ignores_x_site_id(self, env):
+        """Sending X-Site-Id should not filter the sites list."""
+        client, _, sites = env
+        params = {"from": "2025-03-01", "to": "2025-03-31"}
+        r_no_header = client.get("/api/portfolio/consumption/sites", params=params)
+        r_with_header = client.get(
+            "/api/portfolio/consumption/sites",
+            params=params,
+            headers={"X-Site-Id": str(sites[0].id)},
+        )
+        assert r_no_header.status_code == 200
+        assert r_with_header.status_code == 200
+        assert r_no_header.json()["total"] == r_with_header.json()["total"]
+        assert r_no_header.json()["total"] == 3  # All 3 sites returned regardless

--- a/backend/tests/test_portfolio.py
+++ b/backend/tests/test_portfolio.py
@@ -311,3 +311,46 @@ class TestPortfolioV11:
         })
         data = r.json()
         assert data["total"] == 0
+
+
+class TestPortfolioV13:
+    """V1.3: stable ordering, non-null fields, query param robustness."""
+
+    def test_sites_ordering_stable_across_calls(self, env):
+        """Same params → same row order (deterministic)."""
+        client, _, _ = env
+        params = {"from": "2025-03-01", "to": "2025-03-31", "sort": "kwh_desc"}
+        r1 = client.get("/api/portfolio/consumption/sites", params=params).json()
+        r2 = client.get("/api/portfolio/consumption/sites", params=params).json()
+        ids1 = [r["site_id"] for r in r1["rows"]]
+        ids2 = [r["site_id"] for r in r2["rows"]]
+        assert ids1 == ids2
+
+    def test_site_row_fields_non_null(self, env):
+        """All required fields are present and non-null (may be 0 or empty string)."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        for row in data["rows"]:
+            assert row["site_id"] is not None
+            assert row["site_name"] is not None
+            assert row["kwh"] is not None
+            assert row["eur"] is not None
+            assert row["co2"] is not None
+            assert row["confidence"] in ("high", "medium", "low")
+            assert row["diagnostics_count"] is not None
+            assert row["impact_eur_estimated"] is not None
+            assert row["open_actions_count"] is not None
+
+    def test_summary_with_empty_date_range(self, env):
+        """Date range before any data → totals should be 0, no crash."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2020-01-01", "to": "2020-01-31",
+        })
+        assert r.status_code == 200
+        data = r.json()
+        assert data["totals"]["kwh_total"] == 0
+        assert data["coverage"]["sites_with_data"] == 0

--- a/backend/tests/test_portfolio.py
+++ b/backend/tests/test_portfolio.py
@@ -1,0 +1,246 @@
+"""
+PROMEOS — Portfolio Consumption V1 Tests
+Tests for /api/portfolio/consumption/summary and /sites endpoints.
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from main import app
+from models import Base, Site, TypeSite, Meter, MeterReading
+from models.energy_models import EnergyVector, FrequencyType
+from models.consumption_insight import ConsumptionInsight
+from database import get_db
+
+
+@pytest.fixture
+def env():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    def _override():
+        try:
+            yield session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    client = TestClient(app)
+
+    # Seed 3 sites with varying data
+    sites = []
+    for i, name in enumerate(["Site Alpha", "Site Beta", "Site Gamma"]):
+        s = Site(nom=name, type=TypeSite.BUREAU, actif=True)
+        session.add(s)
+        session.flush()
+        sites.append(s)
+
+        m = Meter(meter_id=f"PRM-PF-{i}", name=f"Meter {i}", site_id=s.id,
+                  energy_vector=EnergyVector.ELECTRICITY)
+        session.add(m)
+        session.flush()
+
+        # Site Alpha: 30 days full data, Site Beta: 10 days, Site Gamma: 0 days
+        days_of_data = [30, 10, 0][i]
+        for d in range(days_of_data):
+            dt = datetime(2025, 3, 1) + timedelta(days=d)
+            for h in range(24):
+                session.add(MeterReading(
+                    meter_id=m.id,
+                    timestamp=dt.replace(hour=h),
+                    frequency=FrequencyType.HOURLY,
+                    value_kwh=10 + h * 0.5 + i * 5,
+                ))
+        session.flush()
+
+    # Add a consumption insight for Site Alpha
+    insight = ConsumptionInsight(
+        site_id=sites[0].id,
+        type="derive",
+        severity="high",
+        period_start=datetime(2025, 3, 1),
+        period_end=datetime(2025, 3, 15),
+        estimated_loss_kwh=500,
+        estimated_loss_eur=90,
+        message="Test drift insight",
+    )
+    session.add(insight)
+    session.flush()
+
+    yield client, session, sites
+    app.dependency_overrides.clear()
+    session.close()
+
+
+class TestPortfolioSummary:
+    """GET /api/portfolio/consumption/summary"""
+
+    def test_returns_200(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        assert r.status_code == 200
+
+    def test_schema_keys(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        assert "period" in data
+        assert "totals" in data
+        assert "coverage" in data
+        assert "top_drift" in data
+        assert "top_base_night" in data
+        assert "top_peaks" in data
+
+    def test_totals_kwh_positive(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        assert data["totals"]["kwh_total"] > 0
+        assert data["totals"]["eur_total"] > 0
+        assert data["totals"]["co2_total"] > 0
+
+    def test_coverage_counts(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        cov = data["coverage"]
+        assert cov["sites_total"] == 3
+        assert cov["sites_with_data"] == 2  # Alpha + Beta have data, Gamma has 0
+
+    def test_top_drift_non_empty(self, env):
+        """Site Alpha has 1 insight → should appear in top_drift."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        assert len(data["top_drift"]) >= 1
+        assert data["top_drift"][0]["diagnostics_count"] >= 1
+
+    def test_filter_by_site_ids(self, env):
+        client, _, sites = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "site_ids": str(sites[0].id),
+        })
+        data = r.json()
+        assert data["coverage"]["sites_total"] == 1
+
+    def test_period_dates(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-15",
+        })
+        data = r.json()
+        assert data["period"]["from"] == "2025-03-01"
+        assert data["period"]["to"] == "2025-03-15"
+        assert data["period"]["days"] == 14
+
+
+class TestPortfolioSites:
+    """GET /api/portfolio/consumption/sites"""
+
+    def test_returns_200(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        assert r.status_code == 200
+
+    def test_pagination_schema(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        assert "total" in data
+        assert "offset" in data
+        assert "limit" in data
+        assert "rows" in data
+        assert data["total"] == 3
+
+    def test_row_fields(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        row = data["rows"][0]
+        for key in ["site_id", "site_name", "kwh", "eur", "co2", "confidence",
+                     "peak_kw", "base_night_pct", "diagnostics_count"]:
+            assert key in row, f"Missing key: {key}"
+
+    def test_sort_kwh_desc(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "sort": "kwh_desc",
+        })
+        data = r.json()
+        rows = data["rows"]
+        kwhs = [r["kwh"] for r in rows]
+        assert kwhs == sorted(kwhs, reverse=True)
+
+    def test_filter_confidence(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "confidence": "low",
+        })
+        data = r.json()
+        for row in data["rows"]:
+            assert row["confidence"] == "low"
+
+    def test_filter_with_anomalies(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "with_anomalies": True,
+        })
+        data = r.json()
+        for row in data["rows"]:
+            assert row["diagnostics_count"] > 0
+
+    def test_search_by_name(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "search": "Alpha",
+        })
+        data = r.json()
+        assert data["total"] == 1
+        assert data["rows"][0]["site_name"] == "Site Alpha"
+
+    def test_pagination_limit_offset(self, env):
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "limit": 2, "offset": 0,
+        })
+        data = r.json()
+        assert len(data["rows"]) == 2
+        assert data["total"] == 3
+
+        r2 = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "limit": 2, "offset": 2,
+        })
+        data2 = r2.json()
+        assert len(data2["rows"]) == 1

--- a/backend/tests/test_portfolio.py
+++ b/backend/tests/test_portfolio.py
@@ -388,3 +388,75 @@ class TestPortfolioScopeHeader:
         assert r_with_header.status_code == 200
         assert r_no_header.json()["total"] == r_with_header.json()["total"]
         assert r_no_header.json()["total"] == 3  # All 3 sites returned regardless
+
+
+class TestPortfolioV2Patrimoine:
+    """V2: patrimoine-first — data_status, coverage_pct, without_data filter."""
+
+    def test_site_rows_include_data_status(self, env):
+        """Every site row must have data_status field (ok/partial/none)."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        for row in data["rows"]:
+            assert row["data_status"] in ("ok", "partial", "none"), f"Bad data_status: {row['data_status']}"
+
+    def test_site_rows_include_coverage_pct(self, env):
+        """Every site row must have coverage_pct (0-100)."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        for row in data["rows"]:
+            assert "coverage_pct" in row
+            assert 0 <= row["coverage_pct"] <= 100
+
+    def test_sites_without_data_visible(self, env):
+        """Site Gamma has 0 readings → should appear with data_status='none'."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        gamma = [row for row in data["rows"] if row["site_name"] == "Site Gamma"]
+        assert len(gamma) == 1
+        assert gamma[0]["data_status"] == "none"
+        assert gamma[0]["kwh"] == 0
+        assert gamma[0]["coverage_pct"] == 0
+
+    def test_without_data_filter(self, env):
+        """without_data=true → only sites with no readings."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "without_data": True,
+        })
+        data = r.json()
+        assert data["total"] == 1  # Only Site Gamma
+        assert data["rows"][0]["data_status"] == "none"
+
+    def test_coverage_sort(self, env):
+        """sort=coverage → highest coverage first."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/sites", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+            "sort": "coverage",
+        })
+        data = r.json()
+        pcts = [row["coverage_pct"] for row in data["rows"]]
+        assert pcts == sorted(pcts, reverse=True)
+
+    def test_summary_includes_sites_without_data(self, env):
+        """Summary coverage must include sites_without_data count."""
+        client, _, _ = env
+        r = client.get("/api/portfolio/consumption/summary", params={
+            "from": "2025-03-01", "to": "2025-03-31",
+        })
+        data = r.json()
+        cov = data["coverage"]
+        assert "sites_without_data" in cov
+        assert cov["sites_without_data"] == cov["sites_total"] - cov["sites_with_data"]
+        assert cov["sites_without_data"] >= 1  # At least Site Gamma

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -154,6 +154,54 @@ class TestAPICrudChain:
         assert r.status_code == 200
 
 
+class TestBillingRouterMount:
+    """Verify billing router is registered and insight detail uses GET."""
+
+    def test_billing_router_mounted(self, client):
+        """OpenAPI schema must contain /api/billing/ paths."""
+        schema = client.get("/openapi.json").json()
+        billing_paths = [p for p in schema["paths"] if "/api/billing/" in p]
+        assert len(billing_paths) >= 1, "billing router not mounted — check imports"
+
+    def test_insight_detail_is_get(self, client):
+        """The insight detail route must accept GET, not POST."""
+        schema = client.get("/openapi.json").json()
+        path = "/api/billing/insights/{insight_id}"
+        assert path in schema["paths"], f"{path} not in OpenAPI"
+        assert "get" in schema["paths"][path], f"{path} does not accept GET"
+
+    def test_insight_detail_returns_404_for_missing(self, client):
+        """GET /api/billing/insights/999999 should return 404, not 405."""
+        r = client.get("/api/billing/insights/999999")
+        assert r.status_code == 404, f"Expected 404, got {r.status_code}"
+
+    def test_import_sites_router_mounted(self, client):
+        """import_sites router must not crash (Python 3.14 Optional fix)."""
+        schema = client.get("/openapi.json").json()
+        import_paths = [p for p in schema["paths"] if "/api/import/" in p]
+        assert len(import_paths) >= 1, "import router not mounted — Optional import missing?"
+
+    def test_insight_detail_returns_breakdown(self, client):
+        """GET insight detail must include V2 breakdown keys when invoice has lines."""
+        # Get first available insight
+        r = client.get("/api/billing/insights")
+        if r.status_code != 200:
+            pytest.skip("No billing insights endpoint")
+        data = r.json()
+        if not data.get("insights"):
+            pytest.skip("No insights in DB")
+        iid = data["insights"][0]["id"]
+        r2 = client.get(f"/api/billing/insights/{iid}")
+        assert r2.status_code == 200
+        detail = r2.json()
+        m = detail.get("metrics", {})
+        # V2 breakdown keys must be present after on-demand recalculation
+        assert m.get("expected_ttc") is not None, "expected_ttc missing"
+        assert m.get("expected_fourniture_ht") is not None, "expected_fourniture_ht missing"
+        assert m.get("delta_pct") is not None, "delta_pct missing"
+        assert m.get("confidence") is not None, "confidence missing"
+
+
 class TestOpenAPISchema:
     """Verify OpenAPI spec is valid and complete."""
 

--- a/docs/decisions/v66_billing_audit.md
+++ b/docs/decisions/v66_billing_audit.md
@@ -1,0 +1,95 @@
+# V66 — Billing Audit + Shadow-Billing V1 : Décisions
+
+> Date : 2026-02-23  |  Sprint : V66  |  Auteur : PROMEOS team
+
+---
+
+## 1. FAITS — État de la brique Billing avant V66
+
+| Composant | Fichier | État V65- |
+|-----------|---------|-----------|
+| Routing 15 endpoints | `backend/routes/billing.py` | ✓ Opérationnel — **0 org-scoping** |
+| Shadow billing + R1-R10 | `backend/services/billing_service.py` | ✓ Complet — bridge ActionItem absent |
+| PDF parser EDF/Engie | `backend/app/bill_intelligence/parsers/pdf_parser.py` | ✓ Templates OK — dépendance `pdfplumber` absente de requirements |
+| BillIntelPage UI | `frontend/src/pages/BillIntelPage.jsx` | ✓ CSV + audit — pas de PDF upload ni CTA "Créer action" |
+| 12 wrappers API | `frontend/src/services/api.js:583-604` | ✓ Complet |
+| Site360 Factures tab | `frontend/src/pages/Site360.jsx` | ✗ Stub mort `<TabStub title="Factures">` |
+| AnomaliesPage | `frontend/src/pages/AnomaliesPage.jsx` | ✓ Patrimoine — anomalies billing absentes |
+| Action Center bridge | `backend/models/action_item.py` | ActionSourceType.BILLING présent — jamais instancié depuis billing |
+
+---
+
+## 2. ROOT CAUSES — 5 défauts critiques
+
+### RC1 — Aucun org-scoping dans routes/billing.py
+- **Impact** : Data leakage cross-org. Un tenant peut lire/créer des factures d'un autre tenant.
+- **Cause** : `resolve_org_id()` présent dans `scope_utils.py` et utilisé par 12 autres routers — oublié lors du sprint billing initial.
+- **Décision** : Appliquer `resolve_org_id()` + `_org_sites_query()` sur les 13 endpoints de données (hors `/rules` statique et `/seed-demo` admin).
+
+### RC2 — Pas de response_model Pydantic
+- **Impact** : Swagger inutilisable, validation outbound absente, risque de fuite de champs internes.
+- **Décision** : Ajouter 4 schemas `ContractResponse`, `InvoiceResponse`, `BillingInsightResponse`, `BillingSummaryResponse` et les appliquer sur les 6 endpoints GET principaux.
+
+### RC3 — pdf_parser.py utilise pdfplumber (absent de requirements.txt)
+- **Impact** : `POST /billing/import-pdf` inexistant ; pdf_parser.py non appelable en production.
+- **Cause** : Développé en local avec pdfplumber, pymupdf (fitz) était déjà dans requirements.
+- **Décision** : Remplacer la fonction d'extraction par `extract_text_with_fitz(content: bytes)` utilisant `fitz` (pymupdf ≥ 1.24.0). Toute la logique template EDF/Engie reste intacte.
+
+### RC4 — Pas de bridge billing → ActionItem
+- **Impact** : Anomalies billing invisibles dans l'Action Center V65 (`/anomalies`).
+- **Décision** : `persist_insights()` crée un `ActionItem` (BILLING, idempotent via `idempotency_key=billing:{invoice.id}:{anomaly_code}`). Route guard `/api/actions` interdit BILLING via API → création DB directe uniquement.
+
+### RC5 — Site360 Factures tab = stub mort
+- **Impact** : UX dégradée — onglet affiché mais inutilisable.
+- **Décision** : Créer `SiteBillingMini.jsx` (KPIs + CTA) et remplacer le stub.
+
+---
+
+## 3. DÉCISIONS ARCHITECTURALES
+
+### D1 — Pas de colonne org_id sur les modèles billing
+Les modèles `EnergyContract`, `EnergyInvoice`, `BillingInsight` n'ont pas de `org_id` direct.
+L'org est dérivée via la chaîne : `site → portefeuille → entite_juridique → organisation`.
+**Raison** : éviter une migration DDL destructive. La chaîne join est déjà établie dans scope_utils.
+
+### D2 — createActionFromBillingInsight utilise source_type='manual'
+La route guard `POST /api/actions` (lignes 167-171) interdit `source_type=BILLING`.
+Le CTA UI ("Créer action" depuis insight) utilise `source_type='manual'` + `idempotency_key=billing-insight:{id}`.
+**Raison** : compatibilité route guard existante sans modification du guard.
+
+### D3 — Anomalies billing dans AnomaliesPage via endpoint dédié
+Un nouveau `GET /api/billing/anomalies-scoped` retourne les insights OPEN au format patrimoine-anomaly.
+**Raison** : séparation claire ; AnomaliesPage agrège déjà les anomalies par `Promise.all`.
+
+### D4 — Confiance PDF minimum 0.5 pour import
+Si `confidence < 0.5` → HTTP 422. L'utilisateur doit corriger le PDF ou saisir manuellement.
+**Raison** : éviter de polluer la DB avec des données mal parsées.
+
+---
+
+## 4. RÈGLES AJOUTÉES (R11 + R12)
+
+| Règle | Code | Sévérité | Condition |
+|-------|------|----------|-----------|
+| R11 TTC Coherence | `ttc_mismatch` | HIGH | Δ(TTC facturé / HT+TVA recalculé) > 2% |
+| R12 Contract Expiry | `contract_expired` | CRITICAL | Date fin contrat < aujourd'hui |
+| R12 Contract Expiry Soon | `contract_expiry_soon` | HIGH | Date fin contrat dans ≤ 90 jours |
+
+---
+
+## 5. FICHIERS MODIFIÉS / CRÉÉS (V66)
+
+| Fichier | Action |
+|---------|--------|
+| `backend/routes/billing.py` | Modifier — org scoping + response_model + import-pdf + anomalies-scoped |
+| `backend/services/billing_service.py` | Modifier — R11 + R12 + ActionItem bridge |
+| `backend/app/bill_intelligence/parsers/pdf_parser.py` | Modifier — fitz remplace pdfplumber |
+| `backend/tests/test_billing_v66_scoping.py` | Créer |
+| `backend/tests/test_billing_v66_pdf.py` | Créer |
+| `backend/tests/test_billing_v66_checks.py` | Créer |
+| `frontend/src/services/api.js` | Modifier — 3 nouveaux wrappers |
+| `frontend/src/pages/BillIntelPage.jsx` | Modifier — PDF upload + "Créer action" |
+| `frontend/src/components/SiteBillingMini.jsx` | Créer |
+| `frontend/src/pages/Site360.jsx` | Modifier — remplacer TabStub Factures |
+| `frontend/src/pages/AnomaliesPage.jsx` | Modifier — merge anomalies billing |
+| `frontend/src/pages/__tests__/billingV66.page.test.js` | Créer |

--- a/docs/decisions/v67_billing_timeline.md
+++ b/docs/decisions/v67_billing_timeline.md
@@ -1,0 +1,180 @@
+# V67 — Billing Timeline & Coverage
+
+> Date : 2026-02-24 | Branche : feat/v67-billing-timeline | Basé sur V66 (commit d5504dc)
+
+---
+
+## FAITS
+
+| Fait | Source |
+|------|--------|
+| `period_start`, `period_end`, `issue_date` : Date nullable sur EnergyInvoice | billing_models.py |
+| Aucun index sur les champs date | billing_models.py — scan complet sur range queries |
+| Tous les endpoints GET retournaient `.all()` sans limit/offset | routes/billing.py (V66) |
+| N+1 dans `get_billing_anomalies_scoped` : 1 + N requêtes Site | routes/billing.py:849-881 |
+| Règle R4 détecte déjà les factures sans dates | billing_service.py |
+| Unique constraint sur `(site_id, invoice_number, period_start, period_end)` | billing_models.py |
+| 17 endpoints billing existants, tous org-scopés (V66) | routes/billing.py |
+| Pas de champ `is_credit` — avoirs détectés via `total_eur <= 0` | billing_models.py |
+
+---
+
+## HYPOTHÈSES
+
+| ID | Hypothèse | Décision |
+|----|-----------|----------|
+| H1 | SoT période = `period_start`/`period_end`, fallback `issue_date` → mois entier | Acceptée |
+| H2 | Seuil couverture = 80% des jours du mois (`COVERAGE_THRESHOLD = 0.80`) | Acceptée |
+| H3 | Avoirs (`total_eur <= 0`) exclus du calcul couverture, inclus dans totaux | Acceptée |
+| H4 | Range auto = min(period_start, issue_date) → max(period_end, issue_date) | Acceptée |
+| H5 | Calcul à la volée sans nouvelle table (cache mémoire org-scoped si perf insuffisante) | Acceptée |
+| H6 | Nouvelle page `/billing` distincte de `/bill-intel` | Acceptée |
+
+---
+
+## DÉCISIONS
+
+| ID | Décision | Justification |
+|----|----------|---------------|
+| D1 | Route frontend `/billing` (alias `/facturation`) | URL bookmarkable + filtres via `?site_id=` |
+| D2 | `GET /api/billing/periods` paginé (limit=24, offset=0) | 24 mois = 2 ans visibles, load more UX |
+| D3 | `GET /api/billing/coverage-summary` pour les KPIs header | Payload léger, compute global |
+| D4 | `GET /api/billing/missing-periods` format patrimoine-anomaly | Compatible AnomaliesPage si besoin |
+| D5 | Index SQLAlchemy sur period_start, period_end, issue_date, (site_id, period_start) | Sans migration manuelle |
+| D6 | Fix N+1 `anomalies-scoped` : dict lookup via `Site.id.in_()` | 1 requête au lieu de N |
+
+---
+
+## CONTRAT API
+
+### GET /api/billing/periods
+
+**Query params :** `site_id` (int), `month_from` (YYYY-MM), `month_to` (YYYY-MM), `limit` (int, défaut 24, max 120), `offset` (int, défaut 0), `org_id` (int override)
+
+**Response 200 :**
+```json
+{
+  "periods": [
+    {
+      "month_key": "2024-12",
+      "month_start": "2024-12-01",
+      "month_end": "2024-12-31",
+      "coverage_status": "covered",
+      "coverage_ratio": 1.0,
+      "invoices_count": 2,
+      "total_ttc": 1234.56,
+      "missing_reason": null
+    }
+  ],
+  "total": 18,
+  "offset": 0,
+  "limit": 24
+}
+```
+
+**coverage_status values :** `"covered"` (≥80%), `"partial"` (1-79%), `"missing"` (0%)
+
+---
+
+### GET /api/billing/coverage-summary
+
+**Query params :** `site_id` (int), `org_id` (int override)
+
+**Response 200 :**
+```json
+{
+  "range": { "min_month": "2023-01", "max_month": "2025-02" },
+  "months_total": 26,
+  "covered": 22,
+  "partial": 1,
+  "missing": 3,
+  "missing_months": ["2025-02", "2024-09", "2023-11"],
+  "top_sites_missing": [
+    { "site_id": 5, "site_name": "Site Alpha", "missing_months_count": 3 }
+  ]
+}
+```
+
+**Response 200 (aucune facture) :**
+```json
+{
+  "range": null,
+  "months_total": 0,
+  "covered": 0,
+  "partial": 0,
+  "missing": 0,
+  "missing_months": [],
+  "top_sites_missing": []
+}
+```
+
+---
+
+### GET /api/billing/missing-periods
+
+**Query params :** `limit` (int, défaut 20, max 100), `offset` (int, défaut 0), `org_id` (int override)
+
+**Response 200 :**
+```json
+{
+  "items": [
+    {
+      "month_key": "2025-02",
+      "site_id": 5,
+      "site_name": "Site Alpha",
+      "coverage_status": "missing",
+      "coverage_ratio": 0.0,
+      "missing_reason": "Aucune facture importée pour ce mois",
+      "regulatory_impact": { "framework": "FACTURATION" },
+      "cta_url": "/bill-intel?site_id=5&month=2025-02"
+    }
+  ],
+  "total": 12,
+  "offset": 0,
+  "limit": 20
+}
+```
+
+---
+
+## RÈGLES DE COUVERTURE
+
+```
+COVERAGE_THRESHOLD = 0.80  # configurable
+
+Pour chaque mois M dans [range_start, range_end] :
+  1. Collecter toutes les factures dont la période intersecte M
+  2. Exclure avoirs (total_eur <= 0) du calcul couverture
+  3. Pour chaque facture non-avoir :
+       covered_days |= {jour pour jour in [max(ps, M.start), min(pe, M.end)]}
+  4. ratio = len(covered_days) / nb_jours_du_mois
+  5. status = "covered" si ratio >= 0.80
+              "partial"  si 0 < ratio < 0.80
+              "missing"  si ratio == 0
+
+SoT période facture :
+  - Si period_start AND period_end: utiliser tels quels
+  - Sinon si issue_date: ps=1er du mois, pe=dernier du mois
+  - Sinon: facture ignorée pour la couverture (R4 l'a déjà signalée)
+```
+
+---
+
+## FICHIERS MODIFIÉS / CRÉÉS (V67)
+
+| Fichier | Action |
+|---------|--------|
+| `backend/models/billing_models.py` | +4 Index SQLAlchemy |
+| `backend/services/billing_coverage.py` | NOUVEAU — moteur couverture |
+| `backend/routes/billing.py` | +3 endpoints, fix N+1 anomalies-scoped |
+| `backend/tests/test_billing_v67_coverage.py` | NOUVEAU — 12 tests |
+| `frontend/src/services/api.js` | +3 wrappers |
+| `frontend/src/pages/BillingPage.jsx` | NOUVEAU — page timeline |
+| `frontend/src/components/BillingTimeline.jsx` | NOUVEAU — liste mensuelle |
+| `frontend/src/components/CoverageBar.jsx` | NOUVEAU — barre visuelle |
+| `frontend/src/pages/Site360.jsx` | +lien "Voir timeline" |
+| `frontend/src/App.jsx` | +route /billing |
+| `frontend/src/layout/NavRegistry.js` | +entrée /billing |
+| `frontend/src/pages/__tests__/billingV67.page.test.js` | NOUVEAU — 25 tests |
+| `docs/decisions/v67_billing_timeline.md` | NOUVEAU (ce fichier) |
+| `docs/dev/v67_billing_manual_test.md` | NOUVEAU |

--- a/docs/decisions/v68_billing_unified.md
+++ b/docs/decisions/v68_billing_unified.md
@@ -1,0 +1,86 @@
+# ADR V68 — Billing Unified (Shadow V2 + Deep-links + Seed 36 mois)
+
+> V67 (Billing Timeline & Coverage) : **DONE** (commit 3cdd172). Ce doc couvre uniquement V68.
+> Date : 2026-02-24
+
+---
+
+## Contexte
+
+V67 a livré le moteur de couverture facturation (Timeline + CoverageBar). V66 avait livré Bill Intelligence (Shadow V1, R1-R12). V68 unifie les deux surfaces sur un contrat de données commun et enrichit l'analyse.
+
+---
+
+## Décisions
+
+| ID | Décision | Choix retenu |
+|----|----------|--------------|
+| D1 | Fix Phase 0 | Optional chaining `summary?.range?.min_month` + `activeMonth` state |
+| D2 | InvoiceNormalized | `billing_normalization.py` + `GET /billing/invoices/normalized` |
+| D3 | Shadow V2 | `billing_shadow_v2.py` avec constantes TURPE/ATRD/ATRT/CSPE/TICGN |
+| D4 | R13 + R14 | `_rule_reseau_mismatch` + `_rule_taxes_mismatch` dans BILLING_RULES (14 règles total) |
+| D5 | BillIntelPage | `useSearchParams` → filtre site_id + month côté front |
+| D6 | BillIntelPage CTA | Bouton "Voir timeline" → `/billing?site_id={X}` |
+| D7 | BillingPage month | Lit `?month=YYYY-MM` → `activeMonth` → highlight BillingTimeline row |
+| D8 | Seed 36 mois | Étend `billing_seed.py` → idempotent via source="seed_36m" |
+| D9 | seed_data.py | Appelle `seed_billing_demo(db)` en fin de main() |
+
+---
+
+## Hypothèses
+
+| ID | Hypothèse |
+|----|-----------|
+| H1 | `price_ref_eur_per_kwh` = prix all-in TTC/kWh dans ce modèle POC |
+| H2 | TURPE simplifié C5 BT 2025 : 0.0453 EUR/kWh |
+| H3 | R13 seuil : delta réseau > 10% (medium), > 20% (high) |
+| H4 | R14 seuil : delta taxes > 5% (medium) |
+| H5 | Seed 36 mois idempotent : check source="seed_36m" |
+
+---
+
+## Contrat API V68
+
+### `GET /api/billing/invoices/normalized`
+
+Query : `site_id?`, `month_key?` (YYYY-MM), `limit=50`, `offset=0`
+
+```json
+{
+  "invoices": [{
+    "id": 12, "org_id": 1, "site_id": 5,
+    "fournisseur": "EDF ENR", "energie": "ELEC",
+    "period_start": "2024-01-01", "period_end": "2024-01-31",
+    "issue_date": "2024-02-05", "month_key": "2024-01",
+    "ttc": 1620.0, "ht": 1420.0, "tva": 200.0,
+    "ht_fourniture": 1020.0, "ht_reseau": 400.0,
+    "kwh": 9000, "invoice_number": "EDF-2024-01",
+    "status": "imported", "pdf_doc_id": null
+  }],
+  "total": 1, "offset": 0, "limit": 50
+}
+```
+
+---
+
+## Navigation bidirectionnelle
+
+```
+BillingTimeline  →  /bill-intel?site_id=X&month=YYYY-MM  →  BillIntelPage
+BillIntelPage    →  /billing?site_id=X                   →  BillingPage (highlight mois)
+Site360          →  /billing?site_id=X                   →  BillingPage
+```
+
+---
+
+## Seed HELIOS 36 mois
+
+| Dimension | Détail |
+|-----------|--------|
+| Période | Jan 2023 – Déc 2025 |
+| Sites | site_a (ELEC 9000 kWh/mois), site_b (GAZ 6000 kWh/mois) |
+| Trous | 2023-03, 2024-09 (site_a missing) ; 2025-02 (site_b missing) |
+| Partiels | 2023-06 (15j), 2024-01 (20j/31) sur site_a |
+| Anomalie R1 | 2024-07 : total_eur = shadow × 1.45 |
+| Anomalie R13 | 2024-11 : NETWORK = TURPE × 2.3 |
+| Anomalie R14 | 2025-01 : TAX = CSPE × 1.08 |

--- a/docs/dev/v66_billing_manual_test.md
+++ b/docs/dev/v66_billing_manual_test.md
@@ -1,0 +1,115 @@
+# V66 — Billing Manual Test Checklist (QA 10 étapes)
+
+> Date : 2026-02-23  |  Prérequis : backend + frontend lancés, org demo seedée
+
+---
+
+## Prérequis
+
+1. `cd backend && uvicorn main:app --reload`
+2. `cd frontend && npm run dev`
+3. `POST /api/demo/seed-pack` → Groupe HELIOS (5 sites)
+4. `POST /api/billing/seed-demo` → 2 contrats + 5 factures demo
+5. Naviguer sur http://localhost:5173
+
+---
+
+## Étapes de test
+
+### T1 — Org scoping de base
+```bash
+# Sans header → devrait retourner données de l'org demo
+curl http://localhost:8000/api/billing/summary
+
+# Avec org inexistant → 403 ou empty
+curl -H "X-Org-Id: 9999" http://localhost:8000/api/billing/summary
+```
+**Attendu** : T1a = données HELIOS, T1b = `{"total_invoices":0,...}` ou 403
+
+---
+
+### T2 — Import CSV org-scopé
+```bash
+# Upload CSV avec site_id valide HELIOS
+curl -X POST "http://localhost:8000/api/billing/import-csv?org_id=<ORG_ID>" \
+  -F "file=@tests/fixtures/billing_sample.csv"
+```
+**Attendu** : `{"status":"ok", "imported": N, "skipped": 0}`
+
+---
+
+### T3 — Import PDF (V66 NEW)
+1. Créer un PDF de test minimal avec le texte "EDF" et un numéro de facture
+2. `curl -X POST "http://localhost:8000/api/billing/import-pdf?site_id=1" -F "file=@facture_test.pdf"`
+**Attendu** : `{"status":"imported", "invoice_id":N, "confidence":0.X, ...}` (confiance ≥ 0.5)
+**Cas erreur** : PDF vide → HTTP 422
+
+---
+
+### T4 — Règle R11 TTC Coherence
+1. Créer une facture avec `total_eur=1000` mais lignes HT+TVA = 1030
+2. `POST /api/billing/audit/{invoice_id}`
+**Attendu** : anomalie `ttc_mismatch` avec severity=HIGH dans les insights
+
+---
+
+### T5 — Règle R12 Contract Expiry
+1. Créer un contrat avec `end_date` = hier ou < aujourd'hui
+2. Lier une facture à ce contrat
+3. `POST /api/billing/audit/{invoice_id}`
+**Attendu** : anomalie `contract_expired` severity=CRITICAL dans les insights
+
+---
+
+### T6 — Bridge ActionItem
+1. Lancer `POST /api/billing/audit-all`
+2. Vérifier que des ActionItem BILLING ont été créés : `GET /api/actions?source_type=billing`
+3. Re-lancer `POST /api/billing/audit-all`
+4. Vérifier pas de doublons (idempotency_key)
+**Attendu** : T6a = N actions créées, T6b = même N (pas de doublon)
+
+---
+
+### T7 — BillIntelPage UI
+1. Aller sur `/bill-intel`
+2. Vérifier que le bouton PDF upload est visible
+3. Vérifier que chaque ligne d'insight a un bouton "Créer action"
+4. Cliquer "Créer action" → bouton doit changer d'état (créé)
+**Attendu** : upload fonctionnel, CTA idempotent
+
+---
+
+### T8 — Site360 Factures tab
+1. Aller sur `/patrimoine` → cliquer sur un site
+2. Cliquer onglet "Factures"
+**Attendu** : `SiteBillingMini` avec KPIs (nb factures, nb anomalies, dernière facture)
+**Non attendu** : texte "à venir" ou stub
+
+---
+
+### T9 — AnomaliesPage billing
+1. Aller sur `/anomalies`
+2. Vérifier que les anomalies framework="FACTURATION" apparaissent
+3. Cliquer "Ouvrir site" sur une anomalie billing → doit naviguer vers `/bill-intel`
+**Attendu** : chip FACTURATION visible, navigation correcte
+
+---
+
+### T10 — Isolation multi-org
+1. Créer deux orgs via seeder (A et B)
+2. Importer factures dans org A
+3. Requêter billing avec org_id de org B
+**Attendu** : `{"invoices": [], "count": 0}` pour org B
+
+---
+
+## Checklist finale avant merge
+
+- [ ] `grep "Organisation.first()" backend/routes/billing.py` → 0 résultats
+- [ ] `grep "resolve_org_id" backend/routes/billing.py` → ≥ 13 occurrences
+- [ ] `grep "response_model" backend/routes/billing.py` → ≥ 6 occurrences
+- [ ] `grep "pdfplumber" backend/` → 0 résultats
+- [ ] `pytest tests/test_billing_v66_scoping.py tests/test_billing_v66_pdf.py tests/test_billing_v66_checks.py -v` → all green
+- [ ] `npx vitest run src/pages/__tests__/billingV66.page.test.js` → all green
+- [ ] `pytest tests/ -x -q` → 0 régression
+- [ ] `npx vitest run` → 0 régression

--- a/docs/dev/v66_billing_routing_map.md
+++ b/docs/dev/v66_billing_routing_map.md
@@ -1,0 +1,85 @@
+# V66 — Billing Routing Map : Routes UI ↔ Endpoints API
+
+> Date : 2026-02-23  |  Préfixe API : `/api/billing`
+
+---
+
+## Routes UI → Endpoints
+
+| Route UI | Composant | Endpoint API | Méthode | Org scoped V66 |
+|----------|-----------|-------------|---------|----------------|
+| `/bill-intel` — liste factures | `BillIntelPage.jsx` | `/billing/invoices` | GET | ✓ |
+| `/bill-intel` — anomalies insights | `BillIntelPage.jsx` | `/billing/insights` | GET | ✓ |
+| `/bill-intel` — KPIs summary | `BillIntelPage.jsx` | `/billing/summary` | GET | ✓ |
+| `/bill-intel` — import CSV | `BillIntelPage.jsx` | `/billing/import-csv` | POST | ✓ |
+| `/bill-intel` — import PDF *(V66 NEW)* | `BillIntelPage.jsx` | `/billing/import-pdf` | POST | ✓ |
+| `/bill-intel` — audit tout | `BillIntelPage.jsx` | `/billing/audit-all` | POST | ✓ |
+| `/bill-intel` — audit facture | `BillIntelPage.jsx` | `/billing/audit/{id}` | POST | ✓ |
+| `/bill-intel` — résoudre insight | `BillIntelPage.jsx` | `/billing/insights/{id}/resolve` | POST | ✓ |
+| `/bill-intel` — "Créer action" CTA *(V66 NEW)* | `BillIntelPage.jsx` | `/actions` (source_type=manual) | POST | via auth |
+| `/anomalies` — billing *(V66 NEW)* | `AnomaliesPage.jsx` | `/billing/anomalies-scoped` | GET | ✓ |
+| Site360 onglet Factures | `SiteBillingMini.jsx` | `/billing/site/{siteId}` | GET | ✓ (site-level) |
+| — | `BillIntelPage.jsx` | `/billing/contracts` | GET | ✓ |
+| — | internal | `/billing/import/batches` | GET | ✓ |
+| — | internal | `/billing/rules` | GET | static (no scope) |
+
+---
+
+## Endpoints par fichier backend
+
+### `routes/billing.py`
+
+```
+POST   /api/billing/contracts            ← ContractCreate + org scope
+GET    /api/billing/contracts            ← org scope (join chain)
+POST   /api/billing/import-csv          ← org_id param → resolve_org_id
+GET    /api/billing/import/batches      ← org scope
+POST   /api/billing/invoices            ← site check via _org_sites_query
+POST   /api/billing/audit/{invoice_id}  ← org check invoice ownership
+POST   /api/billing/audit-all           ← org scope
+GET    /api/billing/summary             ← org scope
+GET    /api/billing/insights            ← org scope
+PATCH  /api/billing/insights/{id}       ← org scope
+POST   /api/billing/insights/{id}/resolve ← org scope
+GET    /api/billing/invoices            ← org scope
+GET    /api/billing/site/{site_id}      ← org scope
+POST   /api/billing/import-pdf         ← V66 NEW — org scope + site check
+GET    /api/billing/anomalies-scoped   ← V66 NEW — org scope
+GET    /api/billing/rules              ← static, no scope
+POST   /api/billing/seed-demo         ← admin, no scope
+```
+
+---
+
+## Chaîne d'org scoping (modèles sans org_id direct)
+
+```
+EnergyInvoice.site_id
+  → Site.portefeuille_id
+    → Portefeuille.entite_juridique_id
+      → EntiteJuridique.organisation_id  ← effectif org_id ici
+```
+
+**Helper** : `_org_sites_query(db, ModelClass, effective_org_id)` encapsule ce join.
+
+---
+
+## Wrappers frontend (api.js)
+
+| Fonction | Endpoint | V66 Status |
+|---------|---------|------------|
+| `getBillingContracts()` | GET /billing/contracts | ✓ existant |
+| `getBillingSummary()` | GET /billing/summary | ✓ existant |
+| `getBillingInsights(params)` | GET /billing/insights | ✓ existant |
+| `getBillingInvoices(params)` | GET /billing/invoices | ✓ existant |
+| `getSiteBilling(siteId)` | GET /billing/site/{siteId} | ✓ existant |
+| `importInvoicesCsv(file, orgId)` | POST /billing/import-csv | ✓ existant |
+| `auditInvoice(id)` | POST /billing/audit/{id} | ✓ existant |
+| `auditAllInvoices()` | POST /billing/audit-all | ✓ existant |
+| `resolveInsight(id, notes)` | POST /billing/insights/{id}/resolve | ✓ existant |
+| `patchInsight(id, data)` | PATCH /billing/insights/{id} | ✓ existant |
+| `getImportBatches(orgId)` | GET /billing/import/batches | ✓ existant |
+| `seedBillingDemo()` | POST /billing/seed-demo | ✓ existant |
+| `importInvoicesPdf(siteId, file)` | POST /billing/import-pdf | **V66 NEW** |
+| `createActionFromBillingInsight(id, title, siteId)` | POST /actions | **V66 NEW** |
+| `getBillingAnomaliesScoped()` | GET /billing/anomalies-scoped | **V66 NEW** |

--- a/docs/dev/v67_billing_manual_test.md
+++ b/docs/dev/v67_billing_manual_test.md
@@ -1,0 +1,86 @@
+# V67 — Checklist QA Manuelle (10 min)
+
+> Prérequis : backend + frontend démarrés, seed billing demo exécuté (`POST /api/billing/seed-demo`)
+
+---
+
+## Étape 1 — Page Timeline (2 min)
+
+1. Aller sur `http://localhost:5173/billing`
+2. ✅ KPIs affichés : mois couverts / partiels / manquants
+3. ✅ CoverageBar visible avec proportion couleurs (vert/orange/rouge)
+4. ✅ Range affiché (ex: "Jan 2024 → Fév 2025")
+5. ✅ Liste timeline : au moins 1 mois visible avec statut
+
+## Étape 2 — Filtrage par site (1 min)
+
+1. Sélectionner un site dans le filtre
+2. ✅ URL se met à jour : `/billing?site_id=X`
+3. ✅ KPIs et timeline rechargent pour ce site
+4. ✅ Réinitialiser le filtre → données globales rechargent
+
+## Étape 3 — Périodes manquantes (2 min)
+
+1. Vérifier la section "Périodes manquantes"
+2. ✅ Si trous présents : liste avec site, mois, raison
+3. ✅ Bouton "Importer" visible sur chaque ligne manquante
+4. Cliquer "Importer" pour le premier trou
+5. ✅ Redirige vers `/bill-intel?site_id=X&month=YYYY-MM`
+
+## Étape 4 — CTA Créer action (1 min)
+
+1. Sur une ligne manquante, cliquer "Créer action"
+2. ✅ Bouton passe à l'état "créé" (idempotent)
+3. Aller dans le Plan d'action → ✅ action visible avec source BILLING
+
+## Étape 5 — Pagination (1 min)
+
+1. Si plus de 24 mois : bouton "Charger plus" visible
+2. ✅ Cliquer → 24 mois supplémentaires chargés
+3. ✅ Pas de doublon dans la liste
+
+## Étape 6 — Lien depuis Site360 (1 min)
+
+1. Aller sur `/patrimoine` → ouvrir un site
+2. Cliquer onglet "Factures"
+3. ✅ `SiteBillingMini` affiché avec KPIs
+4. ✅ Bouton "Voir timeline complète" visible
+5. Cliquer → ✅ Redirige vers `/billing?site_id=X`
+
+## Étape 7 — Navigation (30s)
+
+1. ✅ "Timeline facturation" apparaît dans la nav section "Marché & Factures"
+2. ✅ `/facturation` redirige vers `/billing`
+
+## Étape 8 — Multi-org isolation (1 min)
+
+1. Se connecter avec `sophie@atlas.demo` (org Atlas)
+2. ✅ Données billing visibles
+3. (Si 2e org disponible) Se connecter avec autre org → ✅ aucune donnée Atlas visible
+
+## Étape 9 — Couverture partielle (30s)
+
+1. Importer une facture qui couvre 15/31 jours d'un mois
+2. ✅ Ce mois apparaît comme "partial" (orange) dans la timeline
+3. ✅ Raison affichée : "Couverture X% (Y/Z jours)"
+
+## Étape 10 — API Swagger (30s)
+
+1. Ouvrir `http://localhost:8000/docs`
+2. ✅ `GET /billing/periods` visible avec schéma response
+3. ✅ `GET /billing/coverage-summary` visible
+4. ✅ `GET /billing/missing-periods` visible
+5. Tester `/billing/coverage-summary` → ✅ JSON correct
+
+---
+
+## Checklist finale avant merge
+
+- [ ] `pytest tests/ -x -q` → 0 failed
+- [ ] `vitest run` → 0 failed
+- [ ] `grep -c "resolve_org_id" routes/billing.py` → ≥ 16
+- [ ] `grep "Organisation.first()" routes/billing.py` → 0
+- [ ] Page `/billing` accessible sans erreur console
+- [ ] `/billing?site_id=1` filtre correctement
+- [ ] CoverageBar proportionnelle (vert + orange + rouge = 100%)
+- [ ] Boutons "Importer" pointent vers `/bill-intel` avec site_id

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ const SegmentationPage = lazy(() => import('./pages/SegmentationPage'));
 const CompliancePage = lazy(() => import('./pages/CompliancePage'));
 const ConsumptionDiagPage = lazy(() => import('./pages/ConsumptionDiagPage'));
 const BillIntelPage = lazy(() => import('./pages/BillIntelPage'));
+const BillingPage = lazy(() => import('./pages/BillingPage'));
 const KBExplorerPage = lazy(() => import('./pages/KBExplorerPage'));
 const PurchasePage = lazy(() => import('./pages/PurchasePage'));
 const PurchaseAssistantPage = lazy(() => import('./pages/PurchaseAssistantPage'));
@@ -116,6 +117,7 @@ function App() {
                   <Route path="/compliance" element={<PageSuspense><CompliancePage /></PageSuspense>} />
                   <Route path="/diagnostic-conso" element={<PageSuspense><ConsumptionDiagPage /></PageSuspense>} />
                   <Route path="/bill-intel" element={<PageSuspense><BillIntelPage /></PageSuspense>} />
+                  <Route path="/billing" element={<PageSuspense><BillingPage /></PageSuspense>} />
                   <Route path="/achat-energie" element={<PageSuspense><PurchasePage /></PageSuspense>} />
                   <Route path="/achat-assistant" element={<PageSuspense><PurchaseAssistantPage /></PageSuspense>} />
                   <Route path="/kb" element={<PageSuspense><KBExplorerPage /></PageSuspense>} />
@@ -136,7 +138,7 @@ function App() {
                   <Route path="/plan-action" element={<Navigate to="/actions" replace />} />
                   <Route path="/plan-actions" element={<Navigate to="/actions" replace />} />
                   <Route path="/factures" element={<Navigate to="/bill-intel" replace />} />
-                  <Route path="/facturation" element={<Navigate to="/bill-intel" replace />} />
+                  <Route path="/facturation" element={<Navigate to="/billing" replace />} />
                   <Route path="/anomalies" element={<PageSuspense><AnomaliesPage /></PageSuspense>} />
                   <Route path="/diagnostic" element={<Navigate to="/diagnostic-conso" replace />} />
                   <Route path="/performance" element={<Navigate to="/monitoring" replace />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,6 +45,7 @@ const AdminRolesPage = lazy(() => import('./pages/AdminRolesPage'));
 const AdminAssignmentsPage = lazy(() => import('./pages/AdminAssignmentsPage'));
 const AdminAuditLogPage = lazy(() => import('./pages/AdminAuditLogPage'));
 const ConsumptionExplorerPage = lazy(() => import('./pages/ConsumptionExplorerPage'));
+const ConsumptionPortfolioPage = lazy(() => import('./pages/ConsumptionPortfolioPage'));
 const ActivationPage = lazy(() => import('./pages/ActivationPage'));
 const TertiaireDashboardPage = lazy(() => import('./pages/tertiaire/TertiaireDashboardPage'));
 const TertiaireWizardPage = lazy(() => import('./pages/tertiaire/TertiaireWizardPage'));
@@ -106,10 +107,11 @@ function App() {
                   <Route path="/sites-legacy/:id" element={<PageSuspense><SiteDetail /></PageSuspense>} />
                   <Route path="/action-plan" element={<PageSuspense><ActionPlan /></PageSuspense>} />
                   <Route path="/regops/:id" element={<PageSuspense><RegOps /></PageSuspense>} />
-                  {/* Consommations: 3-tab layout (Explorer | Import & Analyse | KB) */}
+                  {/* Consommations: 4-tab layout (Explorer | Portfolio | Import & Analyse | KB) */}
                   <Route path="/consommations" element={<PageSuspense><ConsommationsPage /></PageSuspense>}>
                     <Route index element={<Navigate to="/consommations/explorer" replace />} />
                     <Route path="explorer" element={<PageSuspense><ConsumptionExplorerPage bare /></PageSuspense>} />
+                    <Route path="portfolio" element={<PageSuspense><ConsumptionPortfolioPage /></PageSuspense>} />
                     <Route path="import" element={<PageSuspense><ConsommationsImportTab /></PageSuspense>} />
                     <Route path="kb" element={<PageSuspense><ConsommationsKBTab /></PageSuspense>} />
                   </Route>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -90,6 +90,8 @@ function App() {
                   <Route path="/patrimoine" element={<PageSuspense><Patrimoine /></PageSuspense>} />
                   <Route path="/sites/:id" element={<PageSuspense><Site360 /></PageSuspense>} />
                   <Route path="/actions" element={<PageSuspense><ActionsPage /></PageSuspense>} />
+                  <Route path="/actions/new" element={<PageSuspense><ActionsPage autoCreate /></PageSuspense>} />
+                  <Route path="/actions/:actionId" element={<PageSuspense><ActionsPage /></PageSuspense>} />
                   <Route path="/conformite" element={<PageSuspense><ConformitePage /></PageSuspense>} />
                   <Route path="/conformite/tertiaire" element={<PageSuspense><TertiaireDashboardPage /></PageSuspense>} />
                   <Route path="/conformite/tertiaire/wizard" element={<PageSuspense><TertiaireWizardPage /></PageSuspense>} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -49,6 +49,7 @@ const TertiaireDashboardPage = lazy(() => import('./pages/tertiaire/TertiaireDas
 const TertiaireWizardPage = lazy(() => import('./pages/tertiaire/TertiaireWizardPage'));
 const TertiaireEfaDetailPage = lazy(() => import('./pages/tertiaire/TertiaireEfaDetailPage'));
 const TertiaireAnomaliesPage = lazy(() => import('./pages/tertiaire/TertiaireAnomaliesPage'));
+const AnomaliesPage = lazy(() => import('./pages/AnomaliesPage'));
 
 function PageSuspense({ children }) {
   return (
@@ -136,7 +137,7 @@ function App() {
                   <Route path="/plan-actions" element={<Navigate to="/actions" replace />} />
                   <Route path="/factures" element={<Navigate to="/bill-intel" replace />} />
                   <Route path="/facturation" element={<Navigate to="/bill-intel" replace />} />
-                  <Route path="/anomalies" element={<Navigate to="/diagnostic-conso" replace />} />
+                  <Route path="/anomalies" element={<PageSuspense><AnomaliesPage /></PageSuspense>} />
                   <Route path="/diagnostic" element={<Navigate to="/diagnostic-conso" replace />} />
                   <Route path="/performance" element={<Navigate to="/monitoring" replace />} />
                   <Route path="/achats" element={<Navigate to="/achat-energie" replace />} />

--- a/frontend/src/components/AnomalyActionModal.jsx
+++ b/frontend/src/components/AnomalyActionModal.jsx
@@ -1,0 +1,161 @@
+/**
+ * AnomalyActionModal — V65
+ * Modale légère (front-only, pas d'API) pour créer ou éditer
+ * une action locale associée à une anomalie.
+ * Stockage : localStorage via anomalyActions.js
+ */
+import { useState, useEffect } from 'react';
+import Modal from '../ui/Modal';
+import { Button, Input } from '../ui';
+import {
+  getAnomalyAction,
+  saveAnomalyAction,
+  ACTION_STATUS,
+  ACTION_STATUS_LABEL,
+} from '../services/anomalyActions';
+
+const STATUS_OPTIONS = [
+  { value: ACTION_STATUS.TODO,        label: ACTION_STATUS_LABEL.todo        },
+  { value: ACTION_STATUS.IN_PROGRESS, label: ACTION_STATUS_LABEL.in_progress },
+  { value: ACTION_STATUS.RESOLVED,    label: ACTION_STATUS_LABEL.resolved    },
+];
+
+const EMPTY_FORM = {
+  title:    '',
+  status:   ACTION_STATUS.TODO,
+  owner:    '',
+  due_date: '',
+  notes:    '',
+};
+
+/**
+ * @param {object}  props
+ * @param {boolean} props.open
+ * @param {function} props.onClose
+ * @param {number|string|null} props.orgId
+ * @param {number}  props.siteId
+ * @param {string}  props.anomalyCode
+ * @param {string}  props.anomalyTitle - Prérempli dans le champ titre
+ */
+export default function AnomalyActionModal({ open, onClose, orgId, siteId, anomalyCode, anomalyTitle }) {
+  const [form, setForm] = useState(EMPTY_FORM);
+
+  // Charger l'action existante (ou préremplir le titre) à l'ouverture
+  useEffect(() => {
+    if (!open) return;
+    const existing = getAnomalyAction(orgId, siteId, anomalyCode);
+    if (existing) {
+      setForm({
+        title:    existing.title    ?? anomalyTitle ?? '',
+        status:   existing.status   ?? ACTION_STATUS.TODO,
+        owner:    existing.owner    ?? '',
+        due_date: existing.due_date ?? '',
+        notes:    existing.notes    ?? '',
+      });
+    } else {
+      setForm({ ...EMPTY_FORM, title: anomalyTitle ?? '' });
+    }
+  }, [open, orgId, siteId, anomalyCode, anomalyTitle]);
+
+  function handleChange(field, value) {
+    setForm(prev => ({ ...prev, [field]: value }));
+  }
+
+  function handleSave(e) {
+    e.preventDefault();
+    if (!form.title.trim()) return;
+    saveAnomalyAction(orgId, siteId, anomalyCode, {
+      title:    form.title.trim(),
+      status:   form.status,
+      owner:    form.owner.trim(),
+      due_date: form.due_date,
+      notes:    form.notes.trim(),
+    });
+    onClose();
+  }
+
+  function handleMarkResolved() {
+    saveAnomalyAction(orgId, siteId, anomalyCode, {
+      title:    (form.title || anomalyTitle || '').trim(),
+      status:   ACTION_STATUS.RESOLVED,
+      owner:    form.owner.trim(),
+      due_date: form.due_date,
+      notes:    form.notes.trim(),
+    });
+    onClose();
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="Action sur anomalie">
+      <form onSubmit={handleSave} className="space-y-3">
+
+        {/* Titre */}
+        <Input
+          label="Titre de l'action"
+          placeholder="ex : Déclarer OPERAT pour ce site"
+          value={form.title}
+          onChange={e => handleChange('title', e.target.value)}
+          required
+        />
+
+        {/* Statut */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-gray-700">Statut</label>
+          <select
+            value={form.status}
+            onChange={e => handleChange('status', e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white"
+          >
+            {STATUS_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Responsable + Échéance */}
+        <div className="grid grid-cols-2 gap-3">
+          <Input
+            label="Responsable"
+            placeholder="Jean Dupont"
+            value={form.owner}
+            onChange={e => handleChange('owner', e.target.value)}
+          />
+          <Input
+            label="Échéance"
+            type="date"
+            value={form.due_date}
+            onChange={e => handleChange('due_date', e.target.value)}
+          />
+        </div>
+
+        {/* Notes */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-gray-700">Notes</label>
+          <textarea
+            rows={2}
+            placeholder="Détails ou contexte supplémentaire..."
+            value={form.notes}
+            onChange={e => handleChange('notes', e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-between pt-1">
+          <button
+            type="button"
+            onClick={handleMarkResolved}
+            className="text-sm font-medium text-green-600 hover:text-green-700 hover:underline transition"
+          >
+            Marquer comme résolu
+          </button>
+          <div className="flex items-center gap-2">
+            <Button variant="secondary" type="button" onClick={onClose}>Annuler</Button>
+            <Button type="submit">Sauvegarder</Button>
+          </div>
+        </div>
+
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/BillingTimeline.jsx
+++ b/frontend/src/components/BillingTimeline.jsx
@@ -45,12 +45,13 @@ function formatEur(amount) {
   return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(amount);
 }
 
-function MonthRow({ period, siteId, onCreateAction, createdActions }) {
+function MonthRow({ period, siteId, onCreateAction, createdActions, activeMonth }) {
   const navigate = useNavigate();
   const cfg = STATUS_CONFIG[period.coverage_status] || STATUS_CONFIG.missing;
   const Icon = cfg.icon;
   const actionKey = `${siteId}-${period.month_key}`;
   const actionCreated = createdActions?.has(actionKey);
+  const isActive = activeMonth && period.month_key === activeMonth;
 
   const handleView = () => {
     const params = new URLSearchParams();
@@ -67,7 +68,7 @@ function MonthRow({ period, siteId, onCreateAction, createdActions }) {
   };
 
   return (
-    <div className={`flex items-center gap-3 px-4 py-3 rounded-lg border ${cfg.bg} ${cfg.border}`}>
+    <div className={`flex items-center gap-3 px-4 py-3 rounded-lg border ${cfg.bg} ${cfg.border}${isActive ? ' ring-2 ring-amber-400' : ''}`}>
       {/* Statut icon */}
       <Icon size={16} className={`flex-shrink-0 ${cfg.color}`} />
 
@@ -127,7 +128,7 @@ function MonthRow({ period, siteId, onCreateAction, createdActions }) {
   );
 }
 
-export default function BillingTimeline({ periods = [], siteId, onCreateAction, createdActions }) {
+export default function BillingTimeline({ periods = [], siteId, onCreateAction, createdActions, activeMonth }) {
   if (periods.length === 0) {
     return (
       <div className="text-center py-8 text-sm text-gray-500">
@@ -143,6 +144,7 @@ export default function BillingTimeline({ periods = [], siteId, onCreateAction, 
           key={period.month_key}
           period={period}
           siteId={siteId}
+          activeMonth={activeMonth}
           onCreateAction={onCreateAction}
           createdActions={createdActions}
         />

--- a/frontend/src/components/BillingTimeline.jsx
+++ b/frontend/src/components/BillingTimeline.jsx
@@ -1,0 +1,152 @@
+/**
+ * PROMEOS — BillingTimeline (V67)
+ * Liste mensuelle des périodes de facturation.
+ * Props: { periods, siteId, onCreateAction, createdActions }
+ */
+import { useNavigate } from 'react-router-dom';
+import { CheckCircle, AlertTriangle, XCircle, FileText, Upload, Zap } from 'lucide-react';
+import { Button, Badge } from '../ui';
+
+const STATUS_CONFIG = {
+  covered: {
+    icon: CheckCircle,
+    color: 'text-green-600',
+    bg: 'bg-green-50',
+    border: 'border-green-200',
+    label: 'Couvert',
+    badgeVariant: 'success',
+  },
+  partial: {
+    icon: AlertTriangle,
+    color: 'text-orange-500',
+    bg: 'bg-orange-50',
+    border: 'border-orange-200',
+    label: 'Partiel',
+    badgeVariant: 'warning',
+  },
+  missing: {
+    icon: XCircle,
+    color: 'text-red-500',
+    bg: 'bg-red-50',
+    border: 'border-red-200',
+    label: 'Manquant',
+    badgeVariant: 'danger',
+  },
+};
+
+function formatMonthKey(monthKey) {
+  const [y, m] = monthKey.split('-');
+  const d = new Date(parseInt(y), parseInt(m) - 1, 1);
+  return d.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+}
+
+function formatEur(amount) {
+  if (amount == null) return '—';
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(amount);
+}
+
+function MonthRow({ period, siteId, onCreateAction, createdActions }) {
+  const navigate = useNavigate();
+  const cfg = STATUS_CONFIG[period.coverage_status] || STATUS_CONFIG.missing;
+  const Icon = cfg.icon;
+  const actionKey = `${siteId}-${period.month_key}`;
+  const actionCreated = createdActions?.has(actionKey);
+
+  const handleView = () => {
+    const params = new URLSearchParams();
+    if (siteId) params.set('site_id', siteId);
+    params.set('month', period.month_key);
+    navigate(`/bill-intel?${params.toString()}`);
+  };
+
+  const handleImport = () => {
+    const params = new URLSearchParams();
+    if (siteId) params.set('site_id', siteId);
+    params.set('month', period.month_key);
+    navigate(`/bill-intel?${params.toString()}`);
+  };
+
+  return (
+    <div className={`flex items-center gap-3 px-4 py-3 rounded-lg border ${cfg.bg} ${cfg.border}`}>
+      {/* Statut icon */}
+      <Icon size={16} className={`flex-shrink-0 ${cfg.color}`} />
+
+      {/* Mois */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium text-gray-800 capitalize">
+            {formatMonthKey(period.month_key)}
+          </span>
+          <Badge variant={cfg.badgeVariant} size="xs">{cfg.label}</Badge>
+          {period.coverage_ratio > 0 && period.coverage_status !== 'covered' && (
+            <span className="text-xs text-gray-500">
+              {Math.round(period.coverage_ratio * 100)}%
+            </span>
+          )}
+        </div>
+        {period.missing_reason && (
+          <p className="text-xs text-gray-500 mt-0.5">{period.missing_reason}</p>
+        )}
+      </div>
+
+      {/* KPIs */}
+      <div className="hidden sm:flex items-center gap-4 text-xs text-gray-600 flex-shrink-0">
+        <span className="flex items-center gap-1">
+          <FileText size={12} />
+          {period.invoices_count} facture{period.invoices_count !== 1 ? 's' : ''}
+        </span>
+        {period.total_ttc != null && (
+          <span className="font-medium">{formatEur(period.total_ttc)}</span>
+        )}
+      </div>
+
+      {/* CTAs */}
+      <div className="flex items-center gap-1 flex-shrink-0">
+        {period.coverage_status === 'covered' ? (
+          <Button size="xs" variant="ghost" onClick={handleView}>
+            Voir
+          </Button>
+        ) : (
+          <Button size="xs" variant="secondary" onClick={handleImport}>
+            <Upload size={11} /> Importer
+          </Button>
+        )}
+        {period.coverage_status !== 'covered' && onCreateAction && (
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={() => onCreateAction(actionKey, period)}
+            disabled={actionCreated}
+            title={actionCreated ? 'Action déjà créée' : 'Créer une action de suivi'}
+          >
+            {actionCreated ? '✓' : <Zap size={11} />}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function BillingTimeline({ periods = [], siteId, onCreateAction, createdActions }) {
+  if (periods.length === 0) {
+    return (
+      <div className="text-center py-8 text-sm text-gray-500">
+        Aucune période à afficher.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {periods.map(period => (
+        <MonthRow
+          key={period.month_key}
+          period={period}
+          siteId={siteId}
+          onCreateAction={onCreateAction}
+          createdActions={createdActions}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/BillingTimeline.jsx
+++ b/frontend/src/components/BillingTimeline.jsx
@@ -1,11 +1,15 @@
 /**
- * PROMEOS — BillingTimeline (V67)
+ * PROMEOS — BillingTimeline (V70)
  * Liste mensuelle des périodes de facturation.
- * Props: { periods, siteId, onCreateAction, createdActions }
+ * Props: { periods, siteId, onCreateAction, createdActions, activeMonth, onImport }
+ *
+ * CTA Voir: invoice_ids.length === 1 → détail facture, sinon → /bill-intel filtré.
+ * CTA Importer: appelle onImport(siteId, monthKey, type) → file picker parent.
  */
 import { useNavigate } from 'react-router-dom';
-import { CheckCircle, AlertTriangle, XCircle, FileText, Upload, Zap } from 'lucide-react';
+import { CheckCircle, AlertTriangle, XCircle, FileText, Upload, Zap, Eye } from 'lucide-react';
 import { Button, Badge } from '../ui';
+import { deepLinkWithContext } from '../services/deepLink';
 
 const STATUS_CONFIG = {
   covered: {
@@ -50,7 +54,7 @@ function formatKwh(kwh) {
   return new Intl.NumberFormat('fr-FR', { maximumFractionDigits: 0 }).format(kwh) + '\u00a0kWh';
 }
 
-function MonthRow({ period, siteId, onCreateAction, createdActions, activeMonth }) {
+function MonthRow({ period, siteId, onCreateAction, createdActions, activeMonth, onImport }) {
   const navigate = useNavigate();
   const cfg = STATUS_CONFIG[period.coverage_status] || STATUS_CONFIG.missing;
   const Icon = cfg.icon;
@@ -59,17 +63,17 @@ function MonthRow({ period, siteId, onCreateAction, createdActions, activeMonth 
   const isActive = activeMonth && period.month_key === activeMonth;
 
   const handleView = () => {
-    const params = new URLSearchParams();
-    if (siteId) params.set('site_id', siteId);
-    params.set('month', period.month_key);
-    navigate(`/bill-intel?${params.toString()}`);
+    const ids = period.invoice_ids || [];
+    const url = deepLinkWithContext(siteId, period.month_key, ids.length === 1 ? ids[0] : null);
+    navigate(url);
   };
 
-  const handleImport = () => {
-    const params = new URLSearchParams();
-    if (siteId) params.set('site_id', siteId);
-    params.set('month', period.month_key);
-    navigate(`/bill-intel?${params.toString()}`);
+  const handleImportCsv = () => {
+    if (onImport) onImport(siteId, period.month_key, 'csv');
+  };
+
+  const handleImportPdf = () => {
+    if (onImport) onImport(siteId, period.month_key, 'pdf');
   };
 
   return (
@@ -121,12 +125,17 @@ function MonthRow({ period, siteId, onCreateAction, createdActions, activeMonth 
       <div className="flex items-center gap-1 flex-shrink-0">
         {period.coverage_status === 'covered' ? (
           <Button size="xs" variant="ghost" onClick={handleView}>
-            Voir
+            <Eye size={11} /> Voir
           </Button>
         ) : (
-          <Button size="xs" variant="secondary" onClick={handleImport}>
-            <Upload size={11} /> Importer
-          </Button>
+          <>
+            <Button size="xs" variant="secondary" type="button" onClick={handleImportCsv}>
+              <Upload size={11} /> CSV
+            </Button>
+            <Button size="xs" variant="secondary" type="button" onClick={handleImportPdf}>
+              <Upload size={11} /> PDF
+            </Button>
+          </>
         )}
         {period.coverage_status !== 'covered' && onCreateAction && (
           <Button
@@ -144,7 +153,7 @@ function MonthRow({ period, siteId, onCreateAction, createdActions, activeMonth 
   );
 }
 
-export default function BillingTimeline({ periods = [], siteId, onCreateAction, createdActions, activeMonth }) {
+export default function BillingTimeline({ periods = [], siteId, onCreateAction, createdActions, activeMonth, onImport }) {
   if (periods.length === 0) {
     return (
       <div className="text-center py-8 text-sm text-gray-500">
@@ -163,6 +172,7 @@ export default function BillingTimeline({ periods = [], siteId, onCreateAction, 
           activeMonth={activeMonth}
           onCreateAction={onCreateAction}
           createdActions={createdActions}
+          onImport={onImport}
         />
       ))}
     </div>

--- a/frontend/src/components/BillingTimeline.jsx
+++ b/frontend/src/components/BillingTimeline.jsx
@@ -45,6 +45,11 @@ function formatEur(amount) {
   return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(amount);
 }
 
+function formatKwh(kwh) {
+  if (kwh == null) return null;
+  return new Intl.NumberFormat('fr-FR', { maximumFractionDigits: 0 }).format(kwh) + '\u00a0kWh';
+}
+
 function MonthRow({ period, siteId, onCreateAction, createdActions, activeMonth }) {
   const navigate = useNavigate();
   const cfg = STATUS_CONFIG[period.coverage_status] || STATUS_CONFIG.missing;
@@ -98,6 +103,17 @@ function MonthRow({ period, siteId, onCreateAction, createdActions, activeMonth 
         </span>
         {period.total_ttc != null && (
           <span className="font-medium">{formatEur(period.total_ttc)}</span>
+        )}
+        {period.energy_kwh != null && (
+          <span className="flex items-center gap-1">
+            <Zap size={12} />
+            {formatKwh(period.energy_kwh)}
+          </span>
+        )}
+        {period.pdl_prm && (
+          <span className="font-mono text-gray-400" title="PDL/PRM">
+            {period.pdl_prm}
+          </span>
         )}
       </div>
 

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -35,7 +35,10 @@ function KpiTile({ icon: Icon, label, value, sub, color = 'text-gray-900', toolt
 
 export default function ConsoKpiHeader({ tunnel, hphc, progression, confidence }) {
   // --- kWh total ---
-  const totalKwh = tunnel?.total_kwh ?? progression?.ytd_actual_kwh ?? null;
+  // Priority: hphc.total_kwh (sum of readings HP+HC, always available when data exists)
+  // then tunnel.total_kwh (not returned by current tunnel service)
+  // then progression.ytd_actual_kwh (YTD targets — may be null if no targets configured)
+  const totalKwh = hphc?.total_kwh ?? tunnel?.total_kwh ?? progression?.ytd_actual_kwh ?? null;
   const kwhLabel = totalKwh != null ? `${Math.round(totalKwh).toLocaleString('fr-FR')} kWh` : '—';
 
   // --- EUR total (from hphc or progression) ---

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -1,18 +1,26 @@
 /**
- * PROMEOS — ConsoKpiHeader (QW2)
+ * PROMEOS — ConsoKpiHeader (QW2 / P1.1 polish)
  * 6-KPI header row for ConsumptionExplorerPage.
  * Reads motor data (tunnel, hphc, progression) to compute:
  *   kWh total, EUR total, EUR/MWh, CO2e, Pic kW (P95), Base nocturne %
  * Respects scope global (site + period) via motor props.
+ *
+ * P1.1: confidence tooltip "Comment calcule ?", EUR source tooltip.
  */
-import { Zap, Euro, TrendingUp, Leaf, Activity, Moon } from 'lucide-react';
+import { Zap, Euro, TrendingUp, Leaf, Activity, Moon, HelpCircle } from 'lucide-react';
 import { TrustBadge } from '../ui';
 
 const CO2E_FACTOR = 0.052; // kgCO2e/kWh (ADEME 2024 France electricity mix)
 
-function KpiTile({ icon: Icon, label, value, sub, color = 'text-gray-900' }) {
+const CONFIDENCE_TOOLTIP = {
+  high: 'Haute : > 500 releves, donnees homogenes',
+  medium: 'Moyenne : entre 100 et 500 releves',
+  low: 'Basse : < 100 releves — indicatif uniquement',
+};
+
+function KpiTile({ icon: Icon, label, value, sub, color = 'text-gray-900', tooltip }) {
   return (
-    <div className="flex items-center gap-3 bg-white rounded-xl border border-gray-200 px-4 py-3 min-w-0">
+    <div className="flex items-center gap-3 bg-white rounded-xl border border-gray-200 px-4 py-3 min-w-0" title={tooltip}>
       <div className="w-9 h-9 rounded-lg bg-gray-100 flex items-center justify-center shrink-0">
         <Icon size={18} className="text-gray-500" />
       </div>
@@ -33,8 +41,9 @@ export default function ConsoKpiHeader({ tunnel, hphc, progression, confidence }
   // --- EUR total (from hphc or progression) ---
   const totalEur = hphc?.total_cost_eur ?? null;
   const eurLabel = totalEur != null ? `${Math.round(totalEur).toLocaleString('fr-FR')} EUR` : '—';
+  const eurSource = hphc?.total_cost_eur != null ? 'Estime HP/HC' : 'Non disponible';
 
-  // --- EUR/MWh réel ---
+  // --- EUR/MWh reel ---
   const eurMwh = totalEur != null && totalKwh > 0
     ? Math.round((totalEur / totalKwh) * 1000 * 100) / 100
     : null;
@@ -65,7 +74,7 @@ export default function ConsoKpiHeader({ tunnel, hphc, progression, confidence }
     if (dayAvg === 0) return null;
     return Math.round((nightAvg / dayAvg) * 100);
   })();
-  const basePctLabel = basePct != null ? `${basePct}%` : '—';
+  const basePctLabel = basePct != null ? `${basePct} %` : '—';
   const basePctColor = basePct != null
     ? (basePct > 60 ? 'text-red-600' : basePct > 40 ? 'text-amber-600' : 'text-green-600')
     : 'text-gray-900';
@@ -73,20 +82,26 @@ export default function ConsoKpiHeader({ tunnel, hphc, progression, confidence }
   const confBadge = confidence
     ? { high: { label: 'Haute', variant: 'ok' }, medium: { label: 'Moyenne', variant: 'warn' }, low: { label: 'Basse', variant: 'crit' } }[confidence] || null
     : null;
+  const confTooltip = confidence ? CONFIDENCE_TOOLTIP[confidence] : null;
 
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
         <h3 className="text-sm font-semibold text-gray-600">KPIs Consommation</h3>
-        {confBadge && <TrustBadge level={confBadge.variant} label={`Confiance ${confBadge.label}`} size="sm" />}
+        {confBadge && (
+          <span className="inline-flex items-center gap-1" title={`Comment calcule ? ${confTooltip}`}>
+            <TrustBadge level={confBadge.variant} label={`Confiance ${confBadge.label}`} size="sm" />
+            <HelpCircle size={12} className="text-gray-400 cursor-help" />
+          </span>
+        )}
       </div>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
-        <KpiTile icon={Zap} label="kWh total" value={kwhLabel} />
-        <KpiTile icon={Euro} label="EUR total" value={eurLabel} />
-        <KpiTile icon={TrendingUp} label="EUR/MWh" value={eurMwhLabel} />
-        <KpiTile icon={Leaf} label="CO2e" value={co2Label} sub="ADEME 2024" />
-        <KpiTile icon={Activity} label="Pic kW (P95)" value={p95Label} />
-        <KpiTile icon={Moon} label="Base nocturne" value={basePctLabel} color={basePctColor} />
+        <KpiTile icon={Zap} label="kWh total" value={kwhLabel} tooltip="Somme des releves sur la periode selectionnee" />
+        <KpiTile icon={Euro} label="EUR total" value={eurLabel} sub={eurSource} tooltip={`Calcul : ${eurSource}. Basé sur les prix HP/HC du contrat ou estimés.`} />
+        <KpiTile icon={TrendingUp} label="EUR/MWh" value={eurMwhLabel} tooltip="Prix moyen = EUR total / MWh total" />
+        <KpiTile icon={Leaf} label="CO2e" value={co2Label} sub="ADEME 2024" tooltip="Facteur ADEME 2024 : 0,052 kgCO2e/kWh (mix France)" />
+        <KpiTile icon={Activity} label="Pic kW (P95)" value={p95Label} tooltip="95e percentile de puissance sur les creneaux horaires" />
+        <KpiTile icon={Moon} label="Base nocturne" value={basePctLabel} color={basePctColor} tooltip="Ratio consommation nuit (22h-6h) / jour (6h-22h) en semaine" />
       </div>
     </div>
   );

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -1,0 +1,93 @@
+/**
+ * PROMEOS — ConsoKpiHeader (QW2)
+ * 6-KPI header row for ConsumptionExplorerPage.
+ * Reads motor data (tunnel, hphc, progression) to compute:
+ *   kWh total, EUR total, EUR/MWh, CO2e, Pic kW (P95), Base nocturne %
+ * Respects scope global (site + period) via motor props.
+ */
+import { Zap, Euro, TrendingUp, Leaf, Activity, Moon } from 'lucide-react';
+import { TrustBadge } from '../ui';
+
+const CO2E_FACTOR = 0.052; // kgCO2e/kWh (ADEME 2024 France electricity mix)
+
+function KpiTile({ icon: Icon, label, value, sub, color = 'text-gray-900' }) {
+  return (
+    <div className="flex items-center gap-3 bg-white rounded-xl border border-gray-200 px-4 py-3 min-w-0">
+      <div className="w-9 h-9 rounded-lg bg-gray-100 flex items-center justify-center shrink-0">
+        <Icon size={18} className="text-gray-500" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-[10px] text-gray-400 uppercase tracking-wider font-medium truncate">{label}</p>
+        <p className={`text-lg font-bold ${color} truncate leading-tight`}>{value ?? '—'}</p>
+        {sub && <p className="text-[11px] text-gray-400 truncate">{sub}</p>}
+      </div>
+    </div>
+  );
+}
+
+export default function ConsoKpiHeader({ tunnel, hphc, progression, confidence }) {
+  // --- kWh total ---
+  const totalKwh = tunnel?.total_kwh ?? progression?.ytd_actual_kwh ?? null;
+  const kwhLabel = totalKwh != null ? `${Math.round(totalKwh).toLocaleString('fr-FR')} kWh` : '—';
+
+  // --- EUR total (from hphc or progression) ---
+  const totalEur = hphc?.total_cost_eur ?? null;
+  const eurLabel = totalEur != null ? `${Math.round(totalEur).toLocaleString('fr-FR')} EUR` : '—';
+
+  // --- EUR/MWh réel ---
+  const eurMwh = totalEur != null && totalKwh > 0
+    ? Math.round((totalEur / totalKwh) * 1000 * 100) / 100
+    : null;
+  const eurMwhLabel = eurMwh != null ? `${eurMwh.toLocaleString('fr-FR')} EUR/MWh` : '—';
+
+  // --- CO2e ---
+  const co2Kg = totalKwh != null ? Math.round(totalKwh * CO2E_FACTOR) : null;
+  const co2Label = co2Kg != null ? `${co2Kg.toLocaleString('fr-FR')} kg` : '—';
+
+  // --- Pic kW (P95 from tunnel envelope) ---
+  const p95 = (() => {
+    if (!tunnel?.envelope) return null;
+    const slots = tunnel.envelope.weekday || tunnel.envelope.weekend || [];
+    if (!slots.length) return null;
+    return Math.max(...slots.map(s => s.p95 ?? s.p90 ?? 0));
+  })();
+  const p95Label = p95 != null ? `${Math.round(p95).toLocaleString('fr-FR')} kW` : '—';
+
+  // --- Base nocturne % (ratio of night hours P50 vs overall P50) ---
+  const basePct = (() => {
+    if (!tunnel?.envelope?.weekday) return null;
+    const slots = tunnel.envelope.weekday;
+    if (slots.length < 24) return null;
+    const nightSlots = slots.filter(s => s.hour < 6 || s.hour >= 22);
+    const daySlots = slots.filter(s => s.hour >= 6 && s.hour < 22);
+    const nightAvg = nightSlots.reduce((s, x) => s + (x.p50 || 0), 0) / (nightSlots.length || 1);
+    const dayAvg = daySlots.reduce((s, x) => s + (x.p50 || 0), 0) / (daySlots.length || 1);
+    if (dayAvg === 0) return null;
+    return Math.round((nightAvg / dayAvg) * 100);
+  })();
+  const basePctLabel = basePct != null ? `${basePct}%` : '—';
+  const basePctColor = basePct != null
+    ? (basePct > 60 ? 'text-red-600' : basePct > 40 ? 'text-amber-600' : 'text-green-600')
+    : 'text-gray-900';
+
+  const confBadge = confidence
+    ? { high: { label: 'Haute', variant: 'ok' }, medium: { label: 'Moyenne', variant: 'warn' }, low: { label: 'Basse', variant: 'crit' } }[confidence] || null
+    : null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-semibold text-gray-600">KPIs Consommation</h3>
+        {confBadge && <TrustBadge level={confBadge.variant} label={`Confiance ${confBadge.label}`} size="sm" />}
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+        <KpiTile icon={Zap} label="kWh total" value={kwhLabel} />
+        <KpiTile icon={Euro} label="EUR total" value={eurLabel} />
+        <KpiTile icon={TrendingUp} label="EUR/MWh" value={eurMwhLabel} />
+        <KpiTile icon={Leaf} label="CO2e" value={co2Label} sub="ADEME 2024" />
+        <KpiTile icon={Activity} label="Pic kW (P95)" value={p95Label} />
+        <KpiTile icon={Moon} label="Base nocturne" value={basePctLabel} color={basePctColor} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CoverageBar.jsx
+++ b/frontend/src/components/CoverageBar.jsx
@@ -1,0 +1,47 @@
+/**
+ * PROMEOS — CoverageBar (V67)
+ * Barre visuelle proportionnelle : covered (vert) | partial (orange) | missing (rouge).
+ * Props: { covered, partial, missing, total, minMonth, maxMonth }
+ */
+
+export default function CoverageBar({ covered = 0, partial = 0, missing = 0, total = 0, minMonth, maxMonth }) {
+  if (total === 0) return null;
+
+  const pctCovered = Math.round((covered / total) * 100);
+  const pctPartial = Math.round((partial / total) * 100);
+  const pctMissing = 100 - pctCovered - pctPartial;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex h-3 rounded-full overflow-hidden bg-gray-100">
+        {pctCovered > 0 && (
+          <div
+            className="bg-green-500 transition-all"
+            style={{ width: `${pctCovered}%` }}
+            title={`${covered} mois couverts`}
+          />
+        )}
+        {pctPartial > 0 && (
+          <div
+            className="bg-orange-400 transition-all"
+            style={{ width: `${pctPartial}%` }}
+            title={`${partial} mois partiels`}
+          />
+        )}
+        {pctMissing > 0 && (
+          <div
+            className="bg-red-400 transition-all"
+            style={{ width: `${Math.max(pctMissing, 0)}%` }}
+            title={`${missing} mois manquants`}
+          />
+        )}
+      </div>
+      {(minMonth || maxMonth) && (
+        <div className="flex justify-between text-xs text-gray-400">
+          <span>{minMonth || ''}</span>
+          <span>{maxMonth || ''}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/InsightDrawer.jsx
+++ b/frontend/src/components/InsightDrawer.jsx
@@ -80,6 +80,7 @@ export default function InsightDrawer({ open, onClose, insightId }) {
       .catch((err) => {
         setDetail(null);
         setError({
+          method: 'GET',
           status: err?.response?.status,
           message: err?.response?.data?.detail || err?.message || 'Erreur inconnue',
           endpoint: `/billing/insights/${insightId}`,
@@ -106,7 +107,8 @@ export default function InsightDrawer({ open, onClose, insightId }) {
           {isExpert && error && (
             <div className="mt-4 bg-red-50 rounded-lg p-3 text-left">
               <p className="text-xs font-semibold text-red-600">Debug</p>
-              <p className="text-xs text-red-500 mt-1">Endpoint : {error.endpoint}</p>
+              <p className="text-xs text-red-500 mt-1">Method : {error.method}</p>
+              <p className="text-xs text-red-500">Endpoint : {error.endpoint}</p>
               <p className="text-xs text-red-500">Status : {error.status || 'N/A'}</p>
               <p className="text-xs text-red-500">Message : {error.message}</p>
             </div>

--- a/frontend/src/components/InsightDrawer.jsx
+++ b/frontend/src/components/InsightDrawer.jsx
@@ -69,13 +69,22 @@ export default function InsightDrawer({ open, onClose, insightId }) {
   const { isExpert } = useExpertMode();
   const [detail, setDetail] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    if (!open || !insightId) { setDetail(null); return; }
+    if (!open || !insightId) { setDetail(null); setError(null); return; }
     setLoading(true);
+    setError(null);
     getInsightDetail(insightId)
-      .then(setDetail)
-      .catch(() => setDetail(null))
+      .then((data) => { setDetail(data); setError(null); })
+      .catch((err) => {
+        setDetail(null);
+        setError({
+          status: err?.response?.status,
+          message: err?.response?.data?.detail || err?.message || 'Erreur inconnue',
+          endpoint: `/billing/insights/${insightId}`,
+        });
+      })
       .finally(() => setLoading(false));
   }, [open, insightId]);
 
@@ -92,7 +101,17 @@ export default function InsightDrawer({ open, onClose, insightId }) {
           <SkeletonCard lines={4} />
         </div>
       ) : !detail ? (
-        <p className="text-sm text-gray-500 text-center py-8">Détail non disponible.</p>
+        <div className="text-center py-8">
+          <p className="text-sm text-gray-500">Détail non disponible.</p>
+          {isExpert && error && (
+            <div className="mt-4 bg-red-50 rounded-lg p-3 text-left">
+              <p className="text-xs font-semibold text-red-600">Debug</p>
+              <p className="text-xs text-red-500 mt-1">Endpoint : {error.endpoint}</p>
+              <p className="text-xs text-red-500">Status : {error.status || 'N/A'}</p>
+              <p className="text-xs text-red-500">Message : {error.message}</p>
+            </div>
+          )}
+        </div>
       ) : (
         <div className="space-y-6">
           {/* En-tête */}

--- a/frontend/src/components/InsightDrawer.jsx
+++ b/frontend/src/components/InsightDrawer.jsx
@@ -42,7 +42,9 @@ function fmt(v) {
 }
 
 const CAUSE_LABELS = {
-  shadow_gap: (m) => `L'écart entre le montant facturé (${fmt(m.actual_ttc)} €) et le shadow billing (${fmt(m.expected_ttc)} €) dépasse le seuil de ${m.threshold_pct || 10}%.`,
+  shadow_gap: (m) => m.expected_ttc != null
+    ? `L'écart entre le montant facturé (${fmt(m.actual_ttc)} €) et le shadow billing (${fmt(m.expected_ttc)} €) dépasse le seuil de ${m.threshold_pct || 10}%.`
+    : `L'écart entre le montant facturé (${fmt(m.actual_total_eur)} €) et le shadow billing (${fmt(m.shadow_total_eur)} €) dépasse le seuil de ${m.threshold_pct || 10}%.`,
   unit_price_high: (m) => `Le prix unitaire (${m.unit_price?.toFixed(4) || '?'} €/kWh) dépasse le seuil de ${m.threshold || 0.30} €/kWh pour ce type d'énergie.`,
   duplicate_invoice: () => `Cette facture est un doublon (même site, même période, même montant).`,
   missing_period: () => `Aucune facture ne couvre cette période. Vérifiez l'import ou contactez le fournisseur.`,
@@ -124,6 +126,28 @@ export default function InsightDrawer({ open, onClose, insightId }) {
             <p className="text-sm text-gray-800">{cause}</p>
           </div>
 
+          {/* Confiance & Hypothèses */}
+          {m.confidence && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-500 uppercase mb-2">Confiance</h4>
+              <div className="flex items-center gap-2">
+                <Badge status={m.confidence === 'high' ? 'ok' : m.confidence === 'medium' ? 'info' : 'warn'}>
+                  {m.confidence === 'high' ? 'Élevée' : m.confidence === 'medium' ? 'Moyenne' : 'Faible'}
+                </Badge>
+              </div>
+              {m.assumptions?.length > 0 && (
+                <ul className="mt-2 space-y-1">
+                  {m.assumptions.map((a, i) => (
+                    <li key={i} className="text-xs text-gray-600 flex items-center gap-1.5">
+                      <span className="w-1 h-1 rounded-full bg-gray-400 shrink-0" />
+                      {a}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
           {/* Tableau Facturé vs Attendu */}
           {hasBreakdown && (
             <div>
@@ -168,6 +192,14 @@ export default function InsightDrawer({ open, onClose, insightId }) {
                   </tr>
                 </tbody>
               </table>
+            </div>
+          )}
+
+          {/* Écart détecté (types sans breakdown V2) */}
+          {!hasBreakdown && detail.estimated_loss_eur > 0 && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-500 uppercase mb-2">Écart détecté</h4>
+              <p className="text-lg font-bold text-red-600">{fmt(detail.estimated_loss_eur)} €</p>
             </div>
           )}
 

--- a/frontend/src/components/InsightDrawer.jsx
+++ b/frontend/src/components/InsightDrawer.jsx
@@ -1,0 +1,200 @@
+/**
+ * PROMEOS — InsightDrawer (V70)
+ * Drawer "Comprendre l'écart" : breakdown facturé vs attendu + cause probable.
+ * Props: { open, onClose, insightId }
+ */
+import { useState, useEffect } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import Drawer from '../ui/Drawer';
+import { Badge } from '../ui';
+import { SkeletonCard } from '../ui/Skeleton';
+import { getInsightDetail } from '../services/api';
+import { useExpertMode } from '../contexts/ExpertModeContext';
+
+const TYPE_LABELS = {
+  shadow_gap: 'Écart shadow billing',
+  unit_price_high: 'Prix unitaire élevé',
+  duplicate_invoice: 'Doublon facture',
+  missing_period: 'Période manquante',
+  period_too_long: 'Période longue',
+  negative_kwh: 'kWh négatifs',
+  zero_amount: 'Montant zéro',
+  lines_sum_mismatch: 'Écart lignes/total',
+  consumption_spike: 'Pic de consommation',
+  price_drift: 'Dérive de prix',
+  ttc_coherence: 'Cohérence TTC',
+  contract_expiry: 'Contrat expiré',
+  reseau_mismatch: 'Écart réseau / TURPE',
+  taxes_mismatch: 'Écart taxes / CSPE',
+};
+
+const SEVERITY_LABELS = {
+  critical: 'Critique', high: 'Élevé', medium: 'Moyen', low: 'Faible',
+};
+
+const SEVERITY_BADGE = {
+  critical: 'crit', high: 'warn', medium: 'info', low: 'neutral',
+};
+
+function fmt(v) {
+  if (v == null) return '—';
+  return Number(v).toLocaleString('fr-FR', { maximumFractionDigits: 2 });
+}
+
+const CAUSE_LABELS = {
+  shadow_gap: (m) => `L'écart entre le montant facturé (${fmt(m.actual_ttc)} €) et le shadow billing (${fmt(m.expected_ttc)} €) dépasse le seuil de ${m.threshold_pct || 10}%.`,
+  unit_price_high: (m) => `Le prix unitaire (${m.unit_price?.toFixed(4) || '?'} €/kWh) dépasse le seuil de ${m.threshold || 0.30} €/kWh pour ce type d'énergie.`,
+  duplicate_invoice: () => `Cette facture est un doublon (même site, même période, même montant).`,
+  missing_period: () => `Aucune facture ne couvre cette période. Vérifiez l'import ou contactez le fournisseur.`,
+  period_too_long: (m) => `La période de facturation (${m.days || '?'} jours) est anormalement longue.`,
+  negative_kwh: () => `La consommation est négative — possible erreur de relevé ou inversion d'index.`,
+  zero_amount: () => `Le montant facturé est nul — vérifiez s'il s'agit d'un avoir ou d'une erreur.`,
+  lines_sum_mismatch: (m) => `La somme des lignes (${fmt(m.lines_total)} €) ne correspond pas au total facturé (${fmt(m.invoice_total)} €).`,
+  consumption_spike: (m) => `La consommation (${m.kwh?.toLocaleString() || '?'} kWh) dépasse ${m.threshold_ratio || 2}× la moyenne des 6 derniers mois.`,
+  price_drift: (m) => `Le prix unitaire a dérivé de ${m.drift_pct?.toFixed(1) || '?'}% par rapport à la période précédente.`,
+  reseau_mismatch: (m) => `L'écart réseau/TURPE (${fmt(m.delta_reseau)} €) dépasse le seuil de 10%.`,
+  taxes_mismatch: (m) => `L'écart taxes/CSPE (${fmt(m.delta_taxes)} €) dépasse le seuil de 5%.`,
+};
+
+const BREAKDOWN_ROWS = [
+  { key: 'fourniture', label: 'Énergie (fourniture)' },
+  { key: 'reseau', label: 'Réseau (TURPE)' },
+  { key: 'taxes', label: 'Taxes (CSPE/TICGN)' },
+  { key: 'tva', label: 'TVA' },
+];
+
+export default function InsightDrawer({ open, onClose, insightId }) {
+  const { isExpert } = useExpertMode();
+  const [detail, setDetail] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !insightId) { setDetail(null); return; }
+    setLoading(true);
+    getInsightDetail(insightId)
+      .then(setDetail)
+      .catch(() => setDetail(null))
+      .finally(() => setLoading(false));
+  }, [open, insightId]);
+
+  const m = detail?.metrics || {};
+  const hasBreakdown = m.expected_ttc != null || m.expected_fourniture_ht != null;
+  const causeGen = CAUSE_LABELS[detail?.type];
+  const cause = causeGen ? causeGen(m) : detail?.message || '';
+
+  return (
+    <Drawer open={open} onClose={onClose} title="Comprendre l'écart" wide>
+      {loading ? (
+        <div className="space-y-3">
+          <SkeletonCard lines={2} />
+          <SkeletonCard lines={4} />
+        </div>
+      ) : !detail ? (
+        <p className="text-sm text-gray-500 text-center py-8">Détail non disponible.</p>
+      ) : (
+        <div className="space-y-6">
+          {/* En-tête */}
+          <div className="flex items-center gap-3">
+            <AlertTriangle size={20} className={detail.severity === 'critical' ? 'text-red-600' : detail.severity === 'high' ? 'text-orange-600' : 'text-amber-500'} />
+            <div>
+              <h3 className="text-sm font-semibold text-gray-900">
+                {TYPE_LABELS[detail.type] || detail.type}
+              </h3>
+              <div className="flex items-center gap-2 mt-1">
+                <Badge status={SEVERITY_BADGE[detail.severity] || 'neutral'}>
+                  {SEVERITY_LABELS[detail.severity] || detail.severity}
+                </Badge>
+                {detail.estimated_loss_eur > 0 && (
+                  <span className="text-sm font-bold text-red-600">
+                    {detail.estimated_loss_eur.toLocaleString()} €
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Message */}
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-sm text-gray-700">{detail.message}</p>
+          </div>
+
+          {/* Cause probable */}
+          <div>
+            <h4 className="text-xs font-semibold text-gray-500 uppercase mb-2">Cause probable</h4>
+            <p className="text-sm text-gray-800">{cause}</p>
+          </div>
+
+          {/* Tableau Facturé vs Attendu */}
+          {hasBreakdown && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-500 uppercase mb-2">Facturé vs Attendu</h4>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-200">
+                    <th className="text-left py-2 text-xs font-medium text-gray-500">Composante</th>
+                    <th className="text-right py-2 text-xs font-medium text-gray-500">Facturé</th>
+                    <th className="text-right py-2 text-xs font-medium text-gray-500">Attendu</th>
+                    <th className="text-right py-2 text-xs font-medium text-gray-500">Écart</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {BREAKDOWN_ROWS.map(row => {
+                    const actual = m[`actual_${row.key}_ht`] ?? m[`actual_${row.key}`];
+                    const expected = m[`expected_${row.key}_ht`] ?? m[`expected_${row.key}`];
+                    const delta = m[`delta_${row.key}`];
+                    if (actual == null && expected == null) return null;
+                    return (
+                      <tr key={row.key} className="border-b border-gray-100">
+                        <td className="py-2 text-gray-700">{row.label}</td>
+                        <td className="py-2 text-right font-medium">{fmt(actual)} €</td>
+                        <td className="py-2 text-right">{fmt(expected)} €</td>
+                        <td className={`py-2 text-right font-medium ${delta > 0 ? 'text-red-600' : delta < 0 ? 'text-green-600' : 'text-gray-500'}`}>
+                          {delta != null ? `${delta > 0 ? '+' : ''}${fmt(delta)} €` : '—'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {/* Total */}
+                  <tr className="border-t-2 border-gray-300 font-semibold">
+                    <td className="py-2 text-gray-900">Total TTC</td>
+                    <td className="py-2 text-right">{fmt(m.actual_ttc)} €</td>
+                    <td className="py-2 text-right">{fmt(m.expected_ttc)} €</td>
+                    <td className={`py-2 text-right ${m.delta_ttc > 0 ? 'text-red-600' : m.delta_ttc < 0 ? 'text-green-600' : 'text-gray-500'}`}>
+                      {m.delta_ttc != null ? `${m.delta_ttc > 0 ? '+' : ''}${fmt(m.delta_ttc)} €` : '—'}
+                      {m.delta_pct != null && (
+                        <span className="ml-1 text-xs font-normal">({m.delta_pct > 0 ? '+' : ''}{m.delta_pct.toFixed(1)}%)</span>
+                      )}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Mode Expert */}
+          {isExpert && (
+            <div className="bg-slate-50 rounded-lg p-3 text-xs text-gray-500 space-y-1">
+              <p className="font-semibold text-gray-600">Expert</p>
+              {m.rule_id && <p>Règle : {m.rule_id}</p>}
+              {m.method && <p>Méthode : {m.method}</p>}
+              {m.energy_type && <p>Énergie : {m.energy_type}</p>}
+              {m.price_ref != null && <p>Prix ref : {m.price_ref} €/kWh</p>}
+              {m.kwh != null && <p>kWh : {m.kwh.toLocaleString()}</p>}
+              {m.threshold_pct != null && <p>Seuil : {m.threshold_pct}%</p>}
+              {detail.recommended_actions?.length > 0 && (
+                <div>
+                  <p className="font-semibold text-gray-600 mt-2">Actions recommandées</p>
+                  <ul className="list-disc list-inside mt-1">
+                    {detail.recommended_actions.map((a, i) => (
+                      <li key={i}>{typeof a === 'string' ? a : a.label || JSON.stringify(a)}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </Drawer>
+  );
+}

--- a/frontend/src/components/PatrimoineHeatmap.jsx
+++ b/frontend/src/components/PatrimoineHeatmap.jsx
@@ -187,7 +187,7 @@ function SiteTile({ tile, allTiles, onOpenSite }) {
 
 /* ── Composant principal ─────────────────────────────────────────────────── */
 
-export default function PatrimoineHeatmap({ tiles = [], onOpenSite, loading = false, error = null }) {
+export default function PatrimoineHeatmap({ tiles = [], onOpenSite, loading = false, error = null, topSlot = null }) {
   const navigate = useNavigate();
 
   // Filtres locaux
@@ -305,6 +305,9 @@ export default function PatrimoineHeatmap({ tiles = [], onOpenSite, loading = fa
           )}
         </div>
       </div>
+
+      {/* ── V64 Distribution du risque ── */}
+      {topSlot}
 
       {/* ── Bandeau Top-15 (discret, 1 ligne) ── */}
       {showTopBanner && (

--- a/frontend/src/components/PatrimoineRiskDistributionBar.jsx
+++ b/frontend/src/components/PatrimoineRiskDistributionBar.jsx
@@ -1,0 +1,107 @@
+/**
+ * PatrimoineRiskDistributionBar — V64
+ *
+ * Barre de distribution du risque financier (OK / À surveiller / Critique).
+ * Pas de Card wrapper — destiné à être inséré dans une Card existante.
+ *
+ * Algorithme : quantiles p40/p80 sur le tableau des risques.
+ * Cas spécial N < 8 : top1 critique, next2 à surveiller, reste OK.
+ */
+import React from 'react';
+
+/* ── Utilitaire formatage ── */
+
+function fmtK(n) {
+  if (!n || n <= 0) return '0 €';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)} M€`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)} k€`;
+  return `${Math.round(n)} €`;
+}
+
+/* ── Calcul des buckets ── */
+
+/**
+ * Calcule les buckets OK / À surveiller / Critique depuis un tableau de risques.
+ *
+ * @param {number[]} risks - Tableau de valeurs de risque (€). Peut contenir des zéros.
+ * @returns {{ ok: number, warn: number, critical: number, thresholds: { p40: number, p80: number } }}
+ */
+export function computeRiskBuckets(risks) {
+  const n = risks.length;
+  if (n === 0) return { ok: 0, warn: 0, critical: 0, thresholds: { p40: 0, p80: 0 } };
+
+  const allZero = risks.every(r => r === 0);
+  if (allZero) return { ok: n, warn: 0, critical: 0, thresholds: { p40: 0, p80: 0 } };
+
+  const sorted = [...risks].sort((a, b) => a - b);
+  const p40 = sorted[Math.floor(0.4 * (n - 1))];
+  const p80 = sorted[Math.floor(0.8 * (n - 1))];
+
+  if (n < 8) {
+    // Petite population : classement fixe
+    const critical = 1;
+    const warn = Math.min(2, n - 1);
+    const ok = n - critical - warn;
+    return { ok, warn, critical, thresholds: { p40, p80 } };
+  }
+
+  let ok = 0, warn = 0, critical = 0;
+  for (const r of risks) {
+    if (r <= p40) ok++;
+    else if (r <= p80) warn++;
+    else critical++;
+  }
+  return { ok, warn, critical, thresholds: { p40, p80 } };
+}
+
+/* ── Composant ── */
+
+/**
+ * Barre compacte de distribution du risque.
+ * Nécessite que les sites aient un champ `total_risk_eur`, `risque_eur` ou `risk_eur`.
+ *
+ * @param {{ sites: Array }} props
+ */
+export default function PatrimoineRiskDistributionBar({ sites }) {
+  if (!sites || sites.length === 0) return null;
+
+  const risks = sites.map(s => Number(s.total_risk_eur ?? s.risque_eur ?? s.risk_eur ?? 0));
+  const { ok, warn, critical, thresholds } = computeRiskBuckets(risks);
+  const n = risks.length;
+
+  const okPct   = (ok       / n) * 100;
+  const warnPct = (warn     / n) * 100;
+  const critPct = (critical / n) * 100;
+
+  const tooltip = `Basé sur quantiles du risque (€/site) — p40 : ${fmtK(thresholds.p40)}, p80 : ${fmtK(thresholds.p80)}`;
+
+  const parts = [];
+  if (ok       > 0) parts.push({ key: 'ok',   text: `${ok} OK`,            cls: 'text-green-600 font-semibold' });
+  if (warn     > 0) parts.push({ key: 'warn', text: `${warn} À surveiller`, cls: 'text-amber-600 font-semibold' });
+  if (critical > 0) parts.push({ key: 'crit', text: `${critical} Critique`,  cls: 'text-red-500 font-semibold'  });
+
+  return (
+    <div className="flex items-center gap-3 py-1" title={tooltip}>
+      {/* Barre segmentée */}
+      <div
+        className="flex h-2 rounded-full overflow-hidden flex-1 min-w-0 bg-gray-100"
+        role="img"
+        aria-label={`Distribution du risque : ${ok} OK, ${warn} à surveiller, ${critical} critique`}
+      >
+        {okPct   > 0 && <div className="bg-green-300 transition-all" style={{ width: `${okPct}%`   }} />}
+        {warnPct > 0 && <div className="bg-amber-400 transition-all" style={{ width: `${warnPct}%` }} />}
+        {critPct > 0 && <div className="bg-red-500   transition-all" style={{ width: `${critPct}%` }} />}
+      </div>
+
+      {/* Résumé textuel */}
+      <span className="text-[11px] text-gray-500 whitespace-nowrap shrink-0 flex items-center gap-1.5">
+        {parts.map((p, i) => (
+          <React.Fragment key={p.key}>
+            {i > 0 && <span className="text-gray-300">•</span>}
+            <span className={p.cls}>{p.text}</span>
+          </React.Fragment>
+        ))}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/SiteAnomalyPanel.jsx
+++ b/frontend/src/components/SiteAnomalyPanel.jsx
@@ -1,0 +1,287 @@
+/**
+ * SiteAnomalyPanel — V65
+ * Panneau enrichi pour l'onglet Anomalies du SiteDrawer.
+ * Remplace PatrimoineHealthCard dans le contexte drawer :
+ *   - Toutes les anomalies (pas seulement top 3)
+ *   - Filtres rapides : Tous / Critiques / Facturation / Décret Tertiaire / BACS
+ *   - Statut action (localStorage) + bouton "Créer action"
+ *   - Tri par priority_score DESC
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { AlertTriangle, ShieldCheck, AlertCircle, Info, Euro, RefreshCw } from 'lucide-react';
+import { getPatrimoineAnomalies } from '../services/api';
+import {
+  getAnomalyAction,
+  ACTION_STATUS_LABEL,
+  ACTION_STATUS_COLOR,
+} from '../services/anomalyActions';
+import AnomalyActionModal from './AnomalyActionModal';
+
+/* ── Constantes locales ── */
+
+const SEVERITY_CONFIG = {
+  CRITICAL: { label: 'Critique',  color: 'text-red-700',    bg: 'bg-red-50',    border: 'border-red-200',    icon: AlertCircle,   dot: 'bg-red-500'    },
+  HIGH:     { label: 'Élevé',     color: 'text-orange-700', bg: 'bg-orange-50', border: 'border-orange-200', icon: AlertTriangle, dot: 'bg-orange-400' },
+  MEDIUM:   { label: 'Moyen',     color: 'text-amber-700',  bg: 'bg-amber-50',  border: 'border-amber-200',  icon: AlertTriangle, dot: 'bg-amber-400'  },
+  LOW:      { label: 'Faible',    color: 'text-blue-700',   bg: 'bg-blue-50',   border: 'border-blue-200',   icon: Info,          dot: 'bg-blue-400'   },
+};
+
+const FRAMEWORK_CHIP = {
+  DECRET_TERTIAIRE: { label: 'Décret Tertiaire', color: 'bg-purple-100 text-purple-700' },
+  FACTURATION:      { label: 'Facturation',       color: 'bg-blue-100 text-blue-700'    },
+  BACS:             { label: 'BACS',              color: 'bg-teal-100 text-teal-700'    },
+  NONE:             null,
+};
+
+const QUICK_FILTERS = [
+  { key: 'all',              label: 'Tous'            },
+  { key: 'CRITICAL',        label: 'Critiques'       },
+  { key: 'FACTURATION',     label: 'Facturation'     },
+  { key: 'DECRET_TERTIAIRE',label: 'Décret Tertiaire'},
+  { key: 'BACS',            label: 'BACS'            },
+];
+
+/* ── Sous-composants ── */
+
+function ScoreGauge({ score }) {
+  const barColor = score >= 80 ? 'bg-green-500' : score >= 50 ? 'bg-amber-400' : 'bg-red-500';
+  const textColor = score >= 80 ? 'text-green-700' : score >= 50 ? 'text-amber-700' : 'text-red-700';
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-gray-600">Score de complétude</span>
+        <span className={`text-sm font-bold ${textColor}`}>{score} / 100</span>
+      </div>
+      <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+        <div className={`h-full rounded-full transition-all duration-500 ${barColor}`} style={{ width: `${score}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function fmtEurRisk(eur) {
+  if (!eur || eur <= 0) return null;
+  if (eur >= 1000) return `~${(eur / 1000).toFixed(0)} k€`;
+  return `~${eur.toFixed(0)} €`;
+}
+
+/* ── Composant principal ── */
+
+/**
+ * @param {{ siteId: number, orgId: number|null }} props
+ */
+export default function SiteAnomalyPanel({ siteId, orgId }) {
+  const [data, setData]       = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError]     = useState(null);
+  const [activeFilter, setActiveFilter] = useState('all');
+  const [actionModal, setActionModal]   = useState(null); // { code, title }
+  const [actionTick, setActionTick]     = useState(0);   // force re-render after save
+
+  const fetchAnomalies = useCallback(() => {
+    if (!siteId) return;
+    setLoading(true);
+    setError(null);
+    getPatrimoineAnomalies(siteId)
+      .then(setData)
+      .catch(() => setError('Impossible de charger les anomalies.'))
+      .finally(() => setLoading(false));
+  }, [siteId]);
+
+  useEffect(() => { fetchAnomalies(); }, [fetchAnomalies]);
+
+  /* ── États de chargement ── */
+
+  if (loading) {
+    return (
+      <div className="space-y-2 animate-pulse">
+        <div className="h-4 bg-gray-100 rounded w-2/3" />
+        <div className="h-2 bg-gray-100 rounded" />
+        <div className="h-16 bg-gray-50 rounded-lg border" />
+        <div className="h-16 bg-gray-50 rounded-lg border" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-6 text-gray-400">
+        <AlertTriangle size={22} className="mx-auto mb-1 text-amber-400" />
+        <p className="text-xs text-gray-500">{error}</p>
+        <button onClick={fetchAnomalies} className="mt-2 inline-flex items-center gap-1 text-xs text-blue-600 hover:underline">
+          <RefreshCw size={11} /> Réessayer
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { anomalies, completude_score, nb_anomalies, total_estimated_risk_eur } = data;
+
+  /* ── Tri : priority_score DESC ── */
+  const sortedAnomalies = [...anomalies].sort(
+    (a, b) => (b.priority_score ?? 0) - (a.priority_score ?? 0)
+  );
+
+  /* ── Filtre rapide ── */
+  const filteredAnomalies = sortedAnomalies.filter(a => {
+    if (activeFilter === 'all')      return true;
+    if (activeFilter === 'CRITICAL') return a.severity === 'CRITICAL';
+    return a.regulatory_impact?.framework === activeFilter;
+  });
+
+  /* ── État vide ── */
+  if (nb_anomalies === 0) {
+    return (
+      <div className="space-y-3">
+        <ScoreGauge score={completude_score} />
+        <div className="text-center py-6">
+          <ShieldCheck size={28} className="mx-auto mb-2 text-green-400" />
+          <p className="text-sm font-medium text-gray-700">Patrimoine complet</p>
+          <p className="text-xs text-gray-400">Aucune anomalie détectée sur ce site.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const totalRiskFmt = fmtEurRisk(total_estimated_risk_eur);
+
+  return (
+    <div className="space-y-3">
+
+      {/* Score */}
+      <ScoreGauge score={completude_score} />
+
+      {/* Résumé + risque total */}
+      <div className="flex items-center justify-between flex-wrap gap-1">
+        <div className="flex items-center gap-1.5 text-xs text-gray-600">
+          <AlertTriangle size={13} className="text-amber-500 flex-shrink-0" />
+          <span>
+            <span className="font-semibold">{nb_anomalies}</span> anomalie{nb_anomalies > 1 ? 's' : ''} détectée{nb_anomalies > 1 ? 's' : ''}
+          </span>
+        </div>
+        {totalRiskFmt && (
+          <span className="inline-flex items-center gap-1 text-[11px] font-medium text-red-600 bg-red-50 border border-red-100 rounded px-2 py-0.5">
+            <Euro size={10} /> Risque estimé {totalRiskFmt}
+          </span>
+        )}
+      </div>
+
+      {/* Filtres rapides */}
+      <div className="flex items-center gap-1 flex-wrap">
+        {QUICK_FILTERS.map(f => (
+          <button
+            key={f.key}
+            onClick={() => setActiveFilter(f.key)}
+            className={`text-[11px] px-2.5 py-1 rounded-full font-medium transition whitespace-nowrap ${
+              activeFilter === f.key
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            {f.label}
+            {f.key === 'all' && <span className="ml-1 text-[10px] opacity-70">({nb_anomalies})</span>}
+          </button>
+        ))}
+      </div>
+
+      {/* Liste anomalies */}
+      <div className="space-y-2">
+        {filteredAnomalies.length === 0 ? (
+          <p className="text-xs text-gray-400 text-center py-3">Aucune anomalie ne correspond à ce filtre.</p>
+        ) : (
+          filteredAnomalies.map((anom, idx) => {
+            const cfg       = SEVERITY_CONFIG[anom.severity] || SEVERITY_CONFIG.LOW;
+            const framework = anom.regulatory_impact?.framework;
+            const fwCfg     = framework ? FRAMEWORK_CHIP[framework] : null;
+            const impact    = anom.business_impact?.estimated_risk_eur;
+            const impactFmt = fmtEurRisk(impact);
+            const action    = getAnomalyAction(orgId, siteId, anom.code); // eslint-disable-line no-unused-vars
+            // actionTick forces re-read after modal save
+            void actionTick;
+            const currentAction = getAnomalyAction(orgId, siteId, anom.code);
+            const statusLabel   = currentAction ? ACTION_STATUS_LABEL[currentAction.status] : null;
+            const statusColor   = currentAction ? ACTION_STATUS_COLOR[currentAction.status] : null;
+
+            return (
+              <div key={`${anom.code}-${idx}`} className={`rounded-lg border p-2.5 ${cfg.bg} ${cfg.border}`}>
+                <div className="flex items-start gap-2">
+                  <span className={`mt-0.5 h-2 w-2 flex-shrink-0 rounded-full ${cfg.dot}`} />
+                  <div className="flex-1 min-w-0">
+
+                    {/* Titre + chips */}
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      <span className={`text-[10px] font-semibold uppercase tracking-wide ${cfg.color}`}>
+                        {cfg.label}
+                      </span>
+                      {fwCfg && (
+                        <span className={`text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${fwCfg.color}`}>
+                          {fwCfg.label}
+                        </span>
+                      )}
+                      <span className="text-xs font-medium text-gray-800 truncate">{anom.title_fr}</span>
+                    </div>
+
+                    {/* Détail */}
+                    <p className="text-[11px] text-gray-600 mt-0.5 leading-snug">{anom.detail_fr}</p>
+
+                    {/* Fix hint */}
+                    {anom.fix_hint_fr && (
+                      <p className="text-[10px] text-gray-500 mt-0.5 italic">{anom.fix_hint_fr}</p>
+                    )}
+
+                    {/* Risque € + score + statut action */}
+                    <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
+                      {impactFmt && (
+                        <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-gray-500 bg-gray-50 border border-gray-100 rounded px-1.5 py-0.5">
+                          <Euro size={9} /> {impactFmt}
+                        </span>
+                      )}
+                      {anom.priority_score != null && (
+                        <span className="text-[9px] text-gray-400">score {anom.priority_score}</span>
+                      )}
+                      {statusLabel && (
+                        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${statusColor}`}>
+                          {statusLabel}
+                        </span>
+                      )}
+                    </div>
+
+                    {/* CTA Créer action */}
+                    <div className="mt-1.5">
+                      <button
+                        type="button"
+                        onClick={() => setActionModal({ code: anom.code, title: anom.title_fr })}
+                        className="text-[11px] font-semibold text-blue-600 hover:text-blue-800 hover:underline transition"
+                      >
+                        {currentAction ? 'Modifier l\'action' : 'Créer action'}
+                      </button>
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Modale action */}
+      {actionModal && (
+        <AnomalyActionModal
+          open={!!actionModal}
+          onClose={() => {
+            setActionModal(null);
+            setActionTick(t => t + 1); // rafraîchir statuts
+          }}
+          orgId={orgId}
+          siteId={siteId}
+          anomalyCode={actionModal.code}
+          anomalyTitle={actionModal.title}
+        />
+      )}
+
+    </div>
+  );
+}

--- a/frontend/src/components/SiteBillingMini.jsx
+++ b/frontend/src/components/SiteBillingMini.jsx
@@ -1,0 +1,126 @@
+/**
+ * PROMEOS - SiteBillingMini
+ * V66: Mini billing KPIs for Site360 Factures tab.
+ * Props: siteId
+ * Calls getSiteBilling(siteId) → shows 3 KPIs + CTA to /bill-intel.
+ */
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getSiteBilling } from '../services/api';
+import { Card, CardBody, Badge, Button, EmptyState } from '../ui';
+import { SkeletonCard } from '../ui/Skeleton';
+import { FileText, AlertTriangle, Calendar, ExternalLink } from 'lucide-react';
+
+function KpiCard({ icon: Icon, label, value, color = 'text-gray-700' }) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 bg-gray-50 rounded-lg">
+      <Icon size={16} className={color} />
+      <div>
+        <p className="text-xs text-gray-500">{label}</p>
+        <p className="text-sm font-bold text-gray-800">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function SiteBillingMini({ siteId }) {
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!siteId) return;
+    setLoading(true);
+    setError(null);
+    getSiteBilling(siteId)
+      .then(d => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Impossible de charger les données de facturation');
+        setLoading(false);
+      });
+  }, [siteId]);
+
+  if (loading) return <SkeletonCard lines={3} />;
+
+  if (error) {
+    return (
+      <div className="py-4 text-center text-sm text-red-500">{error}</div>
+    );
+  }
+
+  const invoices = data?.invoices || [];
+  const insights = data?.insights || [];
+  const lastInvoice = invoices.length > 0 ? invoices[invoices.length - 1] : null;
+  const openInsights = insights.filter(i => i.insight_status === 'open' || !i.insight_status);
+
+  if (!data || invoices.length === 0) {
+    return (
+      <EmptyState
+        icon={FileText}
+        title="Aucune facture"
+        description="Importer des factures CSV ou PDF dans le module Facturation."
+        action={
+          <Button size="sm" onClick={() => navigate('/bill-intel')}>
+            <ExternalLink size={14} /> Voir Facturation
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4 pt-4">
+      {/* KPIs */}
+      <div className="grid grid-cols-3 gap-3">
+        <KpiCard
+          icon={FileText}
+          label="Factures"
+          value={invoices.length}
+          color="text-blue-600"
+        />
+        <KpiCard
+          icon={AlertTriangle}
+          label="Anomalies"
+          value={openInsights.length}
+          color={openInsights.length > 0 ? 'text-red-500' : 'text-green-500'}
+        />
+        <KpiCard
+          icon={Calendar}
+          label="Dernière facture"
+          value={lastInvoice?.period_end || lastInvoice?.issue_date || '—'}
+          color="text-gray-500"
+        />
+      </div>
+
+      {/* Anomalies summary */}
+      {openInsights.length > 0 && (
+        <Card>
+          <CardBody>
+            <p className="text-xs font-semibold text-red-600 mb-2">
+              {openInsights.length} anomalie{openInsights.length > 1 ? 's' : ''} ouverte{openInsights.length > 1 ? 's' : ''}
+            </p>
+            <ul className="space-y-1">
+              {openInsights.slice(0, 3).map(ins => (
+                <li key={ins.id} className="text-xs text-gray-600 flex items-center gap-1">
+                  <AlertTriangle size={11} className="text-orange-400 flex-shrink-0" />
+                  {ins.message || ins.type}
+                </li>
+              ))}
+            </ul>
+          </CardBody>
+        </Card>
+      )}
+
+      {/* CTA */}
+      <div className="flex justify-end pt-1">
+        <Button size="sm" variant="secondary" onClick={() => navigate('/bill-intel')}>
+          <ExternalLink size={14} /> Voir toutes les factures
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/contexts/ScopeContext.jsx
+++ b/frontend/src/contexts/ScopeContext.jsx
@@ -16,16 +16,13 @@ const STORAGE_KEY = 'promeos_scope';
 const DEMO_ORGS_KEY = 'promeos_demo_orgs';
 
 const MOCK_ORGS = [
-  { id: 1, nom: 'Groupe Casino' },
-  { id: 2, nom: 'Nexity Immobilier' },
+  { id: 1, nom: 'Groupe HELIOS' },
 ];
 
 const MOCK_PORTEFEUILLES = [
-  { id: 1, org_id: 1, nom: 'Hypermarches' },
-  { id: 2, org_id: 1, nom: 'Proximite' },
-  { id: 3, org_id: 1, nom: 'Logistique' },
-  { id: 4, org_id: 2, nom: 'IDF' },
-  { id: 5, org_id: 2, nom: 'PACA' },
+  { id: 1, org_id: 1, nom: 'Siège & Bureaux' },
+  { id: 2, org_id: 1, nom: 'Sites Industriels' },
+  { id: 3, org_id: 1, nom: 'Patrimoine Tertiaire' },
 ];
 
 // Assign sites to portefeuilles deterministically
@@ -234,7 +231,7 @@ export function ScopeProvider({ children }) {
       sites = mockSites.slice(0, 10).filter((s) => {
         const pfId = sitePortefeuille(s);
         const pf = MOCK_PORTEFEUILLES.find((p) => p.id === pfId);
-        return pf && pf.org_id === 1; // offline sample from Casino
+        return pf && pf.org_id === 1; // offline sample from HELIOS
       });
       if (scope.portefeuilleId) {
         sites = sites.filter((s) => sitePortefeuille(s) === scope.portefeuilleId);

--- a/frontend/src/layout/AppShell.jsx
+++ b/frontend/src/layout/AppShell.jsx
@@ -13,6 +13,7 @@ import CommandPalette from '../ui/CommandPalette';
 import { ToastProvider } from '../ui/ToastProvider';
 import { Toggle } from '../ui';
 import { trackRouteChange } from '../services/tracker';
+import { getMetaVersion } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { resolveModule, MODULE_TINTS } from './NavRegistry';
@@ -120,6 +121,12 @@ export default function AppShell() {
   const location = useLocation();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const { isExpert, toggleExpert } = useExpertMode();
+  const [appVersion, setAppVersion] = useState(null);
+
+  useEffect(() => {
+    if (isExpert) getMetaVersion().then(setAppVersion);
+    else setAppVersion(null);
+  }, [isExpert]);
 
   useEffect(() => {
     trackRouteChange(location.pathname);
@@ -174,6 +181,14 @@ export default function AppShell() {
               label="Expert"
               size="sm"
             />
+            {isExpert && appVersion && (
+              <span
+                className="text-xs font-mono text-slate-400 border border-slate-200 rounded px-1.5 py-0.5"
+                title={`branch: ${appVersion.branch} — ${appVersion.build_time}`}
+              >
+                {appVersion.sha}
+              </span>
+            )}
 
             <UserMenu />
           </div>

--- a/frontend/src/layout/NavPanel.jsx
+++ b/frontend/src/layout/NavPanel.jsx
@@ -23,7 +23,7 @@ const BADGE_STYLES = {
 };
 
 /* ── Panel Link (premium active/hover) ── */
-function PanelLink({ to, icon: Icon, label, badge, badgeKey, pinned, onTogglePin, tint }) {
+function PanelLink({ to, icon: Icon, label, badge, badgeKey, pinned, onTogglePin, tint, indent }) {
   const t = TINT_PALETTE[tint] || TINT_PALETTE.slate;
   const badgeStyle = badgeKey ? (BADGE_STYLES[badgeKey] || BADGE_STYLES._default) : BADGE_STYLES._default;
 
@@ -32,7 +32,7 @@ function PanelLink({ to, icon: Icon, label, badge, badgeKey, pinned, onTogglePin
       to={to}
       end={to === '/'}
       className={({ isActive }) =>
-        `group/link flex items-center gap-2.5 h-9 rounded-lg text-[13px] transition-all duration-150 relative px-2.5
+        `group/link flex items-center gap-2.5 h-9 rounded-lg text-[13px] transition-all duration-150 relative px-2.5${indent ? ' ml-4' : ''}
         ${isActive
           ? `${t.activeBg} text-slate-900 font-medium border-l-2 ${t.activeBorder} pl-2`
           : `text-slate-600 hover:${t.hoverBg.replace('bg-', 'bg-')} hover:text-slate-900 font-normal`

--- a/frontend/src/layout/NavRegistry.js
+++ b/frontend/src/layout/NavRegistry.js
@@ -206,8 +206,8 @@ export const NAV_SECTIONS = [
     expertOnly: true,
     order: 4,
     items: [
-      { to: '/billing',         icon: CalendarRange, label: 'Timeline facturation', keywords: ['timeline', 'couverture', 'mois', 'manquant', 'periodes'] },
-      { to: '/bill-intel',      icon: Receipt,      label: 'Facturation', keywords: ['factures', 'billing', 'invoices'] },
+      { to: '/bill-intel',      icon: Receipt,       label: 'Factures & anomalies', keywords: ['factures', 'billing', 'invoices', 'anomalies'] },
+      { to: '/billing',         icon: CalendarRange,  label: 'Timeline & couverture', keywords: ['timeline', 'couverture', 'mois', 'manquant', 'periodes'], indent: true },
       { to: '/achat-energie',   icon: ShoppingCart,  label: 'Achats énergie', keywords: ['achat', 'purchase', 'scenarios', 'strategie'] },
       { to: '/achat-assistant', icon: Target,        label: 'Assistant Achat', keywords: ['assistant', 'wizard', 'rfp', 'arenh', 'corridor'] },
     ],

--- a/frontend/src/layout/NavRegistry.js
+++ b/frontend/src/layout/NavRegistry.js
@@ -10,7 +10,7 @@ import {
   LayoutDashboard, Building2, ShieldCheck, FileText,
   Zap, ListChecks, Activity, Import, Users, Receipt,
   BookOpen, ShoppingCart, Search, Link2, Eye, Bell, Lock,
-  Target, Database, ScanLine, ListPlus,
+  Target, Database, ScanLine, ListPlus, AlertTriangle,
 } from 'lucide-react';
 
 /* ── Route → module mapping (for permission checks + auto-select) ── */
@@ -23,6 +23,7 @@ export const ROUTE_MODULE_MAP = {
   '/conformite/tertiaire/wizard': 'operations',
   '/conformite/tertiaire/anomalies': 'operations',
   '/actions': 'operations',
+  '/anomalies': 'operations',
   '/consommations': 'analyse',
   '/consommations/explorer': 'analyse',
   '/consommations/import': 'analyse',
@@ -182,6 +183,7 @@ export const NAV_SECTIONS = [
       { to: '/conformite', icon: ShieldCheck, label: 'Conformité', keywords: ['compliance', 'reglementation', 'decret'] },
       { to: '/conformite/tertiaire', icon: Building2, label: 'Tertiaire / OPERAT', keywords: ['tertiaire', 'operat', 'efa', 'decret', 'declaration'] },
       { to: '/actions',    icon: ListChecks,  label: "Plan d'actions", keywords: ['actions', 'plan', 'todo'] },
+      { to: '/anomalies',  icon: AlertTriangle, label: 'Action Center', keywords: ['anomalies', 'actions', 'risque', 'priorite'] },
     ],
   },
   {

--- a/frontend/src/layout/NavRegistry.js
+++ b/frontend/src/layout/NavRegistry.js
@@ -8,7 +8,7 @@
  */
 import {
   LayoutDashboard, Building2, ShieldCheck, FileText,
-  Zap, ListChecks, Activity, Import, Users, Receipt,
+  Zap, ListChecks, Activity, Import, Users, Receipt, CalendarRange,
   BookOpen, ShoppingCart, Search, Link2, Eye, Bell, Lock,
   Target, Database, ScanLine, ListPlus, AlertTriangle,
 } from 'lucide-react';
@@ -30,6 +30,7 @@ export const ROUTE_MODULE_MAP = {
   '/consommations/kb': 'analyse',
   '/diagnostic-conso': 'analyse',
   '/monitoring': 'analyse',
+  '/billing': 'marche',
   '/bill-intel': 'marche',
   '/achat-energie': 'marche',
   '/achat-assistant': 'marche',
@@ -205,6 +206,7 @@ export const NAV_SECTIONS = [
     expertOnly: true,
     order: 4,
     items: [
+      { to: '/billing',         icon: CalendarRange, label: 'Timeline facturation', keywords: ['timeline', 'couverture', 'mois', 'manquant', 'periodes'] },
       { to: '/bill-intel',      icon: Receipt,      label: 'Facturation', keywords: ['factures', 'billing', 'invoices'] },
       { to: '/achat-energie',   icon: ShoppingCart,  label: 'Achats énergie', keywords: ['achat', 'purchase', 'scenarios', 'strategie'] },
       { to: '/achat-assistant', icon: Target,        label: 'Assistant Achat', keywords: ['assistant', 'wizard', 'rfp', 'arenh', 'corridor'] },

--- a/frontend/src/layout/__tests__/NavRegistry.test.js
+++ b/frontend/src/layout/__tests__/NavRegistry.test.js
@@ -143,7 +143,7 @@ describe('Expert filtering', () => {
       s.items.filter((item) => !item.expertOnly)
     );
     expect(normalItems.length).toBeGreaterThanOrEqual(6);
-    expect(normalItems.length).toBeLessThanOrEqual(8);
+    expect(normalItems.length).toBeLessThanOrEqual(12); // V65: +1 Action Center
   });
 
   it('Diagnostic is expertOnly within Analyser', () => {

--- a/frontend/src/mocks/sites.js
+++ b/frontend/src/mocks/sites.js
@@ -1,50 +1,151 @@
 /**
- * Mock data: 60 sites for Patrimoine + Site 360
- * Structure aligned with backend Site model.
+ * Mock data: 5 sites HELIOS (démo canonique)
+ * Alignés avec le pack "helios" de backend/services/demo_seed/packs.py.
+ * Utilisés comme fallback offline (ScopeContext) et dans MonitoringPage.
  */
 
-const VILLES = [
-  'Paris', 'Lyon', 'Marseille', 'Toulouse', 'Bordeaux', 'Nantes', 'Lille',
-  'Strasbourg', 'Montpellier', 'Rennes', 'Nice', 'Grenoble', 'Rouen',
-  'Dijon', 'Clermont-Ferrand',
-];
-
-const USAGES = ['bureau', 'commerce', 'entrepot', 'hotel', 'sante', 'enseignement', 'copropriete', 'collectivite'];
-const STATUTS = ['conforme', 'non_conforme', 'a_risque', 'a_evaluer'];
-const REGIONS = ['IDF', 'ARA', 'PACA', 'NAQ', 'OCC', 'HDF', 'GE', 'BRE', 'NOR', 'BFC'];
-
-function rand(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
-function pick(arr) { return arr[rand(0, arr.length - 1)]; }
-
-function generateSite(id) {
-  const ville = pick(VILLES);
-  const usage = pick(USAGES);
-  const statut = pick(STATUTS);
-  const surface = rand(200, 15000);
-  const risque = statut === 'conforme' ? 0 : rand(500, 50000);
-  const anomalies = statut === 'conforme' ? rand(0, 1) : rand(1, 8);
-
-  return {
-    id,
-    nom: `${usage === 'bureau' ? 'Bureau' : usage === 'commerce' ? 'Magasin' : usage === 'hotel' ? 'Hotel' : usage === 'sante' ? 'Clinique' : usage === 'entrepot' ? 'Entrepot' : usage === 'enseignement' ? 'Lycee' : usage === 'copropriete' ? 'Residence' : 'Mairie'} ${ville} ${id}`,
-    ville,
-    region: pick(REGIONS),
-    usage,
-    surface_m2: surface,
-    statut_conformite: statut,
-    risque_eur: risque,
-    anomalies_count: anomalies,
-    conso_kwh_an: rand(50000, 2000000),
-    nb_compteurs: rand(1, 5),
+export const mockSites = [
+  {
+    id: 1,
+    nom: 'Siege HELIOS Paris',
+    ville: 'Paris',
+    region: 'IDF',
+    code_postal: '75008',
+    usage: 'bureau',
+    type: 'bureau',
+    surface_m2: 3500,
     actif: true,
-    adresse: `${rand(1, 200)} rue ${pick(['de la Paix', 'Victor Hugo', 'Pasteur', 'Gambetta', 'Jean Jaures', 'de la Republique'])}`,
-    code_postal: `${rand(10, 95)}000`.slice(0, 5),
-    operat_status: pick(['submitted', 'not_started', 'verified', null]),
+    is_demo: true,
+    risque_eur: 45000,
+    risque_financier_euro: 45000,
+    statut_conformite: 'en_cours',
+    statut_decret_tertiaire: 'EN_COURS',
+    statut_bacs: 'CONFORME',
+    avancement_decret_pct: 72,
+    annual_kwh_total: 800000,
+    conso_kwh_an: 800000,
+    anomalies_count: 2,
+    nb_compteurs: 2,
+    portefeuille_id: 1,
+    operat_status: 'SUBMITTED',
     derniere_evaluation: '2026-01-15',
-  };
-}
-
-export const mockSites = Array.from({ length: 60 }, (_, i) => generateSite(i + 1));
+    adresse: 'Avenue des Champs-Élysées, Paris',
+    latitude: 48.8738,
+    longitude: 2.2950,
+  },
+  {
+    id: 2,
+    nom: 'Bureau Regional Lyon',
+    ville: 'Lyon',
+    region: 'ARA',
+    code_postal: '69002',
+    usage: 'bureau',
+    type: 'bureau',
+    surface_m2: 1200,
+    actif: true,
+    is_demo: true,
+    risque_eur: 18000,
+    risque_financier_euro: 18000,
+    statut_conformite: 'conforme',
+    statut_decret_tertiaire: 'CONFORME',
+    statut_bacs: 'A_RISQUE',
+    avancement_decret_pct: 91,
+    annual_kwh_total: 350000,
+    conso_kwh_an: 350000,
+    anomalies_count: 1,
+    nb_compteurs: 1,
+    portefeuille_id: 1,
+    operat_status: 'IN_PROGRESS',
+    derniere_evaluation: '2026-01-15',
+    adresse: 'Rue de la République, Lyon',
+    latitude: 45.7580,
+    longitude: 4.8320,
+  },
+  {
+    id: 3,
+    nom: 'Usine HELIOS Toulouse',
+    ville: 'Toulouse',
+    region: 'OCC',
+    code_postal: '31100',
+    usage: 'entrepot',
+    type: 'entrepot',
+    surface_m2: 6000,
+    actif: true,
+    is_demo: true,
+    risque_eur: 120000,
+    risque_financier_euro: 120000,
+    statut_conformite: 'a_risque',
+    statut_decret_tertiaire: 'A_RISQUE',
+    statut_bacs: 'A_RISQUE',
+    avancement_decret_pct: 34,
+    annual_kwh_total: 2500000,
+    conso_kwh_an: 2500000,
+    anomalies_count: 5,
+    nb_compteurs: 2,
+    portefeuille_id: 2,
+    operat_status: null,
+    derniere_evaluation: '2026-01-15',
+    adresse: 'Zone Industrielle, Toulouse',
+    latitude: 43.5780,
+    longitude: 1.4020,
+  },
+  {
+    id: 4,
+    nom: 'Hotel Helios Nice',
+    ville: 'Nice',
+    region: 'PACA',
+    code_postal: '06000',
+    usage: 'hotel',
+    type: 'hotel',
+    surface_m2: 4000,
+    actif: true,
+    is_demo: true,
+    risque_eur: 62000,
+    risque_financier_euro: 62000,
+    statut_conformite: 'en_cours',
+    statut_decret_tertiaire: 'EN_COURS',
+    statut_bacs: 'CONFORME',
+    avancement_decret_pct: 58,
+    annual_kwh_total: 1200000,
+    conso_kwh_an: 1200000,
+    anomalies_count: 3,
+    nb_compteurs: 2,
+    portefeuille_id: 3,
+    operat_status: 'NOT_STARTED',
+    derniere_evaluation: '2026-01-15',
+    adresse: 'Promenade des Anglais, Nice',
+    latitude: 43.7050,
+    longitude: 7.2650,
+  },
+  {
+    id: 5,
+    nom: 'Ecole Jules Ferry Marseille',
+    ville: 'Marseille',
+    region: 'PACA',
+    code_postal: '13005',
+    usage: 'enseignement',
+    type: 'enseignement',
+    surface_m2: 2800,
+    actif: true,
+    is_demo: true,
+    risque_eur: 28000,
+    risque_financier_euro: 28000,
+    statut_conformite: 'conforme',
+    statut_decret_tertiaire: 'CONFORME',
+    statut_bacs: 'EN_COURS',
+    avancement_decret_pct: 85,
+    annual_kwh_total: 600000,
+    conso_kwh_an: 600000,
+    anomalies_count: 0,
+    nb_compteurs: 1,
+    portefeuille_id: 3,
+    operat_status: 'IN_PROGRESS',
+    derniere_evaluation: '2026-01-15',
+    adresse: 'Rue Jules Ferry, Marseille',
+    latitude: 43.2950,
+    longitude: 5.3950,
+  },
+];
 
 export function getMockSite(id) {
   return mockSites.find((s) => s.id === Number(id));

--- a/frontend/src/models/leverActionModel.js
+++ b/frontend/src/models/leverActionModel.js
@@ -210,23 +210,19 @@ export function buildActionPayload(lever) {
 }
 
 /**
- * Construit un deep-link vers le Command Center avec pre-filtre levier.
+ * Construit un deep-link vers la création d'action avec contexte levier.
  *
  * @param {import('./leverEngineModel').Lever} lever
  * @returns {string}
  */
 export function buildLeverDeepLink(lever) {
-  if (!lever || !lever.actionKey) return '/command-center';
+  if (!lever || !lever.actionKey) return '/actions';
 
-  const params = new URLSearchParams({
-    filter: 'leviers',
-    type: lever.type,
-    key: lever.actionKey,
-  });
+  const params = new URLSearchParams();
+  params.set('type', lever.type || 'levier');
+  params.set('source', 'lever_engine');
+  params.set('ref_id', lever.actionKey);
+  if (lever.label) params.set('titre', lever.label);
 
-  if (lever.impactEur != null) {
-    params.set('impact', String(lever.impactEur));
-  }
-
-  return `/command-center?${params.toString()}`;
+  return `/actions/new?${params.toString()}`;
 }

--- a/frontend/src/pages/ActionsPage.jsx
+++ b/frontend/src/pages/ActionsPage.jsx
@@ -4,7 +4,7 @@
  * inline status change, context-aware empty states, impact bulk bar.
  */
 import { useState, useMemo, useEffect, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useParams } from 'react-router-dom';
 import {
   Plus, Download, Printer, Clock, ListChecks, RefreshCw,
   MessageSquare, Paperclip, AlertTriangle, BadgeEuro, ShieldCheck,
@@ -302,11 +302,12 @@ function GroupedTableView({ actions, groupBy, onCardClick, selected, onToggleSel
 }
 
 /* ── Main Component ──────────────────────────────────────────── */
-export default function ActionsPage() {
+export default function ActionsPage({ autoCreate = false }) {
   const { scopedSites } = useScope();
   const { isExpert } = useExpertMode();
   const { toast } = useToast();
   const [searchParams] = useSearchParams();
+  const { actionId: urlActionId } = useParams();
   const [actions, setActions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
@@ -347,6 +348,29 @@ export default function ActionsPage() {
   }, []);
 
   useEffect(() => { fetchActions(); }, [fetchActions]);
+
+  // Auto-open detail drawer when navigating to /actions/:actionId
+  useEffect(() => {
+    if (urlActionId && actions.length > 0 && !detailAction) {
+      const found = actions.find(a => String(a.id) === urlActionId);
+      if (found) setDetailAction(found);
+    }
+  }, [urlActionId, actions]);
+
+  // Auto-open create modal when navigating to /actions/new
+  useEffect(() => {
+    if (autoCreate && !showCreate) {
+      const prefill = {};
+      const type = searchParams.get('type');
+      const siteId = searchParams.get('site_id');
+      const titre = searchParams.get('titre');
+      if (type) prefill.type = type;
+      if (siteId) prefill.site_id = parseInt(siteId);
+      if (titre) prefill.titre = decodeURIComponent(titre);
+      setCreatePrefill(prefill);
+      setShowCreate(true);
+    }
+  }, [autoCreate]);
 
   async function handleSync() {
     setSyncing(true);

--- a/frontend/src/pages/AnomaliesPage.jsx
+++ b/frontend/src/pages/AnomaliesPage.jsx
@@ -1,0 +1,409 @@
+/**
+ * AnomaliesPage — V65
+ * Action Center cross-sites : liste agrégée des anomalies du scope courant.
+ * Route : /anomalies
+ *
+ * Data : Promise.all sur scopedSites.slice(0, 20) via getPatrimoineAnomalies.
+ * KPIs : total anomalies | critiques | risque € estimé.
+ * Filtres : framework, severity, site, recherche texte.
+ * Tri : impact € DESC puis priority_score DESC.
+ * CTAs : "Ouvrir site" (→ /patrimoine avec drawer) + "Créer action" (AnomalyActionModal).
+ */
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  AlertTriangle, Search, X, Euro, ChevronRight, Building2, Upload,
+} from 'lucide-react';
+import { PageShell, EmptyState, Tooltip } from '../ui';
+import { useScope } from '../contexts/ScopeContext';
+import { getPatrimoineAnomalies } from '../services/api';
+import {
+  getAnomalyAction,
+  ACTION_STATUS_LABEL,
+  ACTION_STATUS_COLOR,
+} from '../services/anomalyActions';
+import AnomalyActionModal from '../components/AnomalyActionModal';
+
+/* ── Constantes ── */
+
+const MAX_SITES = 20;
+
+const SEV_LABEL   = { CRITICAL: 'Critique', HIGH: 'Élevé', MEDIUM: 'Moyen', LOW: 'Faible' };
+const SEV_COLOR   = {
+  CRITICAL: 'bg-red-100 text-red-700',
+  HIGH:     'bg-orange-100 text-orange-700',
+  MEDIUM:   'bg-amber-100 text-amber-700',
+  LOW:      'bg-blue-100 text-blue-700',
+};
+const FW_LABEL  = { DECRET_TERTIAIRE: 'Décret Tertiaire', FACTURATION: 'Facturation', BACS: 'BACS' };
+const FW_COLOR  = {
+  DECRET_TERTIAIRE: 'bg-purple-50 text-purple-700',
+  FACTURATION:      'bg-blue-50 text-blue-700',
+  BACS:             'bg-teal-50 text-teal-700',
+};
+
+function fmtEur(n) {
+  if (!n || n <= 0) return '—';
+  if (n >= 1_000_000) return `~${(n / 1_000_000).toFixed(1)} M€`;
+  if (n >= 1_000)     return `~${Math.round(n / 1_000)} k€`;
+  return `~${Math.round(n)} €`;
+}
+
+/* ── Page ── */
+
+export default function AnomaliesPage() {
+  const navigate = useNavigate();
+  const { scopedSites, scope, sitesLoading } = useScope();
+
+  const [anomalies, setAnomalies] = useState([]);  // flat [{...anomaly, site_id, site_nom}]
+  const [loading,   setLoading]   = useState(false);
+  const [error,     setError]     = useState(null);
+  const fetchIdRef                = useRef(0);
+
+  // Filtres
+  const [filterFw,   setFilterFw]   = useState('');
+  const [filterSev,  setFilterSev]  = useState('');
+  const [filterSite, setFilterSite] = useState('');
+  const [search,     setSearch]     = useState('');
+
+  // Modale action
+  const [actionModal, setActionModal] = useState(null); // { code, title, siteId }
+  const [actionTick,  setActionTick]  = useState(0);
+
+  /* ── Fetch anomalies ── */
+  useEffect(() => {
+    if (scopedSites.length === 0) {
+      setAnomalies([]);
+      setLoading(false);
+      return;
+    }
+    const sitesToFetch = scopedSites.slice(0, MAX_SITES);
+    const fetchId = ++fetchIdRef.current;
+    setLoading(true);
+    setError(null);
+
+    Promise.all(
+      sitesToFetch.map(site =>
+        getPatrimoineAnomalies(site.id)
+          .then(data => ({ site, data, ok: true }))
+          .catch(() => ({ site, data: null, ok: false }))
+      )
+    ).then(results => {
+      if (fetchIdRef.current !== fetchId) return;
+      const flat = results.flatMap(({ site, data, ok }) => {
+        if (!ok || !data) return [];
+        return (data.anomalies ?? []).map(a => ({
+          ...a,
+          site_id:  site.id,
+          site_nom: site.nom,
+        }));
+      });
+      setAnomalies(flat);
+      setLoading(false);
+    }).catch(() => {
+      if (fetchIdRef.current !== fetchId) return;
+      setError('Impossible de charger les anomalies du parc.');
+      setLoading(false);
+    });
+  }, [scopedSites]);
+
+  /* ── KPIs ── */
+  const kpis = useMemo(() => {
+    const total     = anomalies.length;
+    const critiques = anomalies.filter(a => a.severity === 'CRITICAL').length;
+    const risque    = anomalies.reduce((s, a) => s + (a.business_impact?.estimated_risk_eur ?? 0), 0);
+    return { total, critiques, risque };
+  }, [anomalies]);
+
+  /* ── Filtrage + tri ── */
+  const filtered = useMemo(() => {
+    let r = [...anomalies];
+    if (filterFw)   r = r.filter(a => a.regulatory_impact?.framework === filterFw);
+    if (filterSev)  r = r.filter(a => a.severity === filterSev);
+    if (filterSite) r = r.filter(a => String(a.site_id) === filterSite);
+    if (search) {
+      const q = search.toLowerCase();
+      r = r.filter(a =>
+        a.title_fr?.toLowerCase().includes(q) ||
+        a.site_nom?.toLowerCase().includes(q)
+      );
+    }
+    // Tri : impact € DESC puis priority_score DESC
+    r.sort((a, b) => {
+      const ra = a.business_impact?.estimated_risk_eur ?? 0;
+      const rb = b.business_impact?.estimated_risk_eur ?? 0;
+      if (rb !== ra) return rb - ra;
+      return (b.priority_score ?? 0) - (a.priority_score ?? 0);
+    });
+    return r;
+  }, [anomalies, filterFw, filterSev, filterSite, search]);
+
+  /* ── Helpers ── */
+  const hasFilters = filterFw || filterSev || filterSite || search;
+
+  function resetFilters() {
+    setFilterFw(''); setFilterSev(''); setFilterSite(''); setSearch('');
+  }
+
+  function openSite(siteId) {
+    navigate('/patrimoine', { state: { openSiteId: siteId, openTab: 'anomalies' } });
+  }
+
+  /* ── Rendu ── */
+
+  if (sitesLoading) {
+    return (
+      <PageShell icon={AlertTriangle} title="Action Center" subtitle="Chargement...">
+        <div className="space-y-2 animate-pulse">
+          {[...Array(4)].map((_, i) => <div key={i} className="h-14 bg-gray-100 rounded-lg" />)}
+        </div>
+      </PageShell>
+    );
+  }
+
+  if (scopedSites.length === 0) {
+    return (
+      <PageShell icon={AlertTriangle} title="Action Center" subtitle="Aucun site dans le scope">
+        <EmptyState
+          icon={Building2}
+          title="Aucun site dans le scope"
+          text="Importez votre patrimoine ou chargez les données de démonstration HELIOS pour voir les anomalies."
+          ctaLabel="Importer mon patrimoine"
+          onCta={() => navigate('/import')}
+          actions={
+            <button onClick={() => navigate('/import')} className="flex items-center gap-1.5 text-sm font-semibold text-blue-600 bg-blue-50 border border-blue-100 rounded-lg px-4 py-2 hover:bg-blue-100 transition">
+              <Upload size={14} /> Charger HELIOS
+            </button>
+          }
+        />
+      </PageShell>
+    );
+  }
+
+  const subtitle = loading
+    ? 'Chargement des anomalies...'
+    : `${kpis.total} anomalie${kpis.total > 1 ? 's' : ''} · ${kpis.critiques} critique${kpis.critiques > 1 ? 's' : ''} · ${fmtEur(kpis.risque)} de risque estimé`;
+
+  return (
+    <PageShell icon={AlertTriangle} title="Action Center" subtitle={subtitle}>
+      <div className="space-y-4">
+
+        {/* ── KPI row ── */}
+        <div className="grid grid-cols-3 gap-3">
+          <KpiCard icon={AlertTriangle} color="bg-blue-600"  label="Anomalies totales" value={kpis.total}    loading={loading} />
+          <KpiCard icon={AlertTriangle} color="bg-red-600"   label="Critiques"         value={kpis.critiques} loading={loading} />
+          <KpiCard icon={Euro}          color="bg-amber-600" label="Risque estimé"     value={fmtEur(kpis.risque)} loading={loading} />
+        </div>
+
+        {/* ── Toolbar ── */}
+        <div className="flex items-center gap-2 flex-wrap">
+          {/* Recherche texte */}
+          <div className="relative flex-1 min-w-[180px] max-w-sm">
+            <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Rechercher une anomalie ou un site..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="w-full pl-8 pr-3 py-1.5 border border-gray-200 rounded-lg text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+            />
+          </div>
+
+          {/* Framework */}
+          <QuickSelect
+            value={filterFw}
+            onChange={setFilterFw}
+            options={[
+              { value: '',                 label: 'Framework'        },
+              { value: 'DECRET_TERTIAIRE', label: 'Décret Tertiaire' },
+              { value: 'FACTURATION',      label: 'Facturation'      },
+              { value: 'BACS',             label: 'BACS'             },
+            ]}
+          />
+
+          {/* Sévérité */}
+          <QuickSelect
+            value={filterSev}
+            onChange={setFilterSev}
+            options={[
+              { value: '',         label: 'Sévérité' },
+              { value: 'CRITICAL', label: 'Critique' },
+              { value: 'HIGH',     label: 'Élevé'    },
+              { value: 'MEDIUM',   label: 'Moyen'    },
+              { value: 'LOW',      label: 'Faible'   },
+            ]}
+          />
+
+          {/* Site */}
+          <QuickSelect
+            value={filterSite}
+            onChange={setFilterSite}
+            options={[
+              { value: '', label: 'Tous les sites' },
+              ...scopedSites.slice(0, MAX_SITES).map(s => ({ value: String(s.id), label: s.nom })),
+            ]}
+          />
+
+          {/* Reset */}
+          {hasFilters && (
+            <button onClick={resetFilters} className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 transition">
+              <X size={12} /> Réinitialiser
+            </button>
+          )}
+        </div>
+
+        {/* ── Erreur ── */}
+        {error && (
+          <div className="flex items-center gap-2 text-xs text-red-600 bg-red-50 border border-red-100 rounded-lg px-4 py-2">
+            <AlertTriangle size={13} className="shrink-0" /> {error}
+          </div>
+        )}
+
+        {/* ── Liste anomalies ── */}
+        {loading ? (
+          <div className="space-y-2 animate-pulse">
+            {[...Array(5)].map((_, i) => <div key={i} className="h-14 bg-gray-100 rounded-lg" />)}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-10 text-gray-400">
+            <Search size={28} className="mx-auto mb-2" />
+            <p className="text-sm font-medium text-gray-600">Aucune anomalie ne correspond</p>
+            {hasFilters && (
+              <button onClick={resetFilters} className="mt-2 text-xs text-blue-600 hover:underline">
+                Réinitialiser les filtres
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            {filtered.map((anom, idx) => {
+              // actionTick forces re-read after modal save
+              void actionTick;
+              const currentAction = getAnomalyAction(scope.orgId, anom.site_id, anom.code);
+              const statusLabel   = currentAction ? ACTION_STATUS_LABEL[currentAction.status] : null;
+              const statusColor   = currentAction ? ACTION_STATUS_COLOR[currentAction.status]  : null;
+              const impactFmt     = fmtEur(anom.business_impact?.estimated_risk_eur);
+
+              return (
+                <div
+                  key={`${anom.site_id}-${anom.code}-${idx}`}
+                  className="flex items-start gap-3 px-3 py-2.5 bg-white border border-gray-100 rounded-lg hover:border-gray-200 transition"
+                >
+                  {/* Infos anomalie */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      {/* Site */}
+                      <span className="text-[10px] font-medium text-gray-500 bg-gray-100 rounded px-1.5 py-0.5 shrink-0">
+                        {anom.site_nom}
+                      </span>
+                      {/* Severity */}
+                      <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded shrink-0 ${SEV_COLOR[anom.severity] ?? 'bg-gray-100 text-gray-600'}`}>
+                        {SEV_LABEL[anom.severity] ?? anom.severity}
+                      </span>
+                      {/* Framework */}
+                      {anom.regulatory_impact?.framework && anom.regulatory_impact.framework !== 'NONE' && (
+                        <span className={`text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${FW_COLOR[anom.regulatory_impact.framework] ?? 'bg-gray-50 text-gray-600'}`}>
+                          {FW_LABEL[anom.regulatory_impact.framework] ?? anom.regulatory_impact.framework}
+                        </span>
+                      )}
+                      {/* Titre */}
+                      <span className="text-sm font-medium text-gray-800 truncate">{anom.title_fr}</span>
+                    </div>
+                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                      {impactFmt !== '—' && (
+                        <span className="text-[10px] text-gray-500 flex items-center gap-0.5">
+                          <Euro size={9} /> {impactFmt}
+                        </span>
+                      )}
+                      {statusLabel && (
+                        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${statusColor}`}>
+                          {statusLabel}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* CTAs */}
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Tooltip text="Ouvrir la fiche site (onglet Anomalies)">
+                      <button
+                        type="button"
+                        onClick={() => openSite(anom.site_id)}
+                        className="flex items-center gap-1 text-[11px] font-medium text-blue-600 bg-blue-50 border border-blue-100 rounded px-2 py-1 hover:bg-blue-100 transition"
+                      >
+                        Ouvrir site <ChevronRight size={11} />
+                      </button>
+                    </Tooltip>
+                    <Tooltip text="Créer ou modifier l'action locale">
+                      <button
+                        type="button"
+                        onClick={() => setActionModal({ code: anom.code, title: anom.title_fr, siteId: anom.site_id })}
+                        className="text-[11px] font-medium text-gray-600 bg-gray-100 border border-gray-200 rounded px-2 py-1 hover:bg-gray-200 transition"
+                      >
+                        Créer action
+                      </button>
+                    </Tooltip>
+                  </div>
+                </div>
+              );
+            })}
+
+            <p className="text-[11px] text-gray-400 text-center pt-1">
+              {filtered.length} résultat{filtered.length > 1 ? 's' : ''}
+              {scopedSites.length > MAX_SITES && ` · ${MAX_SITES} sites analysés sur ${scopedSites.length}`}
+            </p>
+          </div>
+        )}
+
+      </div>
+
+      {/* Modale action */}
+      {actionModal && (
+        <AnomalyActionModal
+          open={!!actionModal}
+          onClose={() => {
+            setActionModal(null);
+            setActionTick(t => t + 1);
+          }}
+          orgId={scope.orgId}
+          siteId={actionModal.siteId}
+          anomalyCode={actionModal.code}
+          anomalyTitle={actionModal.title}
+        />
+      )}
+    </PageShell>
+  );
+}
+
+/* ── Sous-composants ── */
+
+function KpiCard({ icon: Icon, color, label, value, loading }) {
+  return (
+    <div className="bg-white border border-gray-100 rounded-xl p-3 flex items-center gap-3">
+      <div className={`p-2 rounded-lg ${color}`}>
+        <Icon size={16} className="text-white" />
+      </div>
+      <div>
+        <p className="text-[11px] text-gray-400 font-medium">{label}</p>
+        {loading
+          ? <div className="h-5 w-12 bg-gray-100 rounded animate-pulse mt-0.5" />
+          : <p className="text-lg font-bold text-gray-900 leading-tight">{value}</p>
+        }
+      </div>
+    </div>
+  );
+}
+
+function QuickSelect({ value, onChange, options }) {
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      className={`text-xs px-2.5 py-1.5 rounded-lg border bg-white cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+        value ? 'border-blue-300 text-blue-700 font-medium' : 'border-gray-200 text-gray-600'
+      }`}
+    >
+      {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+    </select>
+  );
+}

--- a/frontend/src/pages/AnomaliesPage.jsx
+++ b/frontend/src/pages/AnomaliesPage.jsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react';
 import { PageShell, EmptyState, Tooltip } from '../ui';
 import { useScope } from '../contexts/ScopeContext';
-import { getPatrimoineAnomalies } from '../services/api';
+import { getPatrimoineAnomalies, getBillingAnomaliesScoped } from '../services/api';
 import {
   getAnomalyAction,
   ACTION_STATUS_LABEL,
@@ -82,15 +82,21 @@ export default function AnomaliesPage() {
     setLoading(true);
     setError(null);
 
-    Promise.all(
-      sitesToFetch.map(site =>
-        getPatrimoineAnomalies(site.id)
-          .then(data => ({ site, data, ok: true }))
-          .catch(() => ({ site, data: null, ok: false }))
-      )
-    ).then(results => {
+    const patrimoinePromises = sitesToFetch.map(site =>
+      getPatrimoineAnomalies(site.id)
+        .then(data => ({ site, data, ok: true }))
+        .catch(() => ({ site, data: null, ok: false }))
+    );
+    const billingPromise = getBillingAnomaliesScoped()
+      .then(data => ({ data, ok: true }))
+      .catch(() => ({ data: null, ok: false }));
+
+    Promise.all([...patrimoinePromises, billingPromise]).then(allResults => {
       if (fetchIdRef.current !== fetchId) return;
-      const flat = results.flatMap(({ site, data, ok }) => {
+      const billingResult = allResults[allResults.length - 1];
+      const patrimoineResults = allResults.slice(0, -1);
+
+      const flat = patrimoineResults.flatMap(({ site, data, ok }) => {
         if (!ok || !data) return [];
         return (data.anomalies ?? []).map(a => ({
           ...a,
@@ -98,6 +104,18 @@ export default function AnomaliesPage() {
           site_nom: site.nom,
         }));
       });
+
+      // Merge billing anomalies — normalize to patrimoine format
+      if (billingResult.ok && billingResult.data?.anomalies?.length) {
+        for (const b of billingResult.data.anomalies) {
+          flat.push({
+            ...b,
+            regulatory_impact: { framework: 'FACTURATION' },
+            _isBilling: true,
+          });
+        }
+      }
+
       setAnomalies(flat);
       setLoading(false);
     }).catch(() => {
@@ -145,8 +163,12 @@ export default function AnomaliesPage() {
     setFilterFw(''); setFilterSev(''); setFilterSite(''); setSearch('');
   }
 
-  function openSite(siteId) {
-    navigate('/patrimoine', { state: { openSiteId: siteId, openTab: 'anomalies' } });
+  function openSite(siteId, isBilling = false) {
+    if (isBilling) {
+      navigate('/bill-intel');
+    } else {
+      navigate('/patrimoine', { state: { openSiteId: siteId, openTab: 'anomalies' } });
+    }
   }
 
   /* ── Rendu ── */
@@ -328,7 +350,7 @@ export default function AnomaliesPage() {
                     <Tooltip text="Ouvrir la fiche site (onglet Anomalies)">
                       <button
                         type="button"
-                        onClick={() => openSite(anom.site_id)}
+                        onClick={() => openSite(anom.site_id, anom._isBilling)}
                         className="flex items-center gap-1 text-[11px] font-medium text-blue-600 bg-blue-50 border border-blue-100 rounded px-2 py-1 hover:bg-blue-100 transition"
                       >
                         Ouvrir site <ChevronRight size={11} />

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -2,7 +2,7 @@
  * PROMEOS - Bill Intelligence Page (/bill-intel)
  * Sprint 7.1: invoices overview, anomaly insights with workflow, seed demo, audit-all.
  */
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   getBillingSummary,
@@ -96,6 +96,8 @@ export default function BillIntelPage() {
   const [invoiceStatusFilter, setInvoiceStatusFilter] = useState('');
   const [periodPreset, setPeriodPreset] = useState('all');
   const [sites, setSites] = useState([]);
+  const csvInputRef = useRef(null);
+  const pdfInputRef = useRef(null);
 
   async function fetchData() {
     setLoading(true);
@@ -176,18 +178,24 @@ export default function BillIntelPage() {
     setAuditing(false);
   }
 
+  function handleCsvClick() {
+    if (isExpert) console.log('[BillIntelPage] CSV button clicked, pdfSiteId:', pdfSiteId);
+    csvInputRef.current?.click();
+  }
+
   async function handleCsvImport(e) {
     const file = e.target.files[0];
     if (!file) return;
-    if (isExpert) console.log('[BillIntelPage] CSV import start:', file.name, file.size, 'bytes');
+    if (isExpert) console.log('[BillIntelPage] CSV file selected:', file.name, file.size, 'bytes');
     try {
+      if (isExpert) console.log('[BillIntelPage] CSV import request → POST /billing/import-csv');
       const result = await importInvoicesCsv(file);
       if (isExpert) console.log('[BillIntelPage] CSV import response:', result);
       track('billing_csv_import', { filename: file.name });
       toast(`Import CSV réussi : ${result?.imported ?? '?'} facture(s) importée(s)`, 'success');
       await fetchData();
     } catch (err) {
-      if (isExpert) console.error('[BillIntelPage] CSV import error:', err);
+      if (isExpert) console.error('[BillIntelPage] CSV import error:', err?.response?.status, err?.response?.data, err);
       toast('Erreur lors de l\'import CSV', 'error');
     }
     e.target.value = '';
@@ -201,18 +209,24 @@ export default function BillIntelPage() {
     } catch { /* ignore */ }
   }
 
+  function handlePdfClick() {
+    if (isExpert) console.log('[BillIntelPage] PDF button clicked, pdfSiteId:', pdfSiteId);
+    pdfInputRef.current?.click();
+  }
+
   async function handlePdfImport(e) {
     const file = e.target.files[0];
     if (!file || !pdfSiteId) return;
-    if (isExpert) console.log('[BillIntelPage] PDF import start:', file.name, file.size, 'bytes, site_id:', pdfSiteId);
+    if (isExpert) console.log('[BillIntelPage] PDF file selected:', file.name, file.size, 'bytes, site_id:', pdfSiteId);
     try {
+      if (isExpert) console.log('[BillIntelPage] PDF import request → POST /billing/import-pdf, site_id:', pdfSiteId);
       const result = await importInvoicesPdf(Number(pdfSiteId), file);
       if (isExpert) console.log('[BillIntelPage] PDF import response:', result);
       track('billing_pdf_import', { filename: file.name });
       toast(`Import PDF réussi : facture ${result?.invoice_id ?? ''} (confiance ${result?.confidence ?? '?'})`, 'success');
       await fetchData();
     } catch (err) {
-      if (isExpert) console.error('[BillIntelPage] PDF import error:', err);
+      if (isExpert) console.error('[BillIntelPage] PDF import error:', err?.response?.status, err?.response?.data, err);
       toast('Erreur lors de l\'import PDF', 'error');
     }
     e.target.value = '';
@@ -241,15 +255,17 @@ export default function BillIntelPage() {
               <CalendarRange size={14} /> Voir timeline
             </Button>
           )}
-          <label
-            className={`inline-flex items-center gap-2 ${!pdfSiteId ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={!pdfSiteId}
+            onClick={handleCsvClick}
             title={!pdfSiteId ? 'Sélectionnez un site' : undefined}
           >
-            <Button variant="secondary" size="sm" as="span" disabled={!pdfSiteId}>
-              <Upload size={14} /> Importer CSV
-            </Button>
-            <input type="file" accept=".csv" className="sr-only" onChange={handleCsvImport} disabled={!pdfSiteId} />
-          </label>
+            <Upload size={14} /> Importer CSV
+          </Button>
+          <input ref={csvInputRef} type="file" accept=".csv" className="sr-only" onChange={handleCsvImport} />
           <div className="inline-flex items-center gap-1">
             <select
               value={pdfSiteId}
@@ -261,15 +277,17 @@ export default function BillIntelPage() {
                 <option key={s.id} value={s.id}>{s.nom}</option>
               ))}
             </select>
-            <label
-              className={`inline-flex items-center gap-2 ${!pdfSiteId ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={!pdfSiteId}
+              onClick={handlePdfClick}
               title={!pdfSiteId ? 'Sélectionnez un site' : undefined}
             >
-              <Button variant="secondary" size="sm" as="span" disabled={!pdfSiteId}>
-                <Upload size={14} /> Importer PDF
-              </Button>
-              <input type="file" accept=".pdf" className="sr-only" onChange={handlePdfImport} disabled={!pdfSiteId} />
-            </label>
+              <Upload size={14} /> Importer PDF
+            </Button>
+            <input ref={pdfInputRef} type="file" accept=".pdf" className="sr-only" onChange={handlePdfImport} />
           </div>
           {hasData && (
             <Button size="sm" onClick={handleAuditAll} disabled={auditing}>
@@ -324,12 +342,9 @@ export default function BillIntelPage() {
               <Button onClick={handleSeedDemo} disabled={seeding}>
                 <Zap size={14} /> {seeding ? 'Génération...' : 'Générer démo (5 factures)'}
               </Button>
-              <label className="inline-flex items-center gap-2 cursor-pointer">
-                <Button variant="secondary" as="span">
-                  <Upload size={14} /> Importer CSV
-                </Button>
-                <input type="file" accept=".csv" className="sr-only" onChange={handleCsvImport} />
-              </label>
+              <Button type="button" variant="secondary" onClick={handleCsvClick}>
+                <Upload size={14} /> Importer CSV
+              </Button>
             </div>
           </CardBody>
         </Card>

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -3,6 +3,7 @@
  * Sprint 7.1: invoices overview, anomaly insights with workflow, seed demo, audit-all.
  */
 import { useState, useEffect } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   getBillingSummary,
   getBillingInsights,
@@ -19,7 +20,7 @@ import { SkeletonCard } from '../ui/Skeleton';
 import { useToast } from '../ui/ToastProvider';
 import {
   FileText, AlertTriangle, CheckCircle, Upload, Play, Download,
-  DollarSign, Zap, TrendingUp, RefreshCw, CheckCircle2,
+  DollarSign, Zap, TrendingUp, RefreshCw, CheckCircle2, CalendarRange,
 } from 'lucide-react';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { track } from '../services/tracker';
@@ -74,6 +75,13 @@ const INSIGHT_FILTER_OPTIONS = [
 export default function BillIntelPage() {
   const { isExpert } = useExpertMode();
   const { toast } = useToast();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Deep-link params: ?site_id=X&month=YYYY-MM
+  const [siteFilter, setSiteFilter] = useState(searchParams.get('site_id') || '');
+  const [monthFilter, setMonthFilter] = useState(searchParams.get('month') || '');
+
   const [summary, setSummary] = useState(null);
   const [insights, setInsights] = useState([]);
   const [invoices, setInvoices] = useState([]);
@@ -87,11 +95,12 @@ export default function BillIntelPage() {
   async function fetchData() {
     setLoading(true);
     try {
-      const params = insightFilter !== 'all' ? { status: insightFilter } : {};
+      const insightParams = { ...(insightFilter !== 'all' && { status: insightFilter }), ...(siteFilter && { site_id: siteFilter }) };
+      const invoiceParams = { ...(siteFilter && { site_id: siteFilter }) };
       const [s, i, inv] = await Promise.all([
         getBillingSummary(),
-        getBillingInsights(params),
-        getBillingInvoices(),
+        getBillingInsights(insightParams),
+        getBillingInvoices(invoiceParams),
       ]);
       setSummary(s);
       setInsights(i.insights || []);
@@ -102,7 +111,15 @@ export default function BillIntelPage() {
     setLoading(false);
   }
 
-  useEffect(() => { fetchData(); }, [insightFilter]);
+  useEffect(() => { fetchData(); }, [insightFilter, siteFilter]);
+
+  // Filtrage front sur month_key (period_start commence par YYYY-MM)
+  const filteredInvoices = monthFilter
+    ? invoices.filter(inv => {
+        const d = inv.period_start || inv.issue_date || '';
+        return d.startsWith(monthFilter);
+      })
+    : invoices;
 
   async function handleSeedDemo() {
     setSeeding(true);
@@ -172,6 +189,11 @@ export default function BillIntelPage() {
       subtitle="Shadow billing, TURPE/ATRD/ATRT, ecarts & anomalies"
       actions={
         <>
+          {siteFilter && (
+            <Button size="sm" variant="secondary" onClick={() => navigate(`/billing?site_id=${siteFilter}`)}>
+              <CalendarRange size={14} /> Voir timeline
+            </Button>
+          )}
           <label className="inline-flex items-center gap-2 cursor-pointer">
             <Button variant="secondary" size="sm" as="span">
               <Upload size={14} /> Importer CSV
@@ -209,6 +231,20 @@ export default function BillIntelPage() {
         </>
       }
     >
+
+      {/* Breadcrumb filtres actifs */}
+      {(siteFilter || monthFilter) && (
+        <div className="flex items-center gap-2 text-xs text-gray-500 flex-wrap">
+          {siteFilter && <span className="px-2 py-1 bg-blue-50 text-blue-700 rounded-full">Site : {siteFilter}</span>}
+          {monthFilter && <span className="px-2 py-1 bg-amber-50 text-amber-700 rounded-full">Mois : {monthFilter}</span>}
+          <button
+            className="text-gray-400 hover:text-gray-600 underline"
+            onClick={() => { setSiteFilter(''); setMonthFilter(''); }}
+          >
+            Réinitialiser filtres
+          </button>
+        </div>
+      )}
 
       {/* Summary cards */}
       {summary && (
@@ -331,10 +367,10 @@ export default function BillIntelPage() {
       ) : null}
 
       {/* Invoices table */}
-      {invoices.length > 0 && (
+      {filteredInvoices.length > 0 && (
         <div>
           <h3 className="text-sm font-semibold text-gray-700 mb-3">
-            Factures ({invoices.length})
+            Factures ({filteredInvoices.length}{monthFilter ? ` — ${monthFilter}` : ''})
           </h3>
           <Card>
             <div className="overflow-x-auto">
@@ -350,7 +386,7 @@ export default function BillIntelPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {invoices.map((inv) => (
+                  {filteredInvoices.map((inv) => (
                     <tr key={inv.id} className="border-b border-gray-100 hover:bg-gray-50">
                       <td className="px-4 py-2.5 font-medium text-gray-900">{inv.invoice_number}</td>
                       <td className="px-4 py-2.5 text-gray-600">

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -125,8 +125,12 @@ export default function BillIntelPage() {
   }, []);
 
   useEffect(() => {
-    if (siteFilter && !pdfSiteId) setPdfSiteId(siteFilter);
-  }, [siteFilter]);
+    if (siteFilter) {
+      setPdfSiteId(siteFilter);
+    } else if (!pdfSiteId && sites.length > 0) {
+      setPdfSiteId(String(sites[0].id));
+    }
+  }, [siteFilter, sites]);
 
   // Filtrage front : période (preset ou mois exact), statut, texte libre (N° facture ou PDL)
   const filteredInvoices = useMemo(() => {
@@ -176,10 +180,14 @@ export default function BillIntelPage() {
     const file = e.target.files[0];
     if (!file) return;
     try {
-      await importInvoicesCsv(file);
+      const result = await importInvoicesCsv(file);
       track('billing_csv_import', { filename: file.name });
+      toast(`Import CSV réussi : ${result?.imported ?? '?'} facture(s) importée(s)`, 'success');
       await fetchData();
-    } catch { /* ignore */ }
+    } catch (err) {
+      if (isExpert) console.error('[BillIntelPage] CSV import error:', err);
+      toast('Erreur lors de l\'import CSV', 'error');
+    }
     e.target.value = '';
   }
 
@@ -195,10 +203,14 @@ export default function BillIntelPage() {
     const file = e.target.files[0];
     if (!file || !pdfSiteId) return;
     try {
-      await importInvoicesPdf(Number(pdfSiteId), file);
+      const result = await importInvoicesPdf(Number(pdfSiteId), file);
       track('billing_pdf_import', { filename: file.name });
+      toast(`Import PDF réussi : facture ${result?.invoice_id ?? ''} (confiance ${result?.confidence ?? '?'})`, 'success');
       await fetchData();
-    } catch { /* ignore */ }
+    } catch (err) {
+      if (isExpert) console.error('[BillIntelPage] PDF import error:', err);
+      toast('Erreur lors de l\'import PDF', 'error');
+    }
     e.target.value = '';
   }
 
@@ -225,11 +237,14 @@ export default function BillIntelPage() {
               <CalendarRange size={14} /> Voir timeline
             </Button>
           )}
-          <label className="inline-flex items-center gap-2 cursor-pointer">
-            <Button variant="secondary" size="sm" as="span">
+          <label
+            className={`inline-flex items-center gap-2 ${!pdfSiteId ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+            title={!pdfSiteId ? 'Sélectionnez un site' : undefined}
+          >
+            <Button variant="secondary" size="sm" as="span" disabled={!pdfSiteId}>
               <Upload size={14} /> Importer CSV
             </Button>
-            <input type="file" accept=".csv" className="sr-only" onChange={handleCsvImport} />
+            <input type="file" accept=".csv" className="sr-only" onChange={handleCsvImport} disabled={!pdfSiteId} />
           </label>
           <div className="inline-flex items-center gap-1">
             <select
@@ -242,7 +257,10 @@ export default function BillIntelPage() {
                 <option key={s.id} value={s.id}>{s.nom}</option>
               ))}
             </select>
-            <label className="inline-flex items-center gap-2 cursor-pointer">
+            <label
+              className={`inline-flex items-center gap-2 ${!pdfSiteId ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+              title={!pdfSiteId ? 'Sélectionnez un site' : undefined}
+            >
               <Button variant="secondary" size="sm" as="span" disabled={!pdfSiteId}>
                 <Upload size={14} /> Importer PDF
               </Button>

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -179,8 +179,10 @@ export default function BillIntelPage() {
   async function handleCsvImport(e) {
     const file = e.target.files[0];
     if (!file) return;
+    if (isExpert) console.log('[BillIntelPage] CSV import start:', file.name, file.size, 'bytes');
     try {
       const result = await importInvoicesCsv(file);
+      if (isExpert) console.log('[BillIntelPage] CSV import response:', result);
       track('billing_csv_import', { filename: file.name });
       toast(`Import CSV réussi : ${result?.imported ?? '?'} facture(s) importée(s)`, 'success');
       await fetchData();
@@ -202,8 +204,10 @@ export default function BillIntelPage() {
   async function handlePdfImport(e) {
     const file = e.target.files[0];
     if (!file || !pdfSiteId) return;
+    if (isExpert) console.log('[BillIntelPage] PDF import start:', file.name, file.size, 'bytes, site_id:', pdfSiteId);
     try {
       const result = await importInvoicesPdf(Number(pdfSiteId), file);
+      if (isExpert) console.log('[BillIntelPage] PDF import response:', result);
       track('billing_pdf_import', { filename: file.name });
       toast(`Import PDF réussi : facture ${result?.invoice_id ?? ''} (confiance ${result?.confidence ?? '?'})`, 'success');
       await fetchData();

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -13,7 +13,6 @@ import {
   importInvoicesCsv,
   resolveBillingInsight,
   importInvoicesPdf,
-  createActionFromBillingInsight,
   getSites,
 } from '../services/api';
 import { Card, CardBody, Badge, Button, TrustBadge, PageShell, EmptyState } from '../ui';
@@ -26,6 +25,8 @@ import {
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { track } from '../services/tracker';
 import InsightDrawer from '../components/InsightDrawer';
+import CreateActionModal from '../components/CreateActionModal';
+import ActionDetailDrawer from '../components/ActionDetailDrawer';
 
 const SEVERITY_BADGE = {
   critical: 'crit', high: 'warn', medium: 'info', low: 'neutral',
@@ -106,7 +107,9 @@ export default function BillIntelPage() {
   const [auditing, setAuditing] = useState(false);
   const [seeding, setSeeding] = useState(false);
   const [insightFilter, setInsightFilter] = useState('all');
-  const [createdActions, setCreatedActions] = useState(new Set());
+  const [actionMap, setActionMap] = useState(new Map());
+  const [actionModalInsight, setActionModalInsight] = useState(null);
+  const [viewActionId, setViewActionId] = useState(null);
   const [pdfSiteId, setPdfSiteId] = useState('');
   const [invoiceSearch, setInvoiceSearch] = useState('');
   const [invoiceStatusFilter, setInvoiceStatusFilter] = useState('');
@@ -127,7 +130,14 @@ export default function BillIntelPage() {
         getBillingInvoices(invoiceParams),
       ]);
       setSummary(s);
-      setInsights(i.insights || []);
+      const insightsData = i.insights || [];
+      setInsights(insightsData);
+      // Initialize actionMap from backend action_id
+      const newMap = new Map();
+      for (const ins of insightsData) {
+        if (ins.action_id) newMap.set(ins.id, ins.action_id);
+      }
+      setActionMap(newMap);
       setInvoices(inv.invoices || []);
     } catch {
       toast('Erreur lors du chargement de la facturation', 'error');
@@ -249,16 +259,19 @@ export default function BillIntelPage() {
     e.target.value = '';
   }
 
-  async function handleCreateAction(insight) {
-    if (createdActions.has(insight.id)) return;
-    try {
-      await createActionFromBillingInsight(insight.id, insight.message || insight.type, insight.site_id);
-      setCreatedActions(prev => new Set([...prev, insight.id]));
-      track('billing_create_action', { insight_id: insight.id });
-      toast('Action créée — visible dans le Plan d\'actions', 'success');
-    } catch {
-      toast('Erreur lors de la création de l\'action', 'error');
+  function handleOpenCreateAction(insight) {
+    setActionModalInsight(insight);
+  }
+
+  function handleActionSaved(result) {
+    const insightId = actionModalInsight?.id;
+    const actionId = result?.id;
+    if (insightId) {
+      setActionMap(prev => new Map([...prev, [insightId, actionId || true]]));
     }
+    setActionModalInsight(null);
+    track('billing_create_action', { insight_id: insightId, action_id: actionId });
+    toast('Action créée — visible dans le Plan d\'actions', 'success');
   }
 
   const hasData = summary && summary.total_invoices > 0;
@@ -432,9 +445,9 @@ export default function BillIntelPage() {
                         <CheckCircle2 size={14} /> Résolu
                       </button>
                     )}
-                    {createdActions.has(insight.id) ? (
+                    {actionMap.has(insight.id) ? (
                       <button
-                        onClick={() => navigate('/actions')}
+                        onClick={() => setViewActionId(actionMap.get(insight.id))}
                         className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
                           text-green-700 bg-green-50 hover:bg-green-100 transition-colors whitespace-nowrap"
                       >
@@ -442,7 +455,7 @@ export default function BillIntelPage() {
                       </button>
                     ) : (
                       <button
-                        onClick={() => handleCreateAction(insight)}
+                        onClick={() => handleOpenCreateAction(insight)}
                         className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
                           text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors whitespace-nowrap"
                         title="Créer action"
@@ -559,6 +572,31 @@ export default function BillIntelPage() {
             </div>
           </Card>
         </div>
+      )}
+
+      <CreateActionModal
+        open={!!actionModalInsight}
+        onClose={() => setActionModalInsight(null)}
+        onSave={handleActionSaved}
+        prefill={{
+          titre: actionModalInsight?.message || '',
+          type: 'facture',
+          impact_eur: actionModalInsight?.estimated_loss_eur || '',
+          description: actionModalInsight?.message || '',
+        }}
+        siteId={actionModalInsight?.site_id}
+        sourceType="billing"
+        sourceId={actionModalInsight ? String(actionModalInsight.id) : null}
+        idempotencyKey={actionModalInsight ? `billing-insight:${actionModalInsight.id}` : null}
+      />
+
+      {viewActionId && (
+        <ActionDetailDrawer
+          action={{ id: viewActionId }}
+          open={!!viewActionId}
+          onClose={() => setViewActionId(null)}
+          onUpdate={() => fetchData()}
+        />
       )}
 
       <InsightDrawer

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -2,7 +2,7 @@
  * PROMEOS - Bill Intelligence Page (/bill-intel)
  * Sprint 7.1: invoices overview, anomaly insights with workflow, seed demo, audit-all.
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   getBillingSummary,
@@ -91,6 +91,8 @@ export default function BillIntelPage() {
   const [insightFilter, setInsightFilter] = useState('all');
   const [createdActions, setCreatedActions] = useState(new Set());
   const [pdfSiteId, setPdfSiteId] = useState('');
+  const [invoiceSearch, setInvoiceSearch] = useState('');
+  const [invoiceStatusFilter, setInvoiceStatusFilter] = useState('');
 
   async function fetchData() {
     setLoading(true);
@@ -113,13 +115,24 @@ export default function BillIntelPage() {
 
   useEffect(() => { fetchData(); }, [insightFilter, siteFilter]);
 
-  // Filtrage front sur month_key (period_start commence par YYYY-MM)
-  const filteredInvoices = monthFilter
-    ? invoices.filter(inv => {
+  // Filtrage front : mois, statut, texte libre (N° facture ou PDL)
+  const filteredInvoices = useMemo(() => {
+    return invoices
+      .filter(inv => {
+        if (!monthFilter) return true;
         const d = inv.period_start || inv.issue_date || '';
         return d.startsWith(monthFilter);
       })
-    : invoices;
+      .filter(inv => !invoiceStatusFilter || inv.status === invoiceStatusFilter)
+      .filter(inv => {
+        if (!invoiceSearch) return true;
+        const q = invoiceSearch.toLowerCase();
+        return (
+          (inv.invoice_number || '').toLowerCase().includes(q) ||
+          (inv.pdl_prm || '').toLowerCase().includes(q)
+        );
+      });
+  }, [invoices, monthFilter, invoiceStatusFilter, invoiceSearch]);
 
   async function handleSeedDemo() {
     setSeeding(true);
@@ -367,11 +380,34 @@ export default function BillIntelPage() {
       ) : null}
 
       {/* Invoices table */}
-      {filteredInvoices.length > 0 && (
+      {(filteredInvoices.length > 0 || invoiceSearch || invoiceStatusFilter) && (
         <div>
           <h3 className="text-sm font-semibold text-gray-700 mb-3">
             Factures ({filteredInvoices.length}{monthFilter ? ` — ${monthFilter}` : ''})
           </h3>
+          {/* Filter bar */}
+          <div className="flex flex-wrap gap-2 mb-3 items-center">
+            <input
+              type="text"
+              placeholder="N° facture ou PDL…"
+              value={invoiceSearch}
+              onChange={e => setInvoiceSearch(e.target.value)}
+              className="border border-gray-200 rounded px-2 py-1 text-sm w-48 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            />
+            {['', 'imported', 'audited', 'anomaly', 'archived'].map(s => (
+              <button
+                key={s}
+                onClick={() => setInvoiceStatusFilter(s)}
+                className={`px-2 py-1 rounded text-xs border ${
+                  invoiceStatusFilter === s
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+                }`}
+              >
+                {s === '' ? 'Tous' : s === 'imported' ? 'Importé' : s === 'audited' ? 'Audité' : s === 'anomaly' ? 'Anomalie' : 'Archivé'}
+              </button>
+            ))}
+          </div>
           <Card>
             <div className="overflow-x-auto">
               <table className="w-full text-sm">

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -14,6 +14,7 @@ import {
   resolveBillingInsight,
   importInvoicesPdf,
   createActionFromBillingInsight,
+  getSites,
 } from '../services/api';
 import { Card, CardBody, Badge, Button, TrustBadge, PageShell, EmptyState } from '../ui';
 import { SkeletonCard } from '../ui/Skeleton';
@@ -93,6 +94,8 @@ export default function BillIntelPage() {
   const [pdfSiteId, setPdfSiteId] = useState('');
   const [invoiceSearch, setInvoiceSearch] = useState('');
   const [invoiceStatusFilter, setInvoiceStatusFilter] = useState('');
+  const [periodPreset, setPeriodPreset] = useState('all');
+  const [sites, setSites] = useState([]);
 
   async function fetchData() {
     setLoading(true);
@@ -115,13 +118,28 @@ export default function BillIntelPage() {
 
   useEffect(() => { fetchData(); }, [insightFilter, siteFilter]);
 
-  // Filtrage front : mois, statut, texte libre (N° facture ou PDL)
+  useEffect(() => {
+    getSites({ limit: 200 })
+      .then(data => setSites(Array.isArray(data?.sites) ? data.sites : []))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (siteFilter && !pdfSiteId) setPdfSiteId(siteFilter);
+  }, [siteFilter]);
+
+  // Filtrage front : période (preset ou mois exact), statut, texte libre (N° facture ou PDL)
   const filteredInvoices = useMemo(() => {
+    const now = new Date();
+    const cutoff = periodPreset === 'last3'  ? new Date(now.getFullYear(), now.getMonth() - 3, 1)
+                 : periodPreset === 'last6'  ? new Date(now.getFullYear(), now.getMonth() - 6, 1)
+                 : periodPreset === 'last12' ? new Date(now.getFullYear(), now.getMonth() - 12, 1)
+                 : null;
     return invoices
       .filter(inv => {
-        if (!monthFilter) return true;
-        const d = inv.period_start || inv.issue_date || '';
-        return d.startsWith(monthFilter);
+        if (periodPreset === 'specific') return !monthFilter || (inv.period_start || '').startsWith(monthFilter);
+        if (cutoff) return new Date(inv.period_start || inv.issue_date || '9999') >= cutoff;
+        return true;
       })
       .filter(inv => !invoiceStatusFilter || inv.status === invoiceStatusFilter)
       .filter(inv => {
@@ -132,7 +150,7 @@ export default function BillIntelPage() {
           (inv.pdl_prm || '').toLowerCase().includes(q)
         );
       });
-  }, [invoices, monthFilter, invoiceStatusFilter, invoiceSearch]);
+  }, [invoices, periodPreset, monthFilter, invoiceStatusFilter, invoiceSearch]);
 
   async function handleSeedDemo() {
     setSeeding(true);
@@ -214,13 +232,16 @@ export default function BillIntelPage() {
             <input type="file" accept=".csv" className="sr-only" onChange={handleCsvImport} />
           </label>
           <div className="inline-flex items-center gap-1">
-            <input
-              type="number"
-              placeholder="Site ID"
+            <select
               value={pdfSiteId}
               onChange={e => setPdfSiteId(e.target.value)}
-              className="w-20 text-xs border border-gray-200 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
-            />
+              className="text-xs border border-gray-200 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            >
+              <option value="">Site…</option>
+              {sites.map(s => (
+                <option key={s.id} value={s.id}>{s.nom}</option>
+              ))}
+            </select>
             <label className="inline-flex items-center gap-2 cursor-pointer">
               <Button variant="secondary" size="sm" as="span" disabled={!pdfSiteId}>
                 <Upload size={14} /> Importer PDF
@@ -394,6 +415,25 @@ export default function BillIntelPage() {
               onChange={e => setInvoiceSearch(e.target.value)}
               className="border border-gray-200 rounded px-2 py-1 text-sm w-48 focus:outline-none focus:ring-1 focus:ring-blue-400"
             />
+            <select
+              value={periodPreset}
+              onChange={e => { setPeriodPreset(e.target.value); if (e.target.value !== 'specific') setMonthFilter(''); }}
+              className="border border-gray-200 rounded px-2 py-1 text-sm"
+            >
+              <option value="all">Toutes périodes</option>
+              <option value="last3">3 derniers mois</option>
+              <option value="last6">6 derniers mois</option>
+              <option value="last12">12 derniers mois</option>
+              <option value="specific">Mois spécifique</option>
+            </select>
+            {periodPreset === 'specific' && (
+              <input
+                type="month"
+                value={monthFilter}
+                onChange={e => setMonthFilter(e.target.value)}
+                className="border border-gray-200 rounded px-2 py-1 text-sm"
+              />
+            )}
             {['', 'imported', 'audited', 'anomaly', 'archived'].map(s => (
               <button
                 key={s}

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -25,22 +25,23 @@ import {
 } from 'lucide-react';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { track } from '../services/tracker';
+import InsightDrawer from '../components/InsightDrawer';
 
 const SEVERITY_BADGE = {
   critical: 'crit', high: 'warn', medium: 'info', low: 'neutral',
 };
 
 const TYPE_LABELS = {
-  shadow_gap: 'Ecart shadow billing',
-  unit_price_high: 'Prix unitaire eleve',
+  shadow_gap: 'Écart shadow billing',
+  unit_price_high: 'Prix unitaire élevé',
   duplicate_invoice: 'Doublon facture',
-  missing_period: 'Periode manquante',
-  period_too_long: 'Periode longue',
-  negative_kwh: 'kWh negatifs',
-  zero_amount: 'Montant zero',
-  lines_sum_mismatch: 'Ecart lignes/total',
+  missing_period: 'Période manquante',
+  period_too_long: 'Période longue',
+  negative_kwh: 'kWh négatifs',
+  zero_amount: 'Montant zéro',
+  lines_sum_mismatch: 'Écart lignes/total',
   consumption_spike: 'Pic de consommation',
-  price_drift: 'Derive de prix',
+  price_drift: 'Dérive de prix',
 };
 
 const STATUS_COLORS = {
@@ -49,6 +50,21 @@ const STATUS_COLORS = {
   audited: 'bg-green-100 text-green-700',
   anomaly: 'bg-red-100 text-red-700',
   archived: 'bg-gray-100 text-gray-500',
+};
+
+const STATUS_LABELS = {
+  imported: 'Importé',
+  validated: 'Validé',
+  audited: 'Audité',
+  anomaly: 'Anomalie',
+  archived: 'Archivé',
+};
+
+const SEVERITY_LABELS = {
+  critical: 'Critique',
+  high: 'Élevé',
+  medium: 'Moyen',
+  low: 'Faible',
 };
 
 const INSIGHT_STATUS_COLORS = {
@@ -61,7 +77,7 @@ const INSIGHT_STATUS_COLORS = {
 const INSIGHT_STATUS_LABELS = {
   open: 'Ouvert',
   ack: 'Pris en charge',
-  resolved: 'Resolu',
+  resolved: 'Résolu',
   false_positive: 'Faux positif',
 };
 
@@ -69,7 +85,7 @@ const INSIGHT_FILTER_OPTIONS = [
   { value: 'all', label: 'Tous' },
   { value: 'open', label: 'Ouverts' },
   { value: 'ack', label: 'Pris en charge' },
-  { value: 'resolved', label: 'Resolus' },
+  { value: 'resolved', label: 'Résolus' },
   { value: 'false_positive', label: 'Faux positifs' },
 ];
 
@@ -95,6 +111,7 @@ export default function BillIntelPage() {
   const [invoiceSearch, setInvoiceSearch] = useState('');
   const [invoiceStatusFilter, setInvoiceStatusFilter] = useState('');
   const [periodPreset, setPeriodPreset] = useState('all');
+  const [drawerInsightId, setDrawerInsightId] = useState(null);
   const [sites, setSites] = useState([]);
   const csvInputRef = useRef(null);
   const pdfInputRef = useRef(null);
@@ -238,7 +255,10 @@ export default function BillIntelPage() {
       await createActionFromBillingInsight(insight.id, insight.message || insight.type, insight.site_id);
       setCreatedActions(prev => new Set([...prev, insight.id]));
       track('billing_create_action', { insight_id: insight.id });
-    } catch { /* ignore */ }
+      toast('Action créée — visible dans le Plan d\'actions', 'success');
+    } catch {
+      toast('Erreur lors de la création de l\'action', 'error');
+    }
   }
 
   const hasData = summary && summary.total_invoices > 0;
@@ -247,7 +267,7 @@ export default function BillIntelPage() {
     <PageShell
       icon={FileText}
       title="Facturation"
-      subtitle="Shadow billing, TURPE/ATRD/ATRT, ecarts & anomalies"
+      subtitle="Shadow billing, TURPE/ATRD/ATRT, écarts & anomalies"
       actions={
         <>
           {siteFilter && (
@@ -324,10 +344,10 @@ export default function BillIntelPage() {
       {summary && (
         <div className="grid grid-cols-5 gap-4">
           <SummaryCard icon={FileText} label="Factures" value={summary.total_invoices} color="blue" />
-          <SummaryCard icon={DollarSign} label="Total EUR" value={`${Math.round(summary.total_eur).toLocaleString()}`} color="indigo" />
+          <SummaryCard icon={DollarSign} label="Total €" value={`${Math.round(summary.total_eur).toLocaleString()} €`} color="indigo" />
           <SummaryCard icon={Zap} label="Total kWh" value={`${Math.round(summary.total_kwh).toLocaleString()}`} color="purple" />
           <SummaryCard icon={AlertTriangle} label="Anomalies" value={summary.total_insights} color="red" />
-          <SummaryCard icon={TrendingUp} label="Pertes estimees" value={`${Math.round(summary.total_estimated_loss_eur)} EUR`} color="orange" />
+          <SummaryCard icon={TrendingUp} label="Pertes estimées" value={`${Math.round(summary.total_estimated_loss_eur)} €`} color="orange" />
         </div>
       )}
 
@@ -386,7 +406,7 @@ export default function BillIntelPage() {
                           {TYPE_LABELS[insight.type] || insight.type}
                         </span>
                         <Badge status={SEVERITY_BADGE[insight.severity] || 'neutral'}>
-                          {insight.severity}
+                          {SEVERITY_LABELS[insight.severity] || insight.severity}
                         </Badge>
                         <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${INSIGHT_STATUS_COLORS[istatus] || INSIGHT_STATUS_COLORS.open}`}>
                           {INSIGHT_STATUS_LABELS[istatus] || istatus}
@@ -399,7 +419,7 @@ export default function BillIntelPage() {
                     </div>
                     {insight.estimated_loss_eur > 0 && (
                       <span className="text-sm font-bold text-red-600 whitespace-nowrap">
-                        {insight.estimated_loss_eur.toLocaleString()} EUR
+                        {insight.estimated_loss_eur.toLocaleString()} €
                       </span>
                     )}
                     {istatus !== 'resolved' && istatus !== 'false_positive' && (
@@ -407,22 +427,35 @@ export default function BillIntelPage() {
                         onClick={() => handleResolveInsight(insight.id)}
                         className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
                           text-green-700 bg-green-50 hover:bg-green-100 transition-colors whitespace-nowrap"
-                        title="Marquer comme resolu"
+                        title="Marquer comme résolu"
                       >
-                        <CheckCircle2 size={14} /> Resolu
+                        <CheckCircle2 size={14} /> Résolu
+                      </button>
+                    )}
+                    {createdActions.has(insight.id) ? (
+                      <button
+                        onClick={() => navigate('/actions')}
+                        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
+                          text-green-700 bg-green-50 hover:bg-green-100 transition-colors whitespace-nowrap"
+                      >
+                        ✓ Voir l'action
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handleCreateAction(insight)}
+                        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
+                          text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors whitespace-nowrap"
+                        title="Créer action"
+                      >
+                        Créer action
                       </button>
                     )}
                     <button
-                      onClick={() => handleCreateAction(insight)}
-                      disabled={createdActions.has(insight.id)}
-                      className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
-                        transition-colors whitespace-nowrap
-                        ${createdActions.has(insight.id)
-                          ? 'text-gray-400 bg-gray-50 cursor-default'
-                          : 'text-blue-700 bg-blue-50 hover:bg-blue-100'}`}
-                      title="Créer action"
+                      onClick={() => setDrawerInsightId(insight.id)}
+                      className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
+                        text-purple-700 bg-purple-50 hover:bg-purple-100 transition-colors whitespace-nowrap"
                     >
-                      {createdActions.has(insight.id) ? '✓ Action créée' : 'Créer action'}
+                      Comprendre l'écart
                     </button>
                   </CardBody>
                 </Card>
@@ -508,11 +541,11 @@ export default function BillIntelPage() {
                           : inv.period_start || '-'
                         }
                       </td>
-                      <td className="px-4 py-2.5 text-right font-medium">{inv.total_eur ? `${inv.total_eur.toLocaleString()} EUR` : '-'}</td>
+                      <td className="px-4 py-2.5 text-right font-medium">{inv.total_eur ? `${inv.total_eur.toLocaleString()} €` : '-'}</td>
                       <td className="px-4 py-2.5 text-right">{inv.energy_kwh ? inv.energy_kwh.toLocaleString() : '-'}</td>
                       <td className="px-4 py-2.5 text-center">
                         <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${STATUS_COLORS[inv.status] || STATUS_COLORS.imported}`}>
-                          {inv.status || 'imported'}
+                          {STATUS_LABELS[inv.status] || STATUS_LABELS.imported}
                         </span>
                       </td>
                       <td className="px-4 py-2.5 text-gray-500">{inv.source || '-'}</td>
@@ -527,6 +560,12 @@ export default function BillIntelPage() {
           </Card>
         </div>
       )}
+
+      <InsightDrawer
+        open={!!drawerInsightId}
+        onClose={() => setDrawerInsightId(null)}
+        insightId={drawerInsightId}
+      />
     </PageShell>
   );
 }

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -11,6 +11,8 @@ import {
   seedBillingDemo,
   importInvoicesCsv,
   resolveBillingInsight,
+  importInvoicesPdf,
+  createActionFromBillingInsight,
 } from '../services/api';
 import { Card, CardBody, Badge, Button, TrustBadge, PageShell, EmptyState } from '../ui';
 import { SkeletonCard } from '../ui/Skeleton';
@@ -79,6 +81,8 @@ export default function BillIntelPage() {
   const [auditing, setAuditing] = useState(false);
   const [seeding, setSeeding] = useState(false);
   const [insightFilter, setInsightFilter] = useState('all');
+  const [createdActions, setCreatedActions] = useState(new Set());
+  const [pdfSiteId, setPdfSiteId] = useState('');
 
   async function fetchData() {
     setLoading(true);
@@ -139,6 +143,26 @@ export default function BillIntelPage() {
     } catch { /* ignore */ }
   }
 
+  async function handlePdfImport(e) {
+    const file = e.target.files[0];
+    if (!file || !pdfSiteId) return;
+    try {
+      await importInvoicesPdf(Number(pdfSiteId), file);
+      track('billing_pdf_import', { filename: file.name });
+      await fetchData();
+    } catch { /* ignore */ }
+    e.target.value = '';
+  }
+
+  async function handleCreateAction(insight) {
+    if (createdActions.has(insight.id)) return;
+    try {
+      await createActionFromBillingInsight(insight.id, insight.message || insight.type, insight.site_id);
+      setCreatedActions(prev => new Set([...prev, insight.id]));
+      track('billing_create_action', { insight_id: insight.id });
+    } catch { /* ignore */ }
+  }
+
   const hasData = summary && summary.total_invoices > 0;
 
   return (
@@ -154,6 +178,21 @@ export default function BillIntelPage() {
             </Button>
             <input type="file" accept=".csv" className="sr-only" onChange={handleCsvImport} />
           </label>
+          <div className="inline-flex items-center gap-1">
+            <input
+              type="number"
+              placeholder="Site ID"
+              value={pdfSiteId}
+              onChange={e => setPdfSiteId(e.target.value)}
+              className="w-20 text-xs border border-gray-200 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            />
+            <label className="inline-flex items-center gap-2 cursor-pointer">
+              <Button variant="secondary" size="sm" as="span" disabled={!pdfSiteId}>
+                <Upload size={14} /> Importer PDF
+              </Button>
+              <input type="file" accept=".pdf" className="sr-only" onChange={handlePdfImport} disabled={!pdfSiteId} />
+            </label>
+          </div>
           {hasData && (
             <Button size="sm" onClick={handleAuditAll} disabled={auditing}>
               <Play size={14} /> {auditing ? 'Audit...' : 'Auditer tout'}
@@ -266,6 +305,18 @@ export default function BillIntelPage() {
                         <CheckCircle2 size={14} /> Resolu
                       </button>
                     )}
+                    <button
+                      onClick={() => handleCreateAction(insight)}
+                      disabled={createdActions.has(insight.id)}
+                      className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
+                        transition-colors whitespace-nowrap
+                        ${createdActions.has(insight.id)
+                          ? 'text-gray-400 bg-gray-50 cursor-default'
+                          : 'text-blue-700 bg-blue-50 hover:bg-blue-100'}`}
+                      title="Créer action"
+                    >
+                      {createdActions.has(insight.id) ? '✓ Action créée' : 'Créer action'}
+                    </button>
                   </CardBody>
                 </Card>
               );

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -74,16 +74,11 @@ export default function BillingPage() {
     const params = {};
     if (siteId) params.site_id = siteId;
 
+    // Critical: periods — si ça échoue, rien à afficher
     try {
-      const [summaryData, periodsData] = await Promise.all([
-        getCoverageSummary(params),
-        getBillingPeriods({ ...params, limit: LIMIT, offset }),
-      ]);
-
-      setSummary(summaryData);
+      const periodsData = await getBillingPeriods({ ...params, limit: LIMIT, offset });
       setPeriodsTotal(periodsData.total);
       setPeriodsOffset(offset + periodsData.periods.length);
-
       if (append) {
         setPeriods(prev => [...prev, ...periodsData.periods]);
       } else {
@@ -91,7 +86,7 @@ export default function BillingPage() {
       }
     } catch (err) {
       const status = err?.response?.status;
-      if (status === 404) {
+      if (status === 404 && siteId) {
         // P0: purge stale siteId from localStorage scope
         try {
           const raw = localStorage.getItem('promeos_scope');
@@ -104,7 +99,7 @@ export default function BillingPage() {
         setSiteFilter('');
         const baseMsg = 'Site introuvable. Retour à la vue tous les sites.';
         if (isExpert) {
-          const endpoint = err?.config?.url || '/billing/*';
+          const endpoint = err?.config?.url || '/billing/periods';
           setError(`${baseMsg} [debug: endpoint=${endpoint}, status=404, site_id=${siteId}]`);
         } else {
           setError(baseMsg);
@@ -121,7 +116,18 @@ export default function BillingPage() {
     setLoading(false);
     setLoadingMore(false);
 
-    // Missing-periods : non-bloquant, best-effort (offset 0 only)
+    // Non-bloquant : coverage-summary (best-effort, ne casse pas la timeline)
+    if (offset === 0) {
+      try {
+        const summaryData = await getCoverageSummary(params);
+        setSummary(summaryData);
+      } catch (err) {
+        if (isExpert) console.warn('[BillingPage] coverage-summary failed (non-bloquant):', err);
+        setSummary(null);
+      }
+    }
+
+    // Non-bloquant : missing-periods (best-effort)
     if (offset === 0) {
       try {
         const missingData = await getMissingPeriods({ limit: 10 });

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -1,23 +1,27 @@
 /**
- * PROMEOS — BillingPage (V67)
+ * PROMEOS — BillingPage (V70)
  * Timeline & Couverture Facturation : suivi mensuel, détection périodes manquantes.
+ * Scope unifié via ScopeContext, filtres avancés, import contextuel.
  * Route: /billing (alias /facturation)
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { CalendarRange, AlertTriangle, CheckCircle, XCircle, RefreshCw, Upload, Zap } from 'lucide-react';
+import { CalendarRange, AlertTriangle, CheckCircle, XCircle, RefreshCw, Upload, Zap, Search } from 'lucide-react';
 import {
   getBillingPeriods,
   getCoverageSummary,
   getMissingPeriods,
   createActionFromBillingInsight,
-  getSites,
+  importInvoicesCsv,
+  importInvoicesPdf,
 } from '../services/api';
 import { Card, CardBody, Button, Badge, EmptyState } from '../ui';
 import { SkeletonCard } from '../ui/Skeleton';
 import CoverageBar from '../components/CoverageBar';
 import BillingTimeline from '../components/BillingTimeline';
 import { useExpertMode } from '../contexts/ExpertModeContext';
+import { useScope } from '../contexts/ScopeContext';
+import { useToast } from '../ui/ToastProvider';
 
 const PAGE_TITLE = 'Timeline & Couverture Facturation';
 
@@ -37,11 +41,14 @@ export default function BillingPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { isExpert } = useExpertMode();
+  const { selectedSiteId: scopeSiteId, scopeLabel, orgSites } = useScope();
+  const { toast } = useToast();
 
-  // Filtres depuis l'URL (?site_id=X&month=YYYY-MM)
-  const [siteFilter, setSiteFilter] = useState(searchParams.get('site_id') || '');
+  // Filtres depuis l'URL (?site_id=X&month=YYYY-MM) — init depuis scope global
+  const [siteFilter, setSiteFilter] = useState(
+    searchParams.get('site_id') || (scopeSiteId ? String(scopeSiteId) : '')
+  );
   const [activeMonth, setActiveMonth] = useState(searchParams.get('month') || '');
-  const [sites, setSites] = useState([]);
 
   const [summary, setSummary] = useState(null);
   const [periods, setPeriods] = useState([]);
@@ -55,7 +62,28 @@ export default function BillingPage() {
 
   const [createdActions, setCreatedActions] = useState(new Set());
 
+  // Filtres avancés
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [periodPreset, setPeriodPreset] = useState('all');
+  const [timelineSearch, setTimelineSearch] = useState('');
+  const [sortMode, setSortMode] = useState('date_desc');
+
+  // Import contextuel
+  const [importContext, setImportContext] = useState(null);
+  const csvInputRef = useRef(null);
+  const pdfInputRef = useRef(null);
+
   const LIMIT = 24;
+
+  // Scope indicators
+  const scopeHasSite = !!scopeSiteId;
+  const localFilterActive = siteFilter && String(siteFilter) !== String(scopeSiteId || '');
+
+  // Sync scope global → local
+  useEffect(() => {
+    setSiteFilter(scopeSiteId ? String(scopeSiteId) : '');
+    setPeriodsOffset(0);
+  }, [scopeSiteId]);
 
   // Sync filtre → URL
   useEffect(() => {
@@ -159,12 +187,6 @@ export default function BillingPage() {
     fetchAll(siteFilter, 0, false);
   }, [siteFilter]);
 
-  // Charger la liste des sites pour le filtre
-  useEffect(() => {
-    getSites({ limit: 200 }).catch(() => []).then(data => {
-      setSites(Array.isArray(data?.sites) ? data.sites : Array.isArray(data) ? data : []);
-    });
-  }, []);
 
   const handleLoadMore = () => {
     fetchAll(siteFilter, periodsOffset, true);
@@ -183,6 +205,92 @@ export default function BillingPage() {
   };
 
   const hasMore = periodsOffset < periodsTotal;
+
+  // Client-side filtering
+  const filteredPeriods = useMemo(() => {
+    let result = [...periods];
+
+    // Period preset filter
+    if (periodPreset !== 'all') {
+      const now = new Date();
+      const months = periodPreset === 'last3' ? 3 : periodPreset === 'last6' ? 6 : 12;
+      const cutoff = new Date(now.getFullYear(), now.getMonth() - months, 1);
+      const cutoffKey = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}`;
+      result = result.filter(p => p.month_key >= cutoffKey);
+    }
+
+    // Status filter
+    if (statusFilter !== 'all') {
+      result = result.filter(p => p.coverage_status === statusFilter);
+    }
+
+    // Text search
+    if (timelineSearch.trim()) {
+      const q = timelineSearch.trim().toLowerCase();
+      result = result.filter(p =>
+        p.month_key?.toLowerCase().includes(q) ||
+        p.pdl_prm?.toLowerCase().includes(q)
+      );
+    }
+
+    // Sort
+    if (sortMode === 'priority_missing') {
+      const order = { missing: 0, partial: 1, covered: 2 };
+      result.sort((a, b) => {
+        const diff = (order[a.coverage_status] ?? 3) - (order[b.coverage_status] ?? 3);
+        return diff !== 0 ? diff : (b.month_key || '').localeCompare(a.month_key || '');
+      });
+    }
+
+    return result;
+  }, [periods, periodPreset, statusFilter, timelineSearch, sortMode]);
+
+  const statusCounts = useMemo(() => ({
+    all: periods.length,
+    covered: periods.filter(p => p.coverage_status === 'covered').length,
+    partial: periods.filter(p => p.coverage_status === 'partial').length,
+    missing: periods.filter(p => p.coverage_status === 'missing').length,
+  }), [periods]);
+
+  // Import contextuel handlers
+  const handleImportClick = (siteId, monthKey, type) => {
+    setImportContext({ siteId, monthKey });
+    if (isExpert) console.log('[BillingPage] import click:', { siteId, monthKey, type });
+    if (type === 'csv') csvInputRef.current?.click();
+    else pdfInputRef.current?.click();
+  };
+
+  async function handleContextualCsvImport(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (isExpert) console.log('[BillingPage] CSV file selected:', file.name, importContext);
+    try {
+      await importInvoicesCsv(file, importContext?.siteId);
+      toast('Import CSV réussi', 'success');
+      fetchAll(siteFilter, 0, false);
+    } catch (err) {
+      if (isExpert) console.error('[BillingPage] CSV import failed:', err);
+      toast('Échec import CSV', 'error');
+    }
+    setImportContext(null);
+    e.target.value = '';
+  }
+
+  async function handleContextualPdfImport(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (isExpert) console.log('[BillingPage] PDF file selected:', file.name, importContext);
+    try {
+      await importInvoicesPdf(file, importContext?.siteId);
+      toast('Import PDF réussi', 'success');
+      fetchAll(siteFilter, 0, false);
+    } catch (err) {
+      if (isExpert) console.error('[BillingPage] PDF import failed:', err);
+      toast('Échec import PDF', 'error');
+    }
+    setImportContext(null);
+    e.target.value = '';
+  }
 
   if (loading) {
     return (
@@ -212,22 +320,34 @@ export default function BillingPage() {
         </Button>
       </div>
 
-      {/* Filtres */}
-      <div className="flex flex-wrap gap-2">
-        <select
-          className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 bg-white text-gray-700"
-          value={siteFilter}
-          onChange={e => { setSiteFilter(e.target.value); setPeriodsOffset(0); }}
-        >
-          <option value="">Tous les sites</option>
-          {sites.map(s => (
-            <option key={s.id} value={s.id}>{s.nom}</option>
-          ))}
-        </select>
-        {siteFilter && (
+      {/* Filtres — scope-aware */}
+      <div className="flex flex-wrap gap-2 items-center">
+        {scopeHasSite ? (
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-700">
+            Hérité : {orgSites.find(s => s.id === scopeSiteId)?.nom || `Site ${scopeSiteId}`}
+          </div>
+        ) : (
+          <select
+            className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 bg-white text-gray-700"
+            value={siteFilter}
+            onChange={e => { setSiteFilter(e.target.value); setPeriodsOffset(0); }}
+          >
+            <option value="">Tous les sites</option>
+            {orgSites.map(s => (
+              <option key={s.id} value={s.id}>{s.nom}</option>
+            ))}
+          </select>
+        )}
+        {siteFilter && !scopeHasSite && (
           <Button size="sm" variant="ghost" onClick={() => setSiteFilter('')}>
             Réinitialiser
           </Button>
+        )}
+        {localFilterActive && (
+          <div className="flex items-center gap-1 px-2.5 py-1 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-700">
+            Vue filtrée : Site {orgSites.find(s => String(s.id) === String(siteFilter))?.nom || siteFilter}
+            <span className="text-amber-500">(scope global : {scopeLabel || 'Tous les sites'})</span>
+          </div>
         )}
       </div>
 
@@ -310,9 +430,18 @@ export default function BillingPage() {
                     <Button
                       size="xs"
                       variant="secondary"
-                      onClick={() => navigate(item.cta_url)}
+                      type="button"
+                      onClick={() => handleImportClick(item.site_id, item.month_key, 'csv')}
                     >
-                      <Upload size={11} /> Importer
+                      <Upload size={11} /> CSV
+                    </Button>
+                    <Button
+                      size="xs"
+                      variant="secondary"
+                      type="button"
+                      onClick={() => handleImportClick(item.site_id, item.month_key, 'pdf')}
+                    >
+                      <Upload size={11} /> PDF
                     </Button>
                     <Button
                       size="xs"
@@ -339,6 +468,57 @@ export default function BillingPage() {
         </Card>
       )}
 
+      {/* Barre de filtres timeline */}
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          className="text-xs border border-gray-200 rounded-lg px-2.5 py-1.5 bg-white text-gray-700"
+          value={periodPreset}
+          onChange={e => setPeriodPreset(e.target.value)}
+        >
+          <option value="all">Toutes périodes</option>
+          <option value="last3">3 derniers mois</option>
+          <option value="last6">6 derniers mois</option>
+          <option value="last12">12 derniers mois</option>
+        </select>
+        {[
+          { key: 'all', label: 'Tous' },
+          { key: 'covered', label: 'Couverts' },
+          { key: 'partial', label: 'Partiels' },
+          { key: 'missing', label: 'Manquants' },
+        ].map(opt => (
+          <button
+            key={opt.key}
+            type="button"
+            className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
+              statusFilter === opt.key
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+            onClick={() => setStatusFilter(opt.key)}
+          >
+            {opt.label} ({statusCounts[opt.key]})
+          </button>
+        ))}
+        <div className="relative">
+          <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Mois ou PDL..."
+            value={timelineSearch}
+            onChange={e => setTimelineSearch(e.target.value)}
+            className="text-xs border border-gray-200 rounded-lg pl-6 pr-2 py-1.5 bg-white text-gray-700 w-36"
+          />
+        </div>
+        <select
+          className="text-xs border border-gray-200 rounded-lg px-2.5 py-1.5 bg-white text-gray-700"
+          value={sortMode}
+          onChange={e => setSortMode(e.target.value)}
+        >
+          <option value="date_desc">Date desc</option>
+          <option value="priority_missing">Priorité manquants</option>
+        </select>
+      </div>
+
       {/* Timeline complète */}
       <Card>
         <CardBody>
@@ -346,7 +526,7 @@ export default function BillingPage() {
             Timeline complète
             {periodsTotal > 0 && (
               <span className="ml-2 text-xs font-normal text-gray-400">
-                {periods.length}/{periodsTotal} mois
+                {filteredPeriods.length}/{periods.length} affichées ({periodsTotal} total)
               </span>
             )}
           </h2>
@@ -364,7 +544,7 @@ export default function BillingPage() {
           ) : (
             <>
               <BillingTimeline
-                periods={periods}
+                periods={filteredPeriods}
                 siteId={siteFilter}
                 activeMonth={activeMonth}
                 onCreateAction={handleCreateAction}
@@ -386,6 +566,10 @@ export default function BillingPage() {
           )}
         </CardBody>
       </Card>
+
+      {/* Hidden file inputs for contextual import */}
+      <input ref={csvInputRef} type="file" accept=".csv" className="sr-only" onChange={handleContextualCsvImport} />
+      <input ref={pdfInputRef} type="file" accept=".pdf" className="sr-only" onChange={handleContextualPdfImport} />
     </div>
   );
 }

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -17,6 +17,7 @@ import { Card, CardBody, Button, Badge, EmptyState } from '../ui';
 import { SkeletonCard } from '../ui/Skeleton';
 import CoverageBar from '../components/CoverageBar';
 import BillingTimeline from '../components/BillingTimeline';
+import { useExpertMode } from '../contexts/ExpertModeContext';
 
 const PAGE_TITLE = 'Timeline & Couverture Facturation';
 
@@ -35,6 +36,7 @@ function KpiChip({ icon: Icon, label, value, color }) {
 export default function BillingPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { isExpert } = useExpertMode();
 
   // Filtres depuis l'URL (?site_id=X&month=YYYY-MM)
   const [siteFilter, setSiteFilter] = useState(searchParams.get('site_id') || '');
@@ -73,10 +75,9 @@ export default function BillingPage() {
     if (siteId) params.site_id = siteId;
 
     try {
-      const [summaryData, periodsData, missingData] = await Promise.all([
+      const [summaryData, periodsData] = await Promise.all([
         getCoverageSummary(params),
         getBillingPeriods({ ...params, limit: LIMIT, offset }),
-        offset === 0 ? getMissingPeriods({ limit: 10 }) : Promise.resolve(null),
       ]);
 
       setSummary(summaryData);
@@ -88,15 +89,34 @@ export default function BillingPage() {
       } else {
         setPeriods(periodsData.periods);
       }
-
-      if (missingData) setMissingPeriods(missingData.items || []);
-    } catch {
-      setError('Impossible de charger les données de facturation.');
-    } finally {
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 404) {
+        setSiteFilter('');
+        setError('Site introuvable. Retour à la vue tous les sites.');
+      } else {
+        if (isExpert) console.error('[BillingPage] loadData error:', err);
+        setError('Impossible de charger les données de facturation.');
+      }
       setLoading(false);
       setLoadingMore(false);
+      return;
     }
-  }, []);
+
+    setLoading(false);
+    setLoadingMore(false);
+
+    // Missing-periods : non-bloquant, best-effort (offset 0 only)
+    if (offset === 0) {
+      try {
+        const missingData = await getMissingPeriods({ limit: 10 });
+        setMissingPeriods(missingData.items || []);
+      } catch (err) {
+        if (isExpert) console.warn('[BillingPage] getMissingPeriods failed (non-bloquant):', err);
+        setMissingPeriods([]);
+      }
+    }
+  }, [isExpert]);
 
   useEffect(() => {
     fetchAll(siteFilter, 0, false);

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -86,6 +86,19 @@ export default function BillingPage() {
       }
     } catch (err) {
       const status = err?.response?.status;
+      // Build comprehensive debug payload for Expert mode
+      const debugPayload = {
+        endpoint: err?.config?.url || '/billing/periods',
+        params: err?.config?.params || params,
+        status: status || 0,
+        contentType: err?.response?.headers?.['content-type'] || 'N/A',
+        bodySnippet: typeof err?.response?.data === 'string'
+          ? err.response.data.slice(0, 120)
+          : JSON.stringify(err?.response?.data || err?.message || 'no body').slice(0, 120),
+        orgHeader: err?.config?.headers?.['X-Org-Id'] || 'missing',
+      };
+      if (isExpert) console.error('[BillingPage] getBillingPeriods FAILED:', debugPayload, err);
+
       if (status === 404 && siteId) {
         // P0: purge stale siteId from localStorage scope
         try {
@@ -99,14 +112,17 @@ export default function BillingPage() {
         setSiteFilter('');
         const baseMsg = 'Site introuvable. Retour à la vue tous les sites.';
         if (isExpert) {
-          const endpoint = err?.config?.url || '/billing/periods';
-          setError(`${baseMsg} [debug: endpoint=${endpoint}, status=404, site_id=${siteId}]`);
+          setError(`${baseMsg} [debug: endpoint=${debugPayload.endpoint}, status=404, site_id=${siteId}, org=${debugPayload.orgHeader}, ct=${debugPayload.contentType}]`);
         } else {
           setError(baseMsg);
         }
       } else {
-        if (isExpert) console.error('[BillingPage] loadData error:', err);
-        setError('Impossible de charger les données de facturation.');
+        const baseMsg = 'Impossible de charger les données de facturation.';
+        if (isExpert) {
+          setError(`${baseMsg} [debug: endpoint=${debugPayload.endpoint}, status=${debugPayload.status}, org=${debugPayload.orgHeader}, ct=${debugPayload.contentType}, body=${debugPayload.bodySnippet}]`);
+        } else {
+          setError(baseMsg);
+        }
       }
       setLoading(false);
       setLoadingMore(false);

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -36,8 +36,9 @@ export default function BillingPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Filtre depuis l'URL (?site_id=X)
+  // Filtres depuis l'URL (?site_id=X&month=YYYY-MM)
   const [siteFilter, setSiteFilter] = useState(searchParams.get('site_id') || '');
+  const [activeMonth, setActiveMonth] = useState(searchParams.get('month') || '');
   const [sites, setSites] = useState([]);
 
   const [summary, setSummary] = useState(null);
@@ -192,29 +193,29 @@ export default function BillingPage() {
               <KpiChip
                 icon={CheckCircle}
                 label="Couverts"
-                value={summary.covered}
+                value={summary?.covered ?? 0}
                 color="text-green-600"
               />
               <KpiChip
                 icon={AlertTriangle}
                 label="Partiels"
-                value={summary.partial}
+                value={summary?.partial ?? 0}
                 color="text-orange-500"
               />
               <KpiChip
                 icon={XCircle}
                 label="Manquants"
-                value={summary.missing}
+                value={summary?.missing ?? 0}
                 color="text-red-500"
               />
             </div>
             <CoverageBar
-              covered={summary.covered}
-              partial={summary.partial}
-              missing={summary.missing}
-              total={summary.months_total}
-              minMonth={summary.range?.min_month}
-              maxMonth={summary.range?.max_month}
+              covered={summary?.covered ?? 0}
+              partial={summary?.partial ?? 0}
+              missing={summary?.missing ?? 0}
+              total={summary?.months_total ?? 0}
+              minMonth={summary?.range?.min_month ?? '—'}
+              maxMonth={summary?.range?.max_month ?? '—'}
             />
           </CardBody>
         </Card>
@@ -308,6 +309,7 @@ export default function BillingPage() {
               <BillingTimeline
                 periods={periods}
                 siteId={siteFilter}
+                activeMonth={activeMonth}
                 onCreateAction={handleCreateAction}
                 createdActions={createdActions}
               />

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -1,0 +1,332 @@
+/**
+ * PROMEOS — BillingPage (V67)
+ * Timeline & Couverture Facturation : suivi mensuel, détection périodes manquantes.
+ * Route: /billing (alias /facturation)
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { CalendarRange, AlertTriangle, CheckCircle, XCircle, RefreshCw, Upload, Zap } from 'lucide-react';
+import {
+  getBillingPeriods,
+  getCoverageSummary,
+  getMissingPeriods,
+  createActionFromBillingInsight,
+  getSites,
+} from '../services/api';
+import { Card, CardBody, Button, Badge, EmptyState } from '../ui';
+import { SkeletonCard } from '../ui/Skeleton';
+import CoverageBar from '../components/CoverageBar';
+import BillingTimeline from '../components/BillingTimeline';
+
+const PAGE_TITLE = 'Timeline & Couverture Facturation';
+
+function KpiChip({ icon: Icon, label, value, color }) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 bg-white rounded-lg border border-gray-100 shadow-sm">
+      <Icon size={16} className={color} />
+      <div>
+        <p className="text-xs text-gray-500">{label}</p>
+        <p className={`text-lg font-bold ${color}`}>{value}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function BillingPage() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Filtre depuis l'URL (?site_id=X)
+  const [siteFilter, setSiteFilter] = useState(searchParams.get('site_id') || '');
+  const [sites, setSites] = useState([]);
+
+  const [summary, setSummary] = useState(null);
+  const [periods, setPeriods] = useState([]);
+  const [periodsTotal, setPeriodsTotal] = useState(0);
+  const [periodsOffset, setPeriodsOffset] = useState(0);
+  const [missingPeriods, setMissingPeriods] = useState([]);
+
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(null);
+
+  const [createdActions, setCreatedActions] = useState(new Set());
+
+  const LIMIT = 24;
+
+  // Sync filtre → URL
+  useEffect(() => {
+    if (siteFilter) {
+      setSearchParams({ site_id: siteFilter }, { replace: true });
+    } else {
+      setSearchParams({}, { replace: true });
+    }
+  }, [siteFilter]);
+
+  const fetchAll = useCallback(async (siteId, offset = 0, append = false) => {
+    if (!append) setLoading(true);
+    else setLoadingMore(true);
+    setError(null);
+
+    const params = {};
+    if (siteId) params.site_id = siteId;
+
+    try {
+      const [summaryData, periodsData, missingData] = await Promise.all([
+        getCoverageSummary(params),
+        getBillingPeriods({ ...params, limit: LIMIT, offset }),
+        offset === 0 ? getMissingPeriods({ limit: 10 }) : Promise.resolve(null),
+      ]);
+
+      setSummary(summaryData);
+      setPeriodsTotal(periodsData.total);
+      setPeriodsOffset(offset + periodsData.periods.length);
+
+      if (append) {
+        setPeriods(prev => [...prev, ...periodsData.periods]);
+      } else {
+        setPeriods(periodsData.periods);
+      }
+
+      if (missingData) setMissingPeriods(missingData.items || []);
+    } catch {
+      setError('Impossible de charger les données de facturation.');
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll(siteFilter, 0, false);
+  }, [siteFilter]);
+
+  // Charger la liste des sites pour le filtre
+  useEffect(() => {
+    getSites({ limit: 200 }).catch(() => []).then(data => {
+      setSites(Array.isArray(data?.sites) ? data.sites : Array.isArray(data) ? data : []);
+    });
+  }, []);
+
+  const handleLoadMore = () => {
+    fetchAll(siteFilter, periodsOffset, true);
+  };
+
+  const handleCreateAction = async (actionKey, period) => {
+    if (createdActions.has(actionKey)) return;
+    try {
+      await createActionFromBillingInsight(
+        `missing-${period.month_key}-${siteFilter || 'all'}`,
+        `Période manquante : ${period.month_key}${period.missing_reason ? ' — ' + period.missing_reason : ''}`,
+        siteFilter ? parseInt(siteFilter) : null,
+      );
+      setCreatedActions(prev => new Set([...prev, actionKey]));
+    } catch { /* ignore */ }
+  };
+
+  const hasMore = periodsOffset < periodsTotal;
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-4 max-w-4xl mx-auto">
+        <SkeletonCard lines={1} />
+        <SkeletonCard lines={3} />
+        <SkeletonCard lines={6} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 md:p-6 space-y-5 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-2">
+          <CalendarRange size={20} className="text-amber-600" />
+          <h1 className="text-lg font-bold text-gray-900">{PAGE_TITLE}</h1>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => fetchAll(siteFilter, 0, false)}
+          disabled={loading}
+        >
+          <RefreshCw size={14} /> Actualiser
+        </Button>
+      </div>
+
+      {/* Filtres */}
+      <div className="flex flex-wrap gap-2">
+        <select
+          className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 bg-white text-gray-700"
+          value={siteFilter}
+          onChange={e => { setSiteFilter(e.target.value); setPeriodsOffset(0); }}
+        >
+          <option value="">Tous les sites</option>
+          {sites.map(s => (
+            <option key={s.id} value={s.id}>{s.nom}</option>
+          ))}
+        </select>
+        {siteFilter && (
+          <Button size="sm" variant="ghost" onClick={() => setSiteFilter('')}>
+            Réinitialiser
+          </Button>
+        )}
+      </div>
+
+      {/* Erreur */}
+      {error && (
+        <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3 flex items-center gap-2">
+          <AlertTriangle size={14} />
+          {error}
+          <Button size="xs" variant="ghost" onClick={() => fetchAll(siteFilter, 0, false)}>
+            Réessayer
+          </Button>
+        </div>
+      )}
+
+      {/* KPIs + CoverageBar */}
+      {summary && (
+        <Card>
+          <CardBody>
+            <div className="flex flex-wrap gap-3 mb-4">
+              <KpiChip
+                icon={CheckCircle}
+                label="Couverts"
+                value={summary.covered}
+                color="text-green-600"
+              />
+              <KpiChip
+                icon={AlertTriangle}
+                label="Partiels"
+                value={summary.partial}
+                color="text-orange-500"
+              />
+              <KpiChip
+                icon={XCircle}
+                label="Manquants"
+                value={summary.missing}
+                color="text-red-500"
+              />
+            </div>
+            <CoverageBar
+              covered={summary.covered}
+              partial={summary.partial}
+              missing={summary.missing}
+              total={summary.months_total}
+              minMonth={summary.range?.min_month}
+              maxMonth={summary.range?.max_month}
+            />
+          </CardBody>
+        </Card>
+      )}
+
+      {/* Périodes manquantes / partielles */}
+      {missingPeriods.length > 0 && (
+        <Card>
+          <CardBody>
+            <h2 className="text-sm font-semibold text-red-700 mb-3 flex items-center gap-2">
+              <AlertTriangle size={14} />
+              Périodes manquantes ou incomplètes ({missingPeriods.length})
+            </h2>
+            <div className="space-y-2">
+              {missingPeriods.slice(0, 5).map(item => (
+                <div
+                  key={`${item.site_id}-${item.month_key}`}
+                  className="flex items-center justify-between gap-3 px-3 py-2 bg-red-50 border border-red-100 rounded-lg"
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant={item.coverage_status === 'missing' ? 'danger' : 'warning'} size="xs">
+                        {item.coverage_status === 'missing' ? 'Manquant' : 'Partiel'}
+                      </Badge>
+                      <span className="text-sm font-medium text-gray-800">{item.month_key}</span>
+                      {item.site_name && (
+                        <span className="text-xs text-gray-500">— {item.site_name}</span>
+                      )}
+                    </div>
+                    {item.missing_reason && (
+                      <p className="text-xs text-gray-500 mt-0.5">{item.missing_reason}</p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    <Button
+                      size="xs"
+                      variant="secondary"
+                      onClick={() => navigate(item.cta_url)}
+                    >
+                      <Upload size={11} /> Importer
+                    </Button>
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      disabled={createdActions.has(`missing-${item.month_key}-${item.site_id}`)}
+                      onClick={() => {
+                        const key = `missing-${item.month_key}-${item.site_id}`;
+                        if (!createdActions.has(key)) {
+                          createActionFromBillingInsight(
+                            `missing-${item.month_key}-${item.site_id}`,
+                            `Période manquante : ${item.month_key} — ${item.site_name}`,
+                            item.site_id,
+                          ).then(() => setCreatedActions(prev => new Set([...prev, key]))).catch(() => {});
+                        }
+                      }}
+                    >
+                      {createdActions.has(`missing-${item.month_key}-${item.site_id}`) ? '✓' : <Zap size={11} />}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardBody>
+        </Card>
+      )}
+
+      {/* Timeline complète */}
+      <Card>
+        <CardBody>
+          <h2 className="text-sm font-semibold text-gray-700 mb-3">
+            Timeline complète
+            {periodsTotal > 0 && (
+              <span className="ml-2 text-xs font-normal text-gray-400">
+                {periods.length}/{periodsTotal} mois
+              </span>
+            )}
+          </h2>
+          {periods.length === 0 && !loading ? (
+            <EmptyState
+              icon={CalendarRange}
+              title="Aucune facture"
+              description="Importez des factures CSV ou PDF dans le module Facturation pour voir la timeline."
+              action={
+                <Button size="sm" onClick={() => navigate('/bill-intel')}>
+                  Aller à la Facturation
+                </Button>
+              }
+            />
+          ) : (
+            <>
+              <BillingTimeline
+                periods={periods}
+                siteId={siteFilter}
+                onCreateAction={handleCreateAction}
+                createdActions={createdActions}
+              />
+              {hasMore && (
+                <div className="mt-4 text-center">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={handleLoadMore}
+                    disabled={loadingMore}
+                  >
+                    {loadingMore ? 'Chargement...' : `Charger ${LIMIT} mois de plus`}
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -11,10 +11,10 @@ import {
   getBillingPeriods,
   getCoverageSummary,
   getMissingPeriods,
-  createActionFromBillingInsight,
   importInvoicesCsv,
   importInvoicesPdf,
 } from '../services/api';
+import CreateActionModal from '../components/CreateActionModal';
 import { Card, CardBody, Button, Badge, EmptyState } from '../ui';
 import { SkeletonCard } from '../ui/Skeleton';
 import CoverageBar from '../components/CoverageBar';
@@ -60,7 +60,8 @@ export default function BillingPage() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
 
-  const [createdActions, setCreatedActions] = useState(new Set());
+  const [actionMap, setActionMap] = useState(new Map());
+  const [actionModalContext, setActionModalContext] = useState(null);
 
   // Filtres avancés
   const [statusFilter, setStatusFilter] = useState('all');
@@ -192,17 +193,27 @@ export default function BillingPage() {
     fetchAll(siteFilter, periodsOffset, true);
   };
 
-  const handleCreateAction = async (actionKey, period) => {
-    if (createdActions.has(actionKey)) return;
-    try {
-      await createActionFromBillingInsight(
-        `missing-${period.month_key}-${siteFilter || 'all'}`,
-        `Période manquante : ${period.month_key}${period.missing_reason ? ' — ' + period.missing_reason : ''}`,
-        siteFilter ? parseInt(siteFilter) : null,
-      );
-      setCreatedActions(prev => new Set([...prev, actionKey]));
-    } catch { /* ignore */ }
+  const handleCreateAction = (actionKey, period) => {
+    if (actionMap.has(actionKey)) return;
+    setActionModalContext({
+      key: actionKey,
+      prefill: {
+        titre: `Période manquante : ${period.month_key}${period.missing_reason ? ' — ' + period.missing_reason : ''}`,
+        type: 'facture',
+        description: `Période manquante : ${period.month_key}`,
+      },
+      siteId: siteFilter ? parseInt(siteFilter) : null,
+    });
   };
+
+  function handleActionSaved(result) {
+    const key = actionModalContext?.key;
+    if (key) {
+      setActionMap(prev => new Map([...prev, [key, result?.id || true]]));
+    }
+    setActionModalContext(null);
+    toast('Action créée', 'success');
+  }
 
   const hasMore = periodsOffset < periodsTotal;
 
@@ -446,19 +457,13 @@ export default function BillingPage() {
                     <Button
                       size="xs"
                       variant="ghost"
-                      disabled={createdActions.has(`missing-${item.month_key}-${item.site_id}`)}
-                      onClick={() => {
-                        const key = `missing-${item.month_key}-${item.site_id}`;
-                        if (!createdActions.has(key)) {
-                          createActionFromBillingInsight(
-                            `missing-${item.month_key}-${item.site_id}`,
-                            `Période manquante : ${item.month_key} — ${item.site_name}`,
-                            item.site_id,
-                          ).then(() => setCreatedActions(prev => new Set([...prev, key]))).catch(() => {});
-                        }
-                      }}
+                      disabled={actionMap.has(`missing-${item.month_key}-${item.site_id}`)}
+                      onClick={() => handleCreateAction(
+                        `missing-${item.month_key}-${item.site_id}`,
+                        item
+                      )}
                     >
-                      {createdActions.has(`missing-${item.month_key}-${item.site_id}`) ? '✓' : <Zap size={11} />}
+                      {actionMap.has(`missing-${item.month_key}-${item.site_id}`) ? '✓' : <Zap size={11} />}
                     </Button>
                   </div>
                 </div>
@@ -548,7 +553,7 @@ export default function BillingPage() {
                 siteId={siteFilter}
                 activeMonth={activeMonth}
                 onCreateAction={handleCreateAction}
-                createdActions={createdActions}
+                createdActions={new Set(actionMap.keys())}
                 onImport={handleImportClick}
               />
               {hasMore && (
@@ -571,6 +576,16 @@ export default function BillingPage() {
       {/* Hidden file inputs for contextual import */}
       <input ref={csvInputRef} type="file" accept=".csv" className="sr-only" onChange={handleContextualCsvImport} />
       <input ref={pdfInputRef} type="file" accept=".pdf" className="sr-only" onChange={handleContextualPdfImport} />
+
+      <CreateActionModal
+        open={!!actionModalContext}
+        onClose={() => setActionModalContext(null)}
+        onSave={handleActionSaved}
+        prefill={actionModalContext?.prefill}
+        siteId={actionModalContext?.siteId}
+        sourceType="billing"
+        sourceId={actionModalContext?.key}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -92,8 +92,23 @@ export default function BillingPage() {
     } catch (err) {
       const status = err?.response?.status;
       if (status === 404) {
+        // P0: purge stale siteId from localStorage scope
+        try {
+          const raw = localStorage.getItem('promeos_scope');
+          if (raw) {
+            const scope = JSON.parse(raw);
+            scope.siteId = null;
+            localStorage.setItem('promeos_scope', JSON.stringify(scope));
+          }
+        } catch { /* ignore storage errors */ }
         setSiteFilter('');
-        setError('Site introuvable. Retour à la vue tous les sites.');
+        const baseMsg = 'Site introuvable. Retour à la vue tous les sites.';
+        if (isExpert) {
+          const endpoint = err?.config?.url || '/billing/*';
+          setError(`${baseMsg} [debug: endpoint=${endpoint}, status=404, site_id=${siteId}]`);
+        } else {
+          setError(baseMsg);
+        }
       } else {
         if (isExpert) console.error('[BillingPage] loadData error:', err);
         setError('Impossible de charger les données de facturation.');

--- a/frontend/src/pages/BillingPage.jsx
+++ b/frontend/src/pages/BillingPage.jsx
@@ -265,7 +265,7 @@ export default function BillingPage() {
     if (!file) return;
     if (isExpert) console.log('[BillingPage] CSV file selected:', file.name, importContext);
     try {
-      await importInvoicesCsv(file, importContext?.siteId);
+      await importInvoicesCsv(file);
       toast('Import CSV réussi', 'success');
       fetchAll(siteFilter, 0, false);
     } catch (err) {
@@ -281,7 +281,7 @@ export default function BillingPage() {
     if (!file) return;
     if (isExpert) console.log('[BillingPage] PDF file selected:', file.name, importContext);
     try {
-      await importInvoicesPdf(file, importContext?.siteId);
+      await importInvoicesPdf(importContext?.siteId, file);
       toast('Import PDF réussi', 'success');
       fetchAll(siteFilter, 0, false);
     } catch (err) {
@@ -549,6 +549,7 @@ export default function BillingPage() {
                 activeMonth={activeMonth}
                 onCreateAction={handleCreateAction}
                 createdActions={createdActions}
+                onImport={handleImportClick}
               />
               {hasMore && (
                 <div className="mt-4 text-center">

--- a/frontend/src/pages/ConsommationsPage.jsx
+++ b/frontend/src/pages/ConsommationsPage.jsx
@@ -4,11 +4,12 @@
  * and nested sub-routes via <Outlet />.
  */
 import { NavLink, Outlet } from 'react-router-dom';
-import { BarChart3, Upload, Database, Zap } from 'lucide-react';
+import { BarChart3, Upload, Database, Zap, Building2 } from 'lucide-react';
 import { PageShell } from '../ui';
 
 const TABS = [
   { to: '/consommations/explorer', label: 'Explorer', icon: BarChart3 },
+  { to: '/consommations/portfolio', label: 'Portefeuille', icon: Building2 },
   { to: '/consommations/import', label: 'Import & Analyse', icon: Upload },
   { to: '/consommations/kb', label: 'Knowledge Base', icon: Database },
 ];

--- a/frontend/src/pages/ConsommationsUsages.jsx
+++ b/frontend/src/pages/ConsommationsUsages.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Upload, BarChart3, AlertTriangle, Lightbulb, Database, Search, RefreshCw, CheckCircle, Zap, ArrowRight, Link2, SlidersHorizontal, GitCompareArrows, Info, HelpCircle, Bell, CalendarRange, Activity, RotateCcw } from 'lucide-react';
 import { PageShell, EmptyState, Tooltip } from '../ui';
+import { toConsoExplorer } from '../services/routes';
 import { SkeletonCard } from '../ui/Skeleton';
 import { useToast } from '../ui/ToastProvider';
 import { useExpertMode } from '../contexts/ExpertModeContext';
@@ -333,12 +334,7 @@ function AnalysisResultView({ result, siteId, dateFrom, dateTo }) {
   const interpKwh = interpretKwhM2(kwhM2, result.archetype);
 
   const handleOpenExplorer = () => {
-    const params = new URLSearchParams();
-    if (siteId) params.set('site_id', siteId);
-    if (dateFrom) params.set('date_from', dateFrom);
-    if (dateTo) params.set('date_to', dateTo);
-    const qs = params.toString();
-    navigate(`/consommations/explorer${qs ? '?' + qs : ''}`);
+    navigate(toConsoExplorer({ site_id: siteId, date_from: dateFrom, date_to: dateTo }));
     toast('Analyse terminée — retrouvez vos données dans l\'Explorer', 'success');
   };
 

--- a/frontend/src/pages/ConsumptionDiagPage.jsx
+++ b/frontend/src/pages/ConsumptionDiagPage.jsx
@@ -25,6 +25,7 @@ import { track } from '../services/tracker';
 import CreateActionModal from '../components/CreateActionModal';
 import { fmtEur, fmtKwh, fmtDateFR } from '../utils/format';
 import { deepLinkWithContext, deepLinkNewAction } from '../services/deepLink';
+import { toConsoExplorer } from '../services/routes';
 import { SEVERITY_TINT } from '../ui/colorTokens';
 import {
   Zap, ChevronDown, ChevronUp, Settings, Info, Leaf,
@@ -710,11 +711,11 @@ export default function ConsumptionDiagPage() {
 
   // Open in Explorer
   const handleOpenExplorer = useCallback((insight) => {
-    const params = new URLSearchParams();
-    if (insight.site_id) params.set('site_id', insight.site_id);
-    if (insight.period_start) params.set('date_from', insight.period_start.slice(0, 10));
-    if (insight.period_end) params.set('date_to', insight.period_end.slice(0, 10));
-    navigate(`/consommations/explorer?${params.toString()}`);
+    navigate(toConsoExplorer({
+      site_id: insight.site_id,
+      date_from: insight.period_start ? insight.period_start.slice(0, 10) : undefined,
+      date_to: insight.period_end ? insight.period_end.slice(0, 10) : undefined,
+    }));
   }, [navigate]);
 
   // View invoice (deep-link)

--- a/frontend/src/pages/ConsumptionDiagPage.jsx
+++ b/frontend/src/pages/ConsumptionDiagPage.jsx
@@ -18,12 +18,13 @@ import {
 } from '../services/api';
 import { useScope } from '../contexts/ScopeContext';
 import { normalizeId } from './consumption/helpers';
-import { Card, CardBody, Badge, Button, PageShell, Drawer, Tooltip, Tabs } from '../ui';
+import { Card, CardBody, Badge, Button, PageShell, Drawer, Tooltip, Tabs, SkeletonCard } from '../ui';
 import { useToast } from '../ui/ToastProvider';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { track } from '../services/tracker';
 import CreateActionModal from '../components/CreateActionModal';
 import { fmtEur, fmtKwh, fmtDateFR } from '../utils/format';
+import { deepLinkWithContext, deepLinkNewAction } from '../services/deepLink';
 import { SEVERITY_TINT } from '../ui/colorTokens';
 import {
   Zap, ChevronDown, ChevronUp, Settings, Info, Leaf,
@@ -429,7 +430,7 @@ function FlexTab({ siteId }) {
 
 // ---- Evidence Drawer ----
 
-function EvidenceDrawer({ insight, open, onClose, onStatusChange, onCreateAction, onOpenExplorer }) {
+function EvidenceDrawer({ insight, open, onClose, onStatusChange, onCreateAction, onOpenExplorer, onViewInvoice }) {
   const [tab, setTab] = useState('evidence');
   if (!insight) return null;
 
@@ -503,6 +504,14 @@ function EvidenceDrawer({ insight, open, onClose, onStatusChange, onCreateAction
           >
             <BarChart3 size={15} className="text-blue-600" />
             Ouvrir dans Explorer
+            <ExternalLink size={12} className="ml-auto text-gray-300" />
+          </button>
+          <button
+            onClick={() => onViewInvoice(insight)}
+            className="w-full flex items-center gap-2 px-3 py-2.5 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 transition"
+          >
+            <ExternalLink size={15} className="text-emerald-600" />
+            Voir facture
             <ExternalLink size={12} className="ml-auto text-gray-300" />
           </button>
           <button
@@ -708,6 +717,13 @@ export default function ConsumptionDiagPage() {
     navigate(`/consommations/explorer?${params.toString()}`);
   }, [navigate]);
 
+  // View invoice (deep-link)
+  const handleViewInvoice = useCallback((insight) => {
+    const month = insight.period_start ? insight.period_start.slice(0, 7) : null;
+    navigate(deepLinkWithContext(insight.site_id, month));
+    track('insight_view_invoice', { type: insight.type, id: insight.id, site_id: insight.site_id });
+  }, [navigate]);
+
   // Save action
   const handleSaveAction = useCallback((action) => {
     track('action_create_from_diagnostic', { titre: action.titre });
@@ -777,7 +793,9 @@ export default function ConsumptionDiagPage() {
       )}
 
       {loading ? (
-        <div className="text-center py-16 text-gray-400">Chargement...</div>
+        <div className="grid grid-cols-5 gap-4 mb-6">
+          {[1, 2, 3, 4, 5].map(i => <SkeletonCard key={i} />)}
+        </div>
       ) : !summary || filteredInsights.length === 0 ? (
         <Card>
           <CardBody className="text-center py-12">
@@ -860,6 +878,7 @@ export default function ConsumptionDiagPage() {
         onStatusChange={handleStatusChange}
         onCreateAction={handleCreateAction}
         onOpenExplorer={handleOpenExplorer}
+        onViewInvoice={handleViewInvoice}
       />
 
       {/* Create Action Modal */}

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -1001,7 +1001,7 @@ function GasPanel({ siteId, days, onGenerateDemo, toast }) {
 // ========================================
 
 export default function ConsumptionExplorerPage() {
-  const { selectedSiteId, scopedSites, orgSites, scope, sitesLoading } = useScope();
+  const { selectedSiteId, scopedSites, orgSites, scope, sitesLoading, scopeLabel } = useScope();
   const { toast } = useToast();
 
   // ── UI mode (Classic / Expert) — localStorage only, never in URL ───────
@@ -1207,6 +1207,16 @@ export default function ConsumptionExplorerPage() {
 
   return (
     <div className="space-y-5">
+      {/* V1.3: Scope coherence banner — single site indicator */}
+      {selectedSiteId && siteIds.length === 1 && (
+        <div className="flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-lg px-4 py-2.5 text-sm">
+          <Info size={14} className="text-blue-500 shrink-0" />
+          <span className="text-blue-700">
+            Vous explorez <strong>{scopeLabel}</strong>. La multi-selection est disponible via le selecteur de sites ci-dessous.
+          </span>
+        </div>
+      )}
+
       {/* UI Mode toggle — persisted in localStorage, never in URL */}
       <div className="flex justify-end">
         <button

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -19,6 +19,7 @@ import {
 } from 'recharts';
 import { Card, CardBody, Badge, Button, EmptyState, TrustBadge } from '../ui';
 import { SkeletonCard } from '../ui';
+import { useToast } from '../ui/ToastProvider';
 import { useScope } from '../contexts/ScopeContext';
 import { track } from '../services/tracker';
 import {
@@ -57,6 +58,7 @@ import TimeseriesPanel from './consumption/TimeseriesPanel';
 import SignaturePanel from './consumption/SignaturePanel';
 import MeteoPanel from './consumption/MeteoPanel';
 import InsightsPanel from './consumption/InsightsPanel';
+import ConsoKpiHeader from '../components/ConsoKpiHeader';
 
 // ========================================
 // Constants
@@ -127,7 +129,7 @@ const REASON_CONFIG = {
 // Smart Empty State
 // ========================================
 
-function SmartEmptyState({ reasons, energyTypes, onNavigate, onSwitchEnergy }) {
+function SmartEmptyState({ reasons, energyTypes, onNavigate, onSwitchEnergy, isExpert, onGenerateDemo }) {
   if (!reasons?.length) {
     return (
       <EmptyState
@@ -166,11 +168,23 @@ function SmartEmptyState({ reasons, energyTypes, onNavigate, onSwitchEnergy }) {
             Basculer vers {energyTypes[0]}
           </Button>
         )}
+        {onGenerateDemo && (
+          <Button variant="outline" onClick={onGenerateDemo}>
+            Generer demo
+          </Button>
+        )}
       </div>
       {reasons.length > 1 && (
         <p className="text-xs text-gray-400 mt-4">
           Diagnostics : {reasons.join(', ')}
         </p>
+      )}
+      {isExpert && reasons?.length > 0 && (
+        <div className="mt-4 bg-gray-50 rounded-lg p-3 text-left text-xs max-w-md">
+          <p className="font-semibold text-gray-500">Debug</p>
+          <p className="text-gray-400 mt-1">Reasons: {reasons.join(', ')}</p>
+          {energyTypes?.length > 0 && <p className="text-gray-400">Energy types: {energyTypes.join(', ')}</p>}
+        </div>
       )}
     </div>
   );
@@ -200,7 +214,7 @@ function AvailabilitySkeleton() {
 // Tunnel Panel
 // ========================================
 
-function TunnelPanel({ siteId, days, energyType, showSignature = false }) {
+function TunnelPanel({ siteId, days, energyType, showSignature = false, toast }) {
   const [tunnel, setTunnel] = useState(null);
   const [loading, setLoading] = useState(false);
   const [dayType, setDayType] = useState('weekday');
@@ -218,7 +232,7 @@ function TunnelPanel({ siteId, days, energyType, showSignature = false }) {
       setTunnel(data);
       track('tunnel_loaded', { site_id: siteId, days, energy_type: energyType, mode });
     } catch (e) {
-      console.error('Tunnel load error:', e);
+      toast?.('Erreur chargement tunnel', 'error');
     } finally {
       setLoading(false);
     }
@@ -387,7 +401,7 @@ function TunnelPanel({ siteId, days, energyType, showSignature = false }) {
 // Targets Panel (Objectifs & Budgets)
 // ========================================
 
-function TargetsPanel({ siteId, energyType }) {
+function TargetsPanel({ siteId, energyType, toast }) {
   const [targets, setTargets] = useState([]);
   const [progression, setProgression] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -407,7 +421,7 @@ function TargetsPanel({ siteId, energyType }) {
       setProgression(p);
       track('targets_loaded', { site_id: siteId, year, energy_type: energyType });
     } catch (e) {
-      console.error('Targets load error:', e);
+      toast?.('Erreur chargement objectifs', 'error');
     } finally {
       setLoading(false);
     }
@@ -430,7 +444,7 @@ function TargetsPanel({ siteId, energyType }) {
       setNewTarget({ month: 1, target_kwh: '', target_eur: '' });
       load();
     } catch (e) {
-      console.error('Add target error:', e);
+      toast?.('Erreur ajout objectif', 'error');
     }
   };
 
@@ -439,7 +453,7 @@ function TargetsPanel({ siteId, energyType }) {
       await deleteConsumptionTarget(id);
       load();
     } catch (e) {
-      console.error('Delete target error:', e);
+      toast?.('Erreur suppression objectif', 'error');
     }
   };
 
@@ -629,7 +643,7 @@ function TargetsPanel({ siteId, energyType }) {
 // HP/HC Panel
 // ========================================
 
-function HPHCPanel({ siteId, days }) {
+function HPHCPanel({ siteId, days, toast }) {
   const [breakdown, setBreakdown] = useState(null);
   const [schedule, setSchedule] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -646,7 +660,7 @@ function HPHCPanel({ siteId, days }) {
       setSchedule(s);
       track('hphc_loaded', { site_id: siteId, days });
     } catch (e) {
-      console.error('HP/HC load error:', e);
+      toast?.('Erreur chargement HP/HC', 'error');
     } finally {
       setLoading(false);
     }
@@ -802,7 +816,7 @@ function HPHCPanel({ siteId, days }) {
 // Gas Panel (Beta)
 // ========================================
 
-function GasPanel({ siteId, days, onGenerateDemo }) {
+function GasPanel({ siteId, days, onGenerateDemo, toast }) {
   const [gas, setGas] = useState(null);
   const [weather, setWeather] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -819,7 +833,7 @@ function GasPanel({ siteId, days, onGenerateDemo }) {
       setWeather(w);
       track('gas_loaded', { site_id: siteId, days });
     } catch (e) {
-      console.error('Gas load error:', e);
+      toast?.('Erreur chargement gaz', 'error');
     } finally {
       setLoading(false);
     }
@@ -987,6 +1001,7 @@ function GasPanel({ siteId, days, onGenerateDemo }) {
 
 export default function ConsumptionExplorerPage() {
   const { selectedSiteId, scopedSites, orgSites, scope, sitesLoading } = useScope();
+  const { toast } = useToast();
 
   // ── UI mode (Classic / Expert) — localStorage only, never in URL ───────
   const { uiMode, isClassic, toggleUiMode } = useExplorerMode();
@@ -1145,7 +1160,7 @@ export default function ConsumptionExplorerPage() {
       await fetch(`/api/ems/demo/generate_timeseries?site_id=${siteIds[0]}&days=90&energy_vector=${ev}`, { method: 'POST' });
       setRefreshKey(k => k + 1); // force TimeseriesPanel to remount → fresh fetch
     } catch (e) {
-      console.error('[V21] Demo generation failed', e);
+      toast('Erreur generation demo', 'error');
     }
   }, [siteIds, energyType]);
 
@@ -1259,6 +1274,16 @@ export default function ConsumptionExplorerPage() {
       {/* Context banner (site info + date range) */}
       <ContextBanner availability={availability} />
 
+      {/* KPI Header — 6 KPIs respecting scope global */}
+      {showContent && (
+        <ConsoKpiHeader
+          tunnel={motor.primaryTunnel}
+          hphc={motor.primaryHphc}
+          progression={motor.primaryProgression}
+          confidence={availability?.confidence}
+        />
+      )}
+
       {/* Loading skeleton */}
       {loading && <AvailabilitySkeleton />}
 
@@ -1269,6 +1294,8 @@ export default function ConsumptionExplorerPage() {
           energyTypes={availability.energy_types}
           onNavigate={handleNavigate}
           onSwitchEnergy={handleSwitchEnergy}
+          isExpert={!isClassic}
+          onGenerateDemo={siteIds.length ? handleGenerateDemo : undefined}
         />
       )}
 
@@ -1399,11 +1426,12 @@ export default function ConsumptionExplorerPage() {
                     days={days}
                     energyType={energyType}
                     showSignature={layers.signature}
+                    toast={toast}
                   />
                 )}
-                {activeTab === 'targets' && showContent && <TargetsPanel siteId={siteId} energyType={energyType} />}
-                {activeTab === 'hphc' && showContent && <HPHCPanel siteId={siteId} days={days} />}
-                {activeTab === 'gas' && showContent && <GasPanel siteId={siteId} days={days} onGenerateDemo={siteIds.length ? handleGenerateDemo : undefined} />}
+                {activeTab === 'targets' && showContent && <TargetsPanel siteId={siteId} energyType={energyType} toast={toast} />}
+                {activeTab === 'hphc' && showContent && <HPHCPanel siteId={siteId} days={days} toast={toast} />}
+                {activeTab === 'gas' && showContent && <GasPanel siteId={siteId} days={days} onGenerateDemo={siteIds.length ? handleGenerateDemo : undefined} toast={toast} />}
               </div>
             </>
           )}

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -59,6 +59,7 @@ import SignaturePanel from './consumption/SignaturePanel';
 import MeteoPanel from './consumption/MeteoPanel';
 import InsightsPanel from './consumption/InsightsPanel';
 import ConsoKpiHeader from '../components/ConsoKpiHeader';
+import BenchmarkPanel from './consumption/BenchmarkPanel';
 
 // ========================================
 // Constants
@@ -1344,6 +1345,17 @@ export default function ConsumptionExplorerPage() {
               onGenerateDemo={siteIds.length ? handleGenerateDemo : undefined}
               onMeta={handleMeta}
             />
+            {/* Benchmark: reference profile comparison (Classic mode) */}
+            {showContent && (
+              <BenchmarkPanel
+                siteId={siteId}
+                days={days}
+                startDate={startDate}
+                endDate={endDate}
+                seriesData={null}
+                toast={toast}
+              />
+            )}
           ) : (
             /* ── Expert mode: tab bar always visible + panel routing ── */
             <>
@@ -1406,6 +1418,17 @@ export default function ConsumptionExplorerPage() {
                     onSelectAll={sites.length ? () => setSiteIds(sites.map(s => s.id)) : undefined}
                     onGenerateDemo={siteIds.length ? handleGenerateDemo : undefined}
                     onMeta={handleMeta}
+                  />
+                )}
+                {/* Benchmark: reference profile comparison — below timeseries */}
+                {activeTab === 'timeseries' && showContent && (
+                  <BenchmarkPanel
+                    siteId={siteId}
+                    days={days}
+                    startDate={startDate}
+                    endDate={endDate}
+                    seriesData={null}
+                    toast={toast}
                   />
                 )}
                 {/* Insights: statistical analysis — own data fetch, no Motor dependency */}

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -1327,35 +1327,37 @@ export default function ConsumptionExplorerPage() {
 
           {isClassic ? (
             /* ── Classic mode: TimeseriesPanel ALWAYS rendered (handles own loading/empty/error) ── */
-            <TimeseriesPanel
-              key={refreshKey}
-              siteIds={siteIds}
-              energyType={energyType}
-              days={days}
-              startDate={startDate}
-              endDate={endDate}
-              unit={unit}
-              mode={mode}
-              sites={sites}
-              availability={availability}
-              granularityOverride={granularity === 'auto' ? null : granularity}
-              onNavigate={handleNavigate}
-              onExtendPeriod={() => setDays(365)}
-              onSelectAll={sites.length ? () => setSiteIds(sites.map(s => s.id)) : undefined}
-              onGenerateDemo={siteIds.length ? handleGenerateDemo : undefined}
-              onMeta={handleMeta}
-            />
-            {/* Benchmark: reference profile comparison (Classic mode) */}
-            {showContent && (
-              <BenchmarkPanel
-                siteId={siteId}
+            <>
+              <TimeseriesPanel
+                key={refreshKey}
+                siteIds={siteIds}
+                energyType={energyType}
                 days={days}
                 startDate={startDate}
                 endDate={endDate}
-                seriesData={null}
-                toast={toast}
+                unit={unit}
+                mode={mode}
+                sites={sites}
+                availability={availability}
+                granularityOverride={granularity === 'auto' ? null : granularity}
+                onNavigate={handleNavigate}
+                onExtendPeriod={() => setDays(365)}
+                onSelectAll={sites.length ? () => setSiteIds(sites.map(s => s.id)) : undefined}
+                onGenerateDemo={siteIds.length ? handleGenerateDemo : undefined}
+                onMeta={handleMeta}
               />
-            )}
+              {/* Benchmark: reference profile comparison (Classic mode) */}
+              {showContent && (
+                <BenchmarkPanel
+                  siteId={siteId}
+                  days={days}
+                  startDate={startDate}
+                  endDate={endDate}
+                  seriesData={null}
+                  toast={toast}
+                />
+              )}
+            </>
           ) : (
             /* ── Expert mode: tab bar always visible + panel routing ── */
             <>

--- a/frontend/src/pages/ConsumptionPortfolioPage.jsx
+++ b/frontend/src/pages/ConsumptionPortfolioPage.jsx
@@ -1,13 +1,15 @@
 /**
- * PROMEOS — ConsumptionPortfolioPage (V1)
+ * PROMEOS — ConsumptionPortfolioPage (V1.1)
  * Multi-site B2B portfolio view: 4 KPI cards, top-lists "Ou agir",
  * sortable/filterable site table with row actions.
+ * V1.1: impact EUR, actions filter, grouped action CTA.
  */
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Zap, Euro, Leaf, ShieldCheck, AlertTriangle, Moon, Activity,
   Search, ArrowRight, FileText, Plus, BarChart3, TrendingDown,
+  CheckSquare, DollarSign,
 } from 'lucide-react';
 import {
   PageShell, Card, CardBody, SkeletonCard, EmptyState, TrustBadge,
@@ -47,10 +49,11 @@ export default function ConsumptionPortfolioPage() {
   const [sites, setSites] = useState([]);
   const [sitesTotal, setSitesTotal] = useState(0);
   const [sitesLoading, setSitesLoading] = useState(true);
-  const [sort, setSort] = useState('kwh_desc');
+  const [sort, setSort] = useState('impact_desc');
   const [search, setSearch] = useState('');
   const [confidenceFilter, setConfidenceFilter] = useState(null);
   const [anomalyFilter, setAnomalyFilter] = useState(false);
+  const [actionsFilter, setActionsFilter] = useState(null); // null | 'with' | 'without'
   const [page, setPage] = useState(0);
   const PAGE_SIZE = 25;
 
@@ -72,6 +75,7 @@ export default function ConsumptionPortfolioPage() {
       sort,
       confidence: confidenceFilter || undefined,
       with_anomalies: anomalyFilter || undefined,
+      with_actions: actionsFilter || undefined,
       search: search || undefined,
       limit: PAGE_SIZE,
       offset: page * PAGE_SIZE,
@@ -82,12 +86,12 @@ export default function ConsumptionPortfolioPage() {
       })
       .catch(() => addToast({ type: 'error', message: 'Erreur chargement sites portfolio' }))
       .finally(() => setSitesLoading(false));
-  }, [dates.from, dates.to, sort, confidenceFilter, anomalyFilter, search, page]);
+  }, [dates.from, dates.to, sort, confidenceFilter, anomalyFilter, actionsFilter, search, page]);
 
   useEffect(() => { fetchSites(); }, [fetchSites]);
 
   // Reset page on filter changes
-  useEffect(() => { setPage(0); }, [sort, search, confidenceFilter, anomalyFilter]);
+  useEffect(() => { setPage(0); }, [sort, search, confidenceFilter, anomalyFilter, actionsFilter]);
 
   // ─── Computed ─────────────────────────────────────────────────────────
   const totalPages = Math.ceil(sitesTotal / PAGE_SIZE);
@@ -103,6 +107,27 @@ export default function ConsumptionPortfolioPage() {
     if ((high + medium) / total >= 0.5) return 'medium';
     return 'low';
   }, [cov]);
+
+  // Top 5 sites for grouped action CTA
+  const top5ForAction = useMemo(() => {
+    if (!summary?.top_impact?.length && !summary?.top_drift?.length) return [];
+    // Prefer top_impact, fallback to top_drift
+    const pool = summary.top_impact?.length ? summary.top_impact : summary.top_drift || [];
+    return pool.slice(0, 5);
+  }, [summary]);
+
+  // ─── Grouped action handler ──────────────────────────────────────────
+  function handleGroupedAction() {
+    if (top5ForAction.length === 0) return;
+    const siteIds = top5ForAction.map(r => r.site_id).join(',');
+    const titre = `Campagne portfolio — ${top5ForAction.length} sites prioritaires`;
+    navigate(deepLinkNewAction({
+      type: 'consommation',
+      source: 'portfolio_campagne',
+      titre,
+      site_id: top5ForAction[0].site_id,
+    }) + `&campaign_sites=${siteIds}`);
+  }
 
   // ─── Render ───────────────────────────────────────────────────────────
   return (
@@ -128,8 +153,41 @@ export default function ConsumptionPortfolioPage() {
       {/* ═══ OU AGIR MAINTENANT ═══ */}
       {summary && (
         <div className="mt-6">
-          <h2 className="text-sm font-semibold text-gray-700 mb-3">Ou agir maintenant</h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-gray-700">Ou agir maintenant</h2>
+            {top5ForAction.length > 0 && (
+              <button
+                onClick={handleGroupedAction}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition"
+              >
+                <CheckSquare size={14} />
+                Creer action portefeuille ({top5ForAction.length} sites)
+              </button>
+            )}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            {/* Top impact EUR */}
+            <Card>
+              <CardBody>
+                <div className="flex items-center gap-2 mb-3">
+                  <DollarSign size={16} className="text-rose-500" />
+                  <h3 className="text-sm font-semibold text-gray-700">Impact estime</h3>
+                </div>
+                {summary.top_impact?.length > 0 ? (
+                  <ul className="space-y-2">
+                    {summary.top_impact.map((r) => (
+                      <li key={r.site_id} className="flex items-center justify-between text-xs">
+                        <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
+                        <span className="text-rose-600 font-medium ml-2">{fmtNum(r.impact_eur_estimated, 'EUR')}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-gray-400">Aucun impact detecte</p>
+                )}
+              </CardBody>
+            </Card>
+
             {/* Top derive */}
             <Card>
               <CardBody>
@@ -251,12 +309,35 @@ export default function ConsumptionPortfolioPage() {
             Anomalies
           </button>
 
+          {/* Actions filter */}
+          <button
+            onClick={() => setActionsFilter(actionsFilter === 'with' ? null : 'with')}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition ${
+              actionsFilter === 'with'
+                ? 'bg-green-100 text-green-700'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            Avec actions
+          </button>
+          <button
+            onClick={() => setActionsFilter(actionsFilter === 'without' ? null : 'without')}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition ${
+              actionsFilter === 'without'
+                ? 'bg-gray-200 text-gray-800'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            Sans action
+          </button>
+
           {/* Sort */}
           <select
             value={sort}
             onChange={(e) => setSort(e.target.value)}
             className="text-xs border rounded-lg px-2 py-1.5 bg-white"
           >
+            <option value="impact_desc">Impact EUR decroissant</option>
             <option value="kwh_desc">kWh decroissant</option>
             <option value="kwh_asc">kWh croissant</option>
             <option value="name">Nom A-Z</option>
@@ -282,29 +363,45 @@ export default function ConsumptionPortfolioPage() {
                 <thead>
                   <tr className="border-b border-gray-200 text-left">
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500">Site</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Impact EUR</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">kWh</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">EUR</th>
-                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">CO2e (kg)</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Pic kW</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Base nuit</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center">Diag.</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center">Actions</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center">Confiance</th>
-                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Actions</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right"></th>
                   </tr>
                 </thead>
                 <tbody>
                   {sites.map((row) => (
                     <tr key={row.site_id} className="border-b border-gray-100 hover:bg-gray-50 transition">
                       <td className="py-2 px-3 font-medium text-gray-800">{row.site_name}</td>
+                      <td className="py-2 px-3 text-right">
+                        {row.impact_eur_estimated > 0 ? (
+                          <span className="text-rose-600 font-medium">{fmtNum(row.impact_eur_estimated, 'EUR')}</span>
+                        ) : (
+                          <span className="text-gray-300">—</span>
+                        )}
+                      </td>
                       <td className="py-2 px-3 text-right text-gray-700">{fmtNum(row.kwh)}</td>
                       <td className="py-2 px-3 text-right text-gray-700">{fmtNum(row.eur)}</td>
-                      <td className="py-2 px-3 text-right text-gray-700">{fmtNum(row.co2)}</td>
                       <td className="py-2 px-3 text-right text-gray-700">{row.peak_kw != null ? `${row.peak_kw} kW` : '—'}</td>
                       <td className="py-2 px-3 text-right text-gray-700">{row.base_night_pct != null ? `${row.base_night_pct}%` : '—'}</td>
                       <td className="py-2 px-3 text-center">
                         {row.diagnostics_count > 0 ? (
                           <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 text-amber-700">
                             {row.diagnostics_count}
+                          </span>
+                        ) : (
+                          <span className="text-gray-300">—</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-center">
+                        {row.open_actions_count > 0 ? (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-green-100 text-green-700">
+                            {row.open_actions_count}
                           </span>
                         ) : (
                           <span className="text-gray-300">—</span>

--- a/frontend/src/pages/ConsumptionPortfolioPage.jsx
+++ b/frontend/src/pages/ConsumptionPortfolioPage.jsx
@@ -1,0 +1,386 @@
+/**
+ * PROMEOS — ConsumptionPortfolioPage (V1)
+ * Multi-site B2B portfolio view: 4 KPI cards, top-lists "Ou agir",
+ * sortable/filterable site table with row actions.
+ */
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Zap, Euro, Leaf, ShieldCheck, AlertTriangle, Moon, Activity,
+  Search, ArrowRight, FileText, Plus, BarChart3, TrendingDown,
+} from 'lucide-react';
+import {
+  PageShell, Card, CardBody, SkeletonCard, EmptyState, TrustBadge,
+  KpiCard,
+} from '../ui';
+import { useToast } from '../ui';
+import { getPortfolioSummary, getPortfolioSites } from '../services/api';
+import { deepLinkWithContext, deepLinkNewAction } from '../services/deepLink';
+
+// ─── Date helpers ──────────────────────────────────────────────────────────
+function defaultDateRange() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - 90);
+  return {
+    from: from.toISOString().slice(0, 10),
+    to: to.toISOString().slice(0, 10),
+  };
+}
+
+function fmtNum(n, suffix = '') {
+  if (n == null) return '—';
+  return n.toLocaleString('fr-FR') + (suffix ? ` ${suffix}` : '');
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────
+export default function ConsumptionPortfolioPage() {
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const [dates] = useState(defaultDateRange);
+
+  // Summary KPIs
+  const [summary, setSummary] = useState(null);
+  const [summaryLoading, setSummaryLoading] = useState(true);
+
+  // Sites table
+  const [sites, setSites] = useState([]);
+  const [sitesTotal, setSitesTotal] = useState(0);
+  const [sitesLoading, setSitesLoading] = useState(true);
+  const [sort, setSort] = useState('kwh_desc');
+  const [search, setSearch] = useState('');
+  const [confidenceFilter, setConfidenceFilter] = useState(null);
+  const [anomalyFilter, setAnomalyFilter] = useState(false);
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 25;
+
+  // ─── Fetch summary ────────────────────────────────────────────────────
+  useEffect(() => {
+    setSummaryLoading(true);
+    getPortfolioSummary({ from: dates.from, to: dates.to })
+      .then(setSummary)
+      .catch(() => addToast({ type: 'error', message: 'Erreur chargement resume portfolio' }))
+      .finally(() => setSummaryLoading(false));
+  }, [dates.from, dates.to]);
+
+  // ─── Fetch sites table ────────────────────────────────────────────────
+  const fetchSites = useCallback(() => {
+    setSitesLoading(true);
+    getPortfolioSites({
+      from: dates.from,
+      to: dates.to,
+      sort,
+      confidence: confidenceFilter || undefined,
+      with_anomalies: anomalyFilter || undefined,
+      search: search || undefined,
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    })
+      .then((data) => {
+        setSites(data.rows || []);
+        setSitesTotal(data.total || 0);
+      })
+      .catch(() => addToast({ type: 'error', message: 'Erreur chargement sites portfolio' }))
+      .finally(() => setSitesLoading(false));
+  }, [dates.from, dates.to, sort, confidenceFilter, anomalyFilter, search, page]);
+
+  useEffect(() => { fetchSites(); }, [fetchSites]);
+
+  // Reset page on filter changes
+  useEffect(() => { setPage(0); }, [sort, search, confidenceFilter, anomalyFilter]);
+
+  // ─── Computed ─────────────────────────────────────────────────────────
+  const totalPages = Math.ceil(sitesTotal / PAGE_SIZE);
+  const cov = summary?.coverage;
+  const tot = summary?.totals;
+
+  const confLevel = useMemo(() => {
+    if (!cov) return null;
+    const { high = 0, medium = 0, low = 0 } = cov.confidence_split || {};
+    const total = high + medium + low;
+    if (total === 0) return 'low';
+    if (high / total >= 0.7) return 'high';
+    if ((high + medium) / total >= 0.5) return 'medium';
+    return 'low';
+  }, [cov]);
+
+  // ─── Render ───────────────────────────────────────────────────────────
+  return (
+    <PageShell
+      icon={BarChart3}
+      title="Portefeuille Consommation"
+      subtitle={`Vue multi-sites — ${dates.from} au ${dates.to}`}
+    >
+      {/* ═══ KPI CARDS ═══ */}
+      {summaryLoading ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {[...Array(4)].map((_, i) => <SkeletonCard key={i} />)}
+        </div>
+      ) : summary ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <KpiCard icon={Zap} label="kWh total" value={fmtNum(Math.round(tot?.kwh_total), 'kWh')} />
+          <KpiCard icon={Euro} label="EUR total" value={fmtNum(Math.round(tot?.eur_total), 'EUR')} sub={tot?.eur_source === 'estime' ? 'Estime' : 'Facture'} />
+          <KpiCard icon={Leaf} label="CO2e" value={fmtNum(Math.round(tot?.co2_total), 'kg')} sub="ADEME 2024" />
+          <KpiCard icon={ShieldCheck} label="Couverture" value={`${cov?.sites_with_data || 0} / ${cov?.sites_total || 0}`} sub={confLevel ? `Confiance ${confLevel}` : undefined} />
+        </div>
+      ) : null}
+
+      {/* ═══ OU AGIR MAINTENANT ═══ */}
+      {summary && (
+        <div className="mt-6">
+          <h2 className="text-sm font-semibold text-gray-700 mb-3">Ou agir maintenant</h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {/* Top derive */}
+            <Card>
+              <CardBody>
+                <div className="flex items-center gap-2 mb-3">
+                  <AlertTriangle size={16} className="text-amber-500" />
+                  <h3 className="text-sm font-semibold text-gray-700">Derives detectees</h3>
+                </div>
+                {summary.top_drift?.length > 0 ? (
+                  <ul className="space-y-2">
+                    {summary.top_drift.map((r) => (
+                      <li key={r.site_id} className="flex items-center justify-between text-xs">
+                        <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
+                        <span className="text-amber-600 font-medium ml-2">{r.diagnostics_count} alertes</span>
+                        <button
+                          onClick={() => navigate(`/diagnostic-conso?site_id=${r.site_id}`)}
+                          className="ml-2 text-blue-500 hover:text-blue-700"
+                          title="Voir diagnostic"
+                        >
+                          <ArrowRight size={12} />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-gray-400">Aucune derive detectee</p>
+                )}
+              </CardBody>
+            </Card>
+
+            {/* Top base nocturne */}
+            <Card>
+              <CardBody>
+                <div className="flex items-center gap-2 mb-3">
+                  <Moon size={16} className="text-indigo-500" />
+                  <h3 className="text-sm font-semibold text-gray-700">Base nocturne elevee</h3>
+                </div>
+                {summary.top_base_night?.length > 0 ? (
+                  <ul className="space-y-2">
+                    {summary.top_base_night.map((r) => (
+                      <li key={r.site_id} className="flex items-center justify-between text-xs">
+                        <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
+                        <span className="text-indigo-600 font-medium ml-2">{r.base_night_pct}%</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-gray-400">Pas de donnees</p>
+                )}
+              </CardBody>
+            </Card>
+
+            {/* Top pics */}
+            <Card>
+              <CardBody>
+                <div className="flex items-center gap-2 mb-3">
+                  <Activity size={16} className="text-red-500" />
+                  <h3 className="text-sm font-semibold text-gray-700">Pics de puissance</h3>
+                </div>
+                {summary.top_peaks?.length > 0 ? (
+                  <ul className="space-y-2">
+                    {summary.top_peaks.map((r) => (
+                      <li key={r.site_id} className="flex items-center justify-between text-xs">
+                        <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
+                        <span className="text-red-600 font-medium ml-2">{r.peak_kw} kW</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-gray-400">Pas de donnees</p>
+                )}
+              </CardBody>
+            </Card>
+          </div>
+        </div>
+      )}
+
+      {/* ═══ SITES TABLE ═══ */}
+      <div className="mt-6">
+        <h2 className="text-sm font-semibold text-gray-700 mb-3">Sites du portefeuille</h2>
+
+        {/* Filters bar */}
+        <div className="flex flex-wrap items-center gap-3 mb-3">
+          {/* Search */}
+          <div className="relative">
+            <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Rechercher un site..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-8 pr-3 py-1.5 text-sm border rounded-lg bg-white focus:ring-1 focus:ring-blue-300 focus:border-blue-400 outline-none w-56"
+            />
+          </div>
+
+          {/* Confidence filter */}
+          {['high', 'medium', 'low'].map((c) => (
+            <button
+              key={c}
+              onClick={() => setConfidenceFilter(confidenceFilter === c ? null : c)}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition ${
+                confidenceFilter === c
+                  ? 'bg-blue-100 text-blue-700'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {c === 'high' ? 'Haute' : c === 'medium' ? 'Moyenne' : 'Basse'}
+            </button>
+          ))}
+
+          {/* Anomaly toggle */}
+          <button
+            onClick={() => setAnomalyFilter(!anomalyFilter)}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition ${
+              anomalyFilter
+                ? 'bg-amber-100 text-amber-700'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            Anomalies
+          </button>
+
+          {/* Sort */}
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value)}
+            className="text-xs border rounded-lg px-2 py-1.5 bg-white"
+          >
+            <option value="kwh_desc">kWh decroissant</option>
+            <option value="kwh_asc">kWh croissant</option>
+            <option value="name">Nom A-Z</option>
+            <option value="peak">Pic kW</option>
+            <option value="base_night">Base nocturne</option>
+            <option value="diagnostics">Diagnostics</option>
+          </select>
+        </div>
+
+        {/* Table */}
+        {sitesLoading ? (
+          <div className="space-y-2">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-12 bg-gray-100 rounded animate-pulse" />
+            ))}
+          </div>
+        ) : sites.length === 0 ? (
+          <EmptyState icon={BarChart3} message="Aucun site ne correspond aux filtres" />
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-200 text-left">
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500">Site</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">kWh</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">EUR</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">CO2e (kg)</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Pic kW</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Base nuit</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center">Diag.</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center">Confiance</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sites.map((row) => (
+                    <tr key={row.site_id} className="border-b border-gray-100 hover:bg-gray-50 transition">
+                      <td className="py-2 px-3 font-medium text-gray-800">{row.site_name}</td>
+                      <td className="py-2 px-3 text-right text-gray-700">{fmtNum(row.kwh)}</td>
+                      <td className="py-2 px-3 text-right text-gray-700">{fmtNum(row.eur)}</td>
+                      <td className="py-2 px-3 text-right text-gray-700">{fmtNum(row.co2)}</td>
+                      <td className="py-2 px-3 text-right text-gray-700">{row.peak_kw != null ? `${row.peak_kw} kW` : '—'}</td>
+                      <td className="py-2 px-3 text-right text-gray-700">{row.base_night_pct != null ? `${row.base_night_pct}%` : '—'}</td>
+                      <td className="py-2 px-3 text-center">
+                        {row.diagnostics_count > 0 ? (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 text-amber-700">
+                            {row.diagnostics_count}
+                          </span>
+                        ) : (
+                          <span className="text-gray-300">—</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-center">
+                        <TrustBadge
+                          level={row.confidence === 'high' ? 'ok' : row.confidence === 'medium' ? 'warn' : 'crit'}
+                          label={row.confidence === 'high' ? 'Haute' : row.confidence === 'medium' ? 'Moy.' : 'Basse'}
+                          size="sm"
+                        />
+                      </td>
+                      <td className="py-2 px-3 text-right">
+                        <div className="flex items-center justify-end gap-1.5">
+                          <button
+                            onClick={() => navigate(`/consommations/explorer?site_ids=${row.site_id}`)}
+                            className="p-1 rounded hover:bg-blue-50 text-blue-500"
+                            title="Explorer"
+                          >
+                            <BarChart3 size={14} />
+                          </button>
+                          <button
+                            onClick={() => navigate(`/diagnostic-conso?site_id=${row.site_id}`)}
+                            className="p-1 rounded hover:bg-amber-50 text-amber-500"
+                            title="Diagnostic"
+                          >
+                            <TrendingDown size={14} />
+                          </button>
+                          <button
+                            onClick={() => navigate(deepLinkWithContext(row.site_id))}
+                            className="p-1 rounded hover:bg-gray-100 text-gray-500"
+                            title="Voir facture"
+                          >
+                            <FileText size={14} />
+                          </button>
+                          <button
+                            onClick={() => navigate(deepLinkNewAction({ type: 'consommation', site_id: row.site_id, source: 'portfolio' }))}
+                            className="p-1 rounded hover:bg-green-50 text-green-500"
+                            title="Creer action"
+                          >
+                            <Plus size={14} />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between mt-4">
+                <p className="text-xs text-gray-400">{sitesTotal} sites</p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setPage(Math.max(0, page - 1))}
+                    disabled={page === 0}
+                    className="px-3 py-1 text-xs rounded border bg-white disabled:opacity-40"
+                  >
+                    Precedent
+                  </button>
+                  <span className="text-xs text-gray-500">{page + 1} / {totalPages}</span>
+                  <button
+                    onClick={() => setPage(Math.min(totalPages - 1, page + 1))}
+                    disabled={page >= totalPages - 1}
+                    className="px-3 py-1 text-xs rounded border bg-white disabled:opacity-40"
+                  >
+                    Suivant
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/ConsumptionPortfolioPage.jsx
+++ b/frontend/src/pages/ConsumptionPortfolioPage.jsx
@@ -1,16 +1,17 @@
 /**
- * PROMEOS — ConsumptionPortfolioPage (V1.2)
- * Multi-site B2B portfolio view: 4 KPI cards, top-lists "Ou agir",
- * sortable/filterable site table with row actions.
- * V1.1: impact EUR, actions filter, grouped action CTA.
- * V1.2: scope coherence banner, deep-links on top-lists, guided empty state.
+ * PROMEOS — ConsumptionPortfolioPage (V1.3)
+ * Vue pilotage multi-sites B2B : KPIs, top-lists "Ou agir", table sites.
+ *
+ * V1.3: route registry, scope coherence, row click → Explorer,
+ *       bandeau pilotage, couverture tooltip, actions column smart.
  */
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Zap, Euro, Leaf, ShieldCheck, AlertTriangle, Moon, Activity,
-  Search, ArrowRight, FileText, Plus, BarChart3, TrendingDown,
-  CheckSquare, DollarSign, Info, RotateCcw, Upload,
+  Search, FileText, Plus, BarChart3, TrendingDown,
+  CheckSquare, DollarSign, Info, RotateCcw, Upload, HelpCircle,
+  Eye,
 } from 'lucide-react';
 import {
   Card, CardBody, SkeletonCard, TrustBadge, KpiCard,
@@ -18,9 +19,11 @@ import {
 import { useToast } from '../ui';
 import { useScope } from '../contexts/ScopeContext';
 import { getPortfolioSummary, getPortfolioSites } from '../services/api';
-import { deepLinkWithContext, deepLinkNewAction } from '../services/deepLink';
+import {
+  toConsoExplorer, toConsoDiag, toBillIntel, toActionNew, toAction, toConsoImport,
+} from '../services/routes';
 
-// ─── Date helpers ──────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────
 function defaultDateRange() {
   const to = new Date();
   const from = new Date();
@@ -36,35 +39,41 @@ function fmtNum(n, suffix = '') {
   return n.toLocaleString('fr-FR') + (suffix ? ` ${suffix}` : '');
 }
 
+function fmtDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
 // ─── Top-list row actions (shared by all 4 lists) ─────────────────────────
 function TopListActions({ siteId, navigate }) {
   return (
     <span className="inline-flex items-center gap-0.5 ml-2 shrink-0">
       <button
-        onClick={() => navigate(`/consommations/explorer?site_ids=${siteId}`)}
+        onClick={(e) => { e.stopPropagation(); navigate(toConsoExplorer({ site_id: siteId })); }}
         className="p-0.5 rounded hover:bg-blue-50 text-blue-500"
-        title="Explorer"
+        title="Explorer ce site"
       >
         <BarChart3 size={11} />
       </button>
       <button
-        onClick={() => navigate(`/diagnostic-conso?site_id=${siteId}`)}
+        onClick={(e) => { e.stopPropagation(); navigate(toConsoDiag({ site_id: siteId })); }}
         className="p-0.5 rounded hover:bg-amber-50 text-amber-500"
         title="Diagnostic"
       >
         <TrendingDown size={11} />
       </button>
       <button
-        onClick={() => navigate(deepLinkWithContext(siteId))}
+        onClick={(e) => { e.stopPropagation(); navigate(toBillIntel({ site_id: siteId })); }}
         className="p-0.5 rounded hover:bg-gray-100 text-gray-400"
-        title="Voir facture"
+        title="Voir factures"
       >
         <FileText size={11} />
       </button>
       <button
-        onClick={() => navigate(deepLinkNewAction({ type: 'consommation', site_id: siteId, source: 'portfolio_toplist' }))}
+        onClick={(e) => { e.stopPropagation(); navigate(toActionNew({ source_type: 'consommation', site_id: siteId, source: 'portfolio_toplist' })); }}
         className="p-0.5 rounded hover:bg-green-50 text-green-500"
-        title="Creer action"
+        title="Creer une action"
       >
         <Plus size={11} />
       </button>
@@ -76,7 +85,7 @@ function TopListActions({ siteId, navigate }) {
 export default function ConsumptionPortfolioPage() {
   const navigate = useNavigate();
   const { addToast } = useToast();
-  const { selectedSiteId, resetScope } = useScope();
+  const { selectedSiteId, resetScope, scopeLabel } = useScope();
   const [dates] = useState(defaultDateRange);
 
   // Summary KPIs
@@ -91,7 +100,7 @@ export default function ConsumptionPortfolioPage() {
   const [search, setSearch] = useState('');
   const [confidenceFilter, setConfidenceFilter] = useState(null);
   const [anomalyFilter, setAnomalyFilter] = useState(false);
-  const [actionsFilter, setActionsFilter] = useState(null); // null | 'with' | 'without'
+  const [actionsFilter, setActionsFilter] = useState(null);
   const [page, setPage] = useState(0);
   const PAGE_SIZE = 25;
 
@@ -138,8 +147,6 @@ export default function ConsumptionPortfolioPage() {
   }, [dates.from, dates.to, sort, confidenceFilter, anomalyFilter, actionsFilter, search, page]);
 
   useEffect(() => { fetchSites(); }, [fetchSites]);
-
-  // Reset page on filter changes
   useEffect(() => { setPage(0); }, [sort, search, confidenceFilter, anomalyFilter, actionsFilter]);
 
   // ─── Computed ─────────────────────────────────────────────────────────
@@ -157,10 +164,13 @@ export default function ConsumptionPortfolioPage() {
     return 'low';
   }, [cov]);
 
-  // Top 5 sites for grouped action CTA
+  const coveragePct = useMemo(() => {
+    if (!cov || !cov.sites_total) return 0;
+    return Math.round((cov.sites_with_data / cov.sites_total) * 100);
+  }, [cov]);
+
   const top5ForAction = useMemo(() => {
     if (!summary?.top_impact?.length && !summary?.top_drift?.length) return [];
-    // Prefer top_impact, fallback to top_drift
     const pool = summary.top_impact?.length ? summary.top_impact : summary.top_drift || [];
     return pool.slice(0, 5);
   }, [summary]);
@@ -168,14 +178,19 @@ export default function ConsumptionPortfolioPage() {
   // ─── Grouped action handler ──────────────────────────────────────────
   function handleGroupedAction() {
     if (top5ForAction.length === 0) return;
-    const siteIds = top5ForAction.map(r => r.site_id).join(',');
-    const titre = `Campagne portfolio — ${top5ForAction.length} sites prioritaires`;
-    navigate(deepLinkNewAction({
-      type: 'consommation',
+    const siteIds = top5ForAction.map(r => r.site_id);
+    navigate(toActionNew({
+      source_type: 'consommation',
       source: 'portfolio_campagne',
-      titre,
-      site_id: top5ForAction[0].site_id,
-    }) + `&campaign_sites=${siteIds}`);
+      title: `Campagne portfolio — ${siteIds.length} sites prioritaires`,
+      site_id: siteIds[0],
+      site_ids: siteIds,
+    }));
+  }
+
+  // ─── Row click → Explorer ─────────────────────────────────────────────
+  function handleRowClick(row) {
+    navigate(toConsoExplorer({ site_id: row.site_id }));
   }
 
   // ─── Render ───────────────────────────────────────────────────────────
@@ -186,21 +201,35 @@ export default function ConsumptionPortfolioPage() {
         <div className="flex items-center gap-3 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3">
           <Info size={16} className="text-blue-500 shrink-0" />
           <p className="text-sm text-blue-700 flex-1">
-            Vue portefeuille = multi-sites. Le filtre site du bandeau est ignore sur cette page.
+            <strong>Portefeuille = vue multi-sites.</strong> Le bandeau indique « {scopeLabel} »,
+            mais cette page affiche tous vos sites. Pour explorer un site seul, cliquez sur sa ligne.
           </p>
           <button
             onClick={() => resetScope()}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-blue-700 bg-white border border-blue-300 rounded-lg hover:bg-blue-100 transition"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-blue-700 bg-white border border-blue-300 rounded-lg hover:bg-blue-100 transition shrink-0"
           >
             Passer a Tous les sites
           </button>
         </div>
       )}
 
-      {/* ═══ HEADER ═══ */}
-      <div>
-        <h2 className="text-lg font-bold text-gray-900">Portefeuille Consommation</h2>
-        <p className="text-sm text-gray-500">Vue multi-sites — {dates.from} au {dates.to}</p>
+      {/* ═══ PILOTAGE HEADER ═══ */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-bold text-gray-900">Portefeuille Consommation</h2>
+          <p className="text-sm text-gray-500">
+            Vous pilotez {cov?.sites_total ?? '—'} sites sur la periode
+            du {fmtDate(dates.from)} au {fmtDate(dates.to)}
+          </p>
+        </div>
+        {cov && (
+          <div className="flex items-center gap-1.5 shrink-0" title="La couverture indique le % de sites avec des releves sur la periode. Plus elle est elevee, plus les KPIs sont fiables.">
+            <span className={`text-sm font-semibold ${coveragePct >= 80 ? 'text-green-600' : coveragePct >= 50 ? 'text-amber-600' : 'text-red-600'}`}>
+              Couverture {coveragePct}%
+            </span>
+            <HelpCircle size={13} className="text-gray-400 cursor-help" />
+          </div>
+        )}
       </div>
 
       {/* ═══ KPI CARDS ═══ */}
@@ -211,9 +240,19 @@ export default function ConsumptionPortfolioPage() {
       ) : summary ? (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <KpiCard icon={Zap} label="kWh total" value={fmtNum(Math.round(tot?.kwh_total), 'kWh')} />
-          <KpiCard icon={Euro} label="EUR total" value={fmtNum(Math.round(tot?.eur_total), 'EUR')} sub={tot?.eur_source === 'estime' ? 'Estime' : 'Facture'} />
-          <KpiCard icon={Leaf} label="CO2e" value={fmtNum(Math.round(tot?.co2_total), 'kg')} sub="ADEME 2024" />
-          <KpiCard icon={ShieldCheck} label="Couverture" value={`${cov?.sites_with_data || 0} / ${cov?.sites_total || 0}`} sub={confLevel ? `Confiance ${confLevel}` : undefined} />
+          <KpiCard
+            icon={Euro}
+            label="Cout estime"
+            value={fmtNum(Math.round(tot?.eur_total), 'EUR')}
+            sub={tot?.eur_source === 'estime' ? 'Estimation a 0,18 EUR/kWh' : 'Facture'}
+          />
+          <KpiCard icon={Leaf} label="Emissions CO2" value={fmtNum(Math.round(tot?.co2_total), 'kg')} sub="Facteur ADEME 2024" />
+          <KpiCard
+            icon={ShieldCheck}
+            label="Couverture donnees"
+            value={`${cov?.sites_with_data || 0} / ${cov?.sites_total || 0} sites`}
+            sub={confLevel ? `Confiance ${confLevel === 'high' ? 'haute' : confLevel === 'medium' ? 'moyenne' : 'basse'}` : undefined}
+          />
         </div>
       ) : null}
 
@@ -221,14 +260,14 @@ export default function ConsumptionPortfolioPage() {
       {summary && (
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-sm font-semibold text-gray-700">Ou agir maintenant</h2>
+            <h2 className="text-sm font-semibold text-gray-700">Ou agir en priorite</h2>
             {top5ForAction.length > 0 && (
               <button
                 onClick={handleGroupedAction}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition"
               >
                 <CheckSquare size={14} />
-                Creer action portefeuille ({top5ForAction.length} sites)
+                Lancer campagne ({top5ForAction.length} sites)
               </button>
             )}
           </div>
@@ -238,7 +277,7 @@ export default function ConsumptionPortfolioPage() {
               <CardBody>
                 <div className="flex items-center gap-2 mb-3">
                   <DollarSign size={16} className="text-rose-500" />
-                  <h3 className="text-sm font-semibold text-gray-700">Impact estime</h3>
+                  <h3 className="text-sm font-semibold text-gray-700">Impact financier estime</h3>
                 </div>
                 {summary.top_impact?.length > 0 ? (
                   <ul className="space-y-2">
@@ -284,7 +323,7 @@ export default function ConsumptionPortfolioPage() {
               <CardBody>
                 <div className="flex items-center gap-2 mb-3">
                   <Moon size={16} className="text-indigo-500" />
-                  <h3 className="text-sm font-semibold text-gray-700">Base nocturne elevee</h3>
+                  <h3 className="text-sm font-semibold text-gray-700">Consommation nocturne</h3>
                 </div>
                 {summary.top_base_night?.length > 0 ? (
                   <ul className="space-y-2">
@@ -330,11 +369,10 @@ export default function ConsumptionPortfolioPage() {
 
       {/* ═══ SITES TABLE ═══ */}
       <div>
-        <h2 className="text-sm font-semibold text-gray-700 mb-3">Sites du portefeuille</h2>
+        <h2 className="text-sm font-semibold text-gray-700 mb-3">Tous les sites</h2>
 
         {/* Filters bar */}
         <div className="flex flex-wrap items-center gap-3 mb-3">
-          {/* Search */}
           <div className="relative">
             <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" />
             <input
@@ -346,7 +384,6 @@ export default function ConsumptionPortfolioPage() {
             />
           </div>
 
-          {/* Confidence filter */}
           {['high', 'medium', 'low'].map((c) => (
             <button
               key={c}
@@ -361,25 +398,19 @@ export default function ConsumptionPortfolioPage() {
             </button>
           ))}
 
-          {/* Anomaly toggle */}
           <button
             onClick={() => setAnomalyFilter(!anomalyFilter)}
             className={`px-3 py-1 rounded-full text-xs font-medium transition ${
-              anomalyFilter
-                ? 'bg-amber-100 text-amber-700'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              anomalyFilter ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
             }`}
           >
             Anomalies
           </button>
 
-          {/* Actions filter */}
           <button
             onClick={() => setActionsFilter(actionsFilter === 'with' ? null : 'with')}
             className={`px-3 py-1 rounded-full text-xs font-medium transition ${
-              actionsFilter === 'with'
-                ? 'bg-green-100 text-green-700'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              actionsFilter === 'with' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
             }`}
           >
             Avec actions
@@ -387,15 +418,12 @@ export default function ConsumptionPortfolioPage() {
           <button
             onClick={() => setActionsFilter(actionsFilter === 'without' ? null : 'without')}
             className={`px-3 py-1 rounded-full text-xs font-medium transition ${
-              actionsFilter === 'without'
-                ? 'bg-gray-200 text-gray-800'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              actionsFilter === 'without' ? 'bg-gray-200 text-gray-800' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
             }`}
           >
             Sans action
           </button>
 
-          {/* Sort */}
           <select
             value={sort}
             onChange={(e) => setSort(e.target.value)}
@@ -438,11 +466,11 @@ export default function ConsumptionPortfolioPage() {
                 </button>
               )}
               <button
-                onClick={() => navigate('/consommations/import')}
+                onClick={() => navigate(toConsoImport())}
                 className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition"
               >
                 <Upload size={14} />
-                Aller a Import & Analyse
+                Importer des donnees
               </button>
             </div>
           </div>
@@ -466,7 +494,12 @@ export default function ConsumptionPortfolioPage() {
                 </thead>
                 <tbody>
                   {sites.map((row) => (
-                    <tr key={row.site_id} className="border-b border-gray-100 hover:bg-gray-50 transition">
+                    <tr
+                      key={row.site_id}
+                      className="border-b border-gray-100 hover:bg-gray-50 transition cursor-pointer"
+                      onClick={() => handleRowClick(row)}
+                      title="Cliquez pour explorer ce site"
+                    >
                       <td className="py-2 px-3 font-medium text-gray-800">{row.site_name}</td>
                       <td className="py-2 px-3 text-right">
                         {row.impact_eur_estimated > 0 ? (
@@ -481,20 +514,35 @@ export default function ConsumptionPortfolioPage() {
                       <td className="py-2 px-3 text-right text-gray-700">{row.base_night_pct != null ? `${row.base_night_pct}%` : '—'}</td>
                       <td className="py-2 px-3 text-center">
                         {row.diagnostics_count > 0 ? (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 text-amber-700">
+                          <button
+                            onClick={(e) => { e.stopPropagation(); navigate(toConsoDiag({ site_id: row.site_id })); }}
+                            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 text-amber-700 hover:bg-amber-200 transition"
+                            title="Voir les diagnostics"
+                          >
                             {row.diagnostics_count}
-                          </span>
+                          </button>
                         ) : (
                           <span className="text-gray-300">—</span>
                         )}
                       </td>
                       <td className="py-2 px-3 text-center">
                         {row.open_actions_count > 0 ? (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-green-100 text-green-700">
+                          <button
+                            onClick={(e) => { e.stopPropagation(); navigate(`/actions?site_id=${row.site_id}`); }}
+                            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-green-100 text-green-700 hover:bg-green-200 transition"
+                            title="Voir les actions en cours"
+                          >
+                            <Eye size={10} />
                             {row.open_actions_count}
-                          </span>
+                          </button>
                         ) : (
-                          <span className="text-gray-300">—</span>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); navigate(toActionNew({ source_type: 'consommation', site_id: row.site_id, source: 'portfolio' })); }}
+                            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 text-gray-500 hover:bg-gray-200 transition"
+                            title="Creer une action"
+                          >
+                            <Plus size={10} />
+                          </button>
                         )}
                       </td>
                       <td className="py-2 px-3 text-center">
@@ -507,30 +555,30 @@ export default function ConsumptionPortfolioPage() {
                       <td className="py-2 px-3 text-right">
                         <div className="flex items-center justify-end gap-1.5">
                           <button
-                            onClick={() => navigate(`/consommations/explorer?site_ids=${row.site_id}`)}
+                            onClick={(e) => { e.stopPropagation(); navigate(toConsoExplorer({ site_id: row.site_id })); }}
                             className="p-1 rounded hover:bg-blue-50 text-blue-500"
                             title="Explorer"
                           >
                             <BarChart3 size={14} />
                           </button>
                           <button
-                            onClick={() => navigate(`/diagnostic-conso?site_id=${row.site_id}`)}
+                            onClick={(e) => { e.stopPropagation(); navigate(toConsoDiag({ site_id: row.site_id })); }}
                             className="p-1 rounded hover:bg-amber-50 text-amber-500"
                             title="Diagnostic"
                           >
                             <TrendingDown size={14} />
                           </button>
                           <button
-                            onClick={() => navigate(deepLinkWithContext(row.site_id))}
+                            onClick={(e) => { e.stopPropagation(); navigate(toBillIntel({ site_id: row.site_id })); }}
                             className="p-1 rounded hover:bg-gray-100 text-gray-500"
-                            title="Voir facture"
+                            title="Voir factures"
                           >
                             <FileText size={14} />
                           </button>
                           <button
-                            onClick={() => navigate(deepLinkNewAction({ type: 'consommation', site_id: row.site_id, source: 'portfolio' }))}
+                            onClick={(e) => { e.stopPropagation(); navigate(toActionNew({ source_type: 'consommation', site_id: row.site_id, source: 'portfolio' })); }}
                             className="p-1 rounded hover:bg-green-50 text-green-500"
-                            title="Creer action"
+                            title="Creer une action"
                           >
                             <Plus size={14} />
                           </button>

--- a/frontend/src/pages/ConsumptionPortfolioPage.jsx
+++ b/frontend/src/pages/ConsumptionPortfolioPage.jsx
@@ -20,7 +20,7 @@ import { useToast } from '../ui';
 import { useScope } from '../contexts/ScopeContext';
 import { getPortfolioSummary, getPortfolioSites } from '../services/api';
 import {
-  toConsoExplorer, toConsoDiag, toBillIntel, toActionNew, toAction, toConsoImport,
+  toConsoExplorer, toConsoDiag, toBillIntel, toActionNew, toAction, toActionsList, toConsoImport,
 } from '../services/routes';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -569,7 +569,7 @@ export default function ConsumptionPortfolioPage() {
                       <td className="py-2 px-3 text-center">
                         {row.open_actions_count > 0 ? (
                           <button
-                            onClick={(e) => { e.stopPropagation(); navigate(`/actions?site_id=${row.site_id}`); }}
+                            onClick={(e) => { e.stopPropagation(); navigate(toActionsList({ site_id: row.site_id })); }}
                             className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-green-100 text-green-700 hover:bg-green-200 transition"
                             title="Voir les actions en cours"
                           >

--- a/frontend/src/pages/ConsumptionPortfolioPage.jsx
+++ b/frontend/src/pages/ConsumptionPortfolioPage.jsx
@@ -447,33 +447,74 @@ export default function ConsumptionPortfolioPage() {
             ))}
           </div>
         ) : sites.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <BarChart3 size={40} className="text-gray-300 mb-4" />
-            <p className="text-sm text-gray-500 mb-1">Aucun site ne correspond aux filtres.</p>
-            <p className="text-xs text-gray-400 mb-4">
-              {hasActiveFilters
-                ? 'Essayez de reinitialiser les filtres pour voir tous les sites.'
-                : 'Importez des donnees pour remplir le portefeuille.'}
-            </p>
-            <div className="flex items-center gap-3">
-              {hasActiveFilters && (
+          /* Empty state: Cas A (aucune donnee) vs Cas B (filtres trop restrictifs) */
+          (cov?.sites_total || 0) === 0 ? (
+            /* Cas A: aucune donnee du tout */
+            <div className="flex flex-col items-center justify-center py-12 text-center" data-empty="no-data">
+              <BarChart3 size={40} className="text-gray-300 mb-4" />
+              <p className="text-sm text-gray-500 mb-1">Aucune donnee de consommation disponible sur la periode selectionnee.</p>
+              <p className="text-xs text-gray-400 mb-4">
+                Importez vos releves ou changez la periode pour voir vos sites.
+              </p>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => navigate(toConsoImport())}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition"
+                >
+                  <Upload size={14} />
+                  Importer des donnees
+                </button>
+              </div>
+            </div>
+          ) : (
+            /* Cas B: filtres trop restrictifs */
+            <div className="flex flex-col items-center justify-center py-12 text-center" data-empty="filters">
+              <Search size={40} className="text-gray-300 mb-4" />
+              <p className="text-sm text-gray-500 mb-1">Aucun site ne correspond aux filtres.</p>
+              <p className="text-xs text-gray-400 mb-2">
+                {cov.sites_total} sites existent mais sont masques par vos criteres.
+              </p>
+              {/* Active filter chips */}
+              <div className="flex flex-wrap items-center justify-center gap-2 mb-4">
+                {search && (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] bg-gray-100 text-gray-600">
+                    Recherche : « {search} »
+                  </span>
+                )}
+                {confidenceFilter && (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] bg-blue-100 text-blue-600">
+                    Confiance : {confidenceFilter === 'high' ? 'Haute' : confidenceFilter === 'medium' ? 'Moyenne' : 'Basse'}
+                  </span>
+                )}
+                {anomalyFilter && (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] bg-amber-100 text-amber-600">
+                    Anomalies uniquement
+                  </span>
+                )}
+                {actionsFilter && (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] bg-green-100 text-green-600">
+                    {actionsFilter === 'with' ? 'Avec actions' : 'Sans action'}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-3">
                 <button
                   onClick={handleResetFilters}
                   className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition"
                 >
                   <RotateCcw size={14} />
-                  Reinitialiser filtres
+                  Reinitialiser les filtres
                 </button>
-              )}
-              <button
-                onClick={() => navigate(toConsoImport())}
-                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition"
-              >
-                <Upload size={14} />
-                Importer des donnees
-              </button>
+                <button
+                  onClick={() => navigate(toConsoImport())}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition"
+                >
+                  <Upload size={14} />
+                  Importer des donnees
+                </button>
+              </div>
             </div>
-          </div>
+          )
         ) : (
           <>
             <div className="overflow-x-auto">

--- a/frontend/src/pages/ConsumptionPortfolioPage.jsx
+++ b/frontend/src/pages/ConsumptionPortfolioPage.jsx
@@ -1,21 +1,22 @@
 /**
- * PROMEOS — ConsumptionPortfolioPage (V1.1)
+ * PROMEOS — ConsumptionPortfolioPage (V1.2)
  * Multi-site B2B portfolio view: 4 KPI cards, top-lists "Ou agir",
  * sortable/filterable site table with row actions.
  * V1.1: impact EUR, actions filter, grouped action CTA.
+ * V1.2: scope coherence banner, deep-links on top-lists, guided empty state.
  */
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Zap, Euro, Leaf, ShieldCheck, AlertTriangle, Moon, Activity,
   Search, ArrowRight, FileText, Plus, BarChart3, TrendingDown,
-  CheckSquare, DollarSign,
+  CheckSquare, DollarSign, Info, RotateCcw, Upload,
 } from 'lucide-react';
 import {
-  PageShell, Card, CardBody, SkeletonCard, EmptyState, TrustBadge,
-  KpiCard,
+  Card, CardBody, SkeletonCard, TrustBadge, KpiCard,
 } from '../ui';
 import { useToast } from '../ui';
+import { useScope } from '../contexts/ScopeContext';
 import { getPortfolioSummary, getPortfolioSites } from '../services/api';
 import { deepLinkWithContext, deepLinkNewAction } from '../services/deepLink';
 
@@ -35,10 +36,47 @@ function fmtNum(n, suffix = '') {
   return n.toLocaleString('fr-FR') + (suffix ? ` ${suffix}` : '');
 }
 
+// ─── Top-list row actions (shared by all 4 lists) ─────────────────────────
+function TopListActions({ siteId, navigate }) {
+  return (
+    <span className="inline-flex items-center gap-0.5 ml-2 shrink-0">
+      <button
+        onClick={() => navigate(`/consommations/explorer?site_ids=${siteId}`)}
+        className="p-0.5 rounded hover:bg-blue-50 text-blue-500"
+        title="Explorer"
+      >
+        <BarChart3 size={11} />
+      </button>
+      <button
+        onClick={() => navigate(`/diagnostic-conso?site_id=${siteId}`)}
+        className="p-0.5 rounded hover:bg-amber-50 text-amber-500"
+        title="Diagnostic"
+      >
+        <TrendingDown size={11} />
+      </button>
+      <button
+        onClick={() => navigate(deepLinkWithContext(siteId))}
+        className="p-0.5 rounded hover:bg-gray-100 text-gray-400"
+        title="Voir facture"
+      >
+        <FileText size={11} />
+      </button>
+      <button
+        onClick={() => navigate(deepLinkNewAction({ type: 'consommation', site_id: siteId, source: 'portfolio_toplist' }))}
+        className="p-0.5 rounded hover:bg-green-50 text-green-500"
+        title="Creer action"
+      >
+        <Plus size={11} />
+      </button>
+    </span>
+  );
+}
+
 // ─── Component ─────────────────────────────────────────────────────────────
 export default function ConsumptionPortfolioPage() {
   const navigate = useNavigate();
   const { addToast } = useToast();
+  const { selectedSiteId, resetScope } = useScope();
   const [dates] = useState(defaultDateRange);
 
   // Summary KPIs
@@ -56,6 +94,17 @@ export default function ConsumptionPortfolioPage() {
   const [actionsFilter, setActionsFilter] = useState(null); // null | 'with' | 'without'
   const [page, setPage] = useState(0);
   const PAGE_SIZE = 25;
+
+  const hasActiveFilters = !!search || !!confidenceFilter || anomalyFilter || !!actionsFilter;
+
+  function handleResetFilters() {
+    setSearch('');
+    setConfidenceFilter(null);
+    setAnomalyFilter(false);
+    setActionsFilter(null);
+    setSort('impact_desc');
+    setPage(0);
+  }
 
   // ─── Fetch summary ────────────────────────────────────────────────────
   useEffect(() => {
@@ -131,11 +180,29 @@ export default function ConsumptionPortfolioPage() {
 
   // ─── Render ───────────────────────────────────────────────────────────
   return (
-    <PageShell
-      icon={BarChart3}
-      title="Portefeuille Consommation"
-      subtitle={`Vue multi-sites — ${dates.from} au ${dates.to}`}
-    >
+    <div className="space-y-6">
+      {/* ═══ SCOPE BANNER ═══ */}
+      {selectedSiteId && (
+        <div className="flex items-center gap-3 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3">
+          <Info size={16} className="text-blue-500 shrink-0" />
+          <p className="text-sm text-blue-700 flex-1">
+            Vue portefeuille = multi-sites. Le filtre site du bandeau est ignore sur cette page.
+          </p>
+          <button
+            onClick={() => resetScope()}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-blue-700 bg-white border border-blue-300 rounded-lg hover:bg-blue-100 transition"
+          >
+            Passer a Tous les sites
+          </button>
+        </div>
+      )}
+
+      {/* ═══ HEADER ═══ */}
+      <div>
+        <h2 className="text-lg font-bold text-gray-900">Portefeuille Consommation</h2>
+        <p className="text-sm text-gray-500">Vue multi-sites — {dates.from} au {dates.to}</p>
+      </div>
+
       {/* ═══ KPI CARDS ═══ */}
       {summaryLoading ? (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
@@ -152,7 +219,7 @@ export default function ConsumptionPortfolioPage() {
 
       {/* ═══ OU AGIR MAINTENANT ═══ */}
       {summary && (
-        <div className="mt-6">
+        <div>
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-sm font-semibold text-gray-700">Ou agir maintenant</h2>
             {top5ForAction.length > 0 && (
@@ -176,9 +243,10 @@ export default function ConsumptionPortfolioPage() {
                 {summary.top_impact?.length > 0 ? (
                   <ul className="space-y-2">
                     {summary.top_impact.map((r) => (
-                      <li key={r.site_id} className="flex items-center justify-between text-xs">
+                      <li key={r.site_id} className="flex items-center text-xs">
                         <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
-                        <span className="text-rose-600 font-medium ml-2">{fmtNum(r.impact_eur_estimated, 'EUR')}</span>
+                        <span className="text-rose-600 font-medium ml-2 shrink-0">{fmtNum(r.impact_eur_estimated, 'EUR')}</span>
+                        <TopListActions siteId={r.site_id} navigate={navigate} />
                       </li>
                     ))}
                   </ul>
@@ -198,16 +266,10 @@ export default function ConsumptionPortfolioPage() {
                 {summary.top_drift?.length > 0 ? (
                   <ul className="space-y-2">
                     {summary.top_drift.map((r) => (
-                      <li key={r.site_id} className="flex items-center justify-between text-xs">
+                      <li key={r.site_id} className="flex items-center text-xs">
                         <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
-                        <span className="text-amber-600 font-medium ml-2">{r.diagnostics_count} alertes</span>
-                        <button
-                          onClick={() => navigate(`/diagnostic-conso?site_id=${r.site_id}`)}
-                          className="ml-2 text-blue-500 hover:text-blue-700"
-                          title="Voir diagnostic"
-                        >
-                          <ArrowRight size={12} />
-                        </button>
+                        <span className="text-amber-600 font-medium ml-2 shrink-0">{r.diagnostics_count} alertes</span>
+                        <TopListActions siteId={r.site_id} navigate={navigate} />
                       </li>
                     ))}
                   </ul>
@@ -227,9 +289,10 @@ export default function ConsumptionPortfolioPage() {
                 {summary.top_base_night?.length > 0 ? (
                   <ul className="space-y-2">
                     {summary.top_base_night.map((r) => (
-                      <li key={r.site_id} className="flex items-center justify-between text-xs">
+                      <li key={r.site_id} className="flex items-center text-xs">
                         <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
-                        <span className="text-indigo-600 font-medium ml-2">{r.base_night_pct}%</span>
+                        <span className="text-indigo-600 font-medium ml-2 shrink-0">{r.base_night_pct}%</span>
+                        <TopListActions siteId={r.site_id} navigate={navigate} />
                       </li>
                     ))}
                   </ul>
@@ -249,9 +312,10 @@ export default function ConsumptionPortfolioPage() {
                 {summary.top_peaks?.length > 0 ? (
                   <ul className="space-y-2">
                     {summary.top_peaks.map((r) => (
-                      <li key={r.site_id} className="flex items-center justify-between text-xs">
+                      <li key={r.site_id} className="flex items-center text-xs">
                         <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
-                        <span className="text-red-600 font-medium ml-2">{r.peak_kw} kW</span>
+                        <span className="text-red-600 font-medium ml-2 shrink-0">{r.peak_kw} kW</span>
+                        <TopListActions siteId={r.site_id} navigate={navigate} />
                       </li>
                     ))}
                   </ul>
@@ -265,7 +329,7 @@ export default function ConsumptionPortfolioPage() {
       )}
 
       {/* ═══ SITES TABLE ═══ */}
-      <div className="mt-6">
+      <div>
         <h2 className="text-sm font-semibold text-gray-700 mb-3">Sites du portefeuille</h2>
 
         {/* Filters bar */}
@@ -355,7 +419,33 @@ export default function ConsumptionPortfolioPage() {
             ))}
           </div>
         ) : sites.length === 0 ? (
-          <EmptyState icon={BarChart3} message="Aucun site ne correspond aux filtres" />
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <BarChart3 size={40} className="text-gray-300 mb-4" />
+            <p className="text-sm text-gray-500 mb-1">Aucun site ne correspond aux filtres.</p>
+            <p className="text-xs text-gray-400 mb-4">
+              {hasActiveFilters
+                ? 'Essayez de reinitialiser les filtres pour voir tous les sites.'
+                : 'Importez des donnees pour remplir le portefeuille.'}
+            </p>
+            <div className="flex items-center gap-3">
+              {hasActiveFilters && (
+                <button
+                  onClick={handleResetFilters}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition"
+                >
+                  <RotateCcw size={14} />
+                  Reinitialiser filtres
+                </button>
+              )}
+              <button
+                onClick={() => navigate('/consommations/import')}
+                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition"
+              >
+                <Upload size={14} />
+                Aller a Import & Analyse
+              </button>
+            </div>
+          </div>
         ) : (
           <>
             <div className="overflow-x-auto">
@@ -478,6 +568,6 @@ export default function ConsumptionPortfolioPage() {
           </>
         )}
       </div>
-    </PageShell>
+    </div>
   );
 }

--- a/frontend/src/pages/ConsumptionPortfolioPage.jsx
+++ b/frontend/src/pages/ConsumptionPortfolioPage.jsx
@@ -1,9 +1,10 @@
 /**
- * PROMEOS — ConsumptionPortfolioPage (V1.3)
- * Vue pilotage multi-sites B2B : KPIs, top-lists "Ou agir", table sites.
+ * PROMEOS — ConsumptionPortfolioPage (V2)
+ * Vue pilotage multi-sites B2B — patrimoine-first.
  *
- * V1.3: route registry, scope coherence, row click → Explorer,
- *       bandeau pilotage, couverture tooltip, actions column smart.
+ * V2: tous les sites du patrimoine affiches (meme sans donnees),
+ *     data_status badge, coverage_pct par site, filtre "Sans donnees",
+ *     deep-links avec date_from/date_to, CTA "Importer" inline.
  */
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -11,7 +12,7 @@ import {
   Zap, Euro, Leaf, ShieldCheck, AlertTriangle, Moon, Activity,
   Search, FileText, Plus, BarChart3, TrendingDown,
   CheckSquare, DollarSign, Info, RotateCcw, Upload, HelpCircle,
-  Eye,
+  Eye, Database,
 } from 'lucide-react';
 import {
   Card, CardBody, SkeletonCard, TrustBadge, KpiCard,
@@ -20,7 +21,7 @@ import { useToast } from '../ui';
 import { useScope } from '../contexts/ScopeContext';
 import { getPortfolioSummary, getPortfolioSites } from '../services/api';
 import {
-  toConsoExplorer, toConsoDiag, toBillIntel, toActionNew, toAction, toActionsList, toConsoImport,
+  toConsoExplorer, toConsoDiag, toBillIntel, toActionNew, toActionsList, toConsoImport,
 } from '../services/routes';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -45,12 +46,35 @@ function fmtDate(iso) {
   return d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
+/** Data status badge: ok (green), partial (amber), none (gray) */
+function DataStatusBadge({ status, coveragePct }) {
+  if (status === 'ok') {
+    return (
+      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-100 text-green-700" title={`Couverture ${coveragePct}% — Donnees completes`}>
+        {coveragePct}%
+      </span>
+    );
+  }
+  if (status === 'partial') {
+    return (
+      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700" title={`Couverture ${coveragePct}% — Donnees partielles`}>
+        {coveragePct}%
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 text-gray-400" title="Aucune donnee sur cette periode">
+      —
+    </span>
+  );
+}
+
 // ─── Top-list row actions (shared by all 4 lists) ─────────────────────────
-function TopListActions({ siteId, navigate }) {
+function TopListActions({ siteId, dates, navigate }) {
   return (
     <span className="inline-flex items-center gap-0.5 ml-2 shrink-0">
       <button
-        onClick={(e) => { e.stopPropagation(); navigate(toConsoExplorer({ site_id: siteId })); }}
+        onClick={(e) => { e.stopPropagation(); navigate(toConsoExplorer({ site_id: siteId, date_from: dates.from, date_to: dates.to })); }}
         className="p-0.5 rounded hover:bg-blue-50 text-blue-500"
         title="Explorer ce site"
       >
@@ -101,16 +125,18 @@ export default function ConsumptionPortfolioPage() {
   const [confidenceFilter, setConfidenceFilter] = useState(null);
   const [anomalyFilter, setAnomalyFilter] = useState(false);
   const [actionsFilter, setActionsFilter] = useState(null);
+  const [noDataFilter, setNoDataFilter] = useState(false);
   const [page, setPage] = useState(0);
   const PAGE_SIZE = 25;
 
-  const hasActiveFilters = !!search || !!confidenceFilter || anomalyFilter || !!actionsFilter;
+  const hasActiveFilters = !!search || !!confidenceFilter || anomalyFilter || !!actionsFilter || noDataFilter;
 
   function handleResetFilters() {
     setSearch('');
     setConfidenceFilter(null);
     setAnomalyFilter(false);
     setActionsFilter(null);
+    setNoDataFilter(false);
     setSort('impact_desc');
     setPage(0);
   }
@@ -134,6 +160,7 @@ export default function ConsumptionPortfolioPage() {
       confidence: confidenceFilter || undefined,
       with_anomalies: anomalyFilter || undefined,
       with_actions: actionsFilter || undefined,
+      without_data: noDataFilter || undefined,
       search: search || undefined,
       limit: PAGE_SIZE,
       offset: page * PAGE_SIZE,
@@ -144,10 +171,10 @@ export default function ConsumptionPortfolioPage() {
       })
       .catch(() => addToast({ type: 'error', message: 'Erreur chargement sites portfolio' }))
       .finally(() => setSitesLoading(false));
-  }, [dates.from, dates.to, sort, confidenceFilter, anomalyFilter, actionsFilter, search, page]);
+  }, [dates.from, dates.to, sort, confidenceFilter, anomalyFilter, actionsFilter, noDataFilter, search, page]);
 
   useEffect(() => { fetchSites(); }, [fetchSites]);
-  useEffect(() => { setPage(0); }, [sort, search, confidenceFilter, anomalyFilter, actionsFilter]);
+  useEffect(() => { setPage(0); }, [sort, search, confidenceFilter, anomalyFilter, actionsFilter, noDataFilter]);
 
   // ─── Computed ─────────────────────────────────────────────────────────
   const totalPages = Math.ceil(sitesTotal / PAGE_SIZE);
@@ -188,9 +215,13 @@ export default function ConsumptionPortfolioPage() {
     }));
   }
 
-  // ─── Row click → Explorer ─────────────────────────────────────────────
+  // ─── Row click → Explorer (with date context) ─────────────────────────
   function handleRowClick(row) {
-    navigate(toConsoExplorer({ site_id: row.site_id }));
+    if (row.data_status === 'none') {
+      navigate(toConsoImport());
+      return;
+    }
+    navigate(toConsoExplorer({ site_id: row.site_id, date_from: dates.from, date_to: dates.to }));
   }
 
   // ─── Render ───────────────────────────────────────────────────────────
@@ -220,6 +251,9 @@ export default function ConsumptionPortfolioPage() {
           <p className="text-sm text-gray-500">
             Vous pilotez {cov?.sites_total ?? '—'} sites sur la periode
             du {fmtDate(dates.from)} au {fmtDate(dates.to)}
+            {cov?.sites_without_data > 0 && (
+              <span className="text-amber-600"> — {cov.sites_without_data} sans donnees</span>
+            )}
           </p>
         </div>
         {cov && (
@@ -285,7 +319,7 @@ export default function ConsumptionPortfolioPage() {
                       <li key={r.site_id} className="flex items-center text-xs">
                         <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
                         <span className="text-rose-600 font-medium ml-2 shrink-0">{fmtNum(r.impact_eur_estimated, 'EUR')}</span>
-                        <TopListActions siteId={r.site_id} navigate={navigate} />
+                        <TopListActions siteId={r.site_id} dates={dates} navigate={navigate} />
                       </li>
                     ))}
                   </ul>
@@ -308,7 +342,7 @@ export default function ConsumptionPortfolioPage() {
                       <li key={r.site_id} className="flex items-center text-xs">
                         <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
                         <span className="text-amber-600 font-medium ml-2 shrink-0">{r.diagnostics_count} alertes</span>
-                        <TopListActions siteId={r.site_id} navigate={navigate} />
+                        <TopListActions siteId={r.site_id} dates={dates} navigate={navigate} />
                       </li>
                     ))}
                   </ul>
@@ -331,7 +365,7 @@ export default function ConsumptionPortfolioPage() {
                       <li key={r.site_id} className="flex items-center text-xs">
                         <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
                         <span className="text-indigo-600 font-medium ml-2 shrink-0">{r.base_night_pct}%</span>
-                        <TopListActions siteId={r.site_id} navigate={navigate} />
+                        <TopListActions siteId={r.site_id} dates={dates} navigate={navigate} />
                       </li>
                     ))}
                   </ul>
@@ -354,7 +388,7 @@ export default function ConsumptionPortfolioPage() {
                       <li key={r.site_id} className="flex items-center text-xs">
                         <span className="text-gray-700 truncate flex-1">{r.site_name}</span>
                         <span className="text-red-600 font-medium ml-2 shrink-0">{r.peak_kw} kW</span>
-                        <TopListActions siteId={r.site_id} navigate={navigate} />
+                        <TopListActions siteId={r.site_id} dates={dates} navigate={navigate} />
                       </li>
                     ))}
                   </ul>
@@ -424,6 +458,15 @@ export default function ConsumptionPortfolioPage() {
             Sans action
           </button>
 
+          <button
+            onClick={() => setNoDataFilter(!noDataFilter)}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition ${
+              noDataFilter ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            Sans donnees
+          </button>
+
           <select
             value={sort}
             onChange={(e) => setSort(e.target.value)}
@@ -436,6 +479,7 @@ export default function ConsumptionPortfolioPage() {
             <option value="peak">Pic kW</option>
             <option value="base_night">Base nocturne</option>
             <option value="diagnostics">Diagnostics</option>
+            <option value="coverage">Couverture donnees</option>
           </select>
         </div>
 
@@ -496,6 +540,11 @@ export default function ConsumptionPortfolioPage() {
                     {actionsFilter === 'with' ? 'Avec actions' : 'Sans action'}
                   </span>
                 )}
+                {noDataFilter && (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] bg-red-100 text-red-600">
+                    Sans donnees
+                  </span>
+                )}
               </div>
               <div className="flex items-center gap-3">
                 <button
@@ -522,6 +571,7 @@ export default function ConsumptionPortfolioPage() {
                 <thead>
                   <tr className="border-b border-gray-200 text-left">
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500">Site</th>
+                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center" title="Couverture = % de releves horaires disponibles sur la periode">Couverture</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Impact EUR</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">kWh</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">EUR</th>
@@ -529,7 +579,6 @@ export default function ConsumptionPortfolioPage() {
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right">Base nuit</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center">Diag.</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center">Actions</th>
-                    <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-center">Confiance</th>
                     <th className="py-2 px-3 text-xs font-semibold text-gray-500 text-right"></th>
                   </tr>
                 </thead>
@@ -537,11 +586,19 @@ export default function ConsumptionPortfolioPage() {
                   {sites.map((row) => (
                     <tr
                       key={row.site_id}
-                      className="border-b border-gray-100 hover:bg-gray-50 transition cursor-pointer"
+                      className={`border-b border-gray-100 hover:bg-gray-50 transition cursor-pointer ${row.data_status === 'none' ? 'bg-gray-50/50' : ''}`}
                       onClick={() => handleRowClick(row)}
-                      title="Cliquez pour explorer ce site"
+                      title={row.data_status === 'none' ? 'Aucune donnee — cliquez pour importer' : 'Cliquez pour explorer ce site'}
                     >
-                      <td className="py-2 px-3 font-medium text-gray-800">{row.site_name}</td>
+                      <td className="py-2 px-3">
+                        <span className="font-medium text-gray-800">{row.site_name}</span>
+                        {row.last_reading_date && (
+                          <span className="block text-[10px] text-gray-400">Dernier releve : {fmtDate(row.last_reading_date)}</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-center">
+                        <DataStatusBadge status={row.data_status} coveragePct={row.coverage_pct} />
+                      </td>
                       <td className="py-2 px-3 text-right">
                         {row.impact_eur_estimated > 0 ? (
                           <span className="text-rose-600 font-medium">{fmtNum(row.impact_eur_estimated, 'EUR')}</span>
@@ -549,8 +606,8 @@ export default function ConsumptionPortfolioPage() {
                           <span className="text-gray-300">—</span>
                         )}
                       </td>
-                      <td className="py-2 px-3 text-right text-gray-700">{fmtNum(row.kwh)}</td>
-                      <td className="py-2 px-3 text-right text-gray-700">{fmtNum(row.eur)}</td>
+                      <td className="py-2 px-3 text-right text-gray-700">{row.data_status !== 'none' ? fmtNum(row.kwh) : '—'}</td>
+                      <td className="py-2 px-3 text-right text-gray-700">{row.data_status !== 'none' ? fmtNum(row.eur) : '—'}</td>
                       <td className="py-2 px-3 text-right text-gray-700">{row.peak_kw != null ? `${row.peak_kw} kW` : '—'}</td>
                       <td className="py-2 px-3 text-right text-gray-700">{row.base_night_pct != null ? `${row.base_night_pct}%` : '—'}</td>
                       <td className="py-2 px-3 text-center">
@@ -586,44 +643,48 @@ export default function ConsumptionPortfolioPage() {
                           </button>
                         )}
                       </td>
-                      <td className="py-2 px-3 text-center">
-                        <TrustBadge
-                          level={row.confidence === 'high' ? 'ok' : row.confidence === 'medium' ? 'warn' : 'crit'}
-                          label={row.confidence === 'high' ? 'Haute' : row.confidence === 'medium' ? 'Moy.' : 'Basse'}
-                          size="sm"
-                        />
-                      </td>
                       <td className="py-2 px-3 text-right">
-                        <div className="flex items-center justify-end gap-1.5">
+                        {row.data_status !== 'none' ? (
+                          <div className="flex items-center justify-end gap-1.5">
+                            <button
+                              onClick={(e) => { e.stopPropagation(); navigate(toConsoExplorer({ site_id: row.site_id, date_from: dates.from, date_to: dates.to })); }}
+                              className="p-1 rounded hover:bg-blue-50 text-blue-500"
+                              title="Explorer"
+                            >
+                              <BarChart3 size={14} />
+                            </button>
+                            <button
+                              onClick={(e) => { e.stopPropagation(); navigate(toConsoDiag({ site_id: row.site_id })); }}
+                              className="p-1 rounded hover:bg-amber-50 text-amber-500"
+                              title="Diagnostic"
+                            >
+                              <TrendingDown size={14} />
+                            </button>
+                            <button
+                              onClick={(e) => { e.stopPropagation(); navigate(toBillIntel({ site_id: row.site_id })); }}
+                              className="p-1 rounded hover:bg-gray-100 text-gray-500"
+                              title="Voir factures"
+                            >
+                              <FileText size={14} />
+                            </button>
+                            <button
+                              onClick={(e) => { e.stopPropagation(); navigate(toActionNew({ source_type: 'consommation', site_id: row.site_id, source: 'portfolio' })); }}
+                              className="p-1 rounded hover:bg-green-50 text-green-500"
+                              title="Creer une action"
+                            >
+                              <Plus size={14} />
+                            </button>
+                          </div>
+                        ) : (
                           <button
-                            onClick={(e) => { e.stopPropagation(); navigate(toConsoExplorer({ site_id: row.site_id })); }}
-                            className="p-1 rounded hover:bg-blue-50 text-blue-500"
-                            title="Explorer"
+                            onClick={(e) => { e.stopPropagation(); navigate(toConsoImport()); }}
+                            className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-blue-600 bg-blue-50 rounded hover:bg-blue-100 transition"
+                            title="Importer des donnees pour ce site"
                           >
-                            <BarChart3 size={14} />
+                            <Upload size={10} />
+                            Importer
                           </button>
-                          <button
-                            onClick={(e) => { e.stopPropagation(); navigate(toConsoDiag({ site_id: row.site_id })); }}
-                            className="p-1 rounded hover:bg-amber-50 text-amber-500"
-                            title="Diagnostic"
-                          >
-                            <TrendingDown size={14} />
-                          </button>
-                          <button
-                            onClick={(e) => { e.stopPropagation(); navigate(toBillIntel({ site_id: row.site_id })); }}
-                            className="p-1 rounded hover:bg-gray-100 text-gray-500"
-                            title="Voir factures"
-                          >
-                            <FileText size={14} />
-                          </button>
-                          <button
-                            onClick={(e) => { e.stopPropagation(); navigate(toActionNew({ source_type: 'consommation', site_id: row.site_id, source: 'portfolio' })); }}
-                            className="p-1 rounded hover:bg-green-50 text-green-500"
-                            title="Creer une action"
-                          >
-                            <Plus size={14} />
-                          </button>
-                        </div>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -1,18 +1,27 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { Home } from 'lucide-react';
 import { Button, EmptyState } from '../ui';
+import { useExpertMode } from '../contexts/ExpertModeContext';
 
 export default function NotFound() {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { isExpert } = useExpertMode();
+
   return (
     <div className="px-6 py-6">
       <EmptyState
         icon={Home}
         title="Page introuvable"
-        text="La page que vous cherchez n'existe pas ou a ete deplacee."
+        text={`La page « ${pathname} » n'existe pas ou a été déplacée.`}
         ctaLabel="Retour au Command Center"
         onCta={() => navigate('/')}
       />
+      {isExpert && (
+        <p className="text-xs text-gray-400 text-center mt-4">
+          Route : {pathname} — {new Date().toISOString()}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Patrimoine.jsx
+++ b/frontend/src/pages/Patrimoine.jsx
@@ -4,7 +4,7 @@
  */
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
 import {
   Building2, Search, RotateCcw, Download, Star,
   Plus, Upload, MapPin, ChevronRight,
@@ -25,6 +25,8 @@ import PatrimoineWizard from '../components/PatrimoineWizard';
 import PatrimoineHealthCard from '../components/PatrimoineHealthCard';
 import PatrimoinePortfolioHealthBar from '../components/PatrimoinePortfolioHealthBar';
 import PatrimoineHeatmap from '../components/PatrimoineHeatmap';
+import PatrimoineRiskDistributionBar from '../components/PatrimoineRiskDistributionBar';
+import SiteAnomalyPanel from '../components/SiteAnomalyPanel';
 import { getPatrimoineAnomalies } from '../services/api';
 import { track } from '../services/tracker';
 import { fmtEur, fmtEurFull, fmtArea, fmtAreaCompact, fmtKwh, fmtDateFR, pl } from '../utils/format';
@@ -79,6 +81,7 @@ const PRESET_VIEWS = [
 
 export default function Patrimoine() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [sp, setSp] = useSearchParams();
   const { scopedSites, sitesLoading, scope } = useScope();
   const { isExpert } = useExpertMode();
@@ -135,6 +138,17 @@ export default function Patrimoine() {
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, []);
+
+  // V65 — Auto-ouvrir drawer depuis AnomaliesPage (location.state)
+  useEffect(() => {
+    if (!location.state?.openSiteId) return;
+    const site = scopedSites.find(s => s.id === location.state.openSiteId);
+    if (site) {
+      setDrawerSite(site);
+      setDrawerInitialTab(location.state.openTab || 'anomalies');
+      navigate('.', { replace: true, state: {} }); // clear state
+    }
+  }, [location.state, scopedSites]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // V63 — Enrichissement heatmap : anomalies par site (Promise.all, max 10 sites, guard stale)
   useEffect(() => {
@@ -401,11 +415,13 @@ export default function Patrimoine() {
           <PatrimoinePortfolioHealthBar onSiteClick={openDrawerOnAnomalies} orgId={scope.orgId} />
 
           {/* ── V63 — Heatmap portefeuille (risque / anomalies / framework par site) ── */}
+          {/* ── V64 — Distribution du risque insérée via topSlot ── */}
           <PatrimoineHeatmap
             tiles={hmTiles}
             onOpenSite={openDrawerOnAnomalies}
             loading={hmLoading}
             error={hmError}
+            topSlot={<PatrimoineRiskDistributionBar sites={filtered} />}
           />
 
           {/* ── KPI row (compact) ── */}
@@ -630,6 +646,7 @@ export default function Patrimoine() {
             navigate={navigate}
             onCreateAction={() => openActionFromDrawer(drawerSite.nom)}
             initialTab={drawerInitialTab}
+            orgId={scope.orgId}
           />
         )}
       </Drawer>
@@ -672,7 +689,7 @@ const DRAWER_TABS = [
   { id: 'actions', label: 'Actions' },
 ];
 
-function SiteDrawerContent({ site, navigate, onCreateAction, initialTab = 'resume' }) {
+function SiteDrawerContent({ site, navigate, onCreateAction, initialTab = 'resume', orgId = null }) {
   const [tab, setTab] = useState(initialTab);
   const badge = STATUT_BADGE[site.statut_conformite] || STATUT_BADGE.a_evaluer;
   const usageColor = USAGE_COLOR[site.usage] || 'bg-gray-100 text-gray-600 ring-gray-200';
@@ -735,10 +752,10 @@ function SiteDrawerContent({ site, navigate, onCreateAction, initialTab = 'resum
         </div>
       )}
 
-      {/* Tab: Anomalies — V58 PatrimoineHealthCard */}
+      {/* Tab: Anomalies — V65 SiteAnomalyPanel */}
       {tab === 'anomalies' && (
         <div>
-          <PatrimoineHealthCard siteId={site.id} />
+          <SiteAnomalyPanel siteId={site.id} orgId={orgId} />
         </div>
       )}
 

--- a/frontend/src/pages/RegOps.jsx
+++ b/frontend/src/pages/RegOps.jsx
@@ -93,10 +93,10 @@ export default function RegOps() {
         <div className="text-center">
           <p className="text-gray-500 mb-4">Évaluation non disponible</p>
           <button
-            onClick={() => navigate('/sites')}
+            onClick={() => navigate('/patrimoine')}
             className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
           >
-            Retour aux sites
+            Retour au patrimoine
           </button>
         </div>
       </div>

--- a/frontend/src/pages/Site360.jsx
+++ b/frontend/src/pages/Site360.jsx
@@ -17,6 +17,7 @@ import { applyKB } from '../services/api';
 import { getStatusBadgeProps, SEV_BADGE } from '../lib/constants';
 import IntakeWizard from '../components/IntakeWizard';
 import BacsWizard from '../components/BacsWizard';
+import SiteBillingMini from '../components/SiteBillingMini';
 
 const _sb = (k) => { const { variant, label } = getStatusBadgeProps(k); return { status: variant, label }; };
 const STATUT_BADGE = {
@@ -439,7 +440,7 @@ export default function Site360() {
       {/* Tab content */}
       {activeTab === 'resume' && <TabResume site={site} />}
       {activeTab === 'conso' && <TabStub title="Consommation" text="Courbes de charge, historique et benchmark à venir." />}
-      {activeTab === 'factures' && <TabStub title="Factures" text="Analyse factures, shadow billing et optimisation tarifaire à venir." />}
+      {activeTab === 'factures' && <SiteBillingMini siteId={site.id} />}
       {activeTab === 'conformite' && <TabConformite site={site} />}
       {activeTab === 'actions' && <TabStub title="Actions" text="Plan d'action et suivi des recommandations à venir." />}
 

--- a/frontend/src/pages/Site360.jsx
+++ b/frontend/src/pages/Site360.jsx
@@ -441,6 +441,16 @@ export default function Site360() {
       {activeTab === 'resume' && <TabResume site={site} />}
       {activeTab === 'conso' && <TabStub title="Consommation" text="Courbes de charge, historique et benchmark à venir." />}
       {activeTab === 'factures' && <SiteBillingMini siteId={site.id} />}
+      {activeTab === 'factures' && (
+        <div className="flex justify-end mt-2">
+          <button
+            className="text-xs text-amber-600 hover:underline"
+            onClick={() => navigate(`/billing?site_id=${site.id}`)}
+          >
+            Voir timeline complète
+          </button>
+        </div>
+      )}
       {activeTab === 'conformite' && <TabConformite site={site} />}
       {activeTab === 'actions' && <TabStub title="Actions" text="Plan d'action et suivi des recommandations à venir." />}
 

--- a/frontend/src/pages/__tests__/anomaliesV65.page.test.js
+++ b/frontend/src/pages/__tests__/anomaliesV65.page.test.js
@@ -1,0 +1,191 @@
+/**
+ * anomaliesV65.page.test.js — V65 Anomalies Action Center
+ * Source-guard tests (readFileSync + regex) — no DOM, no mocks needed.
+ * 7 groups, ~30 tests.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const root = resolve(__dirname, '../../../');
+
+function src(relPath) {
+  return readFileSync(resolve(root, relPath), 'utf-8');
+}
+
+/* ── A. anomalyActions.js ── */
+describe('A. anomalyActions.js — localStorage helpers', () => {
+  const code = src('src/services/anomalyActions.js');
+
+  it('uses storage key promeos_anomaly_actions', () => {
+    expect(code).toMatch(/promeos_anomaly_actions/);
+  });
+
+  it('exports ACTION_STATUS with todo / in_progress / resolved', () => {
+    expect(code).toMatch(/export.*ACTION_STATUS/);
+    expect(code).toMatch(/todo/);
+    expect(code).toMatch(/in_progress/);
+    expect(code).toMatch(/resolved/);
+  });
+
+  it('exports 5 public functions', () => {
+    expect(code).toMatch(/export function getAnomalyAction/);
+    expect(code).toMatch(/export function saveAnomalyAction/);
+    expect(code).toMatch(/export function deleteAnomalyAction/);
+    expect(code).toMatch(/export function getAllActionsForSite/);
+    expect(code).toMatch(/export function getAllActionsForOrg/);
+  });
+
+  it('key format uses orgId ?? demo', () => {
+    expect(code).toMatch(/orgId.*\?\?.*demo|demo.*\?\?.*orgId/);
+  });
+
+  it('exports ACTION_STATUS_LABEL', () => {
+    expect(code).toMatch(/export.*ACTION_STATUS_LABEL/);
+  });
+
+  it('exports ACTION_STATUS_COLOR', () => {
+    expect(code).toMatch(/export.*ACTION_STATUS_COLOR/);
+  });
+});
+
+/* ── B. SiteAnomalyPanel.jsx ── */
+describe('B. SiteAnomalyPanel.jsx — enriched drawer panel', () => {
+  const code = src('src/components/SiteAnomalyPanel.jsx');
+
+  it('has default export', () => {
+    expect(code).toMatch(/export default function SiteAnomalyPanel/);
+  });
+
+  it('accepts siteId and orgId props', () => {
+    expect(code).toMatch(/siteId/);
+    expect(code).toMatch(/orgId/);
+  });
+
+  it('has quick filters: Critiques, Facturation, Décret Tertiaire, BACS', () => {
+    expect(code).toMatch(/Critiques/);
+    expect(code).toMatch(/Facturation/);
+    expect(code).toMatch(/D.*cret Tertiaire/);
+    expect(code).toMatch(/BACS/);
+  });
+
+  it('has "Créer action" CTA', () => {
+    expect(code).toMatch(/Cr.*er action/);
+  });
+
+  it('sorts by priority_score', () => {
+    expect(code).toMatch(/priority_score/);
+  });
+
+  it('imports getPatrimoineAnomalies', () => {
+    expect(code).toMatch(/getPatrimoineAnomalies/);
+  });
+});
+
+/* ── C. AnomalyActionModal.jsx ── */
+describe('C. AnomalyActionModal.jsx — front-only action modal', () => {
+  const code = src('src/components/AnomalyActionModal.jsx');
+
+  it('has default export', () => {
+    expect(code).toMatch(/export default function AnomalyActionModal/);
+  });
+
+  it('imports saveAnomalyAction', () => {
+    expect(code).toMatch(/saveAnomalyAction/);
+  });
+
+  it('has "Marquer comme résolu" button', () => {
+    expect(code).toMatch(/Marquer comme r.*solu/);
+  });
+
+  it('has all form fields: title, owner, due_date, notes', () => {
+    expect(code).toMatch(/title/);
+    expect(code).toMatch(/owner/);
+    expect(code).toMatch(/due_date/);
+    expect(code).toMatch(/notes/);
+  });
+
+  it('has status select with the 3 values', () => {
+    expect(code).toMatch(/todo/);
+    expect(code).toMatch(/in_progress/);
+    expect(code).toMatch(/resolved/);
+  });
+});
+
+/* ── D. AnomaliesPage.jsx ── */
+describe('D. AnomaliesPage.jsx — cross-site action center', () => {
+  const code = src('src/pages/AnomaliesPage.jsx');
+
+  it('has default export', () => {
+    expect(code).toMatch(/export default function AnomaliesPage/);
+  });
+
+  it('imports useScope', () => {
+    expect(code).toMatch(/useScope/);
+  });
+
+  it('has "Ouvrir site" CTA', () => {
+    expect(code).toMatch(/Ouvrir site/);
+  });
+
+  it('has "Créer action" CTA', () => {
+    expect(code).toMatch(/Cr.*er action/);
+  });
+
+  it('uses Promise.all for bulk fetch', () => {
+    expect(code).toMatch(/Promise\.all/);
+  });
+
+  it('navigates to /patrimoine with state', () => {
+    expect(code).toMatch(/navigate.*\/patrimoine/);
+    expect(code).toMatch(/openSiteId/);
+  });
+});
+
+/* ── E. App.jsx ── */
+describe('E. App.jsx — routing', () => {
+  const code = src('src/App.jsx');
+
+  it('lazy-imports AnomaliesPage', () => {
+    expect(code).toMatch(/AnomaliesPage.*=.*lazy.*import.*AnomaliesPage/s);
+  });
+
+  it('/anomalies route uses AnomaliesPage, not a Navigate redirect', () => {
+    // Check line by line so dotall does not span into adjacent routes
+    const routeLine = code.split('\n').find(l => l.includes('path="/anomalies"'));
+    expect(routeLine).toBeDefined();
+    expect(routeLine).not.toMatch(/Navigate/);
+    expect(routeLine).toMatch(/AnomaliesPage/);
+  });
+});
+
+/* ── F. NavRegistry.js ── */
+describe('F. NavRegistry.js — navigation', () => {
+  const code = src('src/layout/NavRegistry.js');
+
+  it('/anomalies is mapped to operations module', () => {
+    expect(code).toMatch(/\/anomalies.*operations/);
+  });
+
+  it('"Action Center" label present in nav items', () => {
+    expect(code).toMatch(/Action Center/);
+  });
+});
+
+/* ── G. Patrimoine.jsx ── */
+describe('G. Patrimoine.jsx — SiteAnomalyPanel integration', () => {
+  const code = src('src/pages/Patrimoine.jsx');
+
+  it('imports SiteAnomalyPanel', () => {
+    expect(code).toMatch(/import SiteAnomalyPanel/);
+  });
+
+  it('passes orgId to SiteDrawerContent', () => {
+    expect(code).toMatch(/orgId=\{scope\.orgId\}/);
+  });
+
+  it('imports useLocation and uses location.state?.openSiteId', () => {
+    expect(code).toMatch(/useLocation/);
+    expect(code).toMatch(/location\.state\?\.openSiteId/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV66.page.test.js
+++ b/frontend/src/pages/__tests__/billingV66.page.test.js
@@ -1,0 +1,150 @@
+/**
+ * billingV66.page.test.js — V66 Billing Audit + Shadow-Billing V1
+ * Source-guard tests (readFileSync + regex) — no DOM, no mocks needed.
+ * 6 groups, ~25 tests.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const root = resolve(__dirname, '../../../');
+
+function src(relPath) {
+  return readFileSync(resolve(root, relPath), 'utf-8');
+}
+
+/* ── A. api.js — 3 new V66 wrappers ── */
+describe('A. api.js — V66 billing wrappers', () => {
+  const code = src('src/services/api.js');
+
+  it('exports importInvoicesPdf', () => {
+    expect(code).toMatch(/export const importInvoicesPdf/);
+  });
+
+  it('importInvoicesPdf calls /billing/import-pdf', () => {
+    expect(code).toMatch(/\/billing\/import-pdf/);
+  });
+
+  it('exports createActionFromBillingInsight', () => {
+    expect(code).toMatch(/export const createActionFromBillingInsight/);
+  });
+
+  it('createActionFromBillingInsight uses billing-insight idempotency_key', () => {
+    expect(code).toMatch(/billing-insight/);
+    expect(code).toMatch(/idempotency_key/);
+  });
+
+  it('exports getBillingAnomaliesScoped', () => {
+    expect(code).toMatch(/export const getBillingAnomaliesScoped/);
+  });
+
+  it('getBillingAnomaliesScoped calls /billing/anomalies-scoped', () => {
+    expect(code).toMatch(/\/billing\/anomalies-scoped/);
+  });
+});
+
+/* ── B. BillIntelPage.jsx — PDF upload + "Créer action" CTA ── */
+describe('B. BillIntelPage.jsx — PDF upload + action CTA', () => {
+  const code = src('src/pages/BillIntelPage.jsx');
+
+  it('imports importInvoicesPdf', () => {
+    expect(code).toMatch(/importInvoicesPdf/);
+  });
+
+  it('imports createActionFromBillingInsight', () => {
+    expect(code).toMatch(/createActionFromBillingInsight/);
+  });
+
+  it('has PDF import handler (handlePdfImport)', () => {
+    expect(code).toMatch(/handlePdfImport/);
+  });
+
+  it('has "Créer action" CTA in insight rows', () => {
+    expect(code).toMatch(/Cr.*er action/);
+  });
+
+  it('has createdActions state (Set)', () => {
+    expect(code).toMatch(/createdActions/);
+  });
+
+  it('has pdfSiteId state for site selection', () => {
+    expect(code).toMatch(/pdfSiteId/);
+  });
+
+  it('accepts .pdf file type', () => {
+    expect(code).toMatch(/accept.*\.pdf|\.pdf.*accept/);
+  });
+});
+
+/* ── C. SiteBillingMini.jsx — new component ── */
+describe('C. SiteBillingMini.jsx — new billing mini component', () => {
+  const code = src('src/components/SiteBillingMini.jsx');
+
+  it('has default export', () => {
+    expect(code).toMatch(/export default function SiteBillingMini/);
+  });
+
+  it('imports getSiteBilling', () => {
+    expect(code).toMatch(/getSiteBilling/);
+  });
+
+  it('accepts siteId prop', () => {
+    expect(code).toMatch(/siteId/);
+  });
+
+  it('has CTA to /bill-intel', () => {
+    expect(code).toMatch(/\/bill-intel/);
+  });
+
+  it('shows invoice and anomaly counts (KPIs)', () => {
+    expect(code).toMatch(/invoices\.length|nb.*factures|Factures/i);
+    expect(code).toMatch(/openInsights|Anomalie/i);
+  });
+});
+
+/* ── D. Site360.jsx — Factures tab no longer a TabStub ── */
+describe('D. Site360.jsx — Factures tab wired up', () => {
+  const code = src('src/pages/Site360.jsx');
+
+  it('imports SiteBillingMini', () => {
+    expect(code).toMatch(/import SiteBillingMini/);
+  });
+
+  it('factures tab renders SiteBillingMini (not TabStub)', () => {
+    const factureLine = code.split('\n').find(l => l.includes("factures") && l.includes('activeTab'));
+    expect(factureLine).toBeDefined();
+    expect(factureLine).not.toMatch(/TabStub/);
+    expect(factureLine).toMatch(/SiteBillingMini/);
+  });
+});
+
+/* ── E. AnomaliesPage.jsx — billing anomalies integration ── */
+describe('E. AnomaliesPage.jsx — billing anomalies integration', () => {
+  const code = src('src/pages/AnomaliesPage.jsx');
+
+  it('imports getBillingAnomaliesScoped', () => {
+    expect(code).toMatch(/getBillingAnomaliesScoped/);
+  });
+
+  it('has FACTURATION in FW_LABEL or FW_COLOR', () => {
+    expect(code).toMatch(/FACTURATION/);
+  });
+
+  it('merges billing anomalies (regulatory_impact FACTURATION)', () => {
+    expect(code).toMatch(/regulatory_impact.*FACTURATION|FACTURATION.*regulatory_impact/);
+  });
+
+  it('billing anomalies navigate to /bill-intel', () => {
+    expect(code).toMatch(/\/bill-intel/);
+    expect(code).toMatch(/_isBilling/);
+  });
+});
+
+/* ── F. Routing / nav sanity ── */
+describe('F. NavRegistry.js — /bill-intel still registered', () => {
+  const code = src('src/layout/NavRegistry.js');
+
+  it('/bill-intel appears in nav config', () => {
+    expect(code).toMatch(/bill-intel/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV67.page.test.js
+++ b/frontend/src/pages/__tests__/billingV67.page.test.js
@@ -1,0 +1,170 @@
+/**
+ * billingV67.page.test.js — V67 Billing Timeline & Coverage
+ * Source-guard tests (readFileSync + regex) — no DOM, no mocks needed.
+ * 6 groupes, ~26 tests.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const root = resolve(__dirname, '../../../');
+
+function src(relPath) {
+  return readFileSync(resolve(root, relPath), 'utf-8');
+}
+
+/* ── A. api.js — 3 nouveaux wrappers V67 ── */
+describe('A. api.js — V67 coverage wrappers', () => {
+  const code = src('src/services/api.js');
+
+  it('exports getBillingPeriods', () => {
+    expect(code).toMatch(/export const getBillingPeriods/);
+  });
+
+  it('getBillingPeriods calls /billing/periods', () => {
+    expect(code).toMatch(/\/billing\/periods/);
+  });
+
+  it('exports getCoverageSummary', () => {
+    expect(code).toMatch(/export const getCoverageSummary/);
+  });
+
+  it('getCoverageSummary calls /billing/coverage-summary', () => {
+    expect(code).toMatch(/\/billing\/coverage-summary/);
+  });
+
+  it('exports getMissingPeriods', () => {
+    expect(code).toMatch(/export const getMissingPeriods/);
+  });
+
+  it('getMissingPeriods calls /billing/missing-periods', () => {
+    expect(code).toMatch(/\/billing\/missing-periods/);
+  });
+});
+
+/* ── B. BillingPage.jsx — page timeline complète ── */
+describe('B. BillingPage.jsx — timeline & coverage page', () => {
+  const code = src('src/pages/BillingPage.jsx');
+
+  it('imports getBillingPeriods', () => {
+    expect(code).toMatch(/getBillingPeriods/);
+  });
+
+  it('imports getCoverageSummary', () => {
+    expect(code).toMatch(/getCoverageSummary/);
+  });
+
+  it('imports getMissingPeriods', () => {
+    expect(code).toMatch(/getMissingPeriods/);
+  });
+
+  it('has siteFilter state for site filtering', () => {
+    expect(code).toMatch(/siteFilter/);
+  });
+
+  it('reads site_id from URL search params', () => {
+    expect(code).toMatch(/useSearchParams|site_id/);
+  });
+
+  it('has pagination with load more (periodsOffset)', () => {
+    expect(code).toMatch(/periodsOffset|loadingMore|hasMore/);
+  });
+
+  it('imports CoverageBar component', () => {
+    expect(code).toMatch(/CoverageBar/);
+  });
+
+  it('imports BillingTimeline component', () => {
+    expect(code).toMatch(/BillingTimeline/);
+  });
+
+  it('navigates to /bill-intel for import CTA', () => {
+    expect(code).toMatch(/\/bill-intel/);
+  });
+});
+
+/* ── C. BillingTimeline.jsx — liste mensuelle ── */
+describe('C. BillingTimeline.jsx — monthly rows component', () => {
+  const code = src('src/components/BillingTimeline.jsx');
+
+  it('has default export function BillingTimeline', () => {
+    expect(code).toMatch(/export default function BillingTimeline/);
+  });
+
+  it('handles covered status', () => {
+    expect(code).toMatch(/covered/);
+  });
+
+  it('handles partial status', () => {
+    expect(code).toMatch(/partial/);
+  });
+
+  it('handles missing status', () => {
+    expect(code).toMatch(/missing/);
+  });
+
+  it('has Importer CTA navigating to /bill-intel', () => {
+    expect(code).toMatch(/bill-intel/);
+    expect(code).toMatch(/[Ii]mport/);
+  });
+});
+
+/* ── D. CoverageBar.jsx — barre visuelle ── */
+describe('D. CoverageBar.jsx — visual coverage bar', () => {
+  const code = src('src/components/CoverageBar.jsx');
+
+  it('has default export function CoverageBar', () => {
+    expect(code).toMatch(/export default function CoverageBar/);
+  });
+
+  it('accepts covered prop', () => {
+    expect(code).toMatch(/covered/);
+  });
+
+  it('accepts partial prop', () => {
+    expect(code).toMatch(/partial/);
+  });
+
+  it('accepts missing prop', () => {
+    expect(code).toMatch(/missing/);
+  });
+});
+
+/* ── E. Site360.jsx — lien timeline ── */
+describe('E. Site360.jsx — timeline link in Factures tab', () => {
+  const code = src('src/pages/Site360.jsx');
+
+  it('navigates to /billing with site_id query param', () => {
+    expect(code).toMatch(/\/billing\?site_id/);
+  });
+
+  it('has "Voir timeline" CTA text', () => {
+    expect(code).toMatch(/timeline/i);
+  });
+});
+
+/* ── F. App.jsx + NavRegistry.js — routing ── */
+describe('F. App.jsx + NavRegistry.js — /billing registered', () => {
+  const appCode = src('src/App.jsx');
+  const navCode = src('src/layout/NavRegistry.js');
+
+  it('/billing route declared in App.jsx', () => {
+    expect(appCode).toMatch(/path="\/billing"/);
+  });
+
+  it('BillingPage lazily imported in App.jsx', () => {
+    expect(appCode).toMatch(/BillingPage/);
+  });
+
+  it('/billing appears in NavRegistry ROUTE_MODULE_MAP', () => {
+    expect(navCode).toMatch(/['"]\/billing['"]/);
+  });
+
+  it('CalendarRange icon imported in NavRegistry', () => {
+    expect(navCode).toMatch(/CalendarRange/);
+  });
+
+  it('Timeline facturation label in NavRegistry', () => {
+    expect(navCode).toMatch(/[Tt]imeline/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -1115,4 +1115,13 @@ describe('AE · Insight drawer breakdown guarantee', () => {
     expect(drawer).toMatch(/Debug/);
     expect(drawer).toMatch(/isExpert\s*&&\s*error/);
   });
+
+  it('getInsightDetail uses GET method', () => {
+    const apiSrc = readFileSync(resolve(__dirname, '../../services/api.js'), 'utf-8');
+    expect(apiSrc).toMatch(/getInsightDetail.*api\.get\(/);
+  });
+
+  it('get_insight_detail backend uses @router.get', () => {
+    expect(backend).toMatch(/@router\.get\(["']\/insights\/\{insight_id\}["']\)/);
+  });
 });

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -446,8 +446,9 @@ describe('BillIntelPage.jsx — P0 imports UX', () => {
     expect(code).toMatch(/Importer CSV[\s\S]{0,300}disabled=\{!pdfSiteId\}|disabled=\{!pdfSiteId\}[\s\S]{0,300}Importer CSV/);
   });
 
-  it('CSV file input has disabled prop', () => {
-    expect(code).toMatch(/accept=["'].csv["'][\s\S]{0,200}disabled/);
+  it('CSV button uses ref-based file picker (csvInputRef)', () => {
+    expect(code).toMatch(/csvInputRef/);
+    expect(code).toMatch(/handleCsvClick/);
   });
 
   it('shows tooltip Sélectionnez un site when no site selected', () => {
@@ -463,11 +464,14 @@ describe('BillIntelPage.jsx — P0 imports UX', () => {
   });
 
   it('handlePdfImport calls toast on success', () => {
-    expect(code).toMatch(/handlePdfImport[\s\S]{0,500}toast\(/);
+    // Extract handlePdfImport function body specifically
+    const fnBody = code.match(/async function handlePdfImport[\s\S]{0,1500}/)?.[0] || '';
+    expect(fnBody).toMatch(/toast\(/);
   });
 
   it('handlePdfImport calls toast on error', () => {
-    expect(code).toMatch(/handlePdfImport[\s\S]{0,800}catch[\s\S]{0,200}toast\(/);
+    const fnBody = code.match(/async function handlePdfImport[\s\S]{0,1500}/)?.[0] || '';
+    expect(fnBody).toMatch(/catch[\s\S]{0,300}toast\(/);
   });
 
   it('pre-fills pdfSiteId from first site when no siteFilter', () => {
@@ -478,12 +482,20 @@ describe('BillIntelPage.jsx — P0 imports UX', () => {
     expect(code).toMatch(/Importer PDF[\s\S]{0,500}S.lectionnez un site|S.lectionnez un site[\s\S]{0,500}Importer PDF/);
   });
 
-  it('Expert logs on CSV import start (file name + size)', () => {
-    expect(code).toMatch(/isExpert[\s\S]{0,100}CSV import start/);
+  it('Expert logs on CSV button click', () => {
+    expect(code).toMatch(/isExpert[\s\S]{0,100}CSV button clicked/);
   });
 
-  it('Expert logs on PDF import start (file name + site_id)', () => {
-    expect(code).toMatch(/isExpert[\s\S]{0,100}PDF import start/);
+  it('Expert logs on CSV file selected', () => {
+    expect(code).toMatch(/isExpert[\s\S]{0,100}CSV file selected/);
+  });
+
+  it('Expert logs on PDF button click', () => {
+    expect(code).toMatch(/isExpert[\s\S]{0,100}PDF button clicked/);
+  });
+
+  it('Expert logs on PDF file selected', () => {
+    expect(code).toMatch(/isExpert[\s\S]{0,100}PDF file selected/);
   });
 });
 
@@ -535,5 +547,69 @@ describe('api.js — billing routes use /billing/ prefix', () => {
 
   it('importInvoicesPdf uses /billing/import-pdf', () => {
     expect(code).toMatch(/importInvoicesPdf[\s\S]{0,200}\/billing\/import-pdf/);
+  });
+});
+
+// ============================================================
+// R. BillingPage.jsx — Expert debug payload on getBillingPeriods error
+// ============================================================
+describe('BillingPage.jsx — Expert debug payload', () => {
+  const code = readSrc('pages', 'BillingPage.jsx');
+
+  it('builds debugPayload object with endpoint, params, status, contentType, bodySnippet, orgHeader', () => {
+    expect(code).toMatch(/debugPayload/);
+    expect(code).toMatch(/debugPayload[\s\S]{0,300}endpoint/);
+    expect(code).toMatch(/debugPayload[\s\S]{0,300}status/);
+    expect(code).toMatch(/debugPayload[\s\S]{0,300}contentType/);
+    expect(code).toMatch(/debugPayload[\s\S]{0,300}bodySnippet/);
+    expect(code).toMatch(/debugPayload[\s\S]{0,300}orgHeader/);
+  });
+
+  it('console.error logs debugPayload when isExpert', () => {
+    expect(code).toMatch(/isExpert[\s\S]{0,100}getBillingPeriods FAILED[\s\S]{0,50}debugPayload/);
+  });
+
+  it('displays debug info in error banner for non-404 errors in Expert mode', () => {
+    expect(code).toMatch(/debugPayload\.endpoint[\s\S]{0,200}debugPayload\.status/);
+    expect(code).toMatch(/org=.*debugPayload\.orgHeader/);
+    expect(code).toMatch(/ct=.*debugPayload\.contentType/);
+    expect(code).toMatch(/body=.*debugPayload\.bodySnippet/);
+  });
+});
+
+// ============================================================
+// S. BillIntelPage.jsx — ref-based file picker pattern
+// ============================================================
+describe('BillIntelPage.jsx — ref-based file picker', () => {
+  const code = readSrc('pages', 'BillIntelPage.jsx');
+
+  it('imports useRef', () => {
+    expect(code).toMatch(/useRef/);
+  });
+
+  it('declares csvInputRef and pdfInputRef', () => {
+    expect(code).toMatch(/csvInputRef\s*=\s*useRef/);
+    expect(code).toMatch(/pdfInputRef\s*=\s*useRef/);
+  });
+
+  it('handleCsvClick triggers csvInputRef.current.click()', () => {
+    expect(code).toMatch(/handleCsvClick[\s\S]{0,200}csvInputRef\.current[\s\S]{0,20}click/);
+  });
+
+  it('handlePdfClick triggers pdfInputRef.current.click()', () => {
+    expect(code).toMatch(/handlePdfClick[\s\S]{0,200}pdfInputRef\.current[\s\S]{0,20}click/);
+  });
+
+  it('CSV button uses type="button" and onClick={handleCsvClick}', () => {
+    expect(code).toMatch(/handleCsvClick[\s\S]{0,300}Importer CSV|Importer CSV[\s\S]{0,300}handleCsvClick/);
+  });
+
+  it('PDF button uses type="button" and onClick={handlePdfClick}', () => {
+    expect(code).toMatch(/handlePdfClick[\s\S]{0,300}Importer PDF|Importer PDF[\s\S]{0,300}handlePdfClick/);
+  });
+
+  it('hidden input refs have correct accept attributes', () => {
+    expect(code).toMatch(/ref=\{csvInputRef\}[\s\S]{0,100}accept=["'].csv["']/);
+    expect(code).toMatch(/ref=\{pdfInputRef\}[\s\S]{0,100}accept=["'].pdf["']/);
   });
 });

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -1055,3 +1055,41 @@ describe('Actions CTA — CreateActionModal + action_id (V71)', () => {
     expect(backend).toMatch(/ActionSourceType\.BILLING/);
   });
 });
+
+/* ─── Section AD — CTA Stabilization (6 tests) ─── */
+describe('AD · CTA Stabilization', () => {
+  const app = readFileSync(resolve(__dirname, '../../App.jsx'), 'utf-8');
+  const actionsPage = readFileSync(resolve(__dirname, '../ActionsPage.jsx'), 'utf-8');
+  const billingPage = readFileSync(resolve(__dirname, '../BillingPage.jsx'), 'utf-8');
+  const notFound = readFileSync(resolve(__dirname, '../NotFound.jsx'), 'utf-8');
+
+  it('App.jsx contains route /actions/new', () => {
+    expect(app).toMatch(/path=["']\/actions\/new["']/);
+    expect(app).toMatch(/autoCreate/);
+  });
+
+  it('App.jsx contains route /actions/:actionId', () => {
+    expect(app).toMatch(/path=["']\/actions\/:actionId["']/);
+  });
+
+  it('ActionsPage reads useParams for actionId', () => {
+    expect(actionsPage).toMatch(/useParams/);
+    expect(actionsPage).toMatch(/urlActionId/);
+  });
+
+  it('ActionsPage supports autoCreate prop', () => {
+    expect(actionsPage).toMatch(/autoCreate\s*=\s*false/);
+    expect(actionsPage).toMatch(/autoCreate\s*&&/);
+  });
+
+  it('BillingPage imports CreateActionModal (not createActionFromBillingInsight)', () => {
+    expect(billingPage).toMatch(/import\s+CreateActionModal/);
+    expect(billingPage).not.toMatch(/createActionFromBillingInsight/);
+  });
+
+  it('NotFound.jsx uses useLocation for pathname display', () => {
+    expect(notFound).toMatch(/useLocation/);
+    expect(notFound).toMatch(/pathname/);
+    expect(notFound).toMatch(/isExpert/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -770,3 +770,89 @@ describe('BillingPage — Import Contextuel (V70)', () => {
     expect(code).toMatch(/setImportContext\(\s*null\s*\)/);
   });
 });
+
+
+// ============================================================
+// W. BillingTimeline — CTA Voir avec deepLink (V70)
+// ============================================================
+describe('BillingTimeline — CTA Voir + deepLink (V70)', () => {
+  const code = readSrc('components', 'BillingTimeline.jsx');
+
+  it('imports deepLinkWithContext from services/deepLink', () => {
+    expect(code).toMatch(/import\s*\{[^}]*deepLinkWithContext[^}]*\}\s*from\s*['"]\.\.\/services\/deepLink['"]/);
+  });
+
+  it('uses deepLinkWithContext in handleView', () => {
+    expect(code).toMatch(/deepLinkWithContext\s*\(/);
+  });
+
+  it('passes invoice_ids to deepLinkWithContext (single invoice → detail)', () => {
+    expect(code).toMatch(/invoice_ids/);
+    expect(code).toMatch(/ids\.length\s*===\s*1/);
+  });
+
+  it('renders Eye icon in Voir button', () => {
+    expect(code).toMatch(/Eye/);
+    expect(code).toMatch(/Voir/);
+  });
+
+  it('accepts onImport prop and calls it for CSV/PDF', () => {
+    expect(code).toMatch(/onImport\s*\(/);
+    expect(code).toMatch(/handleImportCsv/);
+    expect(code).toMatch(/handleImportPdf/);
+  });
+
+  it('renders separate CSV and PDF import buttons for non-covered periods', () => {
+    expect(code).toMatch(/CSV/);
+    expect(code).toMatch(/PDF/);
+  });
+});
+
+
+// ============================================================
+// X. deepLink helper — deepLinkWithContext (V70)
+// ============================================================
+describe('deepLink.js — deepLinkWithContext (V70)', () => {
+  const code = readSrc('services', 'deepLink.js');
+
+  it('exports deepLinkWithContext function', () => {
+    expect(code).toMatch(/export\s+function\s+deepLinkWithContext/);
+  });
+
+  it('builds URL with invoice_id param when invoiceId provided', () => {
+    expect(code).toMatch(/invoice_id/);
+  });
+
+  it('builds URL with site_id and month params', () => {
+    expect(code).toMatch(/site_id/);
+    expect(code).toMatch(/month/);
+  });
+
+  it('returns path to /bill-intel', () => {
+    expect(code).toMatch(/\/bill-intel/);
+  });
+});
+
+
+// ============================================================
+// Y. NavRegistry — Timeline sous Facturation (V70)
+// ============================================================
+describe('NavRegistry — Timeline sous Facturation (V70)', () => {
+  const code = readSrc('layout', 'NavRegistry.js');
+
+  it('Factures & anomalies appears before Timeline & couverture', () => {
+    const idxFactures = code.indexOf('Factures & anomalies');
+    const idxTimeline = code.indexOf('Timeline & couverture');
+    expect(idxFactures).toBeGreaterThan(-1);
+    expect(idxTimeline).toBeGreaterThan(-1);
+    expect(idxFactures).toBeLessThan(idxTimeline);
+  });
+
+  it('Timeline has indent: true', () => {
+    expect(code).toMatch(/\/billing[\s\S]{0,200}indent:\s*true/);
+  });
+
+  it('bill-intel label is Factures & anomalies', () => {
+    expect(code).toMatch(/\/bill-intel[\s\S]{0,150}Factures & anomalies/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -288,10 +288,15 @@ describe('BillingPage.jsx — P0 fix getMissingPeriods non-bloquant', () => {
     expect(code).toMatch(/const\s+\{[^}]*isExpert[^}]*\}\s*=\s*useExpertMode/);
   });
 
-  it('getMissingPeriods is NOT in the main Promise.all', () => {
-    // Promise.all should only contain getCoverageSummary and getBillingPeriods
+  it('getCoverageSummary and getMissingPeriods are NOT in Promise.all', () => {
+    // Promise.all should not exist, or if it does, no coverage/missing inside
     const promiseAllBlock = code.match(/Promise\.all\(\[[\s\S]*?\]\)/)?.[0] || '';
     expect(promiseAllBlock).not.toMatch(/getMissingPeriods/);
+    expect(promiseAllBlock).not.toMatch(/getCoverageSummary/);
+  });
+
+  it('getCoverageSummary has its own try/catch (non-bloquant)', () => {
+    expect(code).toMatch(/getCoverageSummary[\s\S]{0,200}catch/);
   });
 
   it('getMissingPeriods has its own try/catch block', () => {
@@ -471,5 +476,13 @@ describe('BillIntelPage.jsx — P0 imports UX', () => {
 
   it('PDF button label has tooltip when no site', () => {
     expect(code).toMatch(/Importer PDF[\s\S]{0,500}S.lectionnez un site|S.lectionnez un site[\s\S]{0,500}Importer PDF/);
+  });
+
+  it('Expert logs on CSV import start (file name + size)', () => {
+    expect(code).toMatch(/isExpert[\s\S]{0,100}CSV import start/);
+  });
+
+  it('Expert logs on PDF import start (file name + site_id)', () => {
+    expect(code).toMatch(/isExpert[\s\S]{0,100}PDF import start/);
   });
 });

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -349,3 +349,55 @@ describe('BillIntelPage.jsx — P1 invoice filter bar', () => {
     expect(code).toMatch(/invoiceStatusFilter/);
   });
 });
+
+// ============================================================
+// L. BillIntelPage.jsx — ÉTAPE 3 : Import PDF site select
+// ============================================================
+describe('BillIntelPage.jsx — PDF import site select (ÉTAPE 3)', () => {
+  const code = readSrc('pages', 'BillIntelPage.jsx');
+
+  it('imports getSites from api', () => {
+    expect(code).toMatch(/getSites/);
+  });
+
+  it('has sites state', () => {
+    expect(code).toMatch(/sites.*useState|useState.*sites/);
+  });
+
+  it('renders a <select> for pdfSiteId (no more number input for pdf)', () => {
+    expect(code).not.toMatch(/type=["']number["'][\s\S]{0,100}pdfSiteId|pdfSiteId[\s\S]{0,100}type=["']number["']/);
+    expect(code).toMatch(/pdfSiteId[\s\S]{0,300}select|select[\s\S]{0,300}pdfSiteId/);
+  });
+
+  it('pre-fills pdfSiteId from siteFilter', () => {
+    expect(code).toMatch(/siteFilter[\s\S]{0,100}pdfSiteId|pdfSiteId[\s\S]{0,100}siteFilter/);
+  });
+});
+
+// ============================================================
+// M. BillIntelPage.jsx — ÉTAPE 4 : Filtre période presets
+// ============================================================
+describe('BillIntelPage.jsx — period filter presets (ÉTAPE 4)', () => {
+  const code = readSrc('pages', 'BillIntelPage.jsx');
+
+  it('has periodPreset state', () => {
+    expect(code).toMatch(/periodPreset/);
+  });
+
+  it('filteredInvoices handles last3/last6/last12 cutoff', () => {
+    expect(code).toMatch(/last3|last6|last12/);
+  });
+
+  it('filteredInvoices uses useMemo with periodPreset dependency', () => {
+    expect(code).toMatch(/filteredInvoices\s*=\s*useMemo/);
+    expect(code).toMatch(/periodPreset[\s\S]{0,200}monthFilter|monthFilter[\s\S]{0,200}periodPreset/);
+  });
+
+  it('has period select UI with Toutes périodes option', () => {
+    expect(code).toMatch(/Toutes p.riodes/);
+  });
+
+  it('shows month input only when specific preset', () => {
+    expect(code).toMatch(/specific[\s\S]{0,200}month|month[\s\S]{0,200}specific/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -1217,4 +1217,16 @@ describe('AG · CTA & Routes — zero dead links', () => {
   it('deepLink.js exports deepLinkWithContext', () => {
     expect(deepLink).toMatch(/export function deepLinkWithContext/);
   });
+
+  // --- Dead route regression guards ---
+  it('leverActionModel does NOT reference /command-center (dead route)', () => {
+    const leverModel = readFileSync(resolve(root, 'src/models/leverActionModel.js'), 'utf-8');
+    expect(leverModel).not.toMatch(/\/command-center/);
+    expect(leverModel).toMatch(/\/actions\/new/);
+  });
+
+  it('ImpactDecisionPanel uses buildLeverDeepLink (not hardcoded route)', () => {
+    const panel = readFileSync(resolve(root, 'src/pages/cockpit/ImpactDecisionPanel.jsx'), 'utf-8');
+    expect(panel).toMatch(/buildLeverDeepLink/);
+  });
 });

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -401,3 +401,75 @@ describe('BillIntelPage.jsx — period filter presets (ÉTAPE 4)', () => {
     expect(code).toMatch(/specific[\s\S]{0,200}month|month[\s\S]{0,200}specific/);
   });
 });
+
+// ============================================================
+// N. BillingPage.jsx — P0 : 404 purge localStorage + expert debug payload
+// ============================================================
+describe('BillingPage.jsx — P0 404 purge + expert debug', () => {
+  const code = readSrc('pages', 'BillingPage.jsx');
+
+  it('reads promeos_scope from localStorage on 404', () => {
+    expect(code).toMatch(/promeos_scope/);
+  });
+
+  it('sets siteId to null in localStorage scope', () => {
+    expect(code).toMatch(/scope\.siteId\s*=\s*null/);
+  });
+
+  it('writes updated scope back to localStorage', () => {
+    expect(code).toMatch(/localStorage\.setItem\(\s*['"]promeos_scope['"]/);
+  });
+
+  it('includes debug payload with endpoint, status, and site_id in expert mode', () => {
+    expect(code).toMatch(/endpoint=/);
+    expect(code).toMatch(/status=404/);
+    expect(code).toMatch(/site_id=/);
+  });
+
+  it('expert debug payload is gated by isExpert', () => {
+    expect(code).toMatch(/isExpert[\s\S]{0,200}endpoint=/);
+  });
+});
+
+// ============================================================
+// O. BillIntelPage.jsx — P0 : imports UX (disabled + tooltip + toast)
+// ============================================================
+describe('BillIntelPage.jsx — P0 imports UX', () => {
+  const code = readSrc('pages', 'BillIntelPage.jsx');
+
+  it('CSV button has disabled prop gated on pdfSiteId', () => {
+    expect(code).toMatch(/Importer CSV[\s\S]{0,300}disabled=\{!pdfSiteId\}|disabled=\{!pdfSiteId\}[\s\S]{0,300}Importer CSV/);
+  });
+
+  it('CSV file input has disabled prop', () => {
+    expect(code).toMatch(/accept=["'].csv["'][\s\S]{0,200}disabled/);
+  });
+
+  it('shows tooltip Sélectionnez un site when no site selected', () => {
+    expect(code).toMatch(/S.lectionnez un site/);
+  });
+
+  it('handleCsvImport calls toast on success', () => {
+    expect(code).toMatch(/handleCsvImport[\s\S]{0,500}toast\(/);
+  });
+
+  it('handleCsvImport calls toast on error', () => {
+    expect(code).toMatch(/handleCsvImport[\s\S]{0,800}catch[\s\S]{0,200}toast\(/);
+  });
+
+  it('handlePdfImport calls toast on success', () => {
+    expect(code).toMatch(/handlePdfImport[\s\S]{0,500}toast\(/);
+  });
+
+  it('handlePdfImport calls toast on error', () => {
+    expect(code).toMatch(/handlePdfImport[\s\S]{0,800}catch[\s\S]{0,200}toast\(/);
+  });
+
+  it('pre-fills pdfSiteId from first site when no siteFilter', () => {
+    expect(code).toMatch(/sites\.length\s*>\s*0[\s\S]{0,100}sites\[0\]/);
+  });
+
+  it('PDF button label has tooltip when no site', () => {
+    expect(code).toMatch(/Importer PDF[\s\S]{0,500}S.lectionnez un site|S.lectionnez un site[\s\S]{0,500}Importer PDF/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -856,3 +856,114 @@ describe('NavRegistry — Timeline sous Facturation (V70)', () => {
     expect(code).toMatch(/\/bill-intel[\s\S]{0,150}Factures & anomalies/);
   });
 });
+
+
+// ============================================================
+// Z. BillIntelPage — 100% Français (V70)
+// ============================================================
+describe('BillIntelPage — 100% Français (V70)', () => {
+  const code = readSrc('pages', 'BillIntelPage.jsx');
+
+  it('has STATUS_LABELS with Importé, Validé, Audité, Anomalie, Archivé', () => {
+    expect(code).toMatch(/STATUS_LABELS/);
+    expect(code).toMatch(/Importé/);
+    expect(code).toMatch(/Validé/);
+    expect(code).toMatch(/Audité/);
+    expect(code).toMatch(/Anomalie/);
+    expect(code).toMatch(/Archivé/);
+  });
+
+  it('has SEVERITY_LABELS with Critique, Élevé, Moyen, Faible', () => {
+    expect(code).toMatch(/SEVERITY_LABELS/);
+    expect(code).toMatch(/Critique/);
+    expect(code).toMatch(/Élevé/);
+    expect(code).toMatch(/Moyen/);
+    expect(code).toMatch(/Faible/);
+  });
+
+  it('TYPE_LABELS use proper accents (Écart, élevé, Période, négatifs, Dérive)', () => {
+    expect(code).toMatch(/Écart/);
+    expect(code).toMatch(/élevé/);
+    expect(code).toMatch(/Période/);
+    expect(code).toMatch(/négatifs/);
+    expect(code).toMatch(/Dérive/);
+  });
+
+  it('uses STATUS_LABELS[...] in rendering (not raw English status)', () => {
+    expect(code).toMatch(/STATUS_LABELS\[/);
+  });
+
+  it('uses SEVERITY_LABELS[...] in rendering', () => {
+    expect(code).toMatch(/SEVERITY_LABELS\[/);
+  });
+
+  it('handleCreateAction calls toast on success', () => {
+    const fn = code.match(/async function handleCreateAction[\s\S]{0,800}/)?.[0] || '';
+    expect(fn).toMatch(/toast\(/);
+    expect(fn).toMatch(/Action créée/);
+  });
+
+  it('has navigate to /actions for Voir l\'action button', () => {
+    expect(code).toMatch(/navigate\(\s*['"]\/actions['"]\s*\)/);
+    expect(code).toMatch(/Voir l'action/);
+  });
+});
+
+
+// ============================================================
+// AA. InsightDrawer — Comprendre l'écart (V70)
+// ============================================================
+describe('InsightDrawer — Comprendre l\'écart (V70)', () => {
+  const code = readSrc('components', 'InsightDrawer.jsx');
+  const page = readSrc('pages', 'BillIntelPage.jsx');
+
+  it('InsightDrawer is imported in BillIntelPage', () => {
+    expect(page).toMatch(/import\s+InsightDrawer\s+from\s+['"]\.\.\/components\/InsightDrawer['"]/);
+  });
+
+  it('BillIntelPage has drawerInsightId state', () => {
+    expect(page).toMatch(/drawerInsightId/);
+    expect(page).toMatch(/setDrawerInsightId/);
+  });
+
+  it('BillIntelPage renders InsightDrawer component', () => {
+    expect(page).toMatch(/<InsightDrawer/);
+    expect(page).toMatch(/insightId=\{drawerInsightId\}/);
+  });
+
+  it('BillIntelPage has Comprendre l\'écart button', () => {
+    expect(page).toMatch(/Comprendre l'écart/);
+  });
+
+  it('InsightDrawer imports getInsightDetail from api', () => {
+    expect(code).toMatch(/import\s*\{[^}]*getInsightDetail[^}]*\}\s*from\s*['"]\.\.\/services\/api['"]/);
+  });
+
+  it('InsightDrawer uses Drawer from ui/Drawer', () => {
+    expect(code).toMatch(/import\s+Drawer\s+from\s+['"]\.\.\/ui\/Drawer['"]/);
+  });
+
+  it('CAUSE_LABELS map covers shadow_gap, unit_price_high, duplicate_invoice', () => {
+    expect(code).toMatch(/CAUSE_LABELS/);
+    expect(code).toMatch(/shadow_gap/);
+    expect(code).toMatch(/unit_price_high/);
+    expect(code).toMatch(/duplicate_invoice/);
+  });
+
+  it('has breakdown table with Facturé and Attendu columns', () => {
+    expect(code).toMatch(/Facturé/);
+    expect(code).toMatch(/Attendu/);
+    expect(code).toMatch(/Écart/);
+  });
+
+  it('getInsightDetail exists in api.js', () => {
+    const apiCode = readSrc('services', 'api.js');
+    expect(apiCode).toMatch(/export\s+(const|function)\s+getInsightDetail/);
+  });
+
+  it('backend has GET /insights/{insight_id} endpoint', () => {
+    const backendCode = readBackend('routes', 'billing.py');
+    expect(backendCode).toMatch(/insights\/\{insight_id\}/);
+    expect(backendCode).toMatch(/metrics_json/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -897,14 +897,14 @@ describe('BillIntelPage — 100% Français (V70)', () => {
     expect(code).toMatch(/SEVERITY_LABELS\[/);
   });
 
-  it('handleCreateAction calls toast on success', () => {
-    const fn = code.match(/async function handleCreateAction[\s\S]{0,800}/)?.[0] || '';
+  it('handleActionSaved calls toast on success', () => {
+    const fn = code.match(/function handleActionSaved[\s\S]{0,800}/)?.[0] || '';
     expect(fn).toMatch(/toast\(/);
     expect(fn).toMatch(/Action créée/);
   });
 
-  it('has navigate to /actions for Voir l\'action button', () => {
-    expect(code).toMatch(/navigate\(\s*['"]\/actions['"]\s*\)/);
+  it('has Voir l\'action button with setViewActionId', () => {
+    expect(code).toMatch(/setViewActionId/);
     expect(code).toMatch(/Voir l'action/);
   });
 });
@@ -965,5 +965,93 @@ describe('InsightDrawer — Comprendre l\'écart (V70)', () => {
     const backendCode = readBackend('routes', 'billing.py');
     expect(backendCode).toMatch(/insights\/\{insight_id\}/);
     expect(backendCode).toMatch(/metrics_json/);
+  });
+});
+
+
+// ============================================================
+// AB. Explainability — V2 breakdown + confidence (V71)
+// ============================================================
+describe('Explainability — V2 breakdown + confidence (V71)', () => {
+  const backend = readBackend('services', 'billing_service.py');
+  const drawer = readSrc('components', 'InsightDrawer.jsx');
+
+  it('R1 _rule_shadow_gap imports shadow_billing_v2', () => {
+    const fn = backend.match(/def _rule_shadow_gap[\s\S]{0,1500}/)?.[0] || '';
+    expect(fn).toMatch(/shadow_billing_v2/);
+  });
+
+  it('R1 metrics include confidence + assumptions', () => {
+    const fn = backend.match(/def _rule_shadow_gap[\s\S]{0,1500}/)?.[0] || '';
+    expect(fn).toMatch(/confidence/);
+    expect(fn).toMatch(/assumptions/);
+  });
+
+  it('R13 metrics spread full V2 result (**res)', () => {
+    const fn = backend.match(/def _rule_reseau_mismatch[\s\S]{0,1200}/)?.[0] || '';
+    expect(fn).toMatch(/\*\*res/);
+  });
+
+  it('run_anomaly_engine injects rule_id into metrics', () => {
+    expect(backend).toMatch(/result\["metrics"\]\["rule_id"\]\s*=\s*rule_id/);
+  });
+
+  it('InsightDrawer renders confidence badge (Élevée/Moyenne/Faible)', () => {
+    expect(drawer).toMatch(/Élevée/);
+    expect(drawer).toMatch(/Moyenne/);
+    expect(drawer).toMatch(/Faible/);
+  });
+
+  it('InsightDrawer renders assumptions list', () => {
+    expect(drawer).toMatch(/m\.assumptions/);
+    expect(drawer).toMatch(/assumptions\.map/);
+  });
+
+  it('InsightDrawer CAUSE_LABELS shadow_gap has actual_total_eur fallback', () => {
+    expect(drawer).toMatch(/actual_total_eur/);
+    expect(drawer).toMatch(/shadow_total_eur/);
+  });
+});
+
+
+// ============================================================
+// AC. Actions CTA — CreateActionModal + action_id (V71)
+// ============================================================
+describe('Actions CTA — CreateActionModal + action_id (V71)', () => {
+  const page = readSrc('pages', 'BillIntelPage.jsx');
+  const backend = readBackend('routes', 'billing.py');
+
+  it('BillIntelPage imports CreateActionModal', () => {
+    expect(page).toMatch(/import\s+CreateActionModal\s+from\s+['"]\.\.\/components\/CreateActionModal['"]/);
+  });
+
+  it('BillIntelPage imports ActionDetailDrawer', () => {
+    expect(page).toMatch(/import\s+ActionDetailDrawer\s+from\s+['"]\.\.\/components\/ActionDetailDrawer['"]/);
+  });
+
+  it('BillIntelPage has actionMap state (Map, not Set)', () => {
+    expect(page).toMatch(/actionMap/);
+    expect(page).toMatch(/setActionMap/);
+    expect(page).toMatch(/new Map\(/);
+  });
+
+  it('BillIntelPage has handleOpenCreateAction + handleActionSaved', () => {
+    expect(page).toMatch(/handleOpenCreateAction/);
+    expect(page).toMatch(/handleActionSaved/);
+  });
+
+  it('BillIntelPage renders <CreateActionModal> in JSX', () => {
+    expect(page).toMatch(/<CreateActionModal/);
+    expect(page).toMatch(/actionModalInsight/);
+  });
+
+  it('BillIntelPage renders <ActionDetailDrawer> with viewActionId', () => {
+    expect(page).toMatch(/<ActionDetailDrawer/);
+    expect(page).toMatch(/viewActionId/);
+  });
+
+  it('list_insights includes action_id in response (backend)', () => {
+    expect(backend).toMatch(/action_map\.get\(str\(i\.id\)\)/);
+    expect(backend).toMatch(/ActionSourceType\.BILLING/);
   });
 });

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -486,3 +486,54 @@ describe('BillIntelPage.jsx — P0 imports UX', () => {
     expect(code).toMatch(/isExpert[\s\S]{0,100}PDF import start/);
   });
 });
+
+// ============================================================
+// P. api.js — content-type guard (non-JSON response detection)
+// ============================================================
+describe('api.js — content-type guard', () => {
+  const code = readSrc('services', 'api.js');
+
+  it('checks response content-type in interceptor', () => {
+    expect(code).toMatch(/content-type/);
+  });
+
+  it('rejects non-JSON responses with explicit proxy/prefix error', () => {
+    expect(code).toMatch(/application\/json/);
+    expect(code).toMatch(/proxy|pr.fixe|prefix/i);
+  });
+
+  it('allows text/plain responses (health-check etc.)', () => {
+    expect(code).toMatch(/text\/plain/);
+  });
+
+  it('skips guard for blob responseType', () => {
+    expect(code).toMatch(/responseType.*blob|blob.*responseType/);
+  });
+});
+
+// ============================================================
+// Q. api.js — billing API routes use /billing/ prefix
+// ============================================================
+describe('api.js — billing routes use /billing/ prefix', () => {
+  const code = readSrc('services', 'api.js');
+
+  it('getBillingPeriods uses /billing/periods', () => {
+    expect(code).toMatch(/getBillingPeriods[\s\S]{0,200}\/billing\/periods/);
+  });
+
+  it('getCoverageSummary uses /billing/coverage-summary', () => {
+    expect(code).toMatch(/getCoverageSummary[\s\S]{0,200}\/billing\/coverage-summary/);
+  });
+
+  it('getNormalizedInvoices uses /billing/invoices/normalized', () => {
+    expect(code).toMatch(/getNormalizedInvoices[\s\S]{0,200}\/billing\/invoices\/normalized/);
+  });
+
+  it('importInvoicesCsv uses /billing/import-csv', () => {
+    expect(code).toMatch(/importInvoicesCsv[\s\S]{0,200}\/billing\/import-csv/);
+  });
+
+  it('importInvoicesPdf uses /billing/import-pdf', () => {
+    expect(code).toMatch(/importInvoicesPdf[\s\S]{0,200}\/billing\/import-pdf/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -613,3 +613,160 @@ describe('BillIntelPage.jsx — ref-based file picker', () => {
     expect(code).toMatch(/ref=\{pdfInputRef\}[\s\S]{0,100}accept=["'].pdf["']/);
   });
 });
+
+
+// ============================================================
+// T. BillingPage — Scope Unifié (V70)
+// ============================================================
+describe('BillingPage — Scope Unifié (V70)', () => {
+  const code = readSrc('pages', 'BillingPage.jsx');
+
+  it('imports useScope from ScopeContext', () => {
+    expect(code).toMatch(/import\s*\{[^}]*useScope[^}]*\}\s*from\s*['"]\.\.\/contexts\/ScopeContext['"]/);
+  });
+
+  it('imports useToast from ToastProvider', () => {
+    expect(code).toMatch(/import\s*\{[^}]*useToast[^}]*\}\s*from\s*['"]\.\.\/ui\/ToastProvider['"]/);
+  });
+
+  it('destructures selectedSiteId from useScope', () => {
+    expect(code).toMatch(/selectedSiteId\s*:\s*scopeSiteId/);
+  });
+
+  it('destructures orgSites from useScope', () => {
+    expect(code).toMatch(/orgSites\s*\}\s*=\s*useScope/);
+  });
+
+  it('derives scopeHasSite', () => {
+    expect(code).toMatch(/const\s+scopeHasSite\s*=\s*!!scopeSiteId/);
+  });
+
+  it('derives localFilterActive', () => {
+    expect(code).toMatch(/const\s+localFilterActive\s*=/);
+  });
+
+  it('syncs scopeSiteId via useEffect', () => {
+    expect(code).toMatch(/useEffect[\s\S]{0,200}setSiteFilter[\s\S]{0,100}scopeSiteId/);
+  });
+
+  it('renders Hérité chip in JSX', () => {
+    expect(code).toMatch(/Hérité\s*:/);
+  });
+
+  it('renders Vue filtrée indicator in JSX', () => {
+    expect(code).toMatch(/Vue filtrée/);
+  });
+
+  it('does NOT import getSites (replaced by orgSites)', () => {
+    expect(code).not.toMatch(/import\s*\{[^}]*getSites[^}]*\}/);
+  });
+});
+
+
+// ============================================================
+// U. BillingPage — Filtres Timeline (V70)
+// ============================================================
+describe('BillingPage — Filtres Timeline (V70)', () => {
+  const code = readSrc('pages', 'BillingPage.jsx');
+
+  it('has statusFilter state', () => {
+    expect(code).toMatch(/useState\s*\(\s*['"]all['"]\s*\)/);
+    expect(code).toMatch(/statusFilter/);
+  });
+
+  it('has periodPreset state', () => {
+    expect(code).toMatch(/periodPreset/);
+    expect(code).toMatch(/setPeriodPreset/);
+  });
+
+  it('has timelineSearch state', () => {
+    expect(code).toMatch(/timelineSearch/);
+    expect(code).toMatch(/setTimelineSearch/);
+  });
+
+  it('has sortMode state', () => {
+    expect(code).toMatch(/sortMode/);
+    expect(code).toMatch(/setSortMode/);
+  });
+
+  it('defines filteredPeriods with useMemo', () => {
+    expect(code).toMatch(/const\s+filteredPeriods\s*=\s*useMemo/);
+  });
+
+  it('defines statusCounts with useMemo', () => {
+    expect(code).toMatch(/const\s+statusCounts\s*=\s*useMemo/);
+  });
+
+  it('renders status chips with statusCounts', () => {
+    expect(code).toMatch(/statusCounts\[/);
+  });
+
+  it('passes filteredPeriods to BillingTimeline', () => {
+    expect(code).toMatch(/periods=\{filteredPeriods\}/);
+  });
+
+  it('supports last3, last6, last12 presets', () => {
+    expect(code).toMatch(/last3/);
+    expect(code).toMatch(/last6/);
+    expect(code).toMatch(/last12/);
+  });
+
+  it('supports priority_missing sort mode', () => {
+    expect(code).toMatch(/priority_missing/);
+  });
+
+  it('imports Search from lucide-react', () => {
+    expect(code).toMatch(/import\s*\{[^}]*Search[^}]*\}\s*from\s*['"]lucide-react['"]/);
+  });
+});
+
+
+// ============================================================
+// V. BillingPage — Import Contextuel (V70)
+// ============================================================
+describe('BillingPage — Import Contextuel (V70)', () => {
+  const code = readSrc('pages', 'BillingPage.jsx');
+
+  it('imports importInvoicesCsv from api', () => {
+    expect(code).toMatch(/import\s*\{[^}]*importInvoicesCsv[^}]*\}\s*from\s*['"]\.\.\/services\/api['"]/);
+  });
+
+  it('imports importInvoicesPdf from api', () => {
+    expect(code).toMatch(/import\s*\{[^}]*importInvoicesPdf[^}]*\}\s*from\s*['"]\.\.\/services\/api['"]/);
+  });
+
+  it('creates csvInputRef with useRef', () => {
+    expect(code).toMatch(/csvInputRef\s*=\s*useRef/);
+  });
+
+  it('creates pdfInputRef with useRef', () => {
+    expect(code).toMatch(/pdfInputRef\s*=\s*useRef/);
+  });
+
+  it('has importContext state', () => {
+    expect(code).toMatch(/importContext/);
+    expect(code).toMatch(/setImportContext/);
+  });
+
+  it('defines handleContextualCsvImport function', () => {
+    expect(code).toMatch(/handleContextualCsvImport/);
+  });
+
+  it('defines handleContextualPdfImport function', () => {
+    expect(code).toMatch(/handleContextualPdfImport/);
+  });
+
+  it('calls toast in CSV import handler', () => {
+    const fn = code.match(/async function handleContextualCsvImport[\s\S]{0,800}/)?.[0] || '';
+    expect(fn).toMatch(/toast\(/);
+  });
+
+  it('calls toast in PDF import handler', () => {
+    const fn = code.match(/async function handleContextualPdfImport[\s\S]{0,800}/)?.[0] || '';
+    expect(fn).toMatch(/toast\(/);
+  });
+
+  it('resets importContext after import', () => {
+    expect(code).toMatch(/setImportContext\(\s*null\s*\)/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -1,0 +1,275 @@
+/**
+ * PROMEOS — V68 Billing Unified — Source-guard tests
+ * Vérifie la présence des constructs V68 dans les fichiers sources.
+ * Tests 100% readFileSync / regex — aucun mock DOM requis.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const root = resolve(__dirname, '../../../');  // → frontend/
+
+const readSrc = (...parts) => readFileSync(resolve(root, 'src', ...parts), 'utf-8');
+const readBackend = (...parts) => readFileSync(resolve(root, '..', 'backend', ...parts), 'utf-8');
+
+// ============================================================
+// A. api.js — getNormalizedInvoices
+// ============================================================
+describe('api.js — getNormalizedInvoices (V68)', () => {
+  const code = readSrc('services', 'api.js');
+
+  it('exports getNormalizedInvoices', () => {
+    expect(code).toMatch(/export const getNormalizedInvoices/);
+  });
+
+  it('calls /billing/invoices/normalized', () => {
+    expect(code).toMatch(/billing\/invoices\/normalized/);
+  });
+
+  it('accepts params object', () => {
+    expect(code).toMatch(/getNormalizedInvoices\s*=\s*\(params\s*=/);
+  });
+});
+
+// ============================================================
+// B. BillingPage.jsx — ?month= param + activeMonth + null-safe
+// ============================================================
+describe('BillingPage.jsx — V68 enhancements', () => {
+  const code = readSrc('pages', 'BillingPage.jsx');
+
+  it('reads ?month from searchParams', () => {
+    expect(code).toMatch(/searchParams\.get\(['"]month['"]\)/);
+  });
+
+  it('defines activeMonth state', () => {
+    expect(code).toMatch(/activeMonth/);
+  });
+
+  it('passes activeMonth to BillingTimeline', () => {
+    expect(code).toMatch(/activeMonth=\{activeMonth\}/);
+  });
+
+  it('optional chaining on summary.range', () => {
+    expect(code).toMatch(/summary\?\.range\?/);
+  });
+
+  it('uses useSearchParams', () => {
+    expect(code).toMatch(/useSearchParams/);
+  });
+
+  it('imports BillingTimeline', () => {
+    expect(code).toMatch(/import BillingTimeline/);
+  });
+});
+
+// ============================================================
+// C. BillIntelPage.jsx — deep-links V68
+// ============================================================
+describe('BillIntelPage.jsx — deep-links V68', () => {
+  const code = readSrc('pages', 'BillIntelPage.jsx');
+
+  it('imports useSearchParams', () => {
+    expect(code).toMatch(/useSearchParams/);
+  });
+
+  it('imports useNavigate', () => {
+    expect(code).toMatch(/useNavigate/);
+  });
+
+  it('reads ?site_id from searchParams', () => {
+    expect(code).toMatch(/searchParams\.get\(['"]site_id['"]\)/);
+  });
+
+  it('reads ?month from searchParams', () => {
+    expect(code).toMatch(/searchParams\.get\(['"]month['"]\)/);
+  });
+
+  it('defines siteFilter state', () => {
+    expect(code).toMatch(/siteFilter/);
+  });
+
+  it('defines monthFilter state', () => {
+    expect(code).toMatch(/monthFilter/);
+  });
+
+  it('has "Voir timeline" CTA navigating to /billing', () => {
+    expect(code).toMatch(/\/billing\?site_id=/);
+  });
+
+  it('filters invoices by monthFilter', () => {
+    expect(code).toMatch(/filteredInvoices/);
+  });
+
+  it('passes site_id to getBillingInsights', () => {
+    expect(code).toMatch(/site_id.*siteFilter|siteFilter.*site_id/);
+  });
+
+  it('imports CalendarRange for Voir timeline button', () => {
+    expect(code).toMatch(/CalendarRange/);
+  });
+});
+
+// ============================================================
+// D. BillingTimeline.jsx — activeMonth prop
+// ============================================================
+describe('BillingTimeline.jsx — activeMonth V68', () => {
+  const code = readSrc('components', 'BillingTimeline.jsx');
+
+  it('accepts activeMonth prop in MonthRow', () => {
+    expect(code).toMatch(/activeMonth/);
+  });
+
+  it('applies ring/highlight class when active', () => {
+    expect(code).toMatch(/ring-2|ring-amber/);
+  });
+
+  it('exports BillingTimeline with activeMonth in signature', () => {
+    expect(code).toMatch(/BillingTimeline\s*\(\s*\{[^}]*activeMonth/);
+  });
+});
+
+// ============================================================
+// E. Backend — billing_normalization.py
+// ============================================================
+describe('billing_normalization.py — V68 schema', () => {
+  const code = readBackend('services', 'billing_normalization.py');
+
+  it('defines InvoiceNormalized Pydantic model', () => {
+    expect(code).toMatch(/class InvoiceNormalized\(BaseModel\)/);
+  });
+
+  it('has org_id field', () => {
+    expect(code).toMatch(/org_id:\s*int/);
+  });
+
+  it('has ht_fourniture field', () => {
+    expect(code).toMatch(/ht_fourniture/);
+  });
+
+  it('has ht_reseau field', () => {
+    expect(code).toMatch(/ht_reseau/);
+  });
+
+  it('exports normalize_invoice function', () => {
+    expect(code).toMatch(/def normalize_invoice/);
+  });
+
+  it('computes month_key from period_start', () => {
+    expect(code).toMatch(/strftime.*%Y-%m/);
+  });
+});
+
+// ============================================================
+// F. Backend — billing_shadow_v2.py
+// ============================================================
+describe('billing_shadow_v2.py — V68 shadow engine', () => {
+  const code = readBackend('services', 'billing_shadow_v2.py');
+
+  it('defines TURPE constant', () => {
+    expect(code).toMatch(/TURPE_EUR_KWH_ELEC/);
+  });
+
+  it('defines CSPE constant', () => {
+    expect(code).toMatch(/CSPE_EUR_KWH_ELEC/);
+  });
+
+  it('defines TICGN constant', () => {
+    expect(code).toMatch(/TICGN_EUR_KWH_GAZ/);
+  });
+
+  it('exports shadow_billing_v2 function', () => {
+    expect(code).toMatch(/def shadow_billing_v2/);
+  });
+
+  it('returns expected_reseau_ht key', () => {
+    expect(code).toMatch(/expected_reseau_ht/);
+  });
+
+  it('returns delta_reseau key', () => {
+    expect(code).toMatch(/delta_reseau/);
+  });
+
+  it('method is shadow_v2_simplified', () => {
+    expect(code).toMatch(/shadow_v2_simplified/);
+  });
+});
+
+// ============================================================
+// G. Backend — billing_service.py — R13/R14
+// ============================================================
+describe('billing_service.py — R13/R14 rules V68', () => {
+  const code = readBackend('services', 'billing_service.py');
+
+  it('defines _rule_reseau_mismatch (R13)', () => {
+    expect(code).toMatch(/def _rule_reseau_mismatch/);
+  });
+
+  it('defines _rule_taxes_mismatch (R14)', () => {
+    expect(code).toMatch(/def _rule_taxes_mismatch/);
+  });
+
+  it('R13 in BILLING_RULES', () => {
+    expect(code).toMatch(/["']R13["']/);
+  });
+
+  it('R14 in BILLING_RULES', () => {
+    expect(code).toMatch(/["']R14["']/);
+  });
+
+  it('BILLING_RULES has 14 entries', () => {
+    const matches = code.match(/\("R\d+"/g);
+    expect(matches).not.toBeNull();
+    expect(matches.length).toBe(14);
+  });
+});
+
+// ============================================================
+// H. Backend — billing_seed.py — 36 mois
+// ============================================================
+describe('billing_seed.py — 36 mois V68', () => {
+  const code = readBackend('services', 'billing_seed.py');
+
+  it('has MONTHS_COUNT = 36', () => {
+    expect(code).toMatch(/MONTHS_COUNT\s*=\s*36/);
+  });
+
+  it('has SOURCE_TAG seed_36m', () => {
+    expect(code).toMatch(/seed_36m/);
+  });
+
+  it('has idempotency check', () => {
+    expect(code).toMatch(/skipped/);
+  });
+
+  it('has controlled gap 2023-03', () => {
+    expect(code).toMatch(/2023.*3|GAPS_SITE_A/);
+  });
+
+  it('defines ANOMALY_SHADOW_GAP', () => {
+    expect(code).toMatch(/ANOMALY_SHADOW_GAP/);
+  });
+
+  it('defines ANOMALY_RESEAU_MISMATCH', () => {
+    expect(code).toMatch(/ANOMALY_RESEAU_MISMATCH/);
+  });
+});
+
+// ============================================================
+// I. Deep-links bidirectionnels — intégration
+// ============================================================
+describe('Deep-links bidirectionnels V68', () => {
+  it('BillingTimeline.jsx generates /bill-intel?site_id links', () => {
+    const code = readSrc('components', 'BillingTimeline.jsx');
+    expect(code).toMatch(/\/bill-intel/);
+  });
+
+  it('BillIntelPage.jsx generates /billing?site_id link (retour timeline)', () => {
+    const code = readSrc('pages', 'BillIntelPage.jsx');
+    expect(code).toMatch(/\/billing\?site_id/);
+  });
+
+  it('BillingPage.jsx generates /bill-intel link (navigation directe)', () => {
+    const code = readSrc('pages', 'BillingPage.jsx');
+    expect(code).toMatch(/bill-intel/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -1093,3 +1093,26 @@ describe('AD · CTA Stabilization', () => {
     expect(notFound).toMatch(/isExpert/);
   });
 });
+
+/* ─── Section AE — Insight drawer breakdown guarantee (3 tests) ─── */
+describe('AE · Insight drawer breakdown guarantee', () => {
+  const backend = readFileSync(resolve(__dirname, '../../../../backend/routes/billing.py'), 'utf-8');
+  const drawer = readFileSync(resolve(__dirname, '../../components/InsightDrawer.jsx'), 'utf-8');
+
+  it('get_insight_detail recalculates V2 when breakdown absent', () => {
+    expect(backend).toMatch(/shadow_billing_v2/);
+    expect(backend).toMatch(/expected_ttc.*is None/);
+    expect(backend).toMatch(/expected_fourniture_ht.*is None/);
+  });
+
+  it('InsightDrawer captures error state', () => {
+    expect(drawer).toMatch(/setError/);
+    expect(drawer).toMatch(/error\.endpoint/);
+  });
+
+  it('InsightDrawer shows debug panel in expert mode when error', () => {
+    expect(drawer).toMatch(/error\.status/);
+    expect(drawer).toMatch(/Debug/);
+    expect(drawer).toMatch(/isExpert\s*&&\s*error/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -1125,3 +1125,46 @@ describe('AE · Insight drawer breakdown guarantee', () => {
     expect(backend).toMatch(/@router\.get\(["']\/insights\/\{insight_id\}["']\)/);
   });
 });
+
+/* ─── Section AF — 405 fix: Optional import + debug method (4 tests) ─── */
+describe('AF · 405 fix — router registration + debug method', () => {
+  const importSites = readFileSync(resolve(__dirname, '../../../../backend/routes/import_sites.py'), 'utf-8');
+  const drawer = readFileSync(resolve(__dirname, '../../components/InsightDrawer.jsx'), 'utf-8');
+  const billingRoute = readFileSync(resolve(__dirname, '../../../../backend/routes/billing.py'), 'utf-8');
+
+  it('import_sites.py imports Optional from typing (Python 3.14 compat)', () => {
+    expect(importSites).toMatch(/from typing import.*Optional/);
+  });
+
+  it('billing.py uses lazy import for shadow_billing_v2 (not module-level)', () => {
+    // Must NOT have module-level import
+    const lines = billingRoute.split('\n');
+    const moduleImports = lines.filter(
+      (l, i) => i < 50 && l.match(/from services\.billing_shadow_v2/)
+    );
+    expect(moduleImports).toHaveLength(0);
+    // Must have lazy import inside function
+    expect(billingRoute).toMatch(/from services\.billing_shadow_v2 import shadow_billing_v2/);
+  });
+
+  it('InsightDrawer error state includes method field', () => {
+    expect(drawer).toMatch(/method:\s*['"]GET['"]/);
+    expect(drawer).toMatch(/error\.method/);
+  });
+
+  it('InsightDrawer debug panel shows Method line', () => {
+    expect(drawer).toMatch(/Method\s*:\s*\{error\.method\}/);
+  });
+
+  it('billing.py recalculation triggers on empty metrics (no falsy guard)', () => {
+    // The condition must NOT have "if metrics and ..." which skips empty dict
+    expect(billingRoute).toMatch(/if metrics\.get\("expected_ttc"\) is None/);
+    // Must NOT have "if metrics and metrics.get" (old buggy guard)
+    expect(billingRoute).not.toMatch(/if metrics and metrics\.get\("expected_ttc"\)/);
+  });
+
+  it('billing.py adds confidence and assumptions when recalculating', () => {
+    expect(billingRoute).toMatch(/confidence.*not in metrics/);
+    expect(billingRoute).toMatch(/assumptions.*not in metrics/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -273,3 +273,79 @@ describe('Deep-links bidirectionnels V68', () => {
     expect(code).toMatch(/bill-intel/);
   });
 });
+
+// ============================================================
+// J. BillingPage.jsx — P0 fix : getMissingPeriods non-bloquant
+// ============================================================
+describe('BillingPage.jsx — P0 fix getMissingPeriods non-bloquant', () => {
+  const code = readSrc('pages', 'BillingPage.jsx');
+
+  it('imports useExpertMode from ExpertModeContext', () => {
+    expect(code).toMatch(/useExpertMode.*ExpertModeContext/);
+  });
+
+  it('uses isExpert hook', () => {
+    expect(code).toMatch(/const\s+\{[^}]*isExpert[^}]*\}\s*=\s*useExpertMode/);
+  });
+
+  it('getMissingPeriods is NOT in the main Promise.all', () => {
+    // Promise.all should only contain getCoverageSummary and getBillingPeriods
+    const promiseAllBlock = code.match(/Promise\.all\(\[[\s\S]*?\]\)/)?.[0] || '';
+    expect(promiseAllBlock).not.toMatch(/getMissingPeriods/);
+  });
+
+  it('getMissingPeriods has its own try/catch block', () => {
+    // After the main try/catch, getMissingPeriods should appear in another try block
+    expect(code).toMatch(/getMissingPeriods[\s\S]{0,200}catch/);
+  });
+
+  it('handles 404 with siteFilter reset', () => {
+    expect(code).toMatch(/status.*404|404.*status/);
+    expect(code).toMatch(/setSiteFilter\(['"]{0,2}\)/);
+  });
+
+  it('logs errors with isExpert guard', () => {
+    expect(code).toMatch(/isExpert.*console\.error|console\.error.*isExpert/);
+  });
+});
+
+// ============================================================
+// K. BillIntelPage.jsx — P1 : filter bar sur la liste factures
+// ============================================================
+describe('BillIntelPage.jsx — P1 invoice filter bar', () => {
+  const code = readSrc('pages', 'BillIntelPage.jsx');
+
+  it('imports useMemo', () => {
+    expect(code).toMatch(/useMemo/);
+  });
+
+  it('defines invoiceSearch state', () => {
+    expect(code).toMatch(/invoiceSearch/);
+  });
+
+  it('defines invoiceStatusFilter state', () => {
+    expect(code).toMatch(/invoiceStatusFilter/);
+  });
+
+  it('filteredInvoices uses useMemo', () => {
+    expect(code).toMatch(/filteredInvoices\s*=\s*useMemo/);
+  });
+
+  it('filteredInvoices filters by invoiceStatusFilter', () => {
+    expect(code).toMatch(/invoiceStatusFilter/);
+  });
+
+  it('filteredInvoices filters by invoiceSearch (invoice_number or pdl_prm)', () => {
+    expect(code).toMatch(/invoice_number[\s\S]{0,100}pdl_prm|pdl_prm[\s\S]{0,100}invoice_number/);
+  });
+
+  it('has a text input for invoice search', () => {
+    expect(code).toMatch(/invoiceSearch[\s\S]{0,200}placeholder|placeholder[\s\S]{0,200}invoiceSearch/);
+  });
+
+  it('has status filter chips rendered via map (array.map + invoiceStatusFilter)', () => {
+    // array of statuses rendered via .map(), invoiceStatusFilter used inside for active state
+    expect(code).toMatch(/\[''.*\]\.map|\['',/);
+    expect(code).toMatch(/invoiceStatusFilter/);
+  });
+});

--- a/frontend/src/pages/__tests__/billingV68.page.test.js
+++ b/frontend/src/pages/__tests__/billingV68.page.test.js
@@ -1168,3 +1168,53 @@ describe('AF · 405 fix — router registration + debug method', () => {
     expect(billingRoute).toMatch(/assumptions.*not in metrics/);
   });
 });
+
+/* ─── Section AG — CTA & Routes audit: zero dead links (8 tests) ─── */
+describe('AG · CTA & Routes — zero dead links', () => {
+  const appJsx = readSrc('App.jsx');
+  const essentials = readFileSync(resolve(root, 'src/pages/cockpit/EssentialsRow.jsx'), 'utf-8');
+  const regops = readFileSync(resolve(root, 'src/pages/RegOps.jsx'), 'utf-8');
+  const notFound = readFileSync(resolve(root, 'src/pages/NotFound.jsx'), 'utf-8');
+  const deepLink = readSrc('services', 'deepLink.js');
+
+  // --- Route existence ---
+  it('App.jsx defines /patrimoine route', () => {
+    expect(appJsx).toMatch(/path=["']\/patrimoine["']/);
+  });
+
+  it('App.jsx defines /actions/new route with autoCreate', () => {
+    expect(appJsx).toMatch(/path=["']\/actions\/new["']/);
+    expect(appJsx).toMatch(/autoCreate/);
+  });
+
+  it('App.jsx defines /consommations/import nested route', () => {
+    expect(appJsx).toMatch(/path=["']import["']/);
+  });
+
+  // --- Dead link fixes ---
+  it('EssentialsRow Patrimoine CTA navigates to /patrimoine (not /sites)', () => {
+    expect(essentials).toMatch(/onNavigate.*\/patrimoine/);
+    expect(essentials).not.toMatch(/onNavigate.*['"]\/sites['"]/);
+  });
+
+  it('RegOps fallback navigates to /patrimoine (not /sites)', () => {
+    expect(regops).toMatch(/navigate.*\/patrimoine/);
+    expect(regops).not.toMatch(/navigate.*['"]\/sites['"]\)/);
+  });
+
+  // --- NotFound ---
+  it('NotFound shows pathname + expert mode', () => {
+    expect(notFound).toMatch(/pathname/);
+    expect(notFound).toMatch(/isExpert/);
+  });
+
+  // --- Deep-links ---
+  it('deepLink.js exports deepLinkAction and deepLinkNewAction', () => {
+    expect(deepLink).toMatch(/export function deepLinkAction/);
+    expect(deepLink).toMatch(/export function deepLinkNewAction/);
+  });
+
+  it('deepLink.js exports deepLinkWithContext', () => {
+    expect(deepLink).toMatch(/export function deepLinkWithContext/);
+  });
+});

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -5,7 +5,7 @@
  */
 import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 
 const root = resolve(__dirname, '../../../');
 const readSrc = (...parts) => readFileSync(resolve(root, 'src', ...parts), 'utf-8');
@@ -1170,5 +1170,122 @@ describe('BJ · Portfolio empty state Cas A vs Cas B', () => {
   it('distinguishes Cas A vs Cas B via sites_total', () => {
     expect(code).toMatch(/sites_total/);
     expect(code).toMatch(/cov\?\.sites_total/);
+  });
+});
+
+// ============================================================
+// BK. Route registry — helpers return valid URLs, no undefined
+// ============================================================
+describe('BK · Route registry helpers', () => {
+  // Dynamic import of route helpers (ESM)
+  let routes;
+  beforeAll(async () => {
+    routes = await import('../../services/routes.js');
+  });
+
+  it('toConsoExplorer() returns /consommations/explorer', () => {
+    expect(routes.toConsoExplorer()).toBe('/consommations/explorer');
+  });
+
+  it('toConsoExplorer({ site_id: 5 }) encodes site param', () => {
+    const url = routes.toConsoExplorer({ site_id: 5 });
+    expect(url).toMatch(/^\/consommations\/explorer\?/);
+    expect(url).toContain('sites=5');
+    expect(url).not.toContain('undefined');
+  });
+
+  it('toConsoExplorer supports date_from / date_to', () => {
+    const url = routes.toConsoExplorer({ site_id: 1, date_from: '2025-01-01', date_to: '2025-01-31' });
+    expect(url).toContain('date_from=2025-01-01');
+    expect(url).toContain('date_to=2025-01-31');
+  });
+
+  it('toConsoExplorer supports multi-site array', () => {
+    const url = routes.toConsoExplorer({ site_id: [1, 2, 3] });
+    expect(url).toContain('sites=1%2C2%2C3');
+  });
+
+  it('toConsoDiag() returns /diagnostic-conso', () => {
+    expect(routes.toConsoDiag()).toBe('/diagnostic-conso');
+  });
+
+  it('toConsoDiag({ site_id: 7 }) encodes site_id', () => {
+    const url = routes.toConsoDiag({ site_id: 7 });
+    expect(url).toBe('/diagnostic-conso?site_id=7');
+  });
+
+  it('toBillIntel() returns /bill-intel', () => {
+    expect(routes.toBillIntel()).toBe('/bill-intel');
+  });
+
+  it('toBillIntel({ site_id: 3, month: "2025-06" }) encodes params', () => {
+    const url = routes.toBillIntel({ site_id: 3, month: '2025-06' });
+    expect(url).toContain('site_id=3');
+    expect(url).toContain('month=2025-06');
+  });
+
+  it('toActionNew() returns /actions/new', () => {
+    expect(routes.toActionNew()).toBe('/actions/new');
+  });
+
+  it('toActionNew with campaign encodes site_ids', () => {
+    const url = routes.toActionNew({ site_ids: [1, 2], source: 'portfolio', title: 'Test' });
+    expect(url).toContain('campaign_sites=1%2C2');
+    expect(url).toContain('source=portfolio');
+    expect(url).toContain('titre=Test');
+  });
+
+  it('toAction(42) returns /actions/42', () => {
+    expect(routes.toAction(42)).toBe('/actions/42');
+  });
+
+  it('toActionsList({ site_id: 5 }) returns /actions?site_id=5', () => {
+    expect(routes.toActionsList({ site_id: 5 })).toBe('/actions?site_id=5');
+  });
+
+  it('toConsoImport() returns /consommations/import', () => {
+    expect(routes.toConsoImport()).toBe('/consommations/import');
+  });
+
+  it('no helper returns a URL containing "undefined"', () => {
+    const urls = [
+      routes.toConsoExplorer(),
+      routes.toConsoExplorer({ site_id: 1 }),
+      routes.toConsoDiag(),
+      routes.toBillIntel(),
+      routes.toActionNew(),
+      routes.toAction(1),
+      routes.toActionsList(),
+      routes.toConsoImport(),
+    ];
+    urls.forEach(url => {
+      expect(url).toMatch(/^\//);
+      expect(url).not.toContain('undefined');
+      expect(url).not.toContain('null');
+    });
+  });
+});
+
+// ============================================================
+// BL. Conso pages — zero hardcoded URLs in conso scope
+// ============================================================
+describe('BL · No hardcoded navigation URLs in conso scope', () => {
+  const portfolio = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+  const diag = readSrc('pages', 'ConsumptionDiagPage.jsx');
+  const usages = readSrc('pages', 'ConsommationsUsages.jsx');
+
+  it('Portfolio uses toActionsList instead of hardcoded /actions?site_id', () => {
+    expect(portfolio).toMatch(/toActionsList/);
+    expect(portfolio).not.toMatch(/navigate\(`\/actions\?site_id=/);
+  });
+
+  it('DiagPage uses toConsoExplorer instead of hardcoded /consommations/explorer', () => {
+    expect(diag).toMatch(/toConsoExplorer/);
+    expect(diag).not.toMatch(/navigate\(`\/consommations\/explorer\?/);
+  });
+
+  it('ConsommationsUsages uses toConsoExplorer instead of hardcoded URL', () => {
+    expect(usages).toMatch(/toConsoExplorer/);
+    expect(usages).not.toMatch(/navigate\(`\/consommations\/explorer/);
   });
 });

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -731,8 +731,9 @@ describe('AX · ConsumptionPortfolioPage structure', () => {
     expect(code).toMatch(/Couverture/);
   });
 
-  it('has "Ou agir maintenant" section with 3 top-lists', () => {
+  it('has "Ou agir maintenant" section with 4 top-lists', () => {
     expect(code).toMatch(/Ou agir maintenant/);
+    expect(code).toMatch(/Impact estime/);
     expect(code).toMatch(/Derives detectees/);
     expect(code).toMatch(/Base nocturne elevee/);
     expect(code).toMatch(/Pics de puissance/);
@@ -799,5 +800,106 @@ describe('AY · Portfolio route & tab integration', () => {
     const api = readSrc('services', 'api.js');
     expect(api).toMatch(/\/portfolio\/consumption\/summary/);
     expect(api).toMatch(/\/portfolio\/consumption\/sites/);
+  });
+});
+
+
+// ============================================================
+// AZ. KPI Explorer coherence fix
+// ============================================================
+describe('AZ · KPI Explorer coherence — totalKwh from hphc', () => {
+  const code = readSrc('components', 'ConsoKpiHeader.jsx');
+
+  it('ConsoKpiHeader uses hphc?.total_kwh as primary kWh source', () => {
+    expect(code).toMatch(/hphc\?\.total_kwh/);
+  });
+
+  it('ConsoKpiHeader fallback chain includes tunnel and progression', () => {
+    // hphc?.total_kwh ?? tunnel?.total_kwh ?? progression?.ytd_actual_kwh
+    expect(code).toMatch(/hphc\?\.total_kwh.*tunnel\?\.total_kwh.*progression\?\.ytd_actual_kwh/);
+  });
+
+  it('ConsoKpiHeader still uses hphc for EUR total', () => {
+    expect(code).toMatch(/hphc\?\.total_cost_eur/);
+  });
+});
+
+
+// ============================================================
+// BA. Portfolio V1.1 — Impact EUR + Actions + CTA groupee
+// ============================================================
+describe('BA · Portfolio V1.1 backend enhancements', () => {
+  const code = readBackend('routes', 'portfolio.py');
+
+  it('imports ActionItem and ActionStatus', () => {
+    expect(code).toMatch(/from models\.action_item import ActionItem/);
+    expect(code).toMatch(/from models\.enums import ActionStatus/);
+  });
+
+  it('has impact_eur_estimated in site row', () => {
+    expect(code).toMatch(/impact_eur_estimated/);
+  });
+
+  it('has open_actions_count in site row', () => {
+    expect(code).toMatch(/open_actions_count/);
+  });
+
+  it('has top_impact list in summary', () => {
+    expect(code).toMatch(/top_impact/);
+  });
+
+  it('has with_actions filter (with/without)', () => {
+    expect(code).toMatch(/with_actions.*with/);
+    expect(code).toMatch(/with_actions.*without/);
+  });
+
+  it('has impact_desc sort option', () => {
+    expect(code).toMatch(/impact_desc/);
+  });
+
+  it('has impact_eur_total in summary totals', () => {
+    expect(code).toMatch(/impact_eur_total/);
+  });
+});
+
+describe('BB · Portfolio V1.1 frontend enhancements', () => {
+  const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+
+  it('has Impact EUR column header', () => {
+    expect(code).toMatch(/Impact EUR/);
+  });
+
+  it('has impact_eur_estimated display in table rows', () => {
+    expect(code).toMatch(/impact_eur_estimated/);
+  });
+
+  it('has open_actions_count display in table rows', () => {
+    expect(code).toMatch(/open_actions_count/);
+  });
+
+  it('has actionsFilter state (with/without)', () => {
+    expect(code).toMatch(/actionsFilter/);
+    expect(code).toMatch(/Avec actions/);
+    expect(code).toMatch(/Sans action/);
+  });
+
+  it('default sort is impact_desc', () => {
+    expect(code).toMatch(/useState\(['"]impact_desc['"]\)/);
+  });
+
+  it('has impact_desc sort option in select', () => {
+    expect(code).toMatch(/value="impact_desc"/);
+    expect(code).toMatch(/Impact EUR decroissant/);
+  });
+
+  it('has grouped action CTA button', () => {
+    expect(code).toMatch(/Creer action portefeuille/);
+    expect(code).toMatch(/handleGroupedAction/);
+    expect(code).toMatch(/campaign_sites/);
+  });
+
+  it('has top_impact section in "Ou agir"', () => {
+    expect(code).toMatch(/top_impact/);
+    expect(code).toMatch(/Impact estime/);
   });
 });

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -657,3 +657,147 @@ describe('AV · P1.1 drill-down CTAs', () => {
     expect(explorer).toMatch(/SignaturePanel siteIds=\{siteIds\}/);
   });
 });
+
+
+// ============================================================
+// AW. Portfolio V1 — Backend endpoints
+// ============================================================
+describe('AW · Portfolio V1 backend endpoints', () => {
+  const code = readBackend('routes', 'portfolio.py');
+
+  it('portfolio.py exists', () => {
+    expect(code).toBeDefined();
+  });
+
+  it('has GET /summary endpoint', () => {
+    expect(code).toMatch(/@router\.get\(["']\/summary["']\)/);
+  });
+
+  it('has GET /sites endpoint', () => {
+    expect(code).toMatch(/@router\.get\(["']\/sites["']\)/);
+  });
+
+  it('returns totals with kwh, eur, co2', () => {
+    expect(code).toMatch(/kwh_total/);
+    expect(code).toMatch(/eur_total/);
+    expect(code).toMatch(/co2_total/);
+  });
+
+  it('returns coverage with sites_total and sites_with_data', () => {
+    expect(code).toMatch(/sites_total/);
+    expect(code).toMatch(/sites_with_data/);
+  });
+
+  it('returns top_drift, top_base_night, top_peaks', () => {
+    expect(code).toMatch(/top_drift/);
+    expect(code).toMatch(/top_base_night/);
+    expect(code).toMatch(/top_peaks/);
+  });
+
+  it('sites endpoint supports sort, confidence, search, pagination', () => {
+    expect(code).toMatch(/sort.*kwh_desc/);
+    expect(code).toMatch(/confidence/);
+    expect(code).toMatch(/search/);
+    expect(code).toMatch(/limit.*Query/);
+    expect(code).toMatch(/offset.*Query/);
+  });
+
+  it('portfolio router is registered in main.py', () => {
+    const main = readBackend('main.py');
+    expect(main).toMatch(/portfolio_router/);
+  });
+});
+
+
+// ============================================================
+// AX. Portfolio V1 — Frontend page
+// ============================================================
+describe('AX · ConsumptionPortfolioPage structure', () => {
+  const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+
+  it('ConsumptionPortfolioPage.jsx exists', () => {
+    expect(code).toBeDefined();
+  });
+
+  it('calls getPortfolioSummary and getPortfolioSites', () => {
+    expect(code).toMatch(/getPortfolioSummary/);
+    expect(code).toMatch(/getPortfolioSites/);
+  });
+
+  it('has 4 KPI cards (kWh, EUR, CO2, Couverture)', () => {
+    expect(code).toMatch(/kWh total/);
+    expect(code).toMatch(/EUR total/);
+    expect(code).toMatch(/CO2e/);
+    expect(code).toMatch(/Couverture/);
+  });
+
+  it('has "Ou agir maintenant" section with 3 top-lists', () => {
+    expect(code).toMatch(/Ou agir maintenant/);
+    expect(code).toMatch(/Derives detectees/);
+    expect(code).toMatch(/Base nocturne elevee/);
+    expect(code).toMatch(/Pics de puissance/);
+  });
+
+  it('has site table with search, sort, confidence filters', () => {
+    expect(code).toMatch(/Rechercher un site/);
+    expect(code).toMatch(/setSort/);
+    expect(code).toMatch(/confidenceFilter/);
+    expect(code).toMatch(/anomalyFilter/);
+  });
+
+  it('has row actions (Explorer, Diagnostic, Voir facture, Creer action)', () => {
+    expect(code).toMatch(/\/consommations\/explorer\?site_ids=/);
+    expect(code).toMatch(/\/diagnostic-conso\?site_id=/);
+    expect(code).toMatch(/deepLinkWithContext/);
+    expect(code).toMatch(/deepLinkNewAction/);
+  });
+
+  it('has loading skeletons and empty state', () => {
+    expect(code).toMatch(/SkeletonCard/);
+    expect(code).toMatch(/EmptyState/);
+  });
+
+  it('has toast error handling', () => {
+    expect(code).toMatch(/useToast/);
+    expect(code).toMatch(/addToast.*error/);
+  });
+
+  it('has pagination (Precedent/Suivant)', () => {
+    expect(code).toMatch(/Precedent/);
+    expect(code).toMatch(/Suivant/);
+  });
+});
+
+
+// ============================================================
+// AY. Portfolio V1 — Route & Tab integration
+// ============================================================
+describe('AY · Portfolio route & tab integration', () => {
+  it('App.jsx has ConsumptionPortfolioPage lazy import', () => {
+    const app = readSrc('App.jsx');
+    expect(app).toMatch(/ConsumptionPortfolioPage/);
+  });
+
+  it('App.jsx has /consommations/portfolio route', () => {
+    const app = readSrc('App.jsx');
+    expect(app).toMatch(/path="portfolio".*ConsumptionPortfolioPage/);
+  });
+
+  it('ConsommationsPage has Portefeuille tab', () => {
+    const page = readSrc('pages', 'ConsommationsPage.jsx');
+    expect(page).toMatch(/Portefeuille/);
+    expect(page).toMatch(/\/consommations\/portfolio/);
+  });
+
+  it('api.js exports getPortfolioSummary and getPortfolioSites', () => {
+    const api = readSrc('services', 'api.js');
+    expect(api).toMatch(/export const getPortfolioSummary/);
+    expect(api).toMatch(/export const getPortfolioSites/);
+  });
+
+  it('api.js calls /portfolio/consumption/ endpoints', () => {
+    const api = readSrc('services', 'api.js');
+    expect(api).toMatch(/\/portfolio\/consumption\/summary/);
+    expect(api).toMatch(/\/portfolio\/consumption\/sites/);
+  });
+});

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -1289,3 +1289,85 @@ describe('BL · No hardcoded navigation URLs in conso scope', () => {
     expect(usages).not.toMatch(/navigate\(`\/consommations\/explorer/);
   });
 });
+
+// ============================================================
+// BM. Portfolio V2 — patrimoine-first features
+// ============================================================
+describe('BM · Portfolio V2 patrimoine-first', () => {
+  const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+  const backend = readBackend('routes', 'portfolio.py');
+
+  it('frontend has DataStatusBadge component', () => {
+    expect(code).toMatch(/DataStatusBadge/);
+    expect(code).toMatch(/data_status/);
+    expect(code).toMatch(/coverage_pct/);
+  });
+
+  it('frontend shows data_status badge per row', () => {
+    expect(code).toMatch(/<DataStatusBadge/);
+    expect(code).toMatch(/status=\{row\.data_status\}/);
+  });
+
+  it('frontend has Couverture column in table header', () => {
+    expect(code).toMatch(/Couverture/);
+  });
+
+  it('frontend has "Sans donnees" filter chip', () => {
+    expect(code).toMatch(/noDataFilter/);
+    expect(code).toMatch(/Sans donnees/);
+    expect(code).toMatch(/without_data/);
+  });
+
+  it('frontend has coverage sort option', () => {
+    expect(code).toMatch(/coverage.*Couverture donnees/);
+  });
+
+  it('frontend row click navigates to import if data_status is none', () => {
+    expect(code).toMatch(/data_status === 'none'/);
+    expect(code).toMatch(/toConsoImport/);
+  });
+
+  it('frontend shows inline "Importer" CTA for sites without data', () => {
+    expect(code).toMatch(/Importer/);
+    expect(code).toMatch(/<Upload/);
+  });
+
+  it('frontend shows last_reading_date per site', () => {
+    expect(code).toMatch(/last_reading_date/);
+    expect(code).toMatch(/Dernier releve/);
+  });
+
+  it('frontend passes date_from/date_to to toConsoExplorer in row actions', () => {
+    expect(code).toMatch(/toConsoExplorer\(\{.*date_from.*dates\.from/s);
+  });
+
+  it('frontend shows "X sans donnees" in header when applicable', () => {
+    expect(code).toMatch(/sites_without_data/);
+    expect(code).toMatch(/sans donnees/);
+  });
+
+  it('backend has data_status field (ok/partial/none)', () => {
+    expect(backend).toMatch(/"data_status":\s*data_status/);
+    expect(backend).toMatch(/data_status = "none"/);
+    expect(backend).toMatch(/data_status = "ok"/);
+    expect(backend).toMatch(/data_status = "partial"/);
+  });
+
+  it('backend has coverage_pct per site', () => {
+    expect(backend).toMatch(/"coverage_pct":\s*coverage_pct/);
+  });
+
+  it('backend has without_data filter', () => {
+    expect(backend).toMatch(/without_data/);
+    expect(backend).toMatch(/data_status.*==.*"none"/);
+  });
+
+  it('backend has coverage sort option', () => {
+    expect(backend).toMatch(/"coverage":/);
+    expect(backend).toMatch(/coverage_pct/);
+  });
+
+  it('backend summary includes sites_without_data', () => {
+    expect(backend).toMatch(/sites_without_data/);
+  });
+});

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -1076,8 +1076,8 @@ describe('BG · Portfolio V1.3 guided empty state', () => {
     expect(code).toMatch(/hasActiveFilters/);
   });
 
-  it('has "Reinitialiser filtres" button with RotateCcw icon', () => {
-    expect(code).toMatch(/Reinitialiser filtres/);
+  it('has "Reinitialiser les filtres" button with RotateCcw icon', () => {
+    expect(code).toMatch(/Reinitialiser les filtres/);
     expect(code).toMatch(/RotateCcw/);
   });
 
@@ -1089,7 +1089,7 @@ describe('BG · Portfolio V1.3 guided empty state', () => {
   it('shows contextual message based on hasActiveFilters', () => {
     expect(code).toMatch(/hasActiveFilters/);
     expect(code).toMatch(/reinitialiser les filtres/i);
-    expect(code).toMatch(/Importez des donnees/);
+    expect(code).toMatch(/Importez vos releves|Importez des donnees/);
   });
 });
 
@@ -1111,5 +1111,64 @@ describe('BH · Explorer scope coherence banner', () => {
 
   it('mentions multi-selection is available', () => {
     expect(code).toMatch(/multi-selection/i);
+  });
+});
+
+// ============================================================
+// BI. Portfolio API — skipSiteHeader defense-in-depth
+// ============================================================
+describe('BI · Portfolio API skipSiteHeader', () => {
+  const apiCode = readSrc('services', 'api.js');
+
+  it('interceptor supports skipSiteHeader flag', () => {
+    expect(apiCode).toMatch(/skipSiteHeader/);
+    expect(apiCode).toMatch(/!config\.skipSiteHeader/);
+  });
+
+  it('getPortfolioSummary passes skipSiteHeader: true', () => {
+    expect(apiCode).toMatch(/getPortfolioSummary.*skipSiteHeader:\s*true/);
+  });
+
+  it('getPortfolioSites passes skipSiteHeader: true', () => {
+    expect(apiCode).toMatch(/getPortfolioSites.*skipSiteHeader:\s*true/);
+  });
+});
+
+// ============================================================
+// BJ. Portfolio empty state — Cas A (no data) vs Cas B (filters)
+// ============================================================
+describe('BJ · Portfolio empty state Cas A vs Cas B', () => {
+  const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+
+  it('has Cas A empty state with data-empty="no-data"', () => {
+    expect(code).toMatch(/data-empty="no-data"/);
+    expect(code).toMatch(/Aucune donnee de consommation disponible/);
+  });
+
+  it('has Cas B empty state with data-empty="filters"', () => {
+    expect(code).toMatch(/data-empty="filters"/);
+    expect(code).toMatch(/Aucun site ne correspond aux filtres/);
+  });
+
+  it('Cas A shows import CTA via toConsoImport', () => {
+    expect(code).toMatch(/toConsoImport/);
+    expect(code).toMatch(/Importer des donnees/);
+  });
+
+  it('Cas B shows reset filters button', () => {
+    expect(code).toMatch(/Reinitialiser les filtres/);
+    expect(code).toMatch(/handleResetFilters/);
+  });
+
+  it('Cas B shows active filter chips (search, confidence, anomaly, actions)', () => {
+    expect(code).toMatch(/confidenceFilter/);
+    expect(code).toMatch(/anomalyFilter/);
+    expect(code).toMatch(/actionsFilter/);
+    expect(code).toMatch(/Anomalies uniquement/);
+  });
+
+  it('distinguishes Cas A vs Cas B via sites_total', () => {
+    expect(code).toMatch(/sites_total/);
+    expect(code).toMatch(/cov\?\.sites_total/);
   });
 });

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -1,0 +1,261 @@
+/**
+ * PROMEOS — Conso V2 Audit — Source-guard tests
+ * Verify consumption/performance/diagnostic pages have required constructs.
+ * Tests 100% readFileSync / regex — no DOM mock needed.
+ */
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const root = resolve(__dirname, '../../../');
+const readSrc = (...parts) => readFileSync(resolve(root, 'src', ...parts), 'utf-8');
+const readBackend = (...parts) => readFileSync(resolve(root, '..', 'backend', ...parts), 'utf-8');
+const srcExists = (...parts) => existsSync(resolve(root, 'src', ...parts));
+
+// ============================================================
+// AH. ConsumptionExplorerPage — filters & panels
+// ============================================================
+describe('AH · ConsumptionExplorerPage structure', () => {
+  const code = readSrc('pages', 'ConsumptionExplorerPage.jsx');
+
+  it('has site filter (useScope or site selector)', () => {
+    expect(code).toMatch(/useScope|StickyFilterBar|selectedSites/);
+  });
+
+  it('has period filter (days/dateRange)', () => {
+    expect(code).toMatch(/days|dateRange|date_from|date_to/);
+  });
+
+  it('has granularity selector', () => {
+    expect(code).toMatch(/granularity|granularite/i);
+  });
+
+  it('has energy type selector', () => {
+    expect(code).toMatch(/energyType|energy_type|electricity|gas/);
+  });
+
+  it('renders TimeseriesPanel', () => {
+    expect(code).toMatch(/TimeseriesPanel/);
+  });
+
+  it('renders TunnelPanel', () => {
+    expect(code).toMatch(/TunnelPanel/);
+  });
+
+  it('renders TargetsPanel', () => {
+    expect(code).toMatch(/TargetsPanel/);
+  });
+
+  it('renders HPHCPanel', () => {
+    expect(code).toMatch(/HPHCPanel/);
+  });
+
+  it('handles availability data (has_data check)', () => {
+    expect(code).toMatch(/has_data|availability/);
+  });
+});
+
+// ============================================================
+// AI. ConsumptionDiagPage — diagnostic capabilities
+// ============================================================
+describe('AI · ConsumptionDiagPage structure', () => {
+  const code = readSrc('pages', 'ConsumptionDiagPage.jsx');
+
+  it('calls getConsumptionInsights', () => {
+    expect(code).toMatch(/getConsumptionInsights/);
+  });
+
+  it('calls runConsumptionDiagnose', () => {
+    expect(code).toMatch(/runConsumptionDiagnose/);
+  });
+
+  it('has insight type filter (hors_horaires, base_load, etc.)', () => {
+    expect(code).toMatch(/hors_horaires|base_load|pointe|derive|data_gap/);
+  });
+
+  it('has EvidenceDrawer component', () => {
+    expect(code).toMatch(/EvidenceDrawer|evidence/i);
+  });
+
+  it('has workflow status management (patchConsumptionInsight)', () => {
+    expect(code).toMatch(/patchConsumptionInsight|insight_status/);
+  });
+
+  it('renders summary KPI cards', () => {
+    expect(code).toMatch(/SummaryCard|estimated_loss/);
+  });
+});
+
+// ============================================================
+// AJ. MonitoringPage — performance capabilities
+// ============================================================
+describe('AJ · MonitoringPage structure', () => {
+  const code = readSrc('pages', 'MonitoringPage.jsx');
+
+  it('calls getMonitoringKpis', () => {
+    expect(code).toMatch(/getMonitoringKpis/);
+  });
+
+  it('has HeatmapGrid component', () => {
+    expect(code).toMatch(/HeatmapGrid|heatmap/i);
+  });
+
+  it('has comparison mode (N-1)', () => {
+    expect(code).toMatch(/compare|getMonitoringKpisCompare|n-1|previous/i);
+  });
+
+  it('has emissions data', () => {
+    expect(code).toMatch(/emissions|co2|CO2/);
+  });
+
+  it('has off-hours analysis', () => {
+    expect(code).toMatch(/off.?hours|hors.?horaires|OffHoursDrawer/i);
+  });
+
+  it('has climate/weather correlation', () => {
+    expect(code).toMatch(/climate|ClimateScatter|weather|meteo/i);
+  });
+
+  it('has alert workflow (ack/resolve)', () => {
+    expect(code).toMatch(/ackMonitoringAlert|resolveMonitoringAlert/);
+  });
+});
+
+// ============================================================
+// AK. Backend — consumption endpoints exist
+// ============================================================
+describe('AK · Backend consumption routes', () => {
+  const diag = readBackend('routes', 'consumption_diagnostic.py');
+  const ems = readBackend('routes', 'ems.py');
+  const monitoring = readBackend('routes', 'monitoring.py');
+
+  it('consumption_diagnostic has /availability endpoint', () => {
+    expect(diag).toMatch(/@router\.(get|post).*availability/i);
+  });
+
+  it('consumption_diagnostic has /tunnel_v2 endpoint', () => {
+    expect(diag).toMatch(/tunnel_v2/);
+  });
+
+  it('consumption_diagnostic has /targets endpoint', () => {
+    expect(diag).toMatch(/@router\.(get|post).*targets/i);
+  });
+
+  it('consumption_diagnostic has /diagnose endpoint', () => {
+    expect(diag).toMatch(/@router\.post.*diagnose/i);
+  });
+
+  it('consumption_diagnostic has /hphc_breakdown_v2 endpoint', () => {
+    expect(diag).toMatch(/hphc_breakdown_v2/);
+  });
+
+  it('EMS has /timeseries endpoint', () => {
+    expect(ems).toMatch(/@router\.get.*timeseries/i);
+  });
+
+  it('EMS has /signature/run endpoint', () => {
+    expect(ems).toMatch(/signature.*run/i);
+  });
+
+  it('EMS has /weather endpoint', () => {
+    expect(ems).toMatch(/@router\.get.*weather/i);
+  });
+
+  it('monitoring has /kpis endpoint', () => {
+    expect(monitoring).toMatch(/@router\.get.*kpis/i);
+  });
+
+  it('monitoring has /kpis/compare endpoint', () => {
+    expect(monitoring).toMatch(/kpis.*compare/i);
+  });
+
+  it('monitoring has /alerts endpoint', () => {
+    expect(monitoring).toMatch(/@router\.get.*alerts/i);
+  });
+
+  it('monitoring has /emissions endpoint', () => {
+    expect(monitoring).toMatch(/emissions/i);
+  });
+});
+
+// ============================================================
+// AL. Backend — diagnostic service capabilities
+// ============================================================
+describe('AL · Diagnostic service detectors', () => {
+  const svc = readBackend('services', 'consumption_diagnostic.py');
+
+  it('has hors_horaires detector', () => {
+    expect(svc).toMatch(/_detect_hors_horaires/);
+  });
+
+  it('has base_load detector', () => {
+    expect(svc).toMatch(/_detect_base_load/);
+  });
+
+  it('has pointe detector', () => {
+    expect(svc).toMatch(/_detect_pointe/);
+  });
+
+  it('has derive detector', () => {
+    expect(svc).toMatch(/_detect_derive/);
+  });
+
+  it('has data_gap detector', () => {
+    expect(svc).toMatch(/_detect_data_gap/);
+  });
+
+  it('generates recommended actions per detector', () => {
+    expect(svc).toMatch(/_actions_hors_horaires|_actions_base_load/);
+  });
+});
+
+// ============================================================
+// AM. api.js — consumption API functions
+// ============================================================
+describe('AM · api.js consumption functions', () => {
+  const api = readSrc('services', 'api.js');
+
+  const required = [
+    'getConsumptionAvailability',
+    'getConsumptionTunnelV2',
+    'getConsumptionTargets',
+    'getTargetsProgressionV2',
+    'getHPHCBreakdownV2',
+    'getConsumptionInsights',
+    'runConsumptionDiagnose',
+    'getMonitoringKpis',
+    'getMonitoringAlerts',
+    'getEmsTimeseries',
+  ];
+
+  required.forEach(fn => {
+    it(`exports ${fn}`, () => {
+      expect(api).toMatch(new RegExp(`export (const|function) ${fn}`));
+    });
+  });
+});
+
+// ============================================================
+// AN. Data quality — backend granularity support
+// ============================================================
+describe('AN · Granularity & data quality', () => {
+  const ems = readBackend('routes', 'ems.py');
+  const tsService = readBackend('services', 'ems', 'timeseries_service.py');
+
+  it('EMS supports multiple granularities', () => {
+    expect(ems).toMatch(/granularity/);
+  });
+
+  it('timeseries service enforces point cap', () => {
+    expect(tsService).toMatch(/5000|MAX_POINTS|cap/i);
+  });
+
+  it('timeseries service has availability/gaps detection', () => {
+    expect(tsService).toMatch(/availability|gaps|coverage/i);
+  });
+
+  it('consumption_diagnostic detects data gaps', () => {
+    const svc = readBackend('services', 'consumption_diagnostic.py');
+    expect(svc).toMatch(/_detect_data_gap/);
+  });
+});

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -259,3 +259,113 @@ describe('AN · Granularity & data quality', () => {
     expect(svc).toMatch(/_detect_data_gap/);
   });
 });
+
+// ============================================================
+// AO. QW6 — Toast errors + empty states + skeletons
+// ============================================================
+describe('AO · QW6 toast errors & empty states', () => {
+  const explorer = readSrc('pages', 'ConsumptionExplorerPage.jsx');
+  const diag = readSrc('pages', 'ConsumptionDiagPage.jsx');
+  const monitoring = readSrc('pages', 'MonitoringPage.jsx');
+
+  it('ConsumptionExplorerPage imports useToast', () => {
+    expect(explorer).toMatch(/useToast/);
+  });
+
+  it('ConsumptionExplorerPage has no console.error', () => {
+    expect(explorer).not.toMatch(/console\.error/);
+  });
+
+  it('ConsumptionExplorerPage passes toast prop to panels', () => {
+    expect(explorer).toMatch(/toast=\{toast\}/);
+  });
+
+  it('ConsumptionExplorerPage SmartEmptyState has onGenerateDemo', () => {
+    expect(explorer).toMatch(/onGenerateDemo/);
+  });
+
+  it('ConsumptionExplorerPage SmartEmptyState has isExpert debug', () => {
+    expect(explorer).toMatch(/isExpert.*&&.*reasons/);
+  });
+
+  it('ConsumptionDiagPage has no console.error', () => {
+    expect(diag).not.toMatch(/console\.error/);
+  });
+
+  it('ConsumptionDiagPage uses SkeletonCard for loading', () => {
+    expect(diag).toMatch(/SkeletonCard/);
+  });
+
+  it('MonitoringPage has no console.error', () => {
+    expect(monitoring).not.toMatch(/console\.error/);
+  });
+
+  it('MonitoringPage uses SkeletonCard', () => {
+    expect(monitoring).toMatch(/SkeletonCard/);
+  });
+});
+
+// ============================================================
+// AP. QW2 — ConsoKpiHeader component
+// ============================================================
+describe('AP · QW2 ConsoKpiHeader', () => {
+  it('ConsoKpiHeader.jsx exists', () => {
+    expect(srcExists('components', 'ConsoKpiHeader.jsx')).toBe(true);
+  });
+
+  it('ConsoKpiHeader has 6 KPI tiles', () => {
+    const code = readSrc('components', 'ConsoKpiHeader.jsx');
+    expect(code).toMatch(/kWh total/);
+    expect(code).toMatch(/EUR total/);
+    expect(code).toMatch(/EUR\/MWh/);
+    expect(code).toMatch(/CO2e/);
+    expect(code).toMatch(/Pic kW.*P95/);
+    expect(code).toMatch(/Base nocturne/);
+  });
+
+  it('ConsoKpiHeader accepts tunnel + hphc + progression props', () => {
+    const code = readSrc('components', 'ConsoKpiHeader.jsx');
+    expect(code).toMatch(/tunnel/);
+    expect(code).toMatch(/hphc/);
+    expect(code).toMatch(/progression/);
+  });
+
+  it('ConsoKpiHeader has confidence badge', () => {
+    const code = readSrc('components', 'ConsoKpiHeader.jsx');
+    expect(code).toMatch(/TrustBadge|confidence/);
+  });
+
+  it('ConsumptionExplorerPage integrates ConsoKpiHeader', () => {
+    const explorer = readSrc('pages', 'ConsumptionExplorerPage.jsx');
+    expect(explorer).toMatch(/ConsoKpiHeader/);
+  });
+});
+
+// ============================================================
+// AQ. QW5 — Deep-link "Voir facture" from diagnostic
+// ============================================================
+describe('AQ · QW5 deep-link facture', () => {
+  const diag = readSrc('pages', 'ConsumptionDiagPage.jsx');
+
+  it('imports deepLinkWithContext', () => {
+    expect(diag).toMatch(/deepLinkWithContext/);
+  });
+
+  it('has onViewInvoice handler', () => {
+    expect(diag).toMatch(/handleViewInvoice|onViewInvoice/);
+  });
+
+  it('EvidenceDrawer has "Voir facture" CTA', () => {
+    expect(diag).toMatch(/Voir facture/);
+  });
+
+  it('navigates to /bill-intel with context', () => {
+    expect(diag).toMatch(/deepLinkWithContext/);
+  });
+
+  it('deepLink.js exports deepLinkWithContext and deepLinkNewAction', () => {
+    const dl = readSrc('services', 'deepLink.js');
+    expect(dl).toMatch(/export function deepLinkWithContext/);
+    expect(dl).toMatch(/export function deepLinkNewAction/);
+  });
+});

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -380,7 +380,7 @@ describe('AR · P1-1 benchmark reference curve', () => {
 
   it('BenchmarkPanel has toggle checkbox', () => {
     const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
-    expect(code).toMatch(/Comparer a une courbe de reference/);
+    expect(code).toMatch(/Comparer a la courbe moyenne/);
     expect(code).toMatch(/type="checkbox"/);
   });
 
@@ -398,8 +398,8 @@ describe('AR · P1-1 benchmark reference curve', () => {
 
   it('BenchmarkPanel has 4 KPI cards (actual, reference, ecart, couverture)', () => {
     const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
-    expect(code).toMatch(/Conso reelle/);
-    expect(code).toMatch(/Reference/);
+    expect(code).toMatch(/Votre consommation/);
+    expect(code).toMatch(/Moyenne sites similaires/);
     expect(code).toMatch(/Ecart/);
     expect(code).toMatch(/Couverture/);
   });
@@ -455,9 +455,9 @@ describe('AS · P1-2 heatmap interactive', () => {
     expect(code).toMatch(/cursor-pointer/);
   });
 
-  it('HeatmapChart shows "Cliquez pour le detail" when clickable', () => {
+  it('HeatmapChart shows "Cliquez sur un creneau pour le detail" when clickable', () => {
     const code = readSrc('pages', 'consumption', 'HeatmapChart.jsx');
-    expect(code).toMatch(/Cliquez pour le detail/);
+    expect(code).toMatch(/Cliquez sur un creneau pour le detail/);
   });
 
   it('HeatmapChart has title attribute on cells for native tooltip', () => {
@@ -478,11 +478,11 @@ describe('AS · P1-2 heatmap interactive', () => {
     expect(code).toMatch(/dayFilter/);
   });
 
-  it('SignaturePanel has filter pills (Semaine typique / Ouvre / Week-end)', () => {
+  it('SignaturePanel has filter pills (Semaine typique / Jours ouvres / Week-ends)', () => {
     const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
     expect(code).toMatch(/Semaine typique/);
-    expect(code).toMatch(/Ouvre/);
-    expect(code).toMatch(/Week-end/);
+    expect(code).toMatch(/Jours ouvres/);
+    expect(code).toMatch(/Week-ends/);
   });
 
   it('SignaturePanel renders drill-down AreaChart for selected cell', () => {
@@ -551,5 +551,109 @@ describe('AT · P1-3 overlay meteo UTC', () => {
   it('backend weather_hourly returns Z suffix timestamps', () => {
     const ems = readBackend('routes', 'ems.py');
     expect(ems).toMatch(/:00:00Z/);
+  });
+});
+
+// ============================================================
+// AU. P1.1 — Polish UX labels + tooltips + confidence
+// ============================================================
+describe('AU · P1.1 polish labels & tooltips', () => {
+  it('BenchmarkPanel uses "courbe moyenne de sites similaires" label', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/courbe moyenne de sites similaires/);
+  });
+
+  it('BenchmarkPanel KPI shows "Votre consommation" and "Moyenne sites similaires"', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/Votre consommation/);
+    expect(code).toMatch(/Moyenne sites similaires/);
+  });
+
+  it('BenchmarkPanel has confidence tooltip with HelpCircle', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/Comment calcule/);
+    expect(code).toMatch(/HelpCircle/);
+  });
+
+  it('BenchmarkPanel KPI shows source (releves / profil statistique)', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/Source : releves/);
+    expect(code).toMatch(/Profil statistique/);
+  });
+
+  it('ConsoKpiHeader has EUR source (Estime HP/HC)', () => {
+    const code = readSrc('components', 'ConsoKpiHeader.jsx');
+    expect(code).toMatch(/Estime HP\/HC/);
+    expect(code).toMatch(/eurSource/);
+  });
+
+  it('ConsoKpiHeader has confidence tooltip with HelpCircle', () => {
+    const code = readSrc('components', 'ConsoKpiHeader.jsx');
+    expect(code).toMatch(/Comment calcule/);
+    expect(code).toMatch(/HelpCircle/);
+  });
+
+  it('ConsoKpiHeader KPI tiles have tooltip prop', () => {
+    const code = readSrc('components', 'ConsoKpiHeader.jsx');
+    expect(code).toMatch(/tooltip=/);
+    // At least 6 tooltip props (one per tile) — some use template literals
+    const matches = code.match(/tooltip[=]/g);
+    expect(matches?.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('SignaturePanel uses "Jours ouvres" and "Week-ends" labels', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/Jours ouvres/);
+    expect(code).toMatch(/Week-ends/);
+  });
+
+  it('HeatmapChart uses "consommation moyenne" label', () => {
+    const code = readSrc('pages', 'consumption', 'HeatmapChart.jsx');
+    expect(code).toMatch(/consommation moyenne/);
+  });
+
+  it('MeteoPanel has weather source badge (reelle vs synthetique)', () => {
+    const code = readSrc('pages', 'consumption', 'MeteoPanel.jsx');
+    expect(code).toMatch(/Meteo reelle/);
+    expect(code).toMatch(/Meteo synthetique/);
+    expect(code).toMatch(/isRealWeather/);
+  });
+});
+
+// ============================================================
+// AV. P1.1 — Drill-down CTAs (Analyser + Voir facture)
+// ============================================================
+describe('AV · P1.1 drill-down CTAs', () => {
+  it('SignaturePanel imports deepLinkWithContext', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/deepLinkWithContext/);
+  });
+
+  it('SignaturePanel has "Analyser ce creneau" CTA linking to /diagnostic-conso', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/Analyser ce creneau/);
+    expect(code).toMatch(/diagnostic-conso/);
+  });
+
+  it('SignaturePanel has "Voir facture" CTA with deepLinkWithContext', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/Voir facture/);
+    expect(code).toMatch(/deepLinkWithContext.*primarySiteId/);
+  });
+
+  it('SignaturePanel uses primarySiteId from siteIds for CTAs', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/primarySiteId.*=.*siteIds/);
+  });
+
+  it('SignaturePanel passes site_id and hour to diagnostic link', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/site_id=.*primarySiteId/);
+    expect(code).toMatch(/hour=.*drillDown\.hour/);
+  });
+
+  it('ConsumptionExplorerPage passes siteIds to SignaturePanel (scope coherence)', () => {
+    const explorer = readSrc('pages', 'ConsumptionExplorerPage.jsx');
+    expect(explorer).toMatch(/SignaturePanel siteIds=\{siteIds\}/);
   });
 });

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -369,3 +369,187 @@ describe('AQ · QW5 deep-link facture', () => {
     expect(dl).toMatch(/export function deepLinkNewAction/);
   });
 });
+
+// ============================================================
+// AR. P1-1 — Benchmark reference curve
+// ============================================================
+describe('AR · P1-1 benchmark reference curve', () => {
+  it('BenchmarkPanel.jsx exists', () => {
+    expect(srcExists('pages', 'consumption', 'BenchmarkPanel.jsx')).toBe(true);
+  });
+
+  it('BenchmarkPanel has toggle checkbox', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/Comparer a une courbe de reference/);
+    expect(code).toMatch(/type="checkbox"/);
+  });
+
+  it('BenchmarkPanel has 3 famille options and 5 puissance options', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/habitat/);
+    expect(code).toMatch(/petit_tertiaire/);
+    expect(code).toMatch(/entreprise/);
+    expect(code).toMatch(/0-6/);
+    expect(code).toMatch(/6-9/);
+    expect(code).toMatch(/9-12/);
+    expect(code).toMatch(/12-36/);
+    expect(code).toMatch(/>36/);
+  });
+
+  it('BenchmarkPanel has 4 KPI cards (actual, reference, ecart, couverture)', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/Conso reelle/);
+    expect(code).toMatch(/Reference/);
+    expect(code).toMatch(/Ecart/);
+    expect(code).toMatch(/Couverture/);
+  });
+
+  it('BenchmarkPanel has TrustBadge for confidence', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/TrustBadge/);
+    expect(code).toMatch(/confidence/);
+  });
+
+  it('BenchmarkPanel calls getEmsReferenceProfile', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/getEmsReferenceProfile/);
+  });
+
+  it('BenchmarkPanel renders dual-area chart (actual + reference)', () => {
+    const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
+    expect(code).toMatch(/dataKey="actual"/);
+    expect(code).toMatch(/dataKey="reference"/);
+  });
+
+  it('ConsumptionExplorerPage integrates BenchmarkPanel in both modes', () => {
+    const explorer = readSrc('pages', 'ConsumptionExplorerPage.jsx');
+    // Should appear at least twice (Classic + Expert)
+    const matches = explorer.match(/BenchmarkPanel/g);
+    expect(matches?.length).toBeGreaterThanOrEqual(3); // import + 2 usages
+  });
+
+  it('api.js exports getEmsReferenceProfile', () => {
+    const api = readSrc('services', 'api.js');
+    expect(api).toMatch(/export const getEmsReferenceProfile/);
+  });
+
+  it('backend has /reference_profile endpoint with REFERENCE_PROFILES', () => {
+    const ems = readBackend('routes', 'ems.py');
+    expect(ems).toMatch(/@router\.get.*reference_profile/);
+    expect(ems).toMatch(/REFERENCE_PROFILES/);
+  });
+});
+
+// ============================================================
+// AS. P1-2 — Heatmap interactive (drill-down + filter)
+// ============================================================
+describe('AS · P1-2 heatmap interactive', () => {
+  it('HeatmapChart accepts onCellClick and filter props', () => {
+    const code = readSrc('pages', 'consumption', 'HeatmapChart.jsx');
+    expect(code).toMatch(/onCellClick/);
+    expect(code).toMatch(/filter/);
+  });
+
+  it('HeatmapChart has cursor-pointer on clickable cells', () => {
+    const code = readSrc('pages', 'consumption', 'HeatmapChart.jsx');
+    expect(code).toMatch(/cursor-pointer/);
+  });
+
+  it('HeatmapChart shows "Cliquez pour le detail" when clickable', () => {
+    const code = readSrc('pages', 'consumption', 'HeatmapChart.jsx');
+    expect(code).toMatch(/Cliquez pour le detail/);
+  });
+
+  it('HeatmapChart has title attribute on cells for native tooltip', () => {
+    const code = readSrc('pages', 'consumption', 'HeatmapChart.jsx');
+    expect(code).toMatch(/title=/);
+  });
+
+  it('HeatmapChart filters weekday/weekend via visibleDays', () => {
+    const code = readSrc('pages', 'consumption', 'HeatmapChart.jsx');
+    expect(code).toMatch(/visibleDays/);
+    expect(code).toMatch(/weekday/);
+    expect(code).toMatch(/weekend/);
+  });
+
+  it('SignaturePanel has drill-down state and dayFilter', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/drillDown/);
+    expect(code).toMatch(/dayFilter/);
+  });
+
+  it('SignaturePanel has filter pills (Semaine typique / Ouvre / Week-end)', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/Semaine typique/);
+    expect(code).toMatch(/Ouvre/);
+    expect(code).toMatch(/Week-end/);
+  });
+
+  it('SignaturePanel renders drill-down AreaChart for selected cell', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/drillDownData/);
+    expect(code).toMatch(/AreaChart/);
+    expect(code).toMatch(/Detail/);
+  });
+
+  it('SignaturePanel passes onCellClick to HeatmapChart', () => {
+    const code = readSrc('pages', 'consumption', 'SignaturePanel.jsx');
+    expect(code).toMatch(/onCellClick/);
+  });
+});
+
+// ============================================================
+// AT. P1-3 — Overlay meteo UTC (DST-safe)
+// ============================================================
+describe('AT · P1-3 overlay meteo UTC', () => {
+  it('MeteoPanel imports getEmsWeatherHourly', () => {
+    const code = readSrc('pages', 'consumption', 'MeteoPanel.jsx');
+    expect(code).toMatch(/getEmsWeatherHourly/);
+  });
+
+  it('MeteoPanel has "Afficher la temperature" toggle', () => {
+    const code = readSrc('pages', 'consumption', 'MeteoPanel.jsx');
+    expect(code).toMatch(/Afficher la temperature/);
+    expect(code).toMatch(/showTemp/);
+  });
+
+  it('MeteoPanel has UTC weather fetch with fallback to synthetic', () => {
+    const code = readSrc('pages', 'consumption', 'MeteoPanel.jsx');
+    expect(code).toMatch(/utcWeather/);
+    expect(code).toMatch(/generateSyntheticTemp/);
+  });
+
+  it('MeteoPanel shows weather source in disclaimer', () => {
+    const code = readSrc('pages', 'consumption', 'MeteoPanel.jsx');
+    expect(code).toMatch(/API UTC.*serveur.*DST-safe/);
+    expect(code).toMatch(/synthetique/);
+  });
+
+  it('MeteoPanel conditionally renders temperature Line and YAxis', () => {
+    const code = readSrc('pages', 'consumption', 'MeteoPanel.jsx');
+    expect(code).toMatch(/showTemp &&/);
+    expect(code).toMatch(/yAxisId="temp"/);
+  });
+
+  it('api.js exports getEmsWeatherHourly', () => {
+    const api = readSrc('services', 'api.js');
+    expect(api).toMatch(/export const getEmsWeatherHourly/);
+  });
+
+  it('backend has /weather_hourly endpoint with UTC timestamps', () => {
+    const ems = readBackend('routes', 'ems.py');
+    expect(ems).toMatch(/@router\.get.*weather_hourly/);
+    expect(ems).toMatch(/timezone.*UTC/);
+  });
+
+  it('backend weather_hourly uses sinusoidal interpolation', () => {
+    const ems = readBackend('routes', 'ems.py');
+    expect(ems).toMatch(/math\.sin/);
+    expect(ems).toMatch(/phase/);
+  });
+
+  it('backend weather_hourly returns Z suffix timestamps', () => {
+    const ems = readBackend('routes', 'ems.py');
+    expect(ems).toMatch(/:00:00Z/);
+  });
+});

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -724,18 +724,18 @@ describe('AX · ConsumptionPortfolioPage structure', () => {
     expect(code).toMatch(/getPortfolioSites/);
   });
 
-  it('has 4 KPI cards (kWh, EUR, CO2, Couverture)', () => {
+  it('has 4 KPI cards (kWh, EUR/Cout, CO2, Couverture)', () => {
     expect(code).toMatch(/kWh total/);
-    expect(code).toMatch(/EUR total/);
-    expect(code).toMatch(/CO2e/);
+    expect(code).toMatch(/Cout estime|EUR total/);
+    expect(code).toMatch(/CO2|Emissions/);
     expect(code).toMatch(/Couverture/);
   });
 
-  it('has "Ou agir maintenant" section with 4 top-lists', () => {
-    expect(code).toMatch(/Ou agir maintenant/);
-    expect(code).toMatch(/Impact estime/);
+  it('has "Ou agir" section with 4 top-lists', () => {
+    expect(code).toMatch(/Ou agir/);
+    expect(code).toMatch(/Impact.*estime/);
     expect(code).toMatch(/Derives detectees/);
-    expect(code).toMatch(/Base nocturne elevee/);
+    expect(code).toMatch(/nocturne/i);
     expect(code).toMatch(/Pics de puissance/);
   });
 
@@ -747,10 +747,10 @@ describe('AX · ConsumptionPortfolioPage structure', () => {
   });
 
   it('has row actions (Explorer, Diagnostic, Voir facture, Creer action)', () => {
-    expect(code).toMatch(/\/consommations\/explorer\?site_ids=/);
-    expect(code).toMatch(/\/diagnostic-conso\?site_id=/);
-    expect(code).toMatch(/deepLinkWithContext/);
-    expect(code).toMatch(/deepLinkNewAction/);
+    expect(code).toMatch(/toConsoExplorer|\/consommations\/explorer/);
+    expect(code).toMatch(/toConsoDiag|\/diagnostic-conso/);
+    expect(code).toMatch(/toBillIntel|deepLinkWithContext/);
+    expect(code).toMatch(/toActionNew|deepLinkNewAction/);
   });
 
   it('has loading skeletons and empty state', () => {
@@ -862,7 +862,7 @@ describe('BA · Portfolio V1.1 backend enhancements', () => {
   });
 });
 
-describe('BB · Portfolio V1.1 frontend enhancements', () => {
+describe('BB · Portfolio V1.1+ frontend enhancements', () => {
   const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
 
   it('has Impact EUR column header', () => {
@@ -893,21 +893,72 @@ describe('BB · Portfolio V1.1 frontend enhancements', () => {
   });
 
   it('has grouped action CTA button', () => {
-    expect(code).toMatch(/Creer action portefeuille/);
     expect(code).toMatch(/handleGroupedAction/);
-    expect(code).toMatch(/campaign_sites/);
+    expect(code).toMatch(/campaign_sites|site_ids/);
+    expect(code).toMatch(/Lancer campagne/);
   });
 
   it('has top_impact section in "Ou agir"', () => {
     expect(code).toMatch(/top_impact/);
-    expect(code).toMatch(/Impact estime/);
+    expect(code).toMatch(/Impact.*estime/);
   });
 });
 
 // ============================================================
-// BC. Portfolio V1.2 — scope banner + deep-links + empty state
+// BC. Route Registry — navigation sans surprise
 // ============================================================
-describe('BC · Portfolio V1.2 scope coherence banner', () => {
+describe('BC · Route registry file exists and exports helpers', () => {
+  const code = readSrc('services', 'routes.js');
+
+  it('exports toConsoExplorer', () => {
+    expect(code).toMatch(/export function toConsoExplorer/);
+  });
+
+  it('exports toConsoDiag', () => {
+    expect(code).toMatch(/export function toConsoDiag/);
+  });
+
+  it('exports toBillIntel', () => {
+    expect(code).toMatch(/export function toBillIntel/);
+  });
+
+  it('exports toActionNew', () => {
+    expect(code).toMatch(/export function toActionNew/);
+  });
+
+  it('exports toAction', () => {
+    expect(code).toMatch(/export function toAction/);
+  });
+
+  it('exports toConsoImport', () => {
+    expect(code).toMatch(/export function toConsoImport/);
+  });
+
+  it('toConsoExplorer builds /consommations/explorer with sites param', () => {
+    expect(code).toMatch(/\/consommations\/explorer/);
+    expect(code).toMatch(/sites/);
+  });
+
+  it('toConsoDiag builds /diagnostic-conso with site_id param', () => {
+    expect(code).toMatch(/\/diagnostic-conso/);
+    expect(code).toMatch(/site_id/);
+  });
+
+  it('toBillIntel builds /bill-intel with site_id and month params', () => {
+    expect(code).toMatch(/\/bill-intel/);
+    expect(code).toMatch(/month/);
+  });
+
+  it('toActionNew builds /actions/new with type, source, campaign_sites', () => {
+    expect(code).toMatch(/\/actions\/new/);
+    expect(code).toMatch(/campaign_sites/);
+  });
+});
+
+// ============================================================
+// BD. Portfolio V1.3 — scope coherence + route registry usage
+// ============================================================
+describe('BD · Portfolio V1.3 scope coherence banner', () => {
   const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
 
   it('imports useScope from ScopeContext', () => {
@@ -915,14 +966,15 @@ describe('BC · Portfolio V1.2 scope coherence banner', () => {
     expect(code).toMatch(/ScopeContext/);
   });
 
-  it('reads selectedSiteId and resetScope from useScope', () => {
+  it('reads selectedSiteId, resetScope, scopeLabel from useScope', () => {
     expect(code).toMatch(/selectedSiteId/);
     expect(code).toMatch(/resetScope/);
+    expect(code).toMatch(/scopeLabel/);
   });
 
-  it('shows scope banner when selectedSiteId is set', () => {
-    expect(code).toMatch(/selectedSiteId/);
-    expect(code).toMatch(/Vue portefeuille = multi-sites/);
+  it('shows scope banner with user-friendly message', () => {
+    expect(code).toMatch(/Portefeuille = vue multi-sites/);
+    expect(code).toMatch(/scopeLabel/);
   });
 
   it('has "Passer a Tous les sites" button calling resetScope', () => {
@@ -935,37 +987,85 @@ describe('BC · Portfolio V1.2 scope coherence banner', () => {
   });
 });
 
-describe('BD · Portfolio V1.2 top-list deep-links', () => {
+describe('BE · Portfolio V1.3 uses route registry (no hardcoded routes)', () => {
   const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
 
-  it('has TopListActions component with 4 action buttons', () => {
-    expect(code).toMatch(/TopListActions/);
+  it('imports route helpers from services/routes', () => {
+    expect(code).toMatch(/from.*services\/routes/);
+    expect(code).toMatch(/toConsoExplorer/);
+    expect(code).toMatch(/toConsoDiag/);
+    expect(code).toMatch(/toBillIntel/);
+    expect(code).toMatch(/toActionNew/);
   });
 
-  it('top-list actions include Explorer link (site_ids param)', () => {
-    expect(code).toMatch(/\/consommations\/explorer\?site_ids=/);
+  it('does NOT import deepLinkWithContext or deepLinkNewAction (replaced by registry)', () => {
+    expect(code).not.toMatch(/deepLinkWithContext/);
+    expect(code).not.toMatch(/deepLinkNewAction/);
   });
 
-  it('top-list actions include Diagnostic link (site_id param)', () => {
-    expect(code).toMatch(/\/diagnostic-conso\?site_id=/);
+  it('TopListActions uses route registry helpers', () => {
+    expect(code).toMatch(/toConsoExplorer.*site_id.*siteId/);
+    expect(code).toMatch(/toConsoDiag.*site_id.*siteId/);
+    expect(code).toMatch(/toBillIntel.*site_id.*siteId/);
+    expect(code).toMatch(/toActionNew.*source.*portfolio_toplist/);
   });
 
-  it('top-list actions include Voir facture via deepLinkWithContext', () => {
-    expect(code).toMatch(/deepLinkWithContext/);
+  it('table row actions use route registry helpers', () => {
+    expect(code).toMatch(/toConsoExplorer.*site_id.*row\.site_id/);
+    expect(code).toMatch(/toBillIntel.*site_id.*row\.site_id/);
   });
 
-  it('top-list actions include Creer action via deepLinkNewAction', () => {
-    expect(code).toMatch(/deepLinkNewAction.*portfolio_toplist/);
-  });
-
-  it('all 4 top-lists use TopListActions', () => {
+  it('has TopListActions with all 4 top-lists', () => {
     const matches = code.match(/TopListActions/g);
-    // TopListActions definition + 4 usages in top-lists + table rows don't use it
     expect(matches.length).toBeGreaterThanOrEqual(5);
   });
 });
 
-describe('BE · Portfolio V1.2 guided empty state', () => {
+describe('BF · Portfolio V1.3 pilotage UX', () => {
+  const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+
+  it('has pilotage header with site count and period', () => {
+    expect(code).toMatch(/Vous pilotez/);
+    expect(code).toMatch(/sites_total/);
+  });
+
+  it('has coverage % with tooltip', () => {
+    expect(code).toMatch(/coveragePct/);
+    expect(code).toMatch(/Couverture/);
+    expect(code).toMatch(/HelpCircle/);
+  });
+
+  it('has KPI card with "Cout estime" label and source explanation', () => {
+    expect(code).toMatch(/Cout estime/);
+    expect(code).toMatch(/0,18 EUR\/kWh/);
+  });
+
+  it('has KPI card with "Emissions CO2" and ADEME source', () => {
+    expect(code).toMatch(/Emissions CO2/);
+    expect(code).toMatch(/ADEME 2024/);
+  });
+
+  it('has row click handler navigating to Explorer', () => {
+    expect(code).toMatch(/handleRowClick/);
+    expect(code).toMatch(/cursor-pointer/);
+    expect(code).toMatch(/Cliquez pour explorer/);
+  });
+
+  it('Actions column is smart: shows eye icon when actions exist, plus icon otherwise', () => {
+    expect(code).toMatch(/Eye/);
+    expect(code).toMatch(/open_actions_count > 0/);
+    expect(code).toMatch(/Voir les actions en cours/);
+    expect(code).toMatch(/Creer une action/);
+  });
+
+  it('Diagnostics count is a clickable button linking to diag page', () => {
+    expect(code).toMatch(/diagnostics_count > 0/);
+    expect(code).toMatch(/Voir les diagnostics/);
+    expect(code).toMatch(/toConsoDiag/);
+  });
+});
+
+describe('BG · Portfolio V1.3 guided empty state', () => {
   const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
 
   it('has handleResetFilters function', () => {
@@ -981,18 +1081,35 @@ describe('BE · Portfolio V1.2 guided empty state', () => {
     expect(code).toMatch(/RotateCcw/);
   });
 
-  it('has "Aller a Import & Analyse" CTA navigating to /consommations/import', () => {
-    expect(code).toMatch(/Aller a Import & Analyse/);
-    expect(code).toMatch(/\/consommations\/import/);
-  });
-
-  it('has Upload icon for import CTA', () => {
-    expect(code).toMatch(/Upload/);
+  it('has "Importer des donnees" CTA using toConsoImport', () => {
+    expect(code).toMatch(/Importer des donnees/);
+    expect(code).toMatch(/toConsoImport/);
   });
 
   it('shows contextual message based on hasActiveFilters', () => {
     expect(code).toMatch(/hasActiveFilters/);
     expect(code).toMatch(/reinitialiser les filtres/i);
     expect(code).toMatch(/Importez des donnees/);
+  });
+});
+
+// ============================================================
+// BH. Explorer scope coherence — single-site banner
+// ============================================================
+describe('BH · Explorer scope coherence banner', () => {
+  const code = readSrc('pages', 'ConsumptionExplorerPage.jsx');
+
+  it('reads scopeLabel from useScope', () => {
+    expect(code).toMatch(/scopeLabel/);
+  });
+
+  it('shows scope banner when selectedSiteId and single site', () => {
+    expect(code).toMatch(/selectedSiteId && siteIds\.length === 1/);
+    expect(code).toMatch(/Vous explorez/);
+    expect(code).toMatch(/scopeLabel/);
+  });
+
+  it('mentions multi-selection is available', () => {
+    expect(code).toMatch(/multi-selection/i);
   });
 });

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -755,7 +755,7 @@ describe('AX · ConsumptionPortfolioPage structure', () => {
 
   it('has loading skeletons and empty state', () => {
     expect(code).toMatch(/SkeletonCard/);
-    expect(code).toMatch(/EmptyState/);
+    expect(code).toMatch(/Aucun site ne correspond aux filtres/);
   });
 
   it('has toast error handling', () => {
@@ -901,5 +901,98 @@ describe('BB · Portfolio V1.1 frontend enhancements', () => {
   it('has top_impact section in "Ou agir"', () => {
     expect(code).toMatch(/top_impact/);
     expect(code).toMatch(/Impact estime/);
+  });
+});
+
+// ============================================================
+// BC. Portfolio V1.2 — scope banner + deep-links + empty state
+// ============================================================
+describe('BC · Portfolio V1.2 scope coherence banner', () => {
+  const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+
+  it('imports useScope from ScopeContext', () => {
+    expect(code).toMatch(/useScope/);
+    expect(code).toMatch(/ScopeContext/);
+  });
+
+  it('reads selectedSiteId and resetScope from useScope', () => {
+    expect(code).toMatch(/selectedSiteId/);
+    expect(code).toMatch(/resetScope/);
+  });
+
+  it('shows scope banner when selectedSiteId is set', () => {
+    expect(code).toMatch(/selectedSiteId/);
+    expect(code).toMatch(/Vue portefeuille = multi-sites/);
+  });
+
+  it('has "Passer a Tous les sites" button calling resetScope', () => {
+    expect(code).toMatch(/Passer a Tous les sites/);
+    expect(code).toMatch(/resetScope/);
+  });
+
+  it('does not use PageShell (nested inside ConsommationsPage)', () => {
+    expect(code).not.toMatch(/PageShell/);
+  });
+});
+
+describe('BD · Portfolio V1.2 top-list deep-links', () => {
+  const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+
+  it('has TopListActions component with 4 action buttons', () => {
+    expect(code).toMatch(/TopListActions/);
+  });
+
+  it('top-list actions include Explorer link (site_ids param)', () => {
+    expect(code).toMatch(/\/consommations\/explorer\?site_ids=/);
+  });
+
+  it('top-list actions include Diagnostic link (site_id param)', () => {
+    expect(code).toMatch(/\/diagnostic-conso\?site_id=/);
+  });
+
+  it('top-list actions include Voir facture via deepLinkWithContext', () => {
+    expect(code).toMatch(/deepLinkWithContext/);
+  });
+
+  it('top-list actions include Creer action via deepLinkNewAction', () => {
+    expect(code).toMatch(/deepLinkNewAction.*portfolio_toplist/);
+  });
+
+  it('all 4 top-lists use TopListActions', () => {
+    const matches = code.match(/TopListActions/g);
+    // TopListActions definition + 4 usages in top-lists + table rows don't use it
+    expect(matches.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('BE · Portfolio V1.2 guided empty state', () => {
+  const code = readSrc('pages', 'ConsumptionPortfolioPage.jsx');
+
+  it('has handleResetFilters function', () => {
+    expect(code).toMatch(/handleResetFilters/);
+  });
+
+  it('has hasActiveFilters computed flag', () => {
+    expect(code).toMatch(/hasActiveFilters/);
+  });
+
+  it('has "Reinitialiser filtres" button with RotateCcw icon', () => {
+    expect(code).toMatch(/Reinitialiser filtres/);
+    expect(code).toMatch(/RotateCcw/);
+  });
+
+  it('has "Aller a Import & Analyse" CTA navigating to /consommations/import', () => {
+    expect(code).toMatch(/Aller a Import & Analyse/);
+    expect(code).toMatch(/\/consommations\/import/);
+  });
+
+  it('has Upload icon for import CTA', () => {
+    expect(code).toMatch(/Upload/);
+  });
+
+  it('shows contextual message based on hasActiveFilters', () => {
+    expect(code).toMatch(/hasActiveFilters/);
+    expect(code).toMatch(/reinitialiser les filtres/i);
+    expect(code).toMatch(/Importez des donnees/);
   });
 });

--- a/frontend/src/pages/__tests__/dataActivationV37.test.js
+++ b/frontend/src/pages/__tests__/dataActivationV37.test.js
@@ -267,7 +267,7 @@ describe('LeverActionModel — data_activation template', () => {
     const lever = { type: 'data_activation', actionKey: 'lev-data-cover', impactEur: null };
     const link = buildLeverDeepLink(lever);
     expect(link).toContain('type=data_activation');
-    expect(link).toContain('key=lev-data-cover');
+    expect(link).toContain('ref_id=lev-data-cover');
   });
 });
 

--- a/frontend/src/pages/__tests__/leverActionModel.test.js
+++ b/frontend/src/pages/__tests__/leverActionModel.test.js
@@ -104,24 +104,24 @@ describe('buildActionPayload', () => {
 // ══════════════════════════════════════════════════════════════════════════════
 
 describe('buildLeverDeepLink', () => {
-  it('genere un deep-link avec type, key et impact', () => {
+  it('genere un deep-link vers /actions/new avec type, source et ref_id', () => {
     const url = buildLeverDeepLink(makeLever());
 
-    expect(url).toContain('/command-center?');
-    expect(url).toContain('filter=leviers');
+    expect(url).toContain('/actions/new?');
     expect(url).toContain('type=conformite');
-    expect(url).toContain('key=lev-conf-nc');
-    expect(url).toContain('impact=20000');
+    expect(url).toContain('source=lever_engine');
+    expect(url).toContain('ref_id=lev-conf-nc');
+    expect(url).toContain('titre=');
   });
 
-  it('omet impact si null', () => {
-    const url = buildLeverDeepLink(makeLever({ impactEur: null }));
-    expect(url).not.toContain('impact=');
+  it('ne genere PAS de lien vers /command-center (route morte)', () => {
+    const url = buildLeverDeepLink(makeLever());
+    expect(url).not.toContain('/command-center');
   });
 
-  it('retourne /command-center si lever null', () => {
-    expect(buildLeverDeepLink(null)).toBe('/command-center');
-    expect(buildLeverDeepLink({})).toBe('/command-center');
+  it('retourne /actions si lever null', () => {
+    expect(buildLeverDeepLink(null)).toBe('/actions');
+    expect(buildLeverDeepLink({})).toBe('/actions');
   });
 });
 

--- a/frontend/src/pages/__tests__/patrimoineV58.test.js
+++ b/frontend/src/pages/__tests__/patrimoineV58.test.js
@@ -100,8 +100,9 @@ describe('Intégration PatrimoineHealthCard dans Patrimoine.jsx', () => {
     expect(PATRIMOINE_JSX).toMatch(/import PatrimoineHealthCard/);
   });
 
-  test('utilise PatrimoineHealthCard dans l\'onglet anomalies', () => {
-    expect(PATRIMOINE_JSX).toMatch(/<PatrimoineHealthCard/);
+  test('utilise SiteAnomalyPanel dans l\'onglet anomalies (V65)', () => {
+    // V65: replaced PatrimoineHealthCard with SiteAnomalyPanel in the drawer
+    expect(PATRIMOINE_JSX).toMatch(/<SiteAnomalyPanel/);
   });
 
   test('passe siteId à PatrimoineHealthCard', () => {

--- a/frontend/src/pages/__tests__/patrimoineV64.distribution.test.js
+++ b/frontend/src/pages/__tests__/patrimoineV64.distribution.test.js
@@ -1,0 +1,181 @@
+/**
+ * patrimoineV64.distribution.test.js — Guards V64 PatrimoineRiskDistributionBar
+ *
+ * 5 tests :
+ *   1. empty array → all zeros
+ *   2. all-zeros → ok = N, warn = 0, critical = 0
+ *   3. N=5 (< 8) → top1 critical, next2 warn, rest ok (stable)
+ *   4. N=20 (≥ 8) → quantile buckets, somme = N, chaque bucket > 0
+ *   5. Integration : composant importable + topSlot dans Patrimoine.jsx
+ */
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { computeRiskBuckets } from '../../components/PatrimoineRiskDistributionBar';
+
+const src = (rel) => readFileSync(path.resolve(__dirname, '..', '..', rel), 'utf8');
+
+const DIST_JSX      = src('components/PatrimoineRiskDistributionBar.jsx');
+const HEATMAP_JSX   = src('components/PatrimoineHeatmap.jsx');
+const PATRIMOINE_JSX = src('pages/Patrimoine.jsx');
+
+// ── 1. Empty ─────────────────────────────────────────────────────────────
+
+describe('computeRiskBuckets — guard 1 : tableau vide', () => {
+  test('retourne {ok:0, warn:0, critical:0, thresholds:{p40:0,p80:0}}', () => {
+    const result = computeRiskBuckets([]);
+    expect(result).toEqual({ ok: 0, warn: 0, critical: 0, thresholds: { p40: 0, p80: 0 } });
+  });
+});
+
+// ── 2. All-zeros ─────────────────────────────────────────────────────────
+
+describe('computeRiskBuckets — guard 2 : tous zéros', () => {
+  test('3 zéros → ok=3, warn=0, critical=0', () => {
+    const { ok, warn, critical } = computeRiskBuckets([0, 0, 0]);
+    expect(ok).toBe(3);
+    expect(warn).toBe(0);
+    expect(critical).toBe(0);
+  });
+
+  test('1 zéro → ok=1', () => {
+    const { ok, warn, critical } = computeRiskBuckets([0]);
+    expect(ok).toBe(1);
+    expect(warn).toBe(0);
+    expect(critical).toBe(0);
+  });
+});
+
+// ── 3. N < 8 (stable) ────────────────────────────────────────────────────
+
+describe('computeRiskBuckets — guard 3 : N=5 (< 8)', () => {
+  const risks = [10_000, 20_000, 30_000, 40_000, 50_000];
+
+  test('critical = 1 (top 1)', () => {
+    const { critical } = computeRiskBuckets(risks);
+    expect(critical).toBe(1);
+  });
+
+  test('warn = 2 (next 2)', () => {
+    const { warn } = computeRiskBuckets(risks);
+    expect(warn).toBe(2);
+  });
+
+  test('ok = 2 (reste)', () => {
+    const { ok } = computeRiskBuckets(risks);
+    expect(ok).toBe(2);
+  });
+
+  test('somme = N = 5', () => {
+    const { ok, warn, critical } = computeRiskBuckets(risks);
+    expect(ok + warn + critical).toBe(5);
+  });
+
+  test('N=2 → critical=1, warn=1, ok=0', () => {
+    const { ok, warn, critical } = computeRiskBuckets([1000, 2000]);
+    expect(critical).toBe(1);
+    expect(warn).toBe(1);
+    expect(ok).toBe(0);
+  });
+
+  test('N=1 → critical=1, warn=0, ok=0', () => {
+    const { ok, warn, critical } = computeRiskBuckets([5000]);
+    expect(critical).toBe(1);
+    expect(warn).toBe(0);
+    expect(ok).toBe(0);
+  });
+});
+
+// ── 4. N=20 (≥ 8, quantiles) ─────────────────────────────────────────────
+
+describe('computeRiskBuckets — guard 4 : N=20 (≥ 8)', () => {
+  // risks = [1k, 2k, ..., 20k]
+  const risks = Array.from({ length: 20 }, (_, i) => (i + 1) * 1_000);
+
+  test('somme ok + warn + critical = 20', () => {
+    const { ok, warn, critical } = computeRiskBuckets(risks);
+    expect(ok + warn + critical).toBe(20);
+  });
+
+  test('ok > 0', () => {
+    const { ok } = computeRiskBuckets(risks);
+    expect(ok).toBeGreaterThan(0);
+  });
+
+  test('warn > 0', () => {
+    const { warn } = computeRiskBuckets(risks);
+    expect(warn).toBeGreaterThan(0);
+  });
+
+  test('critical > 0', () => {
+    const { critical } = computeRiskBuckets(risks);
+    expect(critical).toBeGreaterThan(0);
+  });
+
+  test('thresholds p40 < p80', () => {
+    const { thresholds } = computeRiskBuckets(risks);
+    expect(thresholds.p40).toBeLessThan(thresholds.p80);
+  });
+
+  test('p40 = 8000, p80 = 16000 pour 1k..20k', () => {
+    // p40 = sorted[floor(0.4*19)] = sorted[7] = 8k
+    // p80 = sorted[floor(0.8*19)] = sorted[15] = 16k
+    const { thresholds } = computeRiskBuckets(risks);
+    expect(thresholds.p40).toBe(8_000);
+    expect(thresholds.p80).toBe(16_000);
+  });
+});
+
+// ── 5. Integration source-guards ─────────────────────────────────────────
+
+describe('PatrimoineRiskDistributionBar V64 — intégration', () => {
+  test('default export PatrimoineRiskDistributionBar présent', () => {
+    expect(DIST_JSX).toMatch(/export default function PatrimoineRiskDistributionBar/);
+  });
+
+  test('computeRiskBuckets exporté nominalement', () => {
+    expect(DIST_JSX).toMatch(/export function computeRiskBuckets/);
+  });
+
+  test('barre segmentée bg-green-300 + bg-amber-400 + bg-red-500', () => {
+    expect(DIST_JSX).toMatch(/bg-green-300/);
+    expect(DIST_JSX).toMatch(/bg-amber-400/);
+    expect(DIST_JSX).toMatch(/bg-red-500/);
+  });
+
+  test('aria-label sur la barre', () => {
+    expect(DIST_JSX).toMatch(/aria-label/);
+  });
+
+  test('titre tooltip mentionnant quantiles', () => {
+    expect(DIST_JSX).toMatch(/quantiles/);
+  });
+
+  test('null safety : sites.length === 0 → return null', () => {
+    expect(DIST_JSX).toMatch(/sites\.length\s*===\s*0.*return null|return null.*sites\.length/s);
+  });
+
+  test('fallback risque_eur dans extraction', () => {
+    expect(DIST_JSX).toMatch(/risque_eur/);
+  });
+
+  test('PatrimoineHeatmap accepte topSlot prop', () => {
+    expect(HEATMAP_JSX).toMatch(/topSlot/);
+  });
+
+  test('topSlot rendu dans PatrimoineHeatmap', () => {
+    expect(HEATMAP_JSX).toMatch(/\{topSlot\}/);
+  });
+
+  test('PatrimoineRiskDistributionBar importé dans Patrimoine.jsx', () => {
+    expect(PATRIMOINE_JSX).toMatch(/import PatrimoineRiskDistributionBar/);
+  });
+
+  test('topSlot passé à PatrimoineHeatmap dans Patrimoine.jsx', () => {
+    expect(PATRIMOINE_JSX).toMatch(/topSlot=\{<PatrimoineRiskDistributionBar/);
+  });
+
+  test('sites={filtered} passé à PatrimoineRiskDistributionBar', () => {
+    expect(PATRIMOINE_JSX).toMatch(/sites=\{filtered\}/);
+  });
+});

--- a/frontend/src/pages/cockpit/EssentialsRow.jsx
+++ b/frontend/src/pages/cockpit/EssentialsRow.jsx
@@ -137,7 +137,7 @@ export default function EssentialsRow({ kpis = {}, sites = [], onOpenMaturite, o
           ? `${totalSurfaceM2.toLocaleString('fr-FR')} m² total`
           : 'Surface non renseignée'}
         ctaLabel="Voir"
-        onCta={() => onNavigate?.('/sites')}
+        onCta={() => onNavigate?.('/patrimoine')}
       />
 
       {/* 4 — Maturité */}

--- a/frontend/src/pages/consumption/BenchmarkPanel.jsx
+++ b/frontend/src/pages/consumption/BenchmarkPanel.jsx
@@ -1,0 +1,208 @@
+/**
+ * PROMEOS — BenchmarkPanel (P1-1)
+ * Courbe de référence grand public (Enedis-inspired).
+ * Toggle "Comparer à une courbe de référence" + 2 selectors + KPI écart.
+ */
+import { useState, useEffect, useCallback } from 'react';
+import {
+  AreaChart, Area, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip, ResponsiveContainer, Legend,
+} from 'recharts';
+import { Card, CardBody, TrustBadge } from '../../ui';
+import { SkeletonCard } from '../../ui';
+import { getEmsReferenceProfile } from '../../services/api';
+import { track } from '../../services/tracker';
+import { BarChart3, TrendingUp, TrendingDown } from 'lucide-react';
+
+const FAMILLE_OPTIONS = [
+  { value: 'habitat', label: 'Habitat' },
+  { value: 'petit_tertiaire', label: 'Petit tertiaire' },
+  { value: 'entreprise', label: 'Entreprise' },
+];
+
+const PUISSANCE_OPTIONS = [
+  { value: '0-6', label: '0-6 kVA' },
+  { value: '6-9', label: '6-9 kVA' },
+  { value: '9-12', label: '9-12 kVA' },
+  { value: '12-36', label: '12-36 kVA' },
+  { value: '>36', label: '> 36 kVA' },
+];
+
+const CONFIDENCE_MAP = {
+  high: { label: 'Elevee', variant: 'ok' },
+  medium: { label: 'Moyenne', variant: 'warn' },
+  low: { label: 'Basse', variant: 'crit' },
+};
+
+function formatDate(t) {
+  if (!t || t.length < 10) return t;
+  const d = new Date(t.replace(' ', 'T'));
+  return d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' });
+}
+
+export default function BenchmarkPanel({ siteId, days, startDate, endDate, seriesData, toast }) {
+  const [enabled, setEnabled] = useState(false);
+  const [famille, setFamille] = useState('entreprise');
+  const [puissance, setPuissance] = useState('9-12');
+  const [refData, setRefData] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  // Compute date range
+  const dateFrom = startDate || (() => {
+    const d = new Date();
+    d.setDate(d.getDate() - (days || 30));
+    return d.toISOString().slice(0, 10);
+  })();
+  const dateTo = endDate || new Date().toISOString().slice(0, 10);
+
+  const load = useCallback(async () => {
+    if (!enabled || !siteId) return;
+    setLoading(true);
+    try {
+      const data = await getEmsReferenceProfile(siteId, dateFrom, dateTo, famille, puissance, 'daily');
+      setRefData(data);
+      track('benchmark_loaded', { famille, puissance, site_id: siteId });
+    } catch (e) {
+      toast?.('Erreur chargement profil de reference', 'error');
+      setRefData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled, siteId, dateFrom, dateTo, famille, puissance]);
+
+  useEffect(() => { load(); }, [load]);
+
+  // Merge actual + reference into chart data
+  const chartData = (() => {
+    if (!refData?.series) return [];
+    const refMap = {};
+    for (const pt of refData.series) {
+      const key = pt.t.slice(0, 10);
+      refMap[key] = pt.v;
+    }
+
+    // Actual data from seriesData (parent TimeseriesPanel)
+    const actualMap = {};
+    if (seriesData?.[0]?.data) {
+      for (const pt of seriesData[0].data) {
+        const key = (pt.t || '').slice(0, 10);
+        if (pt.v != null) actualMap[key] = (actualMap[key] || 0) + pt.v;
+      }
+    }
+
+    const allDates = [...new Set([...Object.keys(refMap), ...Object.keys(actualMap)])].sort();
+    return allDates.map(d => ({
+      date: formatDate(d),
+      rawDate: d,
+      actual: actualMap[d] != null ? Math.round(actualMap[d] * 10) / 10 : null,
+      reference: refMap[d] != null ? Math.round(refMap[d] * 10) / 10 : null,
+    }));
+  })();
+
+  const kpi = refData?.kpi;
+  const conf = kpi?.confidence ? CONFIDENCE_MAP[kpi.confidence] : null;
+
+  return (
+    <div className="space-y-3">
+      {/* Toggle */}
+      <div className="flex items-center gap-3">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          />
+          <span className="text-sm font-medium text-gray-700">Comparer a une courbe de reference</span>
+        </label>
+      </div>
+
+      {enabled && (
+        <>
+          {/* Selectors */}
+          <div className="flex items-center gap-4 flex-wrap">
+            <div className="flex items-center gap-2">
+              <label className="text-xs text-gray-500">Type de site</label>
+              <select
+                value={famille}
+                onChange={(e) => setFamille(e.target.value)}
+                className="text-sm border rounded px-2 py-1"
+              >
+                {FAMILLE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-xs text-gray-500">Puissance souscrite</label>
+              <select
+                value={puissance}
+                onChange={(e) => setPuissance(e.target.value)}
+                className="text-sm border rounded px-2 py-1"
+              >
+                {PUISSANCE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+            {conf && <TrustBadge level={conf.variant} label={`Confiance ${conf.label}`} size="sm" />}
+          </div>
+
+          {loading && <SkeletonCard rows={4} />}
+
+          {/* KPI delta cards */}
+          {kpi && !loading && (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <Card>
+                <CardBody className="py-3 px-4 text-center">
+                  <p className="text-xs text-gray-500">Conso reelle</p>
+                  <p className="text-lg font-bold text-gray-800">{Math.round(kpi.actual_kwh).toLocaleString('fr-FR')} kWh</p>
+                </CardBody>
+              </Card>
+              <Card>
+                <CardBody className="py-3 px-4 text-center">
+                  <p className="text-xs text-gray-500">Reference</p>
+                  <p className="text-lg font-bold text-blue-600">{Math.round(kpi.reference_kwh).toLocaleString('fr-FR')} kWh</p>
+                </CardBody>
+              </Card>
+              <Card>
+                <CardBody className="py-3 px-4 text-center">
+                  <p className="text-xs text-gray-500">Ecart</p>
+                  <p className={`text-lg font-bold ${kpi.delta_pct > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                    {kpi.delta_pct > 0 ? '+' : ''}{kpi.delta_pct}%
+                  </p>
+                  <p className="text-xs text-gray-400">{kpi.delta_kwh > 0 ? '+' : ''}{Math.round(kpi.delta_kwh).toLocaleString('fr-FR')} kWh</p>
+                </CardBody>
+              </Card>
+              <Card>
+                <CardBody className="py-3 px-4 text-center">
+                  <p className="text-xs text-gray-500">Couverture</p>
+                  <p className="text-lg font-bold text-gray-800">{kpi.coverage_pct}%</p>
+                </CardBody>
+              </Card>
+            </div>
+          )}
+
+          {/* Chart: actual vs reference */}
+          {chartData.length > 0 && !loading && (
+            <Card>
+              <CardBody>
+                <h4 className="text-sm font-semibold text-gray-700 mb-3">Consommation reelle vs reference</h4>
+                <ResponsiveContainer width="100%" height={280}>
+                  <AreaChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <XAxis dataKey="date" tick={{ fontSize: 10 }} angle={-30} textAnchor="end" height={50} />
+                    <YAxis tick={{ fontSize: 10 }} label={{ value: 'kWh', angle: -90, position: 'insideLeft', style: { fontSize: 11 } }} />
+                    <Tooltip />
+                    <Legend />
+                    <Area type="monotone" dataKey="reference" stroke="#93c5fd" fill="#dbeafe" fillOpacity={0.5} name="Reference" strokeDasharray="5 5" />
+                    <Area type="monotone" dataKey="actual" stroke="#3b82f6" fill="#bfdbfe" fillOpacity={0.3} name="Conso reelle" />
+                  </AreaChart>
+                </ResponsiveContainer>
+                <p className="text-[10px] text-gray-400 mt-1 text-center">
+                  Profil: {FAMILLE_OPTIONS.find(o => o.value === famille)?.label} · {PUISSANCE_OPTIONS.find(o => o.value === puissance)?.label}
+                </p>
+              </CardBody>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/consumption/BenchmarkPanel.jsx
+++ b/frontend/src/pages/consumption/BenchmarkPanel.jsx
@@ -1,7 +1,8 @@
 /**
- * PROMEOS — BenchmarkPanel (P1-1)
- * Courbe de référence grand public (Enedis-inspired).
- * Toggle "Comparer à une courbe de référence" + 2 selectors + KPI écart.
+ * PROMEOS — BenchmarkPanel (P1-1 / P1.1 polish)
+ * Courbe de reference grand public (Enedis-inspired).
+ * Toggle "Comparer a la courbe moyenne de sites similaires" + 2 selectors + KPI ecart.
+ * Confidence tooltip "Comment calcule ?" + KPI source (estime).
  */
 import { useState, useEffect, useCallback } from 'react';
 import {
@@ -12,7 +13,7 @@ import { Card, CardBody, TrustBadge } from '../../ui';
 import { SkeletonCard } from '../../ui';
 import { getEmsReferenceProfile } from '../../services/api';
 import { track } from '../../services/tracker';
-import { BarChart3, TrendingUp, TrendingDown } from 'lucide-react';
+import { BarChart3, HelpCircle, Info } from 'lucide-react';
 
 const FAMILLE_OPTIONS = [
   { value: 'habitat', label: 'Habitat' },
@@ -29,9 +30,9 @@ const PUISSANCE_OPTIONS = [
 ];
 
 const CONFIDENCE_MAP = {
-  high: { label: 'Elevee', variant: 'ok' },
-  medium: { label: 'Moyenne', variant: 'warn' },
-  low: { label: 'Basse', variant: 'crit' },
+  high: { label: 'Elevee', variant: 'ok', desc: 'Couverture > 80 % des points attendus' },
+  medium: { label: 'Moyenne', variant: 'warn', desc: 'Couverture entre 50 % et 80 %' },
+  low: { label: 'Basse', variant: 'crit', desc: 'Couverture < 50 % — profil indicatif' },
 };
 
 function formatDate(t) {
@@ -113,7 +114,7 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
             onChange={(e) => setEnabled(e.target.checked)}
             className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
           />
-          <span className="text-sm font-medium text-gray-700">Comparer a une courbe de reference</span>
+          <span className="text-sm font-medium text-gray-700">Comparer a la courbe moyenne de sites similaires</span>
         </label>
       </div>
 
@@ -141,7 +142,12 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
                 {PUISSANCE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
               </select>
             </div>
-            {conf && <TrustBadge level={conf.variant} label={`Confiance ${conf.label}`} size="sm" />}
+            {conf && (
+              <span className="inline-flex items-center gap-1" title={`Comment calcule ? ${conf.desc}`}>
+                <TrustBadge level={conf.variant} label={`Confiance ${conf.label}`} size="sm" />
+                <HelpCircle size={12} className="text-gray-400 cursor-help" />
+              </span>
+            )}
           </div>
 
           {loading && <SkeletonCard rows={4} />}
@@ -151,29 +157,32 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
               <Card>
                 <CardBody className="py-3 px-4 text-center">
-                  <p className="text-xs text-gray-500">Conso reelle</p>
+                  <p className="text-xs text-gray-500">Votre consommation</p>
                   <p className="text-lg font-bold text-gray-800">{Math.round(kpi.actual_kwh).toLocaleString('fr-FR')} kWh</p>
+                  <p className="text-[10px] text-gray-400" title="Estime a partir des releves compteur">Source : releves</p>
                 </CardBody>
               </Card>
               <Card>
                 <CardBody className="py-3 px-4 text-center">
-                  <p className="text-xs text-gray-500">Reference</p>
+                  <p className="text-xs text-gray-500">Moyenne sites similaires</p>
                   <p className="text-lg font-bold text-blue-600">{Math.round(kpi.reference_kwh).toLocaleString('fr-FR')} kWh</p>
+                  <p className="text-[10px] text-gray-400">Profil statistique</p>
                 </CardBody>
               </Card>
               <Card>
                 <CardBody className="py-3 px-4 text-center">
                   <p className="text-xs text-gray-500">Ecart</p>
                   <p className={`text-lg font-bold ${kpi.delta_pct > 0 ? 'text-red-600' : 'text-green-600'}`}>
-                    {kpi.delta_pct > 0 ? '+' : ''}{kpi.delta_pct}%
+                    {kpi.delta_pct > 0 ? '+' : ''}{kpi.delta_pct} %
                   </p>
                   <p className="text-xs text-gray-400">{kpi.delta_kwh > 0 ? '+' : ''}{Math.round(kpi.delta_kwh).toLocaleString('fr-FR')} kWh</p>
                 </CardBody>
               </Card>
               <Card>
                 <CardBody className="py-3 px-4 text-center">
-                  <p className="text-xs text-gray-500">Couverture</p>
-                  <p className="text-lg font-bold text-gray-800">{kpi.coverage_pct}%</p>
+                  <p className="text-xs text-gray-500">Couverture donnees</p>
+                  <p className="text-lg font-bold text-gray-800">{kpi.coverage_pct} %</p>
+                  <p className="text-[10px] text-gray-400" title="Pourcentage de points de mesure disponibles vs attendus">Points mesures / attendus</p>
                 </CardBody>
               </Card>
             </div>
@@ -183,7 +192,7 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
           {chartData.length > 0 && !loading && (
             <Card>
               <CardBody>
-                <h4 className="text-sm font-semibold text-gray-700 mb-3">Consommation reelle vs reference</h4>
+                <h4 className="text-sm font-semibold text-gray-700 mb-3">Votre consommation vs moyenne de sites similaires</h4>
                 <ResponsiveContainer width="100%" height={280}>
                   <AreaChart data={chartData}>
                     <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
@@ -191,12 +200,12 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
                     <YAxis tick={{ fontSize: 10 }} label={{ value: 'kWh', angle: -90, position: 'insideLeft', style: { fontSize: 11 } }} />
                     <Tooltip />
                     <Legend />
-                    <Area type="monotone" dataKey="reference" stroke="#93c5fd" fill="#dbeafe" fillOpacity={0.5} name="Reference" strokeDasharray="5 5" />
-                    <Area type="monotone" dataKey="actual" stroke="#3b82f6" fill="#bfdbfe" fillOpacity={0.3} name="Conso reelle" />
+                    <Area type="monotone" dataKey="reference" stroke="#93c5fd" fill="#dbeafe" fillOpacity={0.5} name="Moyenne sites similaires" strokeDasharray="5 5" />
+                    <Area type="monotone" dataKey="actual" stroke="#3b82f6" fill="#bfdbfe" fillOpacity={0.3} name="Votre consommation" />
                   </AreaChart>
                 </ResponsiveContainer>
                 <p className="text-[10px] text-gray-400 mt-1 text-center">
-                  Profil: {FAMILLE_OPTIONS.find(o => o.value === famille)?.label} · {PUISSANCE_OPTIONS.find(o => o.value === puissance)?.label}
+                  Profil : {FAMILLE_OPTIONS.find(o => o.value === famille)?.label} · {PUISSANCE_OPTIONS.find(o => o.value === puissance)?.label}
                 </p>
               </CardBody>
             </Card>

--- a/frontend/src/pages/consumption/HeatmapChart.jsx
+++ b/frontend/src/pages/consumption/HeatmapChart.jsx
@@ -36,8 +36,8 @@ export default function HeatmapChart({ data, unit = 'kWh', onCellClick, filter =
         <div className="flex items-center gap-1.5">
           <span className="w-3 h-3 rounded bg-blue-400" /> HC
         </div>
-        <span className="ml-auto">Intensite = conso moyenne ({unit})</span>
-        {onCellClick && <span className="text-blue-500">Cliquez pour le detail</span>}
+        <span className="ml-auto">Intensite = consommation moyenne ({unit})</span>
+        {onCellClick && <span className="text-blue-500">Cliquez sur un creneau pour le detail</span>}
       </div>
 
       <div className="overflow-x-auto">

--- a/frontend/src/pages/consumption/HeatmapChart.jsx
+++ b/frontend/src/pages/consumption/HeatmapChart.jsx
@@ -1,6 +1,7 @@
 /**
  * PROMEOS — HeatmapChart (HP/HC 7x24 grid)
  * Cells colored by HP (red) / HC (blue), intensity = kWh.
+ * P1-2: Clickable cells with drill-down callback + tooltip + filter ouvre/weekend.
  */
 import { useState } from 'react';
 
@@ -13,12 +14,18 @@ function cellColor(avgKwh, isHP, maxKwh) {
   return `rgba(59, 130, 246, ${alpha})`; // blue
 }
 
-export default function HeatmapChart({ data, unit = 'kWh' }) {
+export default function HeatmapChart({ data, unit = 'kWh', onCellClick, filter = 'all' }) {
   const [hover, setHover] = useState(null);
 
   if (!data?.length) return null;
 
-  const maxKwh = Math.max(...data.map(c => c.avg_kwh), 0.01);
+  // Filter: 'all', 'weekday' (Lun-Ven), 'weekend' (Sam-Dim)
+  const visibleDays = filter === 'weekday' ? [0,1,2,3,4]
+    : filter === 'weekend' ? [5,6]
+    : [0,1,2,3,4,5,6];
+
+  const filteredData = data.filter(c => visibleDays.includes(c.day));
+  const maxKwh = Math.max(...filteredData.map(c => c.avg_kwh), 0.01);
 
   return (
     <div className="space-y-2">
@@ -30,6 +37,7 @@ export default function HeatmapChart({ data, unit = 'kWh' }) {
           <span className="w-3 h-3 rounded bg-blue-400" /> HC
         </div>
         <span className="ml-auto">Intensite = conso moyenne ({unit})</span>
+        {onCellClick && <span className="text-blue-500">Cliquez pour le detail</span>}
       </div>
 
       <div className="overflow-x-auto">
@@ -45,11 +53,11 @@ export default function HeatmapChart({ data, unit = 'kWh' }) {
             </tr>
           </thead>
           <tbody>
-            {DAY_LABELS.map((dayLabel, dow) => (
+            {visibleDays.map((dow) => (
               <tr key={dow}>
-                <td className="text-[10px] text-gray-500 font-medium pr-1 text-right">{dayLabel}</td>
+                <td className="text-[10px] text-gray-500 font-medium pr-1 text-right">{DAY_LABELS[dow]}</td>
                 {Array.from({ length: 24 }, (_, h) => {
-                  const cell = data.find(c => c.day === dow && c.hour === h) || { avg_kwh: 0, period: 'HC' };
+                  const cell = filteredData.find(c => c.day === dow && c.hour === h) || { avg_kwh: 0, period: 'HC' };
                   const isHP = cell.period === 'HP';
                   const bg = cellColor(cell.avg_kwh, isHP, maxKwh);
                   const isHovered = hover?.day === dow && hover?.hour === h;
@@ -60,10 +68,12 @@ export default function HeatmapChart({ data, unit = 'kWh' }) {
                       className="p-0"
                       onMouseEnter={() => setHover({ day: dow, hour: h, ...cell })}
                       onMouseLeave={() => setHover(null)}
+                      onClick={() => onCellClick?.({ day: dow, dayLabel: DAY_LABELS[dow], hour: h, ...cell })}
                     >
                       <div
-                        className={`w-7 h-6 rounded-sm border transition ${isHovered ? 'border-gray-500 ring-1 ring-gray-300' : 'border-transparent'}`}
+                        className={`w-7 h-6 rounded-sm border transition ${onCellClick ? 'cursor-pointer' : ''} ${isHovered ? 'border-gray-500 ring-1 ring-gray-300' : 'border-transparent'}`}
                         style={{ backgroundColor: bg }}
+                        title={`${DAY_LABELS[dow]} ${h}h — ${cell.avg_kwh} ${unit} (${cell.period})`}
                       />
                     </td>
                   );

--- a/frontend/src/pages/consumption/MeteoPanel.jsx
+++ b/frontend/src/pages/consumption/MeteoPanel.jsx
@@ -160,7 +160,8 @@ export default function MeteoPanel({ siteIds = [], energyType = 'electricity', d
   const correlationLabel = correlation > 0.5 ? 'Forte' : correlation > 0.2 ? 'Modérée' : 'Faible';
   const correlationColor = correlation > 0.5 ? 'text-blue-700 bg-blue-50' : correlation > 0.2 ? 'text-amber-700 bg-amber-50' : 'text-gray-600 bg-gray-100';
 
-  const weatherSource = utcWeather ? 'UTC (serveur)' : 'synthetique (modele)';
+  const isRealWeather = !!utcWeather;
+  const weatherSource = isRealWeather ? 'Temperature reelle (UTC)' : 'Temperature synthetique (modele)';
 
   // Loading state
   if (status === 'loading') {
@@ -198,7 +199,10 @@ export default function MeteoPanel({ siteIds = [], energyType = 'electricity', d
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
           <h3 className="text-sm font-semibold text-gray-800">Influence climatique</h3>
-          <p className="text-xs text-gray-500">Consommation vs temperature exterieure ({weatherSource})</p>
+          <p className="text-xs text-gray-500">Consommation vs temperature exterieure</p>
+          <span className={`inline-flex items-center gap-1 mt-0.5 px-2 py-0.5 rounded-full text-[10px] font-medium ${isRealWeather ? 'bg-green-50 text-green-700' : 'bg-amber-50 text-amber-700'}`}>
+            {isRealWeather ? 'Meteo reelle' : 'Meteo synthetique'}
+          </span>
         </div>
         <div className="flex items-center gap-2">
           {/* P1-3: Temperature toggle */}

--- a/frontend/src/pages/consumption/MeteoPanel.jsx
+++ b/frontend/src/pages/consumption/MeteoPanel.jsx
@@ -1,27 +1,32 @@
 /**
- * PROMEOS — MeteoPanel (Sprint V21)
- * Consumption vs synthetic temperature overlay + DJU badge + Pearson correlation.
+ * PROMEOS — MeteoPanel (Sprint P1-3)
+ * Consumption vs temperature overlay + DJU badge + Pearson correlation.
  *
  * - Left Y-axis: consumption (kWh, AreaChart)
- * - Right Y-axis: synthetic temperature (°C, dashed Line)
+ * - Right Y-axis: temperature (°C, dashed Line)
  * - DJU badge: sum of max(0, 18 - T) for each period
  * - Pearson R between consumption and temperature
  *
- * Temperature is synthetic (deterministic seasonal sine wave) — no external API needed.
+ * Temperature source:
+ *   1) UTC hourly data from /api/ems/weather_hourly (DST-safe, all timestamps in Z)
+ *   2) Fallback to synthetic (deterministic seasonal sine wave) if API unavailable
+ *
+ * Toggle "Afficher la température" controls weather visibility.
  *
  * Props:
  *   siteIds     — selected site IDs
  *   energyType  — 'electricity' | 'gas'
  *   days        — period in days (from main explorer state)
  */
-import { useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import {
   ComposedChart, Area, Line,
   XAxis, YAxis, CartesianGrid,
   Tooltip, ResponsiveContainer, Legend,
 } from 'recharts';
-import { Cloud } from 'lucide-react';
+import { Cloud, Thermometer } from 'lucide-react';
 import useEmsTimeseries from './useEmsTimeseries';
+import { getEmsWeatherHourly } from '../../services/api';
 
 // ── Synthetic temperature (deterministic, no external API) ────────────────────
 
@@ -86,13 +91,56 @@ function MeteoTooltip({ active, payload, label }) {
 export default function MeteoPanel({ siteIds = [], energyType = 'electricity', days = 90 }) {
   const { status, chartData } = useEmsTimeseries({ siteIds, energyType, days });
 
-  // Enrich chartData with synthetic temperature
+  // P1-3: Toggle temperature visibility
+  const [showTemp, setShowTemp] = useState(true);
+
+  // P1-3: UTC weather from backend (DST-safe)
+  const [utcWeather, setUtcWeather] = useState(null);
+
+  useEffect(() => {
+    if (!siteIds?.length) return;
+    const siteId = siteIds[0];
+    const now = new Date();
+    const from = new Date(now.getTime() - days * 86400000);
+    const dateFrom = from.toISOString().slice(0, 10);
+    const dateTo = now.toISOString().slice(0, 10);
+    getEmsWeatherHourly(siteId, dateFrom, dateTo)
+      .then((res) => {
+        // Build date→temp lookup from UTC hours
+        const lookup = {};
+        for (const h of (res?.hours || [])) {
+          // Aggregate hourly to daily average for overlay
+          const dayKey = h.t?.slice(0, 10);
+          if (!dayKey) continue;
+          if (!lookup[dayKey]) lookup[dayKey] = { sum: 0, count: 0 };
+          lookup[dayKey].sum += h.temp_c;
+          lookup[dayKey].count += 1;
+        }
+        const daily = {};
+        for (const [k, v] of Object.entries(lookup)) {
+          daily[k] = Math.round((v.sum / v.count) * 10) / 10;
+        }
+        setUtcWeather(daily);
+      })
+      .catch(() => setUtcWeather(null)); // Fallback to synthetic
+  }, [siteIds, days]);
+
+  // Enrich chartData with temperature — prefer UTC weather, fallback to synthetic
   const enrichedData = useMemo(() => {
-    return chartData.map((p) => ({
-      ...p,
-      temp: p.date ? Math.round(generateSyntheticTemp(p.date) * 10) / 10 : null,
-    }));
-  }, [chartData]);
+    return chartData.map((p) => {
+      let temp = null;
+      if (p.date) {
+        // Try UTC weather first (date key = YYYY-MM-DD)
+        const dayKey = typeof p.date === 'string' ? p.date.slice(0, 10) : null;
+        if (utcWeather && dayKey && utcWeather[dayKey] != null) {
+          temp = utcWeather[dayKey];
+        } else {
+          temp = Math.round(generateSyntheticTemp(p.date) * 10) / 10;
+        }
+      }
+      return { ...p, temp };
+    });
+  }, [chartData, utcWeather]);
 
   // DJU computation (base 18°C): sum of max(0, 18 - T) per period
   const dju = useMemo(() => {
@@ -111,6 +159,8 @@ export default function MeteoPanel({ siteIds = [], energyType = 'electricity', d
 
   const correlationLabel = correlation > 0.5 ? 'Forte' : correlation > 0.2 ? 'Modérée' : 'Faible';
   const correlationColor = correlation > 0.5 ? 'text-blue-700 bg-blue-50' : correlation > 0.2 ? 'text-amber-700 bg-amber-50' : 'text-gray-600 bg-gray-100';
+
+  const weatherSource = utcWeather ? 'UTC (serveur)' : 'synthetique (modele)';
 
   // Loading state
   if (status === 'loading') {
@@ -144,18 +194,30 @@ export default function MeteoPanel({ siteIds = [], energyType = 'electricity', d
 
   return (
     <div className="space-y-3">
-      {/* Header + badges */}
+      {/* Header + badges + toggle */}
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
           <h3 className="text-sm font-semibold text-gray-800">Influence climatique</h3>
-          <p className="text-xs text-gray-500">Consommation vs température extérieure (synthétique)</p>
+          <p className="text-xs text-gray-500">Consommation vs temperature exterieure ({weatherSource})</p>
         </div>
         <div className="flex items-center gap-2">
+          {/* P1-3: Temperature toggle */}
+          <label className="flex items-center gap-1.5 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showTemp}
+              onChange={(e) => setShowTemp(e.target.checked)}
+              className="w-3.5 h-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <Thermometer size={13} className="text-blue-500" />
+            <span className="text-xs text-gray-600">Afficher la temperature</span>
+          </label>
+          <span className="text-xs text-gray-300">|</span>
           <span className="text-xs text-gray-500">DJU :</span>
           <span className="px-2 py-0.5 text-xs font-medium bg-indigo-50 text-indigo-700 rounded-full">
             {dju.toLocaleString('fr-FR')} °C·j
           </span>
-          <span className="text-xs text-gray-500">Corrélation :</span>
+          <span className="text-xs text-gray-500">Correlation :</span>
           <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${correlationColor}`}>
             {correlationLabel} ({correlation >= 0 ? '+' : ''}{correlation.toFixed(2)})
           </span>
@@ -183,16 +245,18 @@ export default function MeteoPanel({ siteIds = [], energyType = 'electricity', d
             width={50}
             label={{ value: 'kWh', angle: -90, position: 'insideLeft', fontSize: 10, fill: '#94a3b8' }}
           />
-          {/* Right Y: temperature */}
-          <YAxis
-            yAxisId="temp"
-            orientation="right"
-            tick={{ fontSize: 11, fill: '#60a5fa' }}
-            tickLine={false}
-            axisLine={false}
-            width={40}
-            label={{ value: '°C', angle: 90, position: 'insideRight', fontSize: 10, fill: '#60a5fa' }}
-          />
+          {/* Right Y: temperature — hidden when toggle off */}
+          {showTemp && (
+            <YAxis
+              yAxisId="temp"
+              orientation="right"
+              tick={{ fontSize: 11, fill: '#60a5fa' }}
+              tickLine={false}
+              axisLine={false}
+              width={40}
+              label={{ value: '°C', angle: 90, position: 'insideRight', fontSize: 10, fill: '#60a5fa' }}
+            />
+          )}
           <Tooltip content={<MeteoTooltip />} />
           <Legend
             iconType="circle"
@@ -211,23 +275,26 @@ export default function MeteoPanel({ siteIds = [], energyType = 'electricity', d
             dot={false}
             activeDot={{ r: 3 }}
           />
-          <Line
-            yAxisId="temp"
-            type="monotone"
-            dataKey="temp"
-            name="Température"
-            stroke="#60a5fa"
-            strokeWidth={1.5}
-            strokeDasharray="4 2"
-            dot={false}
-            activeDot={{ r: 3 }}
-          />
+          {showTemp && (
+            <Line
+              yAxisId="temp"
+              type="monotone"
+              dataKey="temp"
+              name="Temperature"
+              stroke="#60a5fa"
+              strokeWidth={1.5}
+              strokeDasharray="4 2"
+              dot={false}
+              activeDot={{ r: 3 }}
+            />
+          )}
         </ComposedChart>
       </ResponsiveContainer>
 
       {/* Disclaimer */}
       <p className="text-[11px] text-gray-400">
-        Température synthétique (modèle saisonnier) · DJU base 18 °C · R de Pearson sur la période
+        Source temperature : {utcWeather ? 'API UTC (serveur, DST-safe)' : 'modele saisonnier synthetique'}
+        {' · '}DJU base 18 °C · R de Pearson sur la periode
       </p>
     </div>
   );

--- a/frontend/src/pages/consumption/SignaturePanel.jsx
+++ b/frontend/src/pages/consumption/SignaturePanel.jsx
@@ -1,8 +1,12 @@
 /**
- * PROMEOS — SignaturePanel (Sprint V21)
- * Heatmap weekday × hour showing average kWh consumption pattern.
+ * PROMEOS — SignaturePanel (Sprint P1.1)
+ * Heatmap weekday x hour showing average kWh consumption pattern.
  * Uses its own useEmsTimeseries call (hourly, 90 days) — independent of main granularity.
  * Reuses HeatmapChart from consumption/HeatmapChart.jsx.
+ *
+ * P1.1: FR labels (Jours ouvres / Week-ends), drill-down CTAs
+ *   "Analyser ce creneau" → /diagnostic-conso?site_id=X
+ *   "Voir facture" → deepLinkWithContext(siteId, month)
  *
  * Props:
  *   siteIds     — selected site IDs
@@ -16,10 +20,11 @@ import {
 import useEmsTimeseries from './useEmsTimeseries';
 import HeatmapChart from './HeatmapChart';
 import { Card, CardBody } from '../../ui';
-import { BarChart3 } from 'lucide-react';
+import { BarChart3, ArrowRight, FileText } from 'lucide-react';
+import { deepLinkWithContext } from '../../services/deepLink';
 
 // French weekday index: 0=Mon, 1=Tue, ..., 5=Sat, 6=Sun
-// JS getDay(): 0=Sun, 1=Mon, ..., 6=Sat → convert: frDay = (jsDay + 6) % 7
+// JS getDay(): 0=Sun, 1=Mon, ..., 6=Sat -> convert: frDay = (jsDay + 6) % 7
 function toFrDay(jsDay) {
   return (jsDay + 6) % 7;
 }
@@ -35,12 +40,12 @@ function getHpHc(frDay, hour) {
 /**
  * Aggregate raw series data into HeatmapChart format.
  * @param {Array} seriesData — raw series from useEmsTimeseries
- * @returns {Array<{day, hour, avg_kwh, period}>} — 7×24 cells (only non-zero)
+ * @returns {Array<{day, hour, avg_kwh, period}>} — 7x24 cells (only non-zero)
  */
 export function aggregateToHeatmap(seriesData) {
   if (!seriesData?.length || !seriesData[0]?.data?.length) return [];
 
-  const matrix = {}; // `${frDay}-${hour}` → { sum, count }
+  const matrix = {}; // `${frDay}-${hour}` -> { sum, count }
 
   for (const point of seriesData[0].data) {
     if (point.v == null || isNaN(point.v)) continue;
@@ -84,9 +89,11 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
 
   const heatmapData = useMemo(() => aggregateToHeatmap(seriesData), [seriesData]);
 
-  // P1-2: Filter ouvre/weekend + drill-down state
+  // P1-2: Filter ouvres/week-ends + drill-down state
   const [dayFilter, setDayFilter] = useState('all');
   const [drillDown, setDrillDown] = useState(null);
+
+  const primarySiteId = siteIds?.[0] || null;
 
   // Build drill-down chart data from raw series for clicked day+hour
   const drillDownData = useMemo(() => {
@@ -102,6 +109,7 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
       if (frDay === drillDown.day && hour === drillDown.hour) {
         points.push({
           date: d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' }),
+          rawDate: d.toISOString().slice(0, 7), // YYYY-MM for deep link
           kwh: Math.round(pt.v * 100) / 100,
         });
       }
@@ -133,16 +141,19 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
           <BarChart3 size={28} className="text-blue-400" />
         </div>
         <h3 className="text-base font-semibold text-gray-700 mb-1">
-          Données insuffisantes pour la signature
+          Donnees insuffisantes pour la signature
         </h3>
         <p className="text-sm text-gray-500 max-w-xs">
-          La signature horaire nécessite au moins 48 heures de données. Importez ou générez des données pour ce site.
+          La signature horaire necessite au moins 48 heures de donnees. Importez ou generez des donnees pour ce site.
         </p>
       </div>
     );
   }
 
   const totalPoints = meta?.n_points || heatmapData.length;
+
+  // Most recent month from drillDownData for deep-link
+  const drillMonth = drillDownData.length > 0 ? drillDownData[drillDownData.length - 1].rawDate : null;
 
   return (
     <div className="space-y-3">
@@ -153,7 +164,7 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
           <p className="text-xs text-gray-500">Moyenne kWh par creneau horaire (90 derniers jours)</p>
         </div>
         <div className="flex items-center gap-2">
-          {/* P1-2: Day filter pills */}
+          {/* P1-2: Day filter pills — FR labels */}
           {['all', 'weekday', 'weekend'].map(f => (
             <button
               key={f}
@@ -162,7 +173,7 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
                 dayFilter === f ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               }`}
             >
-              {f === 'all' ? 'Semaine typique' : f === 'weekday' ? 'Ouvre' : 'Week-end'}
+              {f === 'all' ? 'Semaine typique' : f === 'weekday' ? 'Jours ouvres' : 'Week-ends'}
             </button>
           ))}
           <span className="text-xs text-gray-400 ml-2">{totalPoints.toLocaleString('fr-FR')} pts</span>
@@ -177,7 +188,7 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
         onCellClick={(cell) => setDrillDown(cell)}
       />
 
-      {/* P1-2: Drill-down chart for selected cell */}
+      {/* Drill-down chart for selected cell */}
       {drillDown && drillDownData.length > 0 && (
         <Card>
           <CardBody>
@@ -204,6 +215,28 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
             <p className="text-[10px] text-gray-400 mt-1">
               {drillDownData.length} points sur 90 jours pour {drillDown.dayLabel} a {drillDown.hour}h
             </p>
+
+            {/* P1.1: Cross-brique CTAs */}
+            <div className="flex items-center gap-3 mt-3 pt-3 border-t border-gray-100">
+              {primarySiteId && (
+                <a
+                  href={`/diagnostic-conso?site_id=${primarySiteId}&hour=${drillDown.hour}&day_type=${drillDown.day < 5 ? 'weekday' : 'weekend'}`}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 rounded-lg hover:bg-blue-100 transition"
+                >
+                  <ArrowRight size={12} />
+                  Analyser ce creneau
+                </a>
+              )}
+              {primarySiteId && drillMonth && (
+                <a
+                  href={deepLinkWithContext(primarySiteId, drillMonth)}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-50 rounded-lg hover:bg-gray-100 transition"
+                >
+                  <FileText size={12} />
+                  Voir facture
+                </a>
+              )}
+            </div>
           </CardBody>
         </Card>
       )}
@@ -214,8 +247,8 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
 
       {/* Legend note */}
       <p className="text-[11px] text-gray-400">
-        HP = Heures Pleines (lun-ven 6h-22h) · HC = Heures Creuses (nuits + week-end)
-        · Intensite = conso moyenne par creneau
+        HP = Heures Pleines (lun-ven 6h-22h) · HC = Heures Creuses (nuits + week-ends)
+        · Intensite = consommation moyenne par creneau
       </p>
     </div>
   );

--- a/frontend/src/pages/consumption/SignaturePanel.jsx
+++ b/frontend/src/pages/consumption/SignaturePanel.jsx
@@ -8,9 +8,14 @@
  *   siteIds     — selected site IDs
  *   energyType  — 'electricity' | 'gas'
  */
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
+import {
+  AreaChart, Area, XAxis, YAxis, CartesianGrid,
+  Tooltip as RTooltip, ResponsiveContainer,
+} from 'recharts';
 import useEmsTimeseries from './useEmsTimeseries';
 import HeatmapChart from './HeatmapChart';
+import { Card, CardBody } from '../../ui';
 import { BarChart3 } from 'lucide-react';
 
 // French weekday index: 0=Mon, 1=Tue, ..., 5=Sat, 6=Sun
@@ -79,6 +84,31 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
 
   const heatmapData = useMemo(() => aggregateToHeatmap(seriesData), [seriesData]);
 
+  // P1-2: Filter ouvre/weekend + drill-down state
+  const [dayFilter, setDayFilter] = useState('all');
+  const [drillDown, setDrillDown] = useState(null);
+
+  // Build drill-down chart data from raw series for clicked day+hour
+  const drillDownData = useMemo(() => {
+    if (!drillDown || !seriesData?.[0]?.data) return [];
+    const points = [];
+    for (const pt of seriesData[0].data) {
+      if (pt.v == null) continue;
+      const normalized = typeof pt.t === 'string' ? pt.t.replace(' ', 'T') : pt.t;
+      const d = new Date(normalized);
+      if (isNaN(d.getTime())) continue;
+      const frDay = (d.getDay() + 6) % 7;
+      const hour = d.getHours();
+      if (frDay === drillDown.day && hour === drillDown.hour) {
+        points.push({
+          date: d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' }),
+          kwh: Math.round(pt.v * 100) / 100,
+        });
+      }
+    }
+    return points;
+  }, [drillDown, seriesData]);
+
   // Loading state
   if (status === 'loading') {
     return (
@@ -116,22 +146,76 @@ export default function SignaturePanel({ siteIds = [], energyType = 'electricity
 
   return (
     <div className="space-y-3">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+      {/* Header + filter */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
           <h3 className="text-sm font-semibold text-gray-800">Signature de consommation</h3>
-          <p className="text-xs text-gray-500">Moyenne kWh par créneau horaire (90 derniers jours)</p>
+          <p className="text-xs text-gray-500">Moyenne kWh par creneau horaire (90 derniers jours)</p>
         </div>
-        <span className="text-xs text-gray-400">{totalPoints.toLocaleString('fr-FR')} points</span>
+        <div className="flex items-center gap-2">
+          {/* P1-2: Day filter pills */}
+          {['all', 'weekday', 'weekend'].map(f => (
+            <button
+              key={f}
+              onClick={() => { setDayFilter(f); setDrillDown(null); }}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition ${
+                dayFilter === f ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {f === 'all' ? 'Semaine typique' : f === 'weekday' ? 'Ouvre' : 'Week-end'}
+            </button>
+          ))}
+          <span className="text-xs text-gray-400 ml-2">{totalPoints.toLocaleString('fr-FR')} pts</span>
+        </div>
       </div>
 
-      {/* Heatmap */}
-      <HeatmapChart data={heatmapData} unit="kWh" />
+      {/* Heatmap — now clickable */}
+      <HeatmapChart
+        data={heatmapData}
+        unit="kWh"
+        filter={dayFilter}
+        onCellClick={(cell) => setDrillDown(cell)}
+      />
+
+      {/* P1-2: Drill-down chart for selected cell */}
+      {drillDown && drillDownData.length > 0 && (
+        <Card>
+          <CardBody>
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-sm font-semibold text-gray-700">
+                Detail : {drillDown.dayLabel} {drillDown.hour}h ({drillDown.period})
+              </h4>
+              <button
+                onClick={() => setDrillDown(null)}
+                className="text-xs text-gray-400 hover:text-gray-600"
+              >
+                Fermer
+              </button>
+            </div>
+            <ResponsiveContainer width="100%" height={180}>
+              <AreaChart data={drillDownData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <XAxis dataKey="date" tick={{ fontSize: 9 }} angle={-30} textAnchor="end" height={40} />
+                <YAxis tick={{ fontSize: 10 }} label={{ value: 'kWh', angle: -90, position: 'insideLeft', style: { fontSize: 10 } }} />
+                <RTooltip />
+                <Area type="monotone" dataKey="kwh" stroke="#3b82f6" fill="#dbeafe" name="kWh" />
+              </AreaChart>
+            </ResponsiveContainer>
+            <p className="text-[10px] text-gray-400 mt-1">
+              {drillDownData.length} points sur 90 jours pour {drillDown.dayLabel} a {drillDown.hour}h
+            </p>
+          </CardBody>
+        </Card>
+      )}
+
+      {drillDown && drillDownData.length === 0 && (
+        <p className="text-xs text-gray-400 text-center py-4">Aucune donnee pour ce creneau.</p>
+      )}
 
       {/* Legend note */}
       <p className="text-[11px] text-gray-400">
-        HP = Heures Pleines (lun–ven 6h–22h) · HC = Heures Creuses (nuits + week-end)
-        · Intensité = conso moyenne par créneau
+        HP = Heures Pleines (lun-ven 6h-22h) · HC = Heures Creuses (nuits + week-end)
+        · Intensite = conso moyenne par creneau
       </p>
     </div>
   );

--- a/frontend/src/services/anomalyActions.js
+++ b/frontend/src/services/anomalyActions.js
@@ -1,0 +1,107 @@
+/**
+ * anomalyActions.js — V65
+ * Helpers localStorage pour les actions locales sur anomalies.
+ * Front-only (pas de DB). V66 migrera vers backend.
+ *
+ * Clé de stockage : "promeos_anomaly_actions"
+ * Format interne : { "${orgId}:${siteId}:${anomalyCode}": ActionRecord }
+ */
+
+const STORAGE_KEY = 'promeos_anomaly_actions';
+
+export const ACTION_STATUS = {
+  TODO:        'todo',
+  IN_PROGRESS: 'in_progress',
+  RESOLVED:    'resolved',
+};
+
+export const ACTION_STATUS_LABEL = {
+  todo:        'À traiter',
+  in_progress: 'En cours',
+  resolved:    'Résolu',
+};
+
+export const ACTION_STATUS_COLOR = {
+  todo:        'bg-gray-100 text-gray-600',
+  in_progress: 'bg-amber-100 text-amber-700',
+  resolved:    'bg-green-100 text-green-700',
+};
+
+/* ── Helpers internes ── */
+
+function _key(orgId, siteId, anomalyCode) {
+  return `${orgId ?? 'demo'}:${siteId}:${anomalyCode}`;
+}
+
+function _load() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function _save(data) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // silently ignore (private browsing, storage full, etc.)
+  }
+}
+
+/* ── API publique ── */
+
+/**
+ * Charge l'action locale pour une anomalie donnée.
+ * @returns {object|null}
+ */
+export function getAnomalyAction(orgId, siteId, anomalyCode) {
+  return _load()[_key(orgId, siteId, anomalyCode)] ?? null;
+}
+
+/**
+ * Sauvegarde (crée ou met à jour) une action locale.
+ * @param {object} record - { title, status, owner, due_date, notes }
+ */
+export function saveAnomalyAction(orgId, siteId, anomalyCode, record) {
+  const data = _load();
+  data[_key(orgId, siteId, anomalyCode)] = {
+    ...record,
+    anomaly_code: anomalyCode,
+    site_id:      siteId,
+    org_id:       orgId ?? 'demo',
+    updated_at:   new Date().toISOString(),
+  };
+  _save(data);
+}
+
+/**
+ * Supprime l'action locale pour une anomalie.
+ */
+export function deleteAnomalyAction(orgId, siteId, anomalyCode) {
+  const data = _load();
+  delete data[_key(orgId, siteId, anomalyCode)];
+  _save(data);
+}
+
+/**
+ * Retourne toutes les actions locales pour un site.
+ * @returns {object[]}
+ */
+export function getAllActionsForSite(orgId, siteId) {
+  const data = _load();
+  return Object.values(data).filter(
+    r => r.org_id === (orgId ?? 'demo') && r.site_id === siteId
+  );
+}
+
+/**
+ * Retourne toutes les actions locales pour une organisation.
+ * @returns {object[]}
+ */
+export function getAllActionsForOrg(orgId) {
+  const data = _load();
+  return Object.values(data).filter(
+    r => r.org_id === (orgId ?? 'demo')
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -987,6 +987,13 @@ export const getIssueProofs = (issueCode) =>
 export const createOperatProofTemplates = (efaId, year, body) =>
   api.post(`${TERT_BASE}/efa/${efaId}/proofs/templates`, body, { params: { year } }).then(r => r.data);
 
+// ========================================
+// PORTFOLIO CONSUMPTION (V1)
+// ========================================
+
+export const getPortfolioSummary = (params = {}) => _cachedGet('/portfolio/consumption/summary', { params }).then(r => r.data);
+export const getPortfolioSites = (params = {}) => _cachedGet('/portfolio/consumption/sites', { params }).then(r => r.data);
+
 // V69: Meta version (sha + branch) — Expert mode display
 export const getMetaVersion = () =>
   api.get('/meta/version').then(r => r.data).catch(() => null);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -594,6 +594,7 @@ export const putSiteTariff = (siteId, data) => api.put(`/site/${siteId}/tariff`,
 
 export const getBillingSummary = () => api.get('/billing/summary').then(r => r.data);
 export const getBillingInsights = (params = {}) => api.get('/billing/insights', { params }).then(r => r.data);
+export const getInsightDetail = (insightId) => api.get(`/billing/insights/${insightId}`).then(r => r.data);
 export const getBillingInvoices = (params = {}) => api.get('/billing/invoices', { params }).then(r => r.data);
 export const getSiteBilling = (siteId) => api.get(`/billing/site/${siteId}`).then(r => r.data);
 export const getBillingRules = () => api.get('/billing/rules').then(r => r.data);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -976,4 +976,8 @@ export const getIssueProofs = (issueCode) =>
 export const createOperatProofTemplates = (efaId, year, body) =>
   api.post(`${TERT_BASE}/efa/${efaId}/proofs/templates`, body, { params: { year } }).then(r => r.data);
 
+// V69: Meta version (sha + branch) — Expert mode display
+export const getMetaVersion = () =>
+  api.get('/meta/version').then(r => r.data).catch(() => null);
+
 export default api;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -893,6 +893,8 @@ export const getEmsTimeseries = (params) => _cachedGet('/ems/timeseries', { para
 export const getEmsTimeseriesSuggest = (dateFrom, dateTo) => _cachedGet('/ems/timeseries/suggest', { params: { date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
 export const getEmsWeather = (siteId, dateFrom, dateTo) => api.get('/ems/weather', { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
 export const getEmsWeatherMulti = (siteIds, dateFrom, dateTo) => api.get('/ems/weather', { params: { site_ids: siteIds.join(','), date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
+export const getEmsReferenceProfile = (siteId, dateFrom, dateTo, famille, puissance, granularity = 'daily') => api.get('/ems/reference_profile', { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo, famille, puissance, granularity } }).then(r => r.data);
+export const getEmsWeatherHourly = (siteId, dateFrom, dateTo) => api.get('/ems/weather_hourly', { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
 export const runEmsSignature = (siteId, dateFrom, dateTo, meterIds = null) => api.post('/ems/signature/run', null, { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo, meter_ids: meterIds } }).then(r => r.data);
 export const runEmsSignaturePortfolio = (siteIds, dateFrom, dateTo) => api.post('/ems/signature/portfolio', null, { params: { site_ids: siteIds.join(','), date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
 export const getEmsViews = (userId = null) => api.get('/ems/views', { params: userId ? { user_id: userId } : {} }).then(r => r.data);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -626,6 +626,16 @@ export const createActionFromBillingInsight = (insightId, title, siteId) =>
 export const getBillingAnomaliesScoped = () =>
   api.get('/billing/anomalies-scoped').then(r => r.data);
 
+/* ── V67 — Timeline & Coverage ── */
+export const getBillingPeriods = (params = {}) =>
+  api.get('/billing/periods', { params }).then(r => r.data);
+
+export const getCoverageSummary = (params = {}) =>
+  api.get('/billing/coverage-summary', { params }).then(r => r.data);
+
+export const getMissingPeriods = (params = {}) =>
+  api.get('/billing/missing-periods', { params }).then(r => r.data);
+
 // ========================================
 // ACHAT ENERGIE
 // ========================================

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -112,12 +112,12 @@ api.interceptors.request.use((config) => {
   config._startTime = Date.now();
   config.headers['X-Request-Id'] = config._requestId;
 
-  // Scope injection: skip /demo/* endpoints
+  // Scope injection: skip /demo/* endpoints and skipSiteHeader requests
   if (!isDemoPath(config.url)) {
     if (_apiScope.orgId != null) {
       config.headers['X-Org-Id'] = String(_apiScope.orgId);
     }
-    if (_apiScope.siteId != null) {
+    if (_apiScope.siteId != null && !config.skipSiteHeader) {
       config.headers['X-Site-Id'] = String(_apiScope.siteId);
     }
   }
@@ -991,8 +991,9 @@ export const createOperatProofTemplates = (efaId, year, body) =>
 // PORTFOLIO CONSUMPTION (V1)
 // ========================================
 
-export const getPortfolioSummary = (params = {}) => _cachedGet('/portfolio/consumption/summary', { params }).then(r => r.data);
-export const getPortfolioSites = (params = {}) => _cachedGet('/portfolio/consumption/sites', { params }).then(r => r.data);
+// skipSiteHeader: portfolio = multi-sites, never filter by single site scope
+export const getPortfolioSummary = (params = {}) => _cachedGet('/portfolio/consumption/summary', { params, skipSiteHeader: true }).then(r => r.data);
+export const getPortfolioSites = (params = {}) => _cachedGet('/portfolio/consumption/sites', { params, skipSiteHeader: true }).then(r => r.data);
 
 // V69: Meta version (sha + branch) — Expert mode display
 export const getMetaVersion = () =>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -603,6 +603,29 @@ export const patchBillingInsight = (insightId, data) => api.patch(`/billing/insi
 export const resolveBillingInsight = (insightId, notes = null) => api.post(`/billing/insights/${insightId}/resolve`, null, { params: notes ? { notes } : {} }).then(r => r.data);
 export const getImportBatches = (params = {}) => api.get('/billing/import/batches', { params }).then(r => r.data);
 
+// V66 — PDF import + action creation + billing anomalies
+export const importInvoicesPdf = (siteId, file) => {
+  const fd = new FormData();
+  fd.append('file', file);
+  return api.post('/billing/import-pdf', fd, {
+    params: { site_id: siteId },
+    headers: { 'Content-Type': 'multipart/form-data' },
+  }).then(r => r.data);
+};
+
+export const createActionFromBillingInsight = (insightId, title, siteId) =>
+  api.post('/actions', {
+    source_type: 'manual',
+    source_id: String(insightId),
+    source_key: `billing-insight:${insightId}`,
+    idempotency_key: `billing-insight:${insightId}`,
+    title,
+    site_id: siteId,
+  }).then(r => r.data);
+
+export const getBillingAnomaliesScoped = () =>
+  api.get('/billing/anomalies-scoped').then(r => r.data);
+
 // ========================================
 // ACHAT ENERGIE
 // ========================================

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -636,6 +636,9 @@ export const getCoverageSummary = (params = {}) =>
 export const getMissingPeriods = (params = {}) =>
   api.get('/billing/missing-periods', { params }).then(r => r.data);
 
+export const getNormalizedInvoices = (params = {}) =>
+  api.get('/billing/invoices/normalized', { params }).then(r => r.data);
+
 // ========================================
 // ACHAT ENERGIE
 // ========================================

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -182,6 +182,14 @@ export const isSilentUrl = (urlOrConfig) => {
 
 api.interceptors.response.use(
   (response) => {
+    // Guard: detect non-JSON responses (HTML from missing proxy / wrong prefix)
+    const ct = response.headers?.['content-type'] || '';
+    if (ct && !ct.includes('application/json') && !ct.includes('text/plain') && response.config.responseType !== 'blob') {
+      const msg = `[PROMEOS] API returned non-JSON (content-type: ${ct}). Vérifiez le proxy Vite ou le préfixe /api.`;
+      console.error(msg, { url: response.config.url, status: response.status });
+      return Promise.reject(new Error(msg));
+    }
+
     // Track successful request
     const duration = Date.now() - (response.config._startTime || Date.now());
     const entry = {

--- a/frontend/src/services/deepLink.js
+++ b/frontend/src/services/deepLink.js
@@ -1,0 +1,31 @@
+/**
+ * PROMEOS — Deep Link Helper (V70)
+ * Construit des URL contextuelles pour la navigation interne.
+ *
+ * Usage:
+ *   import { deepLinkWithContext } from '../services/deepLink';
+ *   navigate(deepLinkWithContext(siteId, '2025-03', invoiceId));
+ */
+
+/**
+ * Construit un deep link vers la page factures avec contexte pré-appliqué.
+ *
+ * @param {number|string|null} siteId   — filtre site (query param site_id)
+ * @param {string|null}        month    — filtre mois YYYY-MM (query param month)
+ * @param {number|null}        invoiceId — si fourni, pointe vers la facture unique
+ * @returns {string} URL relative prête pour navigate()
+ */
+export function deepLinkWithContext(siteId, month, invoiceId = null) {
+  if (invoiceId) {
+    const params = new URLSearchParams();
+    params.set('invoice_id', String(invoiceId));
+    if (siteId) params.set('site_id', String(siteId));
+    if (month) params.set('month', month);
+    return `/bill-intel?${params.toString()}`;
+  }
+
+  const params = new URLSearchParams();
+  if (siteId) params.set('site_id', String(siteId));
+  if (month) params.set('month', month);
+  return `/bill-intel?${params.toString()}`;
+}

--- a/frontend/src/services/deepLink.js
+++ b/frontend/src/services/deepLink.js
@@ -1,10 +1,12 @@
 /**
- * PROMEOS — Deep Link Helper (V70)
+ * PROMEOS — Deep Link Helper (V71)
  * Construit des URL contextuelles pour la navigation interne.
  *
  * Usage:
- *   import { deepLinkWithContext } from '../services/deepLink';
+ *   import { deepLinkWithContext, deepLinkAction, deepLinkNewAction } from '../services/deepLink';
  *   navigate(deepLinkWithContext(siteId, '2025-03', invoiceId));
+ *   navigate(deepLinkAction(42));
+ *   navigate(deepLinkNewAction({ type: 'facture', site_id: 5 }));
  */
 
 /**
@@ -28,4 +30,29 @@ export function deepLinkWithContext(siteId, month, invoiceId = null) {
   if (siteId) params.set('site_id', String(siteId));
   if (month) params.set('month', month);
   return `/bill-intel?${params.toString()}`;
+}
+
+/**
+ * Deep link vers une action existante.
+ * @param {number|string} actionId
+ * @returns {string} URL relative /actions/:id
+ */
+export function deepLinkAction(actionId) {
+  return `/actions/${actionId}`;
+}
+
+/**
+ * Deep link vers la création d'action avec contexte pré-rempli.
+ * @param {object} opts - { type, site_id, source, ref_id, titre }
+ * @returns {string} URL relative /actions/new?...
+ */
+export function deepLinkNewAction(opts = {}) {
+  const params = new URLSearchParams();
+  if (opts.type) params.set('type', opts.type);
+  if (opts.site_id) params.set('site_id', String(opts.site_id));
+  if (opts.source) params.set('source', opts.source);
+  if (opts.ref_id) params.set('ref_id', String(opts.ref_id));
+  if (opts.titre) params.set('titre', opts.titre);
+  const qs = params.toString();
+  return `/actions/new${qs ? '?' + qs : ''}`;
 }

--- a/frontend/src/services/routes.js
+++ b/frontend/src/services/routes.js
@@ -1,0 +1,96 @@
+/**
+ * PROMEOS — Route Registry
+ * Helpers stables pour la navigation interne. Aucun lien bricole.
+ * Chaque helper retourne une URL relative prete pour navigate().
+ */
+
+/**
+ * Explorer consommation — vue mono ou multi-site.
+ * @param {object} opts
+ * @param {number|string|number[]} [opts.site_id] — ID site ou tableau d'IDs
+ * @param {number} [opts.days] — periode en jours (7, 30, 90, 365)
+ * @param {'electricity'|'gas'} [opts.energy]
+ * @param {'kwh'|'kw'|'eur'} [opts.unit]
+ * @param {'agrege'|'superpose'|'empile'|'separe'} [opts.mode]
+ */
+export function toConsoExplorer(opts = {}) {
+  const p = new URLSearchParams();
+  if (opts.site_id != null) {
+    const ids = Array.isArray(opts.site_id) ? opts.site_id : [opts.site_id];
+    p.set('sites', ids.join(','));
+  }
+  if (opts.days) p.set('days', String(opts.days));
+  if (opts.energy) p.set('energy', opts.energy);
+  if (opts.unit) p.set('unit', opts.unit);
+  if (opts.mode) p.set('mode', opts.mode);
+  const qs = p.toString();
+  return `/consommations/explorer${qs ? '?' + qs : ''}`;
+}
+
+/**
+ * Diagnostic consommation — vue mono-site.
+ * @param {object} opts
+ * @param {number|string} opts.site_id
+ */
+export function toConsoDiag(opts = {}) {
+  const p = new URLSearchParams();
+  if (opts.site_id) p.set('site_id', String(opts.site_id));
+  const qs = p.toString();
+  return `/diagnostic-conso${qs ? '?' + qs : ''}`;
+}
+
+/**
+ * Factures / Bill Intel — vue filtrée par site et mois.
+ * @param {object} opts
+ * @param {number|string} [opts.site_id]
+ * @param {string} [opts.month] — format YYYY-MM
+ * @param {number|string} [opts.invoice_id]
+ */
+export function toBillIntel(opts = {}) {
+  const p = new URLSearchParams();
+  if (opts.invoice_id) p.set('invoice_id', String(opts.invoice_id));
+  if (opts.site_id) p.set('site_id', String(opts.site_id));
+  if (opts.month) p.set('month', opts.month);
+  const qs = p.toString();
+  return `/bill-intel${qs ? '?' + qs : ''}`;
+}
+
+/**
+ * Creation d'action avec contexte pre-rempli.
+ * @param {object} opts
+ * @param {'consommation'|'facture'|'patrimoine'} [opts.source_type]
+ * @param {number|string} [opts.source_id]
+ * @param {number|string} [opts.site_id]
+ * @param {number[]|string} [opts.site_ids] — pour campagnes multi-sites
+ * @param {string} [opts.title]
+ * @param {string} [opts.source] — identifiant origine (portfolio, explorer, etc.)
+ */
+export function toActionNew(opts = {}) {
+  const p = new URLSearchParams();
+  if (opts.source_type) p.set('type', opts.source_type);
+  if (opts.source) p.set('source', opts.source);
+  if (opts.source_id) p.set('ref_id', String(opts.source_id));
+  if (opts.site_id) p.set('site_id', String(opts.site_id));
+  if (opts.title) p.set('titre', opts.title);
+  if (opts.site_ids) {
+    const ids = Array.isArray(opts.site_ids) ? opts.site_ids.join(',') : opts.site_ids;
+    p.set('campaign_sites', ids);
+  }
+  const qs = p.toString();
+  return `/actions/new${qs ? '?' + qs : ''}`;
+}
+
+/**
+ * Vue action existante.
+ * @param {number|string} actionId
+ */
+export function toAction(actionId) {
+  return `/actions/${actionId}`;
+}
+
+/**
+ * Import & Analyse consommation.
+ */
+export function toConsoImport() {
+  return '/consommations/import';
+}

--- a/frontend/src/services/routes.js
+++ b/frontend/src/services/routes.js
@@ -9,6 +9,8 @@
  * @param {object} opts
  * @param {number|string|number[]} [opts.site_id] — ID site ou tableau d'IDs
  * @param {number} [opts.days] — periode en jours (7, 30, 90, 365)
+ * @param {string} [opts.date_from] — date debut YYYY-MM-DD (prioritaire sur days)
+ * @param {string} [opts.date_to] — date fin YYYY-MM-DD
  * @param {'electricity'|'gas'} [opts.energy]
  * @param {'kwh'|'kw'|'eur'} [opts.unit]
  * @param {'agrege'|'superpose'|'empile'|'separe'} [opts.mode]
@@ -20,6 +22,8 @@ export function toConsoExplorer(opts = {}) {
     p.set('sites', ids.join(','));
   }
   if (opts.days) p.set('days', String(opts.days));
+  if (opts.date_from) p.set('date_from', opts.date_from);
+  if (opts.date_to) p.set('date_to', opts.date_to);
   if (opts.energy) p.set('energy', opts.energy);
   if (opts.unit) p.set('unit', opts.unit);
   if (opts.mode) p.set('mode', opts.mode);
@@ -86,6 +90,20 @@ export function toActionNew(opts = {}) {
  */
 export function toAction(actionId) {
   return `/actions/${actionId}`;
+}
+
+/**
+ * Liste des actions filtrée.
+ * @param {object} opts
+ * @param {number|string} [opts.site_id] — filtre par site
+ * @param {string} [opts.source] — filtre par origine (operat, portfolio, etc.)
+ */
+export function toActionsList(opts = {}) {
+  const p = new URLSearchParams();
+  if (opts.site_id) p.set('site_id', String(opts.site_id));
+  if (opts.source) p.set('source', opts.source);
+  const qs = p.toString();
+  return `/actions${qs ? '?' + qs : ''}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Billing Unified (V66-V69)**: shadow billing V2, timeline & coverage engine, bill-intel cockpit DAF, CTA stabilization, deep-links (38 commits)
- **Conso Audit V2**: courbe de référence, heatmap interactive, overlay météo, CTA drill-down, data dedup (9 commits)
- **Portfolio V1→V2**: patrimoine-first UX — summary/sites endpoints, route registry, scope coherence, empty states, coverage badge, inline import (14 commits)

## Branches consolidated (linear chain)
This PR supersedes PR #5 (`feat/v68-billing-unified`) and consolidates:
`feat/v68-billing-unified` → `feat/v2-conso-audit-20260225` → `feat/conso-portfolio-v1-20260225` → `feat/conso-portfolio-v1.3-20260225` → `fix/portfolio-multisite-scope-header-20260225` → `feat/conso-portfolio-p2-sprint-20260225` → `feat/conso-portfolio-v2-20260225`

## Stats
- 61 commits, 82 files changed, ~13 600 insertions
- Backend: new endpoints (portfolio summary, sites, meta/version, billing periods/coverage), data model updates, smoke tests
- Frontend: 5 new pages/components, route registry, deep-link services, 100+ tests

## Test plan
- [ ] Backend smoke tests pass (`pytest backend/tests/`)
- [ ] Frontend unit tests pass (`npx vitest run`)
- [ ] Manual check: billing page, conso page, portfolio page

🤖 Generated with [Claude Code](https://claude.com/claude-code)