### PR TITLE
fix(achat): P0 — dynamic org_id, deep-link filters, assistant API

### DIFF
--- a/backend/routes/purchase.py
+++ b/backend/routes/purchase.py
@@ -3,6 +3,7 @@ PROMEOS — Achat Energie Endpoints V1.1
 V1: Estimation, hypotheses, preferences, scenarios, recommandation.
 V1.1: Portfolio roll-up, renewals, history, actions.
 """
+
 import uuid
 from datetime import datetime, date, timedelta
 from typing import Optional
@@ -15,9 +16,14 @@ from database import get_db
 from middleware.auth import get_optional_auth, AuthContext
 from services.iam_scope import check_site_access
 from models import (
-    PurchaseAssumptionSet, PurchasePreference, PurchaseScenarioResult,
-    PurchaseStrategy, PurchaseRecoStatus, BillingEnergyType,
-    EnergyContract, Site,
+    PurchaseAssumptionSet,
+    PurchasePreference,
+    PurchaseScenarioResult,
+    PurchaseStrategy,
+    PurchaseRecoStatus,
+    BillingEnergyType,
+    EnergyContract,
+    Site,
 )
 from services.purchase_service import (
     estimate_consumption,
@@ -38,6 +44,7 @@ ALLOWED_ENERGY_TYPES = {"elec"}
 
 # ── Pydantic schemas ──
 
+
 class AssumptionSetIn(BaseModel):
     energy_type: str = "elec"
     volume_kwh_an: float = 0
@@ -57,6 +64,7 @@ class PreferenceIn(BaseModel):
 
 # ── 1. Estimation conso ──
 
+
 @router.get("/estimate/{site_id}")
 def get_estimate(site_id: int, db: Session = Depends(get_db), auth: Optional[AuthContext] = Depends(get_optional_auth)):
     """Estimate annual consumption for a site."""
@@ -69,8 +77,11 @@ def get_estimate(site_id: int, db: Session = Depends(get_db), auth: Optional[Aut
 
 # ── 2-3. Assumptions CRUD ──
 
+
 @router.get("/assumptions/{site_id}")
-def get_assumptions(site_id: int, db: Session = Depends(get_db), auth: Optional[AuthContext] = Depends(get_optional_auth)):
+def get_assumptions(
+    site_id: int, db: Session = Depends(get_db), auth: Optional[AuthContext] = Depends(get_optional_auth)
+):
     """Get existing assumptions or defaults."""
     check_site_access(auth, site_id)
     assumption = (
@@ -104,7 +115,12 @@ def get_assumptions(site_id: int, db: Session = Depends(get_db), auth: Optional[
 
 
 @router.put("/assumptions/{site_id}")
-def put_assumptions(site_id: int, data: AssumptionSetIn, db: Session = Depends(get_db), auth: Optional[AuthContext] = Depends(get_optional_auth)):
+def put_assumptions(
+    site_id: int,
+    data: AssumptionSetIn,
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
     """Create or update assumptions for a site."""
     check_site_access(auth, site_id)
     # Energy Gate: block non-ELEC energy types
@@ -112,7 +128,7 @@ def put_assumptions(site_id: int, data: AssumptionSetIn, db: Session = Depends(g
         raise HTTPException(
             status_code=422,
             detail=f"Energie '{data.energy_type}' non supportee. "
-                   f"Seule l'electricite (elec) est disponible dans cette version (post-ARENH).",
+            f"Seule l'electricite (elec) est disponible dans cette version (post-ARENH).",
         )
     existing = (
         db.query(PurchaseAssumptionSet)
@@ -147,6 +163,7 @@ def put_assumptions(site_id: int, data: AssumptionSetIn, db: Session = Depends(g
 
 
 # ── 4-5. Preferences CRUD ──
+
 
 @router.get("/preferences")
 def get_preferences(
@@ -221,6 +238,7 @@ def put_preferences(
 
 # ── V1.1: Renewals ──
 
+
 @router.get("/renewals")
 def get_renewals(
     org_id: Optional[int] = Query(None),
@@ -238,10 +256,14 @@ def get_renewals(
     if not site_ids:
         return {"total": 0, "renewals": []}
 
-    contracts = db.query(EnergyContract).filter(
-        EnergyContract.site_id.in_(site_ids),
-        EnergyContract.end_date.isnot(None),
-    ).all()
+    contracts = (
+        db.query(EnergyContract)
+        .filter(
+            EnergyContract.site_id.in_(site_ids),
+            EnergyContract.end_date.isnot(None),
+        )
+        .all()
+    )
 
     today = date.today()
     renewals = []
@@ -269,26 +291,29 @@ def get_renewals(
             urgency = "gray"
 
         site = site_map.get(c.site_id)
-        renewals.append({
-            "contract_id": c.id,
-            "site_id": c.site_id,
-            "site_nom": site.nom if site else None,
-            "supplier_name": c.supplier_name,
-            "energy_type": c.energy_type.value if c.energy_type else None,
-            "end_date": c.end_date.isoformat(),
-            "notice_period_days": c.notice_period_days,
-            "notice_deadline": notice_deadline.isoformat(),
-            "auto_renew": c.auto_renew,
-            "days_until_expiry": days_until_expiry,
-            "days_until_notice": days_until_notice,
-            "urgency": urgency,
-        })
+        renewals.append(
+            {
+                "contract_id": c.id,
+                "site_id": c.site_id,
+                "site_nom": site.nom if site else None,
+                "supplier_name": c.supplier_name,
+                "energy_type": c.energy_type.value if c.energy_type else None,
+                "end_date": c.end_date.isoformat(),
+                "notice_period_days": c.notice_period_days,
+                "notice_deadline": notice_deadline.isoformat(),
+                "auto_renew": c.auto_renew,
+                "days_until_expiry": days_until_expiry,
+                "days_until_notice": days_until_notice,
+                "urgency": urgency,
+            }
+        )
 
     renewals.sort(key=lambda r: r["days_until_expiry"])
     return {"total": len(renewals), "renewals": renewals}
 
 
 # ── V1.1: Actions ──
+
 
 @router.get("/actions")
 def get_actions(
@@ -303,6 +328,7 @@ def get_actions(
 
 
 # ── V1.1: Portfolio compute ──
+
 
 @router.post("/compute")
 def compute_portfolio(
@@ -325,9 +351,14 @@ def compute_portfolio(
     results_by_site = []
 
     # Get org-level preferences
-    pref = db.query(PurchasePreference).filter(
-        PurchasePreference.org_id == org_id,
-    ).first() or db.query(PurchasePreference).first()
+    pref = (
+        db.query(PurchasePreference)
+        .filter(
+            PurchasePreference.org_id == org_id,
+        )
+        .first()
+        or db.query(PurchasePreference).first()
+    )
     risk_tol = pref.risk_tolerance if pref else "medium"
     budget_pri = pref.budget_priority if pref else 0.5
     green_pref = pref.green_preference if pref else False
@@ -363,7 +394,8 @@ def compute_portfolio(
             continue
 
         scenarios = compute_scenarios(
-            db, sid,
+            db,
+            sid,
             volume_kwh_an=assumption.volume_kwh_an,
             profile_factor=assumption.profile_factor,
             energy_type=energy_type_val,
@@ -371,9 +403,13 @@ def compute_portfolio(
         scenarios = recommend_scenario(scenarios, risk_tol, budget_pri, green_pref)
 
         inputs_hash_val = compute_inputs_hash(
-            assumption.volume_kwh_an, assumption.profile_factor,
-            assumption.horizon_months, energy_type_val,
-            risk_tol, budget_pri, green_pref,
+            assumption.volume_kwh_an,
+            assumption.profile_factor,
+            assumption.horizon_months,
+            energy_type_val,
+            risk_tol,
+            budget_pri,
+            green_pref,
         )
 
         # Persist (keep old results for history)
@@ -403,12 +439,14 @@ def compute_portfolio(
         for i, s in enumerate(scenarios):
             s["id"] = result_ids[i]
 
-        results_by_site.append({
-            "site_id": sid,
-            "run_id": run_id,
-            "volume_kwh_an": assumption.volume_kwh_an,
-            "scenarios": scenarios,
-        })
+        results_by_site.append(
+            {
+                "site_id": sid,
+                "run_id": run_id,
+                "volume_kwh_an": assumption.volume_kwh_an,
+                "scenarios": scenarios,
+            }
+        )
 
     portfolio = aggregate_portfolio_results(results_by_site)
 
@@ -421,6 +459,7 @@ def compute_portfolio(
 
 
 # ── 6. Compute scenarios (per-site) — V1.1: +run_id +inputs_hash, preserve history ──
+
 
 @router.post("/compute/{site_id}")
 def compute(site_id: int, db: Session = Depends(get_db), auth: Optional[AuthContext] = Depends(get_optional_auth)):
@@ -484,9 +523,13 @@ def compute(site_id: int, db: Session = Depends(get_db), auth: Optional[AuthCont
     # V1.1: Generate run_id and inputs_hash
     run_id = str(uuid.uuid4())
     inputs_hash_val = compute_inputs_hash(
-        assumption.volume_kwh_an, assumption.profile_factor,
-        assumption.horizon_months, energy_type_val,
-        risk_tol, budget_pri, green_pref,
+        assumption.volume_kwh_an,
+        assumption.profile_factor,
+        assumption.horizon_months,
+        energy_type_val,
+        risk_tol,
+        budget_pri,
+        green_pref,
     )
 
     # V1.1: No longer delete old results — preserve for history
@@ -527,6 +570,7 @@ def compute(site_id: int, db: Session = Depends(get_db), auth: Optional[AuthCont
 
 
 # ── V1.1: Portfolio results ──
+
 
 @router.get("/results")
 def get_portfolio_results(
@@ -584,20 +628,22 @@ def get_portfolio_results(
         if not results:
             continue
 
-        results_by_site.append({
-            "site_id": sid,
-            "volume_kwh_an": assumption.volume_kwh_an,
-            "scenarios": [
-                {
-                    "strategy": r.strategy.value if r.strategy else None,
-                    "total_annual_eur": r.total_annual_eur,
-                    "risk_score": r.risk_score,
-                    "savings_vs_current_pct": r.savings_vs_current_pct,
-                    "is_recommended": r.is_recommended,
-                }
-                for r in results
-            ],
-        })
+        results_by_site.append(
+            {
+                "site_id": sid,
+                "volume_kwh_an": assumption.volume_kwh_an,
+                "scenarios": [
+                    {
+                        "strategy": r.strategy.value if r.strategy else None,
+                        "total_annual_eur": r.total_annual_eur,
+                        "risk_score": r.risk_score,
+                        "savings_vs_current_pct": r.savings_vs_current_pct,
+                        "is_recommended": r.is_recommended,
+                    }
+                    for r in results
+                ],
+            }
+        )
 
     portfolio = aggregate_portfolio_results(results_by_site)
 
@@ -609,6 +655,7 @@ def get_portfolio_results(
 
 
 # ── 7. Get results (per-site) — V1.1: filter by latest run_id ──
+
 
 @router.get("/results/{site_id}")
 def get_results(site_id: int, db: Session = Depends(get_db), auth: Optional[AuthContext] = Depends(get_optional_auth)):
@@ -676,15 +723,12 @@ def get_results(site_id: int, db: Session = Depends(get_db), auth: Optional[Auth
 
 # ── V1.1: History ──
 
+
 @router.get("/history/{site_id}")
 def get_history(site_id: int, db: Session = Depends(get_db), auth: Optional[AuthContext] = Depends(get_optional_auth)):
     """List past computation runs for a site with timestamps and inputs_hash."""
     check_site_access(auth, site_id)
-    assumptions = (
-        db.query(PurchaseAssumptionSet)
-        .filter(PurchaseAssumptionSet.site_id == site_id)
-        .all()
-    )
+    assumptions = db.query(PurchaseAssumptionSet).filter(PurchaseAssumptionSet.site_id == site_id).all()
     assumption_ids = [a.id for a in assumptions]
     if not assumption_ids:
         return {"site_id": site_id, "total_runs": 0, "runs": []}
@@ -708,16 +752,18 @@ def get_history(site_id: int, db: Session = Depends(get_db), auth: Optional[Auth
                 "computed_at": r.computed_at.isoformat() if r.computed_at else None,
                 "scenarios": [],
             }
-        runs_map[key]["scenarios"].append({
-            "id": r.id,
-            "strategy": r.strategy.value if r.strategy else None,
-            "price_eur_per_kwh": r.price_eur_per_kwh,
-            "total_annual_eur": r.total_annual_eur,
-            "risk_score": r.risk_score,
-            "savings_vs_current_pct": r.savings_vs_current_pct,
-            "is_recommended": r.is_recommended,
-            "reco_status": r.reco_status.value if r.reco_status else None,
-        })
+        runs_map[key]["scenarios"].append(
+            {
+                "id": r.id,
+                "strategy": r.strategy.value if r.strategy else None,
+                "price_eur_per_kwh": r.price_eur_per_kwh,
+                "total_annual_eur": r.total_annual_eur,
+                "risk_score": r.risk_score,
+                "savings_vs_current_pct": r.savings_vs_current_pct,
+                "is_recommended": r.is_recommended,
+                "reco_status": r.reco_status.value if r.reco_status else None,
+            }
+        )
 
     runs = list(runs_map.values())
 
@@ -739,12 +785,11 @@ def get_history(site_id: int, db: Session = Depends(get_db), auth: Optional[Auth
 
 # ── 8. Accept result ──
 
+
 @router.patch("/results/{result_id}/accept")
 def accept_result(result_id: int, db: Session = Depends(get_db)):
     """Accept a recommended scenario."""
-    result = db.query(PurchaseScenarioResult).filter(
-        PurchaseScenarioResult.id == result_id
-    ).first()
+    result = db.query(PurchaseScenarioResult).filter(PurchaseScenarioResult.id == result_id).first()
     if not result:
         raise HTTPException(status_code=404, detail="Result not found")
     result.reco_status = PurchaseRecoStatus.ACCEPTED
@@ -752,21 +797,158 @@ def accept_result(result_id: int, db: Session = Depends(get_db)):
     return {"id": result.id, "reco_status": "accepted"}
 
 
+# ── 9a. Assistant data ──
+
+
+@router.get("/assistant")
+def get_assistant_data(
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Return portfolio summary data for the Purchase Assistant wizard.
+
+    If real sites exist for the org, returns real data.
+    Otherwise returns a minimal demo seed (flagged is_demo=true).
+    """
+    if auth:
+        org_id = auth.org_id
+
+    sites_out = []
+    is_demo = False
+
+    if org_id:
+        site_ids = get_org_site_ids(db, org_id)
+        if site_ids:
+            sites_q = db.query(Site).filter(Site.id.in_(site_ids)).all()
+            for s in sites_q:
+                est = estimate_consumption(db, s.id)
+                sites_out.append(
+                    {
+                        "id": s.id,
+                        "name": s.nom,
+                        "city": getattr(s, "ville", None),
+                        "usage": s.type.value if s.type else None,
+                        "surface_m2": s.surface_m2,
+                        "energy_type": "elec",
+                        "annual_kwh": est.get("volume_kwh_an", 0),
+                        "source": est.get("source", "default"),
+                    }
+                )
+
+    if not sites_out:
+        is_demo = True
+        sites_out = [
+            {
+                "id": 1,
+                "name": "Usine Lyon",
+                "city": "Lyon",
+                "usage": "industriel",
+                "surface_m2": 12000,
+                "energy_type": "elec",
+                "annual_kwh": 2400000,
+                "source": "DEMO",
+            },
+            {
+                "id": 2,
+                "name": "Entrepot Grenoble",
+                "city": "Grenoble",
+                "usage": "logistique",
+                "surface_m2": 5000,
+                "energy_type": "elec",
+                "annual_kwh": 800000,
+                "source": "DEMO",
+            },
+            {
+                "id": 3,
+                "name": "Bureaux Paris 8e",
+                "city": "Paris",
+                "usage": "bureau",
+                "surface_m2": 3000,
+                "energy_type": "elec",
+                "annual_kwh": 600000,
+                "source": "DEMO",
+            },
+            {
+                "id": 4,
+                "name": "Agence Nantes",
+                "city": "Nantes",
+                "usage": "bureau",
+                "surface_m2": 1500,
+                "energy_type": "elec",
+                "annual_kwh": 350000,
+                "source": "DEMO",
+            },
+            {
+                "id": 5,
+                "name": "Atelier Toulouse",
+                "city": "Toulouse",
+                "usage": "industriel",
+                "surface_m2": 8000,
+                "energy_type": "elec",
+                "annual_kwh": 1800000,
+                "source": "DEMO",
+            },
+            {
+                "id": 6,
+                "name": "Datacenter Marseille",
+                "city": "Marseille",
+                "usage": "datacenter",
+                "surface_m2": 2000,
+                "energy_type": "elec",
+                "annual_kwh": 5000000,
+                "source": "DEMO",
+            },
+            {
+                "id": 7,
+                "name": "Depot Lille",
+                "city": "Lille",
+                "usage": "logistique",
+                "surface_m2": 6000,
+                "energy_type": "elec",
+                "annual_kwh": 450000,
+                "source": "DEMO",
+            },
+            {
+                "id": 8,
+                "name": "Siege Bordeaux",
+                "city": "Bordeaux",
+                "usage": "bureau",
+                "surface_m2": 4000,
+                "energy_type": "elec",
+                "annual_kwh": 700000,
+                "source": "DEMO",
+            },
+        ]
+
+    return {
+        "is_demo": is_demo,
+        "org_id": org_id,
+        "sites": sites_out,
+        "total_sites": len(sites_out),
+        "total_annual_kwh": sum(s["annual_kwh"] for s in sites_out),
+    }
+
+
 # ── 9. Seed demo ──
+
 
 @router.post("/seed-demo")
 def seed_demo(db: Session = Depends(get_db)):
     """Seed purchase demo data for 2 sites."""
     from services.purchase_seed import seed_purchase_demo
+
     return seed_purchase_demo(db)
 
 
 # ── Brique 3: WOW multi-site datasets ──
 
+
 @router.post("/seed-wow-happy")
 def seed_wow_happy_endpoint(db: Session = Depends(get_db)):
     """Seed 15-site portfolio with clean, realistic data (happy path demo)."""
     from services.purchase_seed_wow import seed_wow_happy
+
     return seed_wow_happy(db)
 
 
@@ -774,4 +956,5 @@ def seed_wow_happy_endpoint(db: Session = Depends(get_db)):
 def seed_wow_dirty_endpoint(db: Session = Depends(get_db)):
     """Seed 15-site portfolio with degraded/edge-case data (dirty demo)."""
     from services.purchase_seed_wow import seed_wow_dirty
+
     return seed_wow_dirty(db)

--- a/backend/tests/test_purchase.py
+++ b/backend/tests/test_purchase.py
@@ -2,8 +2,10 @@
 PROMEOS - Tests Sprint 8: Achat Energie V1
 Models, service (estimate, scenarios, recommend), endpoints, seed demo.
 """
+
 import sys
 import os
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import json
@@ -15,11 +17,22 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from models import (
-    Base, Site, Organisation, EntiteJuridique, Portefeuille,
-    EnergyContract, EnergyInvoice, SiteOperatingSchedule,
-    PurchaseAssumptionSet, PurchasePreference, PurchaseScenarioResult,
-    PurchaseStrategy, PurchaseRecoStatus, BillingEnergyType,
-    BillingInvoiceStatus, TypeSite,
+    Base,
+    Site,
+    Organisation,
+    EntiteJuridique,
+    Portefeuille,
+    EnergyContract,
+    EnergyInvoice,
+    SiteOperatingSchedule,
+    PurchaseAssumptionSet,
+    PurchasePreference,
+    PurchaseScenarioResult,
+    PurchaseStrategy,
+    PurchaseRecoStatus,
+    BillingEnergyType,
+    BillingInvoiceStatus,
+    TypeSite,
 )
 from database import get_db
 from main import app
@@ -46,6 +59,7 @@ def client(db_session):
             yield db_session
         finally:
             pass
+
     app.dependency_overrides[get_db] = _override
     yield TestClient(app)
     app.dependency_overrides.clear()
@@ -63,9 +77,13 @@ def _create_org_site(db, surface=2000):
     db.add(pf)
     db.flush()
     site = Site(
-        nom="Site A", type=TypeSite.BUREAU,
-        adresse="1 rue Test", code_postal="75001", ville="Paris",
-        surface_m2=surface, portefeuille_id=pf.id,
+        nom="Site A",
+        type=TypeSite.BUREAU,
+        adresse="1 rue Test",
+        code_postal="75001",
+        ville="Paris",
+        surface_m2=surface,
+        portefeuille_id=pf.id,
     )
     db.add(site)
     db.flush()
@@ -76,9 +94,13 @@ def _create_two_sites(db):
     """Helper: create org + 2 sites."""
     org, site_a = _create_org_site(db)
     site_b = Site(
-        nom="Site B", type=TypeSite.ENTREPOT,
-        adresse="2 rue Test", code_postal="69001", ville="Lyon",
-        surface_m2=5000, portefeuille_id=site_a.portefeuille_id,
+        nom="Site B",
+        type=TypeSite.ENTREPOT,
+        adresse="2 rue Test",
+        code_postal="69001",
+        ville="Lyon",
+        surface_m2=5000,
+        portefeuille_id=site_a.portefeuille_id,
     )
     db.add(site_b)
     db.flush()
@@ -88,6 +110,7 @@ def _create_two_sites(db):
 # ========================================
 # Model tests
 # ========================================
+
 
 class TestModels:
     def test_create_assumption_set(self, db_session):
@@ -142,9 +165,11 @@ class TestModels:
 # Service tests
 # ========================================
 
+
 class TestPurchaseService:
     def test_estimate_from_invoices(self, db_session):
         from services.purchase_service import estimate_consumption
+
         _, site = _create_org_site(db_session)
         # Create an invoice within last 12 months
         contract = EnergyContract(
@@ -175,6 +200,7 @@ class TestPurchaseService:
 
     def test_estimate_fallback(self, db_session):
         from services.purchase_service import estimate_consumption
+
         _, site = _create_org_site(db_session)
         result = estimate_consumption(db_session, site.id)
         assert result["source"] == "default"
@@ -183,6 +209,7 @@ class TestPurchaseService:
 
     def test_compute_scenarios_3_strategies(self, db_session):
         from services.purchase_service import compute_scenarios
+
         _, site = _create_org_site(db_session)
         scenarios = compute_scenarios(db_session, site.id, volume_kwh_an=500000)
         assert len(scenarios) == 3
@@ -198,13 +225,29 @@ class TestPurchaseService:
 
     def test_recommend_low_risk(self, db_session):
         from services.purchase_service import recommend_scenario
+
         scenarios = [
-            {"strategy": "fixe", "risk_score": 15, "savings_vs_current_pct": -5,
-             "total_annual_eur": 105000, "price_eur_per_kwh": 0.189},
-            {"strategy": "indexe", "risk_score": 45, "savings_vs_current_pct": 5,
-             "total_annual_eur": 95000, "price_eur_per_kwh": 0.171},
-            {"strategy": "spot", "risk_score": 75, "savings_vs_current_pct": 12,
-             "total_annual_eur": 88000, "price_eur_per_kwh": 0.1584},
+            {
+                "strategy": "fixe",
+                "risk_score": 15,
+                "savings_vs_current_pct": -5,
+                "total_annual_eur": 105000,
+                "price_eur_per_kwh": 0.189,
+            },
+            {
+                "strategy": "indexe",
+                "risk_score": 45,
+                "savings_vs_current_pct": 5,
+                "total_annual_eur": 95000,
+                "price_eur_per_kwh": 0.171,
+            },
+            {
+                "strategy": "spot",
+                "risk_score": 75,
+                "savings_vs_current_pct": 12,
+                "total_annual_eur": 88000,
+                "price_eur_per_kwh": 0.1584,
+            },
         ]
         result = recommend_scenario(scenarios, risk_tolerance="low", budget_priority=0.5)
         # Spot should be excluded (risk > 50)
@@ -216,6 +259,7 @@ class TestPurchaseService:
 # ========================================
 # API tests
 # ========================================
+
 
 class TestPurchaseAPI:
     def test_estimate_endpoint(self, client, db_session):
@@ -230,11 +274,14 @@ class TestPurchaseAPI:
     def test_put_get_assumptions(self, client, db_session):
         _, site = _create_org_site(db_session)
         # PUT
-        resp = client.put(f"/api/purchase/assumptions/{site.id}", json={
-            "energy_type": "elec",
-            "volume_kwh_an": 750000,
-            "horizon_months": 36,
-        })
+        resp = client.put(
+            f"/api/purchase/assumptions/{site.id}",
+            json={
+                "energy_type": "elec",
+                "volume_kwh_an": 750000,
+                "horizon_months": 36,
+            },
+        )
         assert resp.status_code == 200
         assert resp.json()["status"] == "created"
         # GET
@@ -246,11 +293,14 @@ class TestPurchaseAPI:
 
     def test_put_get_preferences(self, client, db_session):
         # PUT
-        resp = client.put("/api/purchase/preferences", json={
-            "risk_tolerance": "low",
-            "budget_priority": 0.3,
-            "green_preference": True,
-        })
+        resp = client.put(
+            "/api/purchase/preferences",
+            json={
+                "risk_tolerance": "low",
+                "budget_priority": 0.3,
+                "green_preference": True,
+            },
+        )
         assert resp.status_code == 200
         assert resp.json()["status"] == "created"
         # GET
@@ -293,9 +343,13 @@ class TestPurchaseAPI:
         # Need at least 2 sites
         org, site_a = _create_org_site(db_session)
         site_b = Site(
-            nom="Site B", type=TypeSite.ENTREPOT,
-            adresse="2 rue Test", code_postal="69001", ville="Lyon",
-            surface_m2=5000, portefeuille_id=site_a.portefeuille_id,
+            nom="Site B",
+            type=TypeSite.ENTREPOT,
+            adresse="2 rue Test",
+            code_postal="69001",
+            ville="Lyon",
+            surface_m2=5000,
+            portefeuille_id=site_a.portefeuille_id,
         )
         db_session.add(site_b)
         db_session.commit()
@@ -310,6 +364,7 @@ class TestPurchaseAPI:
 # ========================================
 # V1.1 Model tests
 # ========================================
+
 
 class TestV11Models:
     def test_energy_contract_notice_period(self, db_session):
@@ -374,6 +429,7 @@ class TestV11Models:
 # ========================================
 # V1.1 API tests
 # ========================================
+
 
 class TestV11API:
     def _seed_contracts(self, db_session):
@@ -538,9 +594,13 @@ class TestV11API:
         """Seed demo V1.1 creates contracts."""
         org, site_a = _create_org_site(db_session)
         site_b = Site(
-            nom="Site B", type=TypeSite.ENTREPOT,
-            adresse="2 rue Test", code_postal="69001", ville="Lyon",
-            surface_m2=5000, portefeuille_id=site_a.portefeuille_id,
+            nom="Site B",
+            type=TypeSite.ENTREPOT,
+            adresse="2 rue Test",
+            code_postal="69001",
+            ville="Lyon",
+            surface_m2=5000,
+            portefeuille_id=site_a.portefeuille_id,
         )
         db_session.add(site_b)
         db_session.commit()
@@ -557,17 +617,63 @@ class TestV11API:
 # Brique 3: Energy Gate tests
 # ========================================
 
+# ========================================
+# P0-3: Assistant endpoint tests
+# ========================================
+
+
+class TestAssistantEndpoint:
+    def test_assistant_returns_200(self, client, db_session):
+        """GET /purchase/assistant returns 200."""
+        resp = client.get("/api/purchase/assistant")
+        assert resp.status_code == 200
+
+    def test_assistant_demo_fallback(self, client, db_session):
+        """Without org sites, returns demo seed with is_demo=true."""
+        resp = client.get("/api/purchase/assistant")
+        data = resp.json()
+        assert data["is_demo"] is True
+        assert len(data["sites"]) >= 5
+        assert data["total_sites"] == len(data["sites"])
+        assert data["total_annual_kwh"] > 0
+
+    def test_assistant_with_real_org(self, client, db_session):
+        """With org + sites, returns real data with is_demo=false."""
+        org, site = _create_org_site(db_session)
+        resp = client.get(f"/api/purchase/assistant?org_id={org.id}")
+        data = resp.json()
+        assert data["is_demo"] is False
+        assert data["org_id"] == org.id
+        assert len(data["sites"]) >= 1
+        assert data["sites"][0]["name"] == "Site A"
+
+    def test_assistant_demo_sites_structure(self, client, db_session):
+        """Demo sites have required fields."""
+        resp = client.get("/api/purchase/assistant")
+        data = resp.json()
+        for site in data["sites"]:
+            assert "id" in site
+            assert "name" in site
+            assert "city" in site
+            assert "energy_type" in site
+            assert "annual_kwh" in site
+            assert "source" in site
+
+
 class TestEnergyGate:
     """Energy Gate: only ELEC energy type is allowed for purchase scenarios."""
 
     def test_put_assumptions_gaz_rejected(self, client, db_session):
         """PUT assumptions with energy_type=gaz returns 422."""
         _, site = _create_org_site(db_session)
-        resp = client.put(f"/api/purchase/assumptions/{site.id}", json={
-            "energy_type": "gaz",
-            "volume_kwh_an": 300000,
-            "horizon_months": 24,
-        })
+        resp = client.put(
+            f"/api/purchase/assumptions/{site.id}",
+            json={
+                "energy_type": "gaz",
+                "volume_kwh_an": 300000,
+                "horizon_months": 24,
+            },
+        )
         assert resp.status_code == 422
         assert "non supportee" in resp.json()["detail"]
         assert "elec" in resp.json()["detail"]
@@ -575,11 +681,14 @@ class TestEnergyGate:
     def test_put_assumptions_elec_accepted(self, client, db_session):
         """PUT assumptions with energy_type=elec succeeds."""
         _, site = _create_org_site(db_session)
-        resp = client.put(f"/api/purchase/assumptions/{site.id}", json={
-            "energy_type": "elec",
-            "volume_kwh_an": 500000,
-            "horizon_months": 24,
-        })
+        resp = client.put(
+            f"/api/purchase/assumptions/{site.id}",
+            json={
+                "energy_type": "elec",
+                "volume_kwh_an": 500000,
+                "horizon_months": 24,
+            },
+        )
         assert resp.status_code == 200
         assert resp.json()["status"] in ("created", "updated")
 
@@ -611,13 +720,17 @@ class TestEnergyGate:
         org, site_a, site_b = _create_two_sites(db_session)
         # Site A: ELEC assumption
         a_elec = PurchaseAssumptionSet(
-            site_id=site_a.id, energy_type=BillingEnergyType.ELEC,
-            volume_kwh_an=500000, profile_factor=1.0,
+            site_id=site_a.id,
+            energy_type=BillingEnergyType.ELEC,
+            volume_kwh_an=500000,
+            profile_factor=1.0,
         )
         # Site B: GAZ assumption (should be skipped)
         b_gaz = PurchaseAssumptionSet(
-            site_id=site_b.id, energy_type=BillingEnergyType.GAZ,
-            volume_kwh_an=300000, profile_factor=1.0,
+            site_id=site_b.id,
+            energy_type=BillingEnergyType.GAZ,
+            volume_kwh_an=300000,
+            profile_factor=1.0,
         )
         db_session.add_all([a_elec, b_gaz])
         db_session.commit()
@@ -632,6 +745,7 @@ class TestEnergyGate:
     def test_allowed_energy_types_constant(self):
         """ALLOWED_ENERGY_TYPES contains only 'elec'."""
         from routes.purchase import ALLOWED_ENERGY_TYPES
+
         assert ALLOWED_ENERGY_TYPES == {"elec"}
         assert "gaz" not in ALLOWED_ENERGY_TYPES
 
@@ -639,9 +753,13 @@ class TestEnergyGate:
         """Seed demo creates ELEC assumptions for both sites (post-Energy Gate)."""
         org, site_a = _create_org_site(db_session)
         site_b = Site(
-            nom="Site B", type=TypeSite.ENTREPOT,
-            adresse="2 rue Test", code_postal="69001", ville="Lyon",
-            surface_m2=5000, portefeuille_id=site_a.portefeuille_id,
+            nom="Site B",
+            type=TypeSite.ENTREPOT,
+            adresse="2 rue Test",
+            code_postal="69001",
+            ville="Lyon",
+            surface_m2=5000,
+            portefeuille_id=site_a.portefeuille_id,
         )
         db_session.add(site_b)
         db_session.commit()
@@ -656,6 +774,7 @@ class TestEnergyGate:
 # ========================================
 # Brique 3: WOW multi-site dataset tests
 # ========================================
+
 
 class TestWowDatasets:
     """WOW multi-site datasets: happy + dirty modes."""

--- a/frontend/src/pages/PurchaseAssistantPage.jsx
+++ b/frontend/src/pages/PurchaseAssistantPage.jsx
@@ -5,23 +5,77 @@
  * Steps: Portfolio → Consumption → Persona → Horizon → Offers → Results → Scoring → Decision
  */
 import { useState, useMemo, useCallback, useEffect } from 'react';
-import { PageShell, Card, CardHeader, CardBody, Button, Badge, KpiCard, Progress, EmptyState, Modal } from '../ui';
+import {
+  PageShell,
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Badge,
+  KpiCard,
+  Progress,
+  EmptyState,
+  Modal,
+} from '../ui';
 import { useToast } from '../ui/ToastProvider';
 import { useExpertMode } from '../contexts/ExpertModeContext';
+import { useScope } from '../contexts/ScopeContext';
+import { getPurchaseAssistantData } from '../services/api';
 import {
-  ShoppingCart, ChevronLeft, ChevronRight, Check, MapPin, Zap,
-  BarChart3, User, Clock, FileText, Shield, TrendingUp, Target,
-  AlertTriangle, Info, Plus, Trash2, Download, Eye, Lock,
-  ArrowRight, Flame, CheckCircle2, XCircle, Minus, Star,
+  ShoppingCart,
+  ChevronLeft,
+  ChevronRight,
+  Check,
+  MapPin,
+  Zap,
+  BarChart3,
+  User,
+  Clock,
+  FileText,
+  Shield,
+  TrendingUp,
+  Target,
+  AlertTriangle,
+  Info,
+  Plus,
+  Trash2,
+  Download,
+  Eye,
+  Lock,
+  ArrowRight,
+  Flame,
+  CheckCircle2,
+  XCircle,
+  Minus,
+  Star,
 } from 'lucide-react';
 import {
-  EnergyType, OfferStructure, ScenarioPreset, Persona, Confidence, ScoreLevel,
-  BREAKDOWN_LABELS, PERSONA_PROFILES, SCENARIO_PRESETS, DEFAULT_MARKET,
-  BRIQUE3_VERSION, createDefaultWizardState,
-  runEngine, clearEngineCache, scoreOffer, recommend,
-  generateDecisionNote, generateRfpPack, generateComparisonCsv,
-  appendDecision, getAuditLog, downloadAuditFile,
-  DEMO_OFFERS, DEMO_ORGANIZATIONS, aggregateDemoSites, getAllDemoSites,
+  EnergyType,
+  OfferStructure,
+  ScenarioPreset,
+  Persona,
+  Confidence,
+  ScoreLevel,
+  BREAKDOWN_LABELS,
+  PERSONA_PROFILES,
+  SCENARIO_PRESETS,
+  DEFAULT_MARKET,
+  BRIQUE3_VERSION,
+  createDefaultWizardState,
+  runEngine,
+  clearEngineCache,
+  scoreOffer,
+  recommend,
+  generateDecisionNote,
+  generateRfpPack,
+  generateComparisonCsv,
+  appendDecision,
+  getAuditLog,
+  downloadAuditFile,
+  DEMO_OFFERS,
+  DEMO_ORGANIZATIONS,
+  aggregateDemoSites,
+  getAllDemoSites,
 } from '../domain/purchase/index.js';
 
 // ── Constants ──────────────────────────────────────────────────────
@@ -110,6 +164,7 @@ function createEmptyOffer(index) {
 export default function PurchaseAssistantPage() {
   const { toast } = useToast();
   const { isExpert } = useExpertMode();
+  const { scope } = useScope();
 
   // Wizard state
   const [step, setStep] = useState(0);
@@ -123,30 +178,84 @@ export default function PurchaseAssistantPage() {
   const [computing, setComputing] = useState(false);
   const [showAuditModal, setShowAuditModal] = useState(false);
 
-  // Demo sites
-  const demoSites = useMemo(() => getAllDemoSites(), []);
+  // API data for assistant
+  const [apiAssistantData, setApiAssistantData] = useState(null);
+
+  // Fetch assistant data from API on mount / org change
+  useEffect(() => {
+    let cancelled = false;
+    getPurchaseAssistantData(scope.orgId)
+      .then((data) => {
+        if (!cancelled) {
+          setApiAssistantData(data);
+          setIsDemo(data.is_demo);
+        }
+      })
+      .catch(() => {
+        // Fallback to local demo data on error
+        if (!cancelled) setApiAssistantData(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [scope.orgId]);
+
+  // Demo sites — prefer API data, fall back to local demo
+  const demoSites = useMemo(() => {
+    if (apiAssistantData?.sites?.length) {
+      return apiAssistantData.sites.map((s) => ({
+        id: s.id,
+        name: s.name,
+        city: s.city,
+        usage: s.usage,
+        surfaceM2: s.surface_m2,
+        energyType: s.energy_type === 'elec' ? EnergyType.ELEC : EnergyType.GAZ,
+        consumption: {
+          annualKwh: s.annual_kwh,
+          granularity: 'monthly',
+          profileFactor: 1,
+          source: s.source,
+        },
+        organizationName: apiAssistantData.is_demo ? 'Demo' : `Org #${apiAssistantData.org_id}`,
+        entityName: '',
+      }));
+    }
+    return getAllDemoSites();
+  }, [apiAssistantData]);
 
   // Selected sites data
   const selectedSitesData = useMemo(() => {
     if (isDemo) {
       return aggregateDemoSites(wizard.selectedSiteIds);
     }
-    return { annualKwh: wizard.totalAnnualKwh, energyType: wizard.energyType, consumption: null, billing: null, anomalies: [] };
+    return {
+      annualKwh: wizard.totalAnnualKwh,
+      energyType: wizard.energyType,
+      consumption: null,
+      billing: null,
+      anomalies: [],
+    };
   }, [isDemo, wizard.selectedSiteIds, wizard.totalAnnualKwh, wizard.energyType]);
 
   // Current offers
-  const offers = wizard.offers.length > 0 ? wizard.offers : (isDemo ? DEMO_OFFERS : []);
+  const offers = wizard.offers.length > 0 ? wizard.offers : isDemo ? DEMO_OFFERS : [];
 
   // ── Navigation ───────────────────────────────────────────────────
 
   const canAdvance = useMemo(() => {
     switch (step) {
-      case 0: return wizard.selectedSiteIds.length > 0 || !isDemo;
-      case 1: return selectedSitesData.annualKwh > 0;
-      case 2: return !!wizard.persona;
-      case 3: return wizard.horizonMonths > 0;
-      case 4: return offers.length > 0;
-      default: return true;
+      case 0:
+        return wizard.selectedSiteIds.length > 0 || !isDemo;
+      case 1:
+        return selectedSitesData.annualKwh > 0;
+      case 2:
+        return !!wizard.persona;
+      case 3:
+        return wizard.horizonMonths > 0;
+      case 4:
+        return offers.length > 0;
+      default:
+        return true;
     }
   }, [step, wizard, isDemo, selectedSitesData, offers]);
 
@@ -156,12 +265,12 @@ export default function PurchaseAssistantPage() {
       if (step === 4) {
         handleCompute();
       }
-      setStep(s => s + 1);
+      setStep((s) => s + 1);
     }
   }, [step, canAdvance]);
 
   const goBack = useCallback(() => {
-    if (step > 0) setStep(s => s - 1);
+    if (step > 0) setStep((s) => s - 1);
   }, [step]);
 
   // ── Computation ──────────────────────────────────────────────────
@@ -186,18 +295,24 @@ export default function PurchaseAssistantPage() {
       setEngineOutput(output);
 
       // Score each offer
-      const scored = output.results.map(result => {
-        const offer = offers.find(o => o.id === result.offerId);
-        if (!offer) return null;
-        const scores = scoreOffer({
-          offerResult: result, offer,
-          budgetEur: wizard.budgetEur,
-          anomalies: selectedSitesData.anomalies || [],
-          consumption: selectedSitesData.consumption || { source: isDemo ? 'DEMO' : 'USER', granularity: 'monthly' },
-          billing: selectedSitesData.billing,
-        });
-        return { ...result, offer, scores };
-      }).filter(Boolean);
+      const scored = output.results
+        .map((result) => {
+          const offer = offers.find((o) => o.id === result.offerId);
+          if (!offer) return null;
+          const scores = scoreOffer({
+            offerResult: result,
+            offer,
+            budgetEur: wizard.budgetEur,
+            anomalies: selectedSitesData.anomalies || [],
+            consumption: selectedSitesData.consumption || {
+              source: isDemo ? 'DEMO' : 'USER',
+              granularity: 'monthly',
+            },
+            billing: selectedSitesData.billing,
+          });
+          return { ...result, offer, scores };
+        })
+        .filter(Boolean);
       setScoredOffers(scored);
 
       // Recommendation
@@ -206,7 +321,10 @@ export default function PurchaseAssistantPage() {
         offers,
         persona: wizard.persona,
         budgetEur: wizard.budgetEur,
-        consumption: selectedSitesData.consumption || { source: isDemo ? 'DEMO' : 'USER', granularity: 'monthly' },
+        consumption: selectedSitesData.consumption || {
+          source: isDemo ? 'DEMO' : 'USER',
+          granularity: 'monthly',
+        },
         billing: selectedSitesData.billing,
         anomalies: selectedSitesData.anomalies || [],
       });
@@ -231,20 +349,59 @@ export default function PurchaseAssistantPage() {
 
   const renderStep = () => {
     switch (step) {
-      case 0: return <StepPortfolio wizard={wizard} setWizard={setWizard} isDemo={isDemo} setIsDemo={setIsDemo} demoSites={demoSites} />;
-      case 1: return <StepConsumption wizard={wizard} setWizard={setWizard} sitesData={selectedSitesData} isDemo={isDemo} />;
-      case 2: return <StepPersona wizard={wizard} setWizard={setWizard} />;
-      case 3: return <StepHorizon wizard={wizard} setWizard={setWizard} isExpert={isExpert} />;
-      case 4: return <StepOffers wizard={wizard} setWizard={setWizard} isDemo={isDemo} />;
-      case 5: return <StepResults engineOutput={engineOutput} scoredOffers={scoredOffers} recommendation={recommendation} computing={computing} onRecompute={handleCompute} />;
-      case 6: return <StepScoring scoredOffers={scoredOffers} recommendation={recommendation} />;
-      case 7: return <StepDecision
-        recommendation={recommendation} scoredOffers={scoredOffers}
-        engineOutput={engineOutput} offers={offers} wizard={wizard}
-        selectedSitesData={selectedSitesData} isDemo={isDemo}
-        onShowAudit={() => setShowAuditModal(true)} toast={toast}
-      />;
-      default: return null;
+      case 0:
+        return (
+          <StepPortfolio
+            wizard={wizard}
+            setWizard={setWizard}
+            isDemo={isDemo}
+            setIsDemo={setIsDemo}
+            demoSites={demoSites}
+          />
+        );
+      case 1:
+        return (
+          <StepConsumption
+            wizard={wizard}
+            setWizard={setWizard}
+            sitesData={selectedSitesData}
+            isDemo={isDemo}
+          />
+        );
+      case 2:
+        return <StepPersona wizard={wizard} setWizard={setWizard} />;
+      case 3:
+        return <StepHorizon wizard={wizard} setWizard={setWizard} isExpert={isExpert} />;
+      case 4:
+        return <StepOffers wizard={wizard} setWizard={setWizard} isDemo={isDemo} />;
+      case 5:
+        return (
+          <StepResults
+            engineOutput={engineOutput}
+            scoredOffers={scoredOffers}
+            recommendation={recommendation}
+            computing={computing}
+            onRecompute={handleCompute}
+          />
+        );
+      case 6:
+        return <StepScoring scoredOffers={scoredOffers} recommendation={recommendation} />;
+      case 7:
+        return (
+          <StepDecision
+            recommendation={recommendation}
+            scoredOffers={scoredOffers}
+            engineOutput={engineOutput}
+            offers={offers}
+            wizard={wizard}
+            selectedSitesData={selectedSitesData}
+            isDemo={isDemo}
+            onShowAudit={() => setShowAuditModal(true)}
+            toast={toast}
+          />
+        );
+      default:
+        return null;
     }
   };
 
@@ -261,7 +418,9 @@ export default function PurchaseAssistantPage() {
           const isActive = i === step;
           const isDone = i < step;
           return (
-            <button key={s.key} onClick={() => i <= step && setStep(i)}
+            <button
+              key={s.key}
+              onClick={() => i <= step && setStep(i)}
               className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium whitespace-nowrap transition
                 ${isActive ? 'bg-blue-600 text-white shadow-sm' : isDone ? 'bg-blue-50 text-blue-700 hover:bg-blue-100' : 'bg-gray-50 text-gray-400 cursor-default'}`}
             >
@@ -274,23 +433,31 @@ export default function PurchaseAssistantPage() {
       </div>
 
       {/* Step content */}
-      <div className="min-h-[400px]">
-        {renderStep()}
-      </div>
+      <div className="min-h-[400px]">{renderStep()}</div>
 
       {/* Navigation */}
       <div className="flex items-center justify-between pt-4 border-t border-gray-200">
-        <button onClick={goBack} disabled={step === 0}
-          className="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 hover:text-gray-900 disabled:opacity-30 disabled:cursor-default transition">
+        <button
+          onClick={goBack}
+          disabled={step === 0}
+          className="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 hover:text-gray-900 disabled:opacity-30 disabled:cursor-default transition"
+        >
           <ChevronLeft size={16} /> Precedent
         </button>
         <div className="text-xs text-gray-400">
           Etape {step + 1} / {STEPS.length}
-          {isDemo && <span className="ml-2 px-2 py-0.5 bg-amber-100 text-amber-700 rounded-full font-medium">MODE DEMO</span>}
+          {isDemo && (
+            <span className="ml-2 px-2 py-0.5 bg-amber-100 text-amber-700 rounded-full font-medium">
+              MODE DEMO
+            </span>
+          )}
         </div>
         {step < STEPS.length - 1 ? (
-          <button onClick={goNext} disabled={!canAdvance}
-            className="flex items-center gap-2 px-5 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-40 disabled:cursor-default transition">
+          <button
+            onClick={goNext}
+            disabled={!canAdvance}
+            className="flex items-center gap-2 px-5 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-40 disabled:cursor-default transition"
+          >
             Suivant <ChevronRight size={16} />
           </button>
         ) : (
@@ -316,16 +483,16 @@ export default function PurchaseAssistantPage() {
 
 function StepPortfolio({ wizard, setWizard, isDemo, setIsDemo, demoSites }) {
   const toggleSite = (id) => {
-    setWizard(prev => ({
+    setWizard((prev) => ({
       ...prev,
       selectedSiteIds: prev.selectedSiteIds.includes(id)
-        ? prev.selectedSiteIds.filter(x => x !== id)
+        ? prev.selectedSiteIds.filter((x) => x !== id)
         : [...prev.selectedSiteIds, id],
     }));
   };
 
   const selectAll = () => {
-    setWizard(prev => ({ ...prev, selectedSiteIds: demoSites.map(s => s.id) }));
+    setWizard((prev) => ({ ...prev, selectedSiteIds: demoSites.map((s) => s.id) }));
   };
 
   return (
@@ -334,8 +501,12 @@ function StepPortfolio({ wizard, setWizard, isDemo, setIsDemo, demoSites }) {
         <h3 className="text-lg font-semibold text-gray-800">Selection du perimetre</h3>
         <div className="flex items-center gap-3">
           <label className="flex items-center gap-2 text-sm">
-            <input type="checkbox" checked={isDemo} onChange={e => setIsDemo(e.target.checked)}
-              className="rounded border-gray-300" />
+            <input
+              type="checkbox"
+              checked={isDemo}
+              onChange={(e) => setIsDemo(e.target.checked)}
+              className="rounded border-gray-300"
+            />
             Mode demo
           </label>
           {isDemo && (
@@ -348,30 +519,38 @@ function StepPortfolio({ wizard, setWizard, isDemo, setIsDemo, demoSites }) {
 
       {isDemo ? (
         <div className="space-y-3">
-          {DEMO_ORGANIZATIONS.map(org => (
+          {DEMO_ORGANIZATIONS.map((org) => (
             <div key={org.id} className="bg-white rounded-lg border border-gray-200 p-4">
               <h4 className="font-medium text-gray-900 mb-3">{org.name}</h4>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                {org.entities.flatMap(e => e.sites).map(site => {
-                  const selected = wizard.selectedSiteIds.includes(site.id);
-                  return (
-                    <button key={site.id} onClick={() => toggleSite(site.id)}
-                      className={`text-left p-3 rounded-lg border-2 transition
-                        ${selected ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300'}`}>
-                      <div className="flex items-center justify-between">
-                        <span className="font-medium text-sm text-gray-900">{site.name}</span>
-                        <Badge variant={site.energyType === 'ELEC' ? 'blue' : 'orange'}>
-                          {site.energyType === 'ELEC' ? <Zap size={12} /> : <Flame size={12} />}
-                          {site.energyType}
-                        </Badge>
-                      </div>
-                      <div className="text-xs text-gray-500 mt-1">{site.city} — {site.usage}</div>
-                      <div className="text-xs text-gray-400 mt-1">
-                        {(site.consumption.annualKwh / 1000).toFixed(0)} MWh/an — {site.surfaceM2.toLocaleString()} m2
-                      </div>
-                    </button>
-                  );
-                })}
+                {org.entities
+                  .flatMap((e) => e.sites)
+                  .map((site) => {
+                    const selected = wizard.selectedSiteIds.includes(site.id);
+                    return (
+                      <button
+                        key={site.id}
+                        onClick={() => toggleSite(site.id)}
+                        className={`text-left p-3 rounded-lg border-2 transition
+                        ${selected ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300'}`}
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium text-sm text-gray-900">{site.name}</span>
+                          <Badge variant={site.energyType === 'ELEC' ? 'blue' : 'orange'}>
+                            {site.energyType === 'ELEC' ? <Zap size={12} /> : <Flame size={12} />}
+                            {site.energyType}
+                          </Badge>
+                        </div>
+                        <div className="text-xs text-gray-500 mt-1">
+                          {site.city} — {site.usage}
+                        </div>
+                        <div className="text-xs text-gray-400 mt-1">
+                          {(site.consumption.annualKwh / 1000).toFixed(0)} MWh/an —{' '}
+                          {site.surfaceM2.toLocaleString()} m2
+                        </div>
+                      </button>
+                    );
+                  })}
               </div>
             </div>
           ))}
@@ -380,8 +559,8 @@ function StepPortfolio({ wizard, setWizard, isDemo, setIsDemo, demoSites }) {
         <Card>
           <CardBody>
             <p className="text-sm text-gray-500">
-              Connectez-vous a votre patrimoine (Brique 1) pour charger les sites reels.
-              En attendant, activez le mode demo pour tester l'assistant.
+              Connectez-vous a votre patrimoine (Brique 1) pour charger les sites reels. En
+              attendant, activez le mode demo pour tester l'assistant.
             </p>
           </CardBody>
         </Card>
@@ -431,16 +610,27 @@ function StepConsumption({ wizard, setWizard, sitesData, isDemo }) {
           <CardBody>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Volume annuel (kWh)</label>
-                <input type="number" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Volume annuel (kWh)
+                </label>
+                <input
+                  type="number"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
                   value={wizard.totalAnnualKwh}
-                  onChange={e => setWizard(prev => ({ ...prev, totalAnnualKwh: Number(e.target.value) }))} />
+                  onChange={(e) =>
+                    setWizard((prev) => ({ ...prev, totalAnnualKwh: Number(e.target.value) }))
+                  }
+                />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Type d'energie</label>
-                <select className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Type d'energie
+                </label>
+                <select
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
                   value={wizard.energyType}
-                  onChange={e => setWizard(prev => ({ ...prev, energyType: e.target.value }))}>
+                  onChange={(e) => setWizard((prev) => ({ ...prev, energyType: e.target.value }))}
+                >
                   <option value={EnergyType.ELEC}>Electricite</option>
                   <option value={EnergyType.GAZ}>Gaz</option>
                 </select>
@@ -457,14 +647,19 @@ function StepConsumption({ wizard, setWizard, sitesData, isDemo }) {
             <div className="flex items-end gap-1 h-24">
               {(sitesData.consumption?.seasonality || []).map((coeff, i) => (
                 <div key={i} className="flex-1 flex flex-col items-center gap-1">
-                  <div className="w-full bg-blue-200 rounded-t" style={{ height: `${coeff * 60}px` }} />
+                  <div
+                    className="w-full bg-blue-200 rounded-t"
+                    style={{ height: `${coeff * 60}px` }}
+                  />
                   <span className="text-[10px] text-gray-400">
                     {['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'][i]}
                   </span>
                 </div>
               ))}
             </div>
-            <p className="text-xs text-gray-400 mt-2">Saisonnalite mensuelle (coefficient normalisé)</p>
+            <p className="text-xs text-gray-400 mt-2">
+              Saisonnalite mensuelle (coefficient normalisé)
+            </p>
           </CardBody>
         </Card>
       )}
@@ -472,12 +667,14 @@ function StepConsumption({ wizard, setWizard, sitesData, isDemo }) {
       {sitesData.anomalies?.length > 0 && (
         <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
           <div className="flex items-center gap-2 text-sm font-medium text-amber-700 mb-2">
-            <AlertTriangle size={16} /> {sitesData.anomalies.length} anomalie(s) de facturation détectée(s)
+            <AlertTriangle size={16} /> {sitesData.anomalies.length} anomalie(s) de facturation
+            détectée(s)
           </div>
           <ul className="space-y-1">
             {sitesData.anomalies.slice(0, 3).map((a, i) => (
               <li key={i} className="text-xs text-amber-600">
-                {a.message} {a.estimatedLossEur > 0 && `(~${a.estimatedLossEur.toLocaleString()} EUR)`}
+                {a.message}{' '}
+                {a.estimatedLossEur > 0 && `(~${a.estimatedLossEur.toLocaleString()} EUR)`}
               </li>
             ))}
           </ul>
@@ -495,15 +692,21 @@ function StepPersona({ wizard, setWizard }) {
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-semibold text-gray-800">Profil decideur</h3>
-      <p className="text-sm text-gray-500">Choisissez le persona qui correspond au destinataire de l'analyse. Les poids de scoring seront adaptes.</p>
+      <p className="text-sm text-gray-500">
+        Choisissez le persona qui correspond au destinataire de l'analyse. Les poids de scoring
+        seront adaptes.
+      </p>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {Object.entries(PERSONA_PROFILES).map(([key, profile]) => {
           const selected = wizard.persona === key;
           return (
-            <button key={key} onClick={() => setWizard(prev => ({ ...prev, persona: key }))}
+            <button
+              key={key}
+              onClick={() => setWizard((prev) => ({ ...prev, persona: key }))}
               className={`text-left p-4 rounded-lg border-2 transition
-                ${selected ? 'border-blue-500 bg-blue-50 shadow-sm' : 'border-gray-200 hover:border-gray-300'}`}>
+                ${selected ? 'border-blue-500 bg-blue-50 shadow-sm' : 'border-gray-200 hover:border-gray-300'}`}
+            >
               <div className="flex items-center justify-between mb-2">
                 <span className="font-semibold text-gray-900">{profile.label}</span>
                 {selected && <Check size={18} className="text-blue-600" />}
@@ -513,7 +716,15 @@ function StepPersona({ wizard, setWizard }) {
                 {Object.entries(profile.weights).map(([axis, w]) => (
                   <div key={axis} className="text-center">
                     <div className="font-medium text-gray-700">{Math.round(w * 100)}%</div>
-                    <div className="text-gray-400">{axis === 'budgetRisk' ? 'Budget' : axis === 'transparency' ? 'Transp.' : axis === 'contractRisk' ? 'Contrat' : 'Data'}</div>
+                    <div className="text-gray-400">
+                      {axis === 'budgetRisk'
+                        ? 'Budget'
+                        : axis === 'transparency'
+                          ? 'Transp.'
+                          : axis === 'contractRisk'
+                            ? 'Contrat'
+                            : 'Data'}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -525,13 +736,24 @@ function StepPersona({ wizard, setWizard }) {
       <Card>
         <CardBody>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Budget plafond annuel (EUR) <span className="text-gray-400 font-normal">— optionnel</span>
+            Budget plafond annuel (EUR){' '}
+            <span className="text-gray-400 font-normal">— optionnel</span>
           </label>
-          <input type="number" placeholder="Ex: 500000"
+          <input
+            type="number"
+            placeholder="Ex: 500000"
             className="w-full max-w-xs border border-gray-300 rounded-lg px-3 py-2 text-sm"
             value={wizard.budgetEur || ''}
-            onChange={e => setWizard(prev => ({ ...prev, budgetEur: e.target.value ? Number(e.target.value) : null }))} />
-          <p className="text-xs text-gray-400 mt-1">Si renseigne, le moteur calculera la probabilite de depassement.</p>
+            onChange={(e) =>
+              setWizard((prev) => ({
+                ...prev,
+                budgetEur: e.target.value ? Number(e.target.value) : null,
+              }))
+            }
+          />
+          <p className="text-xs text-gray-400 mt-1">
+            Si renseigne, le moteur calculera la probabilite de depassement.
+          </p>
         </CardBody>
       </Card>
     </div>
@@ -552,10 +774,13 @@ function StepHorizon({ wizard, setWizard, isExpert }) {
           <CardHeader>Horizon contractuel</CardHeader>
           <CardBody>
             <div className="flex gap-3">
-              {[12, 24, 36].map(m => (
-                <button key={m} onClick={() => setWizard(prev => ({ ...prev, horizonMonths: m }))}
+              {[12, 24, 36].map((m) => (
+                <button
+                  key={m}
+                  onClick={() => setWizard((prev) => ({ ...prev, horizonMonths: m }))}
                   className={`flex-1 py-3 rounded-lg text-sm font-medium transition border-2
-                    ${wizard.horizonMonths === m ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-gray-200 text-gray-600 hover:border-gray-300'}`}>
+                    ${wizard.horizonMonths === m ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-gray-200 text-gray-600 hover:border-gray-300'}`}
+                >
                   {m} mois
                 </button>
               ))}
@@ -568,9 +793,12 @@ function StepHorizon({ wizard, setWizard, isExpert }) {
           <CardBody>
             <div className="space-y-2">
               {Object.entries(SCENARIO_PRESETS).map(([key, preset]) => (
-                <button key={key} onClick={() => setWizard(prev => ({ ...prev, scenarioPreset: key }))}
+                <button
+                  key={key}
+                  onClick={() => setWizard((prev) => ({ ...prev, scenarioPreset: key }))}
                   className={`w-full text-left p-3 rounded-lg border-2 transition
-                    ${wizard.scenarioPreset === key ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300'}`}>
+                    ${wizard.scenarioPreset === key ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300'}`}
+                >
                   <div className="flex items-center justify-between">
                     <span className="font-medium text-sm text-gray-900">{preset.label}</span>
                     {wizard.scenarioPreset === key && <Check size={16} className="text-blue-600" />}
@@ -589,25 +817,49 @@ function StepHorizon({ wizard, setWizard, isExpert }) {
           <CardBody>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">Iterations MC (max 200)</label>
-                <input type="number" min={10} max={200}
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Iterations MC (max 200)
+                </label>
+                <input
+                  type="number"
+                  min={10}
+                  max={200}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
                   value={wizard.mcIterations}
-                  onChange={e => setWizard(prev => ({ ...prev, mcIterations: Math.min(200, Math.max(10, Number(e.target.value))) }))} />
+                  onChange={(e) =>
+                    setWizard((prev) => ({
+                      ...prev,
+                      mcIterations: Math.min(200, Math.max(10, Number(e.target.value))),
+                    }))
+                  }
+                />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">Seed aleatoire</label>
-                <input type="number"
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Seed aleatoire
+                </label>
+                <input
+                  type="number"
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
                   value={wizard.mcSeed}
-                  onChange={e => setWizard(prev => ({ ...prev, mcSeed: Number(e.target.value) }))} />
+                  onChange={(e) =>
+                    setWizard((prev) => ({ ...prev, mcSeed: Number(e.target.value) }))
+                  }
+                />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">Prix base spot (EUR/MWh)</label>
-                <input type="number" disabled
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Prix base spot (EUR/MWh)
+                </label>
+                <input
+                  type="number"
+                  disabled
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-gray-50"
-                  value={DEFAULT_MARKET.baseSpotEurPerMwh} />
-                <p className="text-[10px] text-gray-400 mt-0.5">Non modifiable en v{BRIQUE3_VERSION}</p>
+                  value={DEFAULT_MARKET.baseSpotEurPerMwh}
+                />
+                <p className="text-[10px] text-gray-400 mt-0.5">
+                  Non modifiable en v{BRIQUE3_VERSION}
+                </p>
               </div>
             </div>
           </CardBody>
@@ -625,29 +877,34 @@ function StepOffers({ wizard, setWizard, isDemo }) {
   const offers = wizard.offers;
 
   const addOffer = () => {
-    setWizard(prev => ({ ...prev, offers: [...prev.offers, createEmptyOffer(prev.offers.length)] }));
+    setWizard((prev) => ({
+      ...prev,
+      offers: [...prev.offers, createEmptyOffer(prev.offers.length)],
+    }));
   };
 
   const removeOffer = (id) => {
-    setWizard(prev => ({ ...prev, offers: prev.offers.filter(o => o.id !== id) }));
+    setWizard((prev) => ({ ...prev, offers: prev.offers.filter((o) => o.id !== id) }));
   };
 
   const updateOffer = (id, patch) => {
-    setWizard(prev => ({
+    setWizard((prev) => ({
       ...prev,
-      offers: prev.offers.map(o => o.id === id ? { ...o, ...patch } : o),
+      offers: prev.offers.map((o) => (o.id === id ? { ...o, ...patch } : o)),
     }));
   };
 
   const updatePricing = (id, pricingPatch) => {
-    setWizard(prev => ({
+    setWizard((prev) => ({
       ...prev,
-      offers: prev.offers.map(o => o.id === id ? { ...o, pricing: { ...o.pricing, ...pricingPatch } } : o),
+      offers: prev.offers.map((o) =>
+        o.id === id ? { ...o, pricing: { ...o.pricing, ...pricingPatch } } : o
+      ),
     }));
   };
 
   const loadDemoOffers = () => {
-    setWizard(prev => ({ ...prev, offers: [...DEMO_OFFERS] }));
+    setWizard((prev) => ({ ...prev, offers: [...DEMO_OFFERS] }));
   };
 
   return (
@@ -656,8 +913,7 @@ function StepOffers({ wizard, setWizard, isDemo }) {
         <h3 className="text-lg font-semibold text-gray-800">Offres fournisseurs</h3>
         <div className="flex items-center gap-2">
           {isDemo && (
-            <button onClick={loadDemoOffers}
-              className="text-xs text-blue-600 hover:underline">
+            <button onClick={loadDemoOffers} className="text-xs text-blue-600 hover:underline">
               Charger les 5 offres demo
             </button>
           )}
@@ -670,23 +926,30 @@ function StepOffers({ wizard, setWizard, isDemo }) {
       {isDemo && offers.length === 0 && wizard.offers.length === 0 && (
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-700">
           <Info size={16} className="inline mr-1" />
-          En mode demo, {DEMO_OFFERS.length} offres sont pre-chargees automatiquement.
-          Vous pouvez aussi en creer manuellement.
+          En mode demo, {DEMO_OFFERS.length} offres sont pre-chargees automatiquement. Vous pouvez
+          aussi en creer manuellement.
         </div>
       )}
 
       {offers.length > 0 && (
         <div className="space-y-3">
-          {offers.map(offer => (
-            <OfferCard key={offer.id} offer={offer}
-              onUpdate={updateOffer} onUpdatePricing={updatePricing}
-              onRemove={removeOffer} readOnly={isDemo && DEMO_OFFERS.some(d => d.id === offer.id)} />
+          {offers.map((offer) => (
+            <OfferCard
+              key={offer.id}
+              offer={offer}
+              onUpdate={updateOffer}
+              onUpdatePricing={updatePricing}
+              onRemove={removeOffer}
+              readOnly={isDemo && DEMO_OFFERS.some((d) => d.id === offer.id)}
+            />
           ))}
         </div>
       )}
 
       {wizard.offers.length > 0 && (
-        <p className="text-xs text-gray-400">{wizard.offers.length} offre(s) saisie(s) manuellement</p>
+        <p className="text-xs text-gray-400">
+          {wizard.offers.length} offre(s) saisie(s) manuellement
+        </p>
       )}
     </div>
   );
@@ -699,20 +962,28 @@ function OfferCard({ offer, onUpdate, onUpdatePricing, onRemove, readOnly }) {
     <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center gap-3">
-          <span className={`px-2 py-1 text-xs font-semibold rounded-full ${STRUCTURE_COLORS[offer.structure] || 'bg-gray-100 text-gray-600'}`}>
+          <span
+            className={`px-2 py-1 text-xs font-semibold rounded-full ${STRUCTURE_COLORS[offer.structure] || 'bg-gray-100 text-gray-600'}`}
+          >
             {STRUCTURE_LABELS[offer.structure] || offer.structure}
           </span>
           {readOnly ? (
             <span className="font-medium text-gray-900">{offer.supplierName}</span>
           ) : (
-            <input type="text" placeholder="Nom du fournisseur"
+            <input
+              type="text"
+              placeholder="Nom du fournisseur"
               className="font-medium text-gray-900 border-b border-transparent hover:border-gray-300 focus:border-blue-500 outline-none px-1"
               value={offer.supplierName}
-              onChange={e => onUpdate(offer.id, { supplierName: e.target.value })} />
+              onChange={(e) => onUpdate(offer.id, { supplierName: e.target.value })}
+            />
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button onClick={() => setExpanded(!expanded)} className="text-gray-400 hover:text-gray-600">
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="text-gray-400 hover:text-gray-600"
+          >
             <Eye size={16} />
           </button>
           {!readOnly && (
@@ -727,46 +998,71 @@ function OfferCard({ offer, onUpdate, onUpdatePricing, onRemove, readOnly }) {
         <div className="px-4 pb-3 flex items-center gap-4">
           <div>
             <label className="text-xs text-gray-500">Structure</label>
-            <select className="block border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
+            <select
+              className="block border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
               value={offer.structure}
-              onChange={e => {
+              onChange={(e) => {
                 const s = e.target.value;
-                const pricingPatch = s === OfferStructure.FIXE
-                  ? { fixedSharePct: 1, indexedSharePct: 0, spotSharePct: 0 }
-                  : s === OfferStructure.INDEXE
-                  ? { fixedSharePct: 0, indexedSharePct: 1, spotSharePct: 0 }
-                  : s === OfferStructure.SPOT
-                  ? { fixedSharePct: 0, indexedSharePct: 0, spotSharePct: 1 }
-                  : {};
+                const pricingPatch =
+                  s === OfferStructure.FIXE
+                    ? { fixedSharePct: 1, indexedSharePct: 0, spotSharePct: 0 }
+                    : s === OfferStructure.INDEXE
+                      ? { fixedSharePct: 0, indexedSharePct: 1, spotSharePct: 0 }
+                      : s === OfferStructure.SPOT
+                        ? { fixedSharePct: 0, indexedSharePct: 0, spotSharePct: 1 }
+                        : {};
                 onUpdate(offer.id, { structure: s });
                 if (Object.keys(pricingPatch).length) onUpdatePricing(offer.id, pricingPatch);
-              }}>
+              }}
+            >
               {Object.entries(STRUCTURE_LABELS).map(([k, v]) => (
-                <option key={k} value={k}>{v}</option>
+                <option key={k} value={k}>
+                  {v}
+                </option>
               ))}
             </select>
           </div>
-          {(offer.structure === OfferStructure.FIXE || offer.structure === OfferStructure.HYBRIDE) && (
+          {(offer.structure === OfferStructure.FIXE ||
+            offer.structure === OfferStructure.HYBRIDE) && (
             <div>
               <label className="text-xs text-gray-500">Prix fixe (EUR/MWh)</label>
-              <input type="number" className="block w-24 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
+              <input
+                type="number"
+                className="block w-24 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
                 value={offer.pricing.fixedPriceEurPerMwh}
-                onChange={e => onUpdatePricing(offer.id, { fixedPriceEurPerMwh: Number(e.target.value) })} />
+                onChange={(e) =>
+                  onUpdatePricing(offer.id, { fixedPriceEurPerMwh: Number(e.target.value) })
+                }
+              />
             </div>
           )}
-          {(offer.structure === OfferStructure.INDEXE || offer.structure === OfferStructure.HYBRIDE) && (
+          {(offer.structure === OfferStructure.INDEXE ||
+            offer.structure === OfferStructure.HYBRIDE) && (
             <>
               <div>
                 <label className="text-xs text-gray-500">Spread (EUR/MWh)</label>
-                <input type="number" className="block w-20 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
+                <input
+                  type="number"
+                  className="block w-20 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
                   value={offer.pricing.spreadEurPerMwh || 0}
-                  onChange={e => onUpdatePricing(offer.id, { spreadEurPerMwh: Number(e.target.value) })} />
+                  onChange={(e) =>
+                    onUpdatePricing(offer.id, { spreadEurPerMwh: Number(e.target.value) })
+                  }
+                />
               </div>
               <div>
                 <label className="text-xs text-gray-500">Cap (EUR/MWh)</label>
-                <input type="number" placeholder="—" className="block w-20 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
+                <input
+                  type="number"
+                  placeholder="—"
+                  className="block w-20 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
                   value={offer.pricing.capEurPerMwh ?? ''}
-                  onChange={e => onUpdatePricing(offer.id, { capEurPerMwh: e.target.value ? Number(e.target.value) : null })} />
+                  onChange={(e) =>
+                    onUpdatePricing(offer.id, {
+                      capEurPerMwh: e.target.value ? Number(e.target.value) : null,
+                    })
+                  }
+                />
               </div>
             </>
           )}
@@ -774,21 +1070,42 @@ function OfferCard({ offer, onUpdate, onUpdatePricing, onRemove, readOnly }) {
             <>
               <div>
                 <label className="text-xs text-gray-500">% Fixe</label>
-                <input type="number" min={0} max={100} className="block w-16 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  className="block w-16 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
                   value={Math.round((offer.pricing.fixedSharePct || 0) * 100)}
-                  onChange={e => onUpdatePricing(offer.id, { fixedSharePct: Number(e.target.value) / 100 })} />
+                  onChange={(e) =>
+                    onUpdatePricing(offer.id, { fixedSharePct: Number(e.target.value) / 100 })
+                  }
+                />
               </div>
               <div>
                 <label className="text-xs text-gray-500">% Indexe</label>
-                <input type="number" min={0} max={100} className="block w-16 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  className="block w-16 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
                   value={Math.round((offer.pricing.indexedSharePct || 0) * 100)}
-                  onChange={e => onUpdatePricing(offer.id, { indexedSharePct: Number(e.target.value) / 100 })} />
+                  onChange={(e) =>
+                    onUpdatePricing(offer.id, { indexedSharePct: Number(e.target.value) / 100 })
+                  }
+                />
               </div>
               <div>
                 <label className="text-xs text-gray-500">% Spot</label>
-                <input type="number" min={0} max={100} className="block w-16 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  className="block w-16 border border-gray-300 rounded px-2 py-1 text-sm mt-0.5"
                   value={Math.round((offer.pricing.spotSharePct || 0) * 100)}
-                  onChange={e => onUpdatePricing(offer.id, { spotSharePct: Number(e.target.value) / 100 })} />
+                  onChange={(e) =>
+                    onUpdatePricing(offer.id, { spotSharePct: Number(e.target.value) / 100 })
+                  }
+                />
               </div>
             </>
           )}
@@ -797,13 +1114,36 @@ function OfferCard({ offer, onUpdate, onUpdatePricing, onRemove, readOnly }) {
 
       {expanded && (
         <div className="px-4 pb-4 pt-2 border-t border-gray-100 text-xs text-gray-500 space-y-2">
-          <div><strong>Contrat:</strong> {offer.contractTerms?.durationMonths}m, preavis {offer.contractTerms?.noticePeriodDays}j, resiliation: {offer.contractTerms?.earlyTerminationPenalty}</div>
-          <div><strong>SLA:</strong> {offer.contractTerms?.slaLevel} | Indexation: {offer.contractTerms?.indexationClause} | Vert: {offer.contractTerms?.greenCertified ? 'Oui' : 'Non'}</div>
-          <div><strong>Intermediation:</strong> {offer.intermediation?.hasIntermediary ? `Oui (${offer.intermediation.feeDisclosed ? offer.intermediation.feeEurPerMwh + ' EUR/MWh' : 'Non divulgue'})` : 'Non'}</div>
-          <div><strong>Data:</strong> Courbes: {offer.dataTerms?.curvesAccess ? 'Oui' : 'Non'} | J+1: {offer.dataTerms?.dplus1 ? 'Oui' : 'Non'} | CSV: {offer.dataTerms?.csvExport ? 'Oui' : 'Non'} | API: {offer.dataTerms?.apiAccess ? 'Oui' : 'Non'}</div>
-          <div><strong>Decomposition:</strong> {offer.breakdown?.length || 0} composante(s) ({offer.breakdown?.filter(b => b.status === 'KNOWN').length || 0} connue(s))</div>
+          <div>
+            <strong>Contrat:</strong> {offer.contractTerms?.durationMonths}m, preavis{' '}
+            {offer.contractTerms?.noticePeriodDays}j, resiliation:{' '}
+            {offer.contractTerms?.earlyTerminationPenalty}
+          </div>
+          <div>
+            <strong>SLA:</strong> {offer.contractTerms?.slaLevel} | Indexation:{' '}
+            {offer.contractTerms?.indexationClause} | Vert:{' '}
+            {offer.contractTerms?.greenCertified ? 'Oui' : 'Non'}
+          </div>
+          <div>
+            <strong>Intermediation:</strong>{' '}
+            {offer.intermediation?.hasIntermediary
+              ? `Oui (${offer.intermediation.feeDisclosed ? offer.intermediation.feeEurPerMwh + ' EUR/MWh' : 'Non divulgue'})`
+              : 'Non'}
+          </div>
+          <div>
+            <strong>Data:</strong> Courbes: {offer.dataTerms?.curvesAccess ? 'Oui' : 'Non'} | J+1:{' '}
+            {offer.dataTerms?.dplus1 ? 'Oui' : 'Non'} | CSV:{' '}
+            {offer.dataTerms?.csvExport ? 'Oui' : 'Non'} | API:{' '}
+            {offer.dataTerms?.apiAccess ? 'Oui' : 'Non'}
+          </div>
+          <div>
+            <strong>Decomposition:</strong> {offer.breakdown?.length || 0} composante(s) (
+            {offer.breakdown?.filter((b) => b.status === 'KNOWN').length || 0} connue(s))
+          </div>
           {offer.contractTerms?.clauseFlags?.length > 0 && (
-            <div className="text-red-500"><strong>Alertes clauses:</strong> {offer.contractTerms.clauseFlags.join(', ')}</div>
+            <div className="text-red-500">
+              <strong>Alertes clauses:</strong> {offer.contractTerms.clauseFlags.join(', ')}
+            </div>
           )}
         </div>
       )}
@@ -828,7 +1168,13 @@ function StepResults({ engineOutput, scoredOffers, recommendation, computing, on
   }
 
   if (!engineOutput || scoredOffers.length === 0) {
-    return <EmptyState icon={BarChart3} title="Aucun résultat" description="Revenez à l'étape Offres et avancez pour lancer le calcul." />;
+    return (
+      <EmptyState
+        icon={BarChart3}
+        title="Aucun résultat"
+        description="Revenez à l'étape Offres et avancez pour lancer le calcul."
+      />
+    );
   }
 
   const bestId = recommendation?.bestOfferId;
@@ -837,18 +1183,33 @@ function StepResults({ engineOutput, scoredOffers, recommendation, computing, on
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold text-gray-800">Résultats — Corridor de prix & TCO</h3>
-        <button onClick={onRecompute}
-          className="text-xs text-blue-600 hover:underline">
+        <button onClick={onRecompute} className="text-xs text-blue-600 hover:underline">
           Recalculer
         </button>
       </div>
 
       {/* KPIs */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <KpiCard label="Offres evaluees" value={scoredOffers.length} icon={<FileText size={18} />} />
-        <KpiCard label="Meilleur P50" value={`${Math.min(...scoredOffers.map(s => s.corridor.p50)).toFixed(1)} EUR/MWh`} icon={<TrendingUp size={18} />} />
-        <KpiCard label="Horizon" value={`${engineOutput.params.horizonMonths} mois`} icon={<Clock size={18} />} />
-        <KpiCard label="Iterations MC" value={engineOutput.params.mcIterations} icon={<BarChart3 size={18} />} />
+        <KpiCard
+          label="Offres evaluees"
+          value={scoredOffers.length}
+          icon={<FileText size={18} />}
+        />
+        <KpiCard
+          label="Meilleur P50"
+          value={`${Math.min(...scoredOffers.map((s) => s.corridor.p50)).toFixed(1)} EUR/MWh`}
+          icon={<TrendingUp size={18} />}
+        />
+        <KpiCard
+          label="Horizon"
+          value={`${engineOutput.params.horizonMonths} mois`}
+          icon={<Clock size={18} />}
+        />
+        <KpiCard
+          label="Iterations MC"
+          value={engineOutput.params.mcIterations}
+          icon={<BarChart3 size={18} />}
+        />
       </div>
 
       {/* Offer comparison table */}
@@ -870,7 +1231,7 @@ function StepResults({ engineOutput, scoredOffers, recommendation, computing, on
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
-            {scoredOffers.map(s => {
+            {scoredOffers.map((s) => {
               const isBest = s.offerId === bestId;
               return (
                 <tr key={s.offerId} className={isBest ? 'bg-blue-50' : 'hover:bg-gray-50'}>
@@ -879,25 +1240,42 @@ function StepResults({ engineOutput, scoredOffers, recommendation, computing, on
                     {s.supplierName}
                   </td>
                   <td className="px-4 py-3">
-                    <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${STRUCTURE_COLORS[s.structure]}`}>
+                    <span
+                      className={`px-2 py-0.5 text-xs font-medium rounded-full ${STRUCTURE_COLORS[s.structure]}`}
+                    >
                       {STRUCTURE_LABELS[s.structure]}
                     </span>
                   </td>
                   <td className="px-4 py-3 text-right tabular-nums">{s.corridor.p10.toFixed(1)}</td>
-                  <td className="px-4 py-3 text-right tabular-nums font-semibold">{s.corridor.p50.toFixed(1)}</td>
+                  <td className="px-4 py-3 text-right tabular-nums font-semibold">
+                    {s.corridor.p50.toFixed(1)}
+                  </td>
                   <td className="px-4 py-3 text-right tabular-nums">{s.corridor.p90.toFixed(1)}</td>
-                  <td className="px-4 py-3 text-right tabular-nums">{Math.round(s.corridor.tcoP50).toLocaleString()}</td>
-                  <td className="px-4 py-3 text-right tabular-nums">{Math.round(s.annualCostP50).toLocaleString()}</td>
-                  <td className="px-4 py-3 text-right tabular-nums">{Math.round(s.volatility).toLocaleString()}</td>
-                  <td className="px-4 py-3 text-right tabular-nums">{Math.round(s.cvar90).toLocaleString()}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {Math.round(s.corridor.tcoP50).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {Math.round(s.annualCostP50).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {Math.round(s.volatility).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {Math.round(s.cvar90).toLocaleString()}
+                  </td>
                   <td className="px-4 py-3 text-right tabular-nums">
                     {s.probExceedBudget != null ? `${(s.probExceedBudget * 100).toFixed(0)}%` : '—'}
                   </td>
                   <td className="px-4 py-3 text-center">
-                    <span className={`inline-block w-10 text-center font-bold text-xs py-0.5 rounded ${
-                      s.scores.overall >= 70 ? 'bg-green-100 text-green-700' :
-                      s.scores.overall >= 40 ? 'bg-amber-100 text-amber-700' : 'bg-red-100 text-red-700'
-                    }`}>
+                    <span
+                      className={`inline-block w-10 text-center font-bold text-xs py-0.5 rounded ${
+                        s.scores.overall >= 70
+                          ? 'bg-green-100 text-green-700'
+                          : s.scores.overall >= 40
+                            ? 'bg-amber-100 text-amber-700'
+                            : 'bg-red-100 text-red-700'
+                      }`}
+                    >
                       {s.scores.overall}
                     </span>
                   </td>
@@ -909,12 +1287,14 @@ function StepResults({ engineOutput, scoredOffers, recommendation, computing, on
       </div>
 
       {/* Hybrid normalization warnings */}
-      {scoredOffers.filter(s => s.hybridNormalized).map(s => (
-        <div key={s.offerId} className="bg-amber-50 rounded-lg p-2 text-xs text-amber-700">
-          <AlertTriangle size={12} className="inline mr-1" />
-          {s.supplierName}: {s.hybridNormMessage}
-        </div>
-      ))}
+      {scoredOffers
+        .filter((s) => s.hybridNormalized)
+        .map((s) => (
+          <div key={s.offerId} className="bg-amber-50 rounded-lg p-2 text-xs text-amber-700">
+            <AlertTriangle size={12} className="inline mr-1" />
+            {s.supplierName}: {s.hybridNormMessage}
+          </div>
+        ))}
     </div>
   );
 }
@@ -925,10 +1305,16 @@ function StepResults({ engineOutput, scoredOffers, recommendation, computing, on
 
 function StepScoring({ scoredOffers, recommendation }) {
   const [selectedOfferId, setSelectedOfferId] = useState(null);
-  const selected = scoredOffers.find(s => s.offerId === selectedOfferId) || scoredOffers[0];
+  const selected = scoredOffers.find((s) => s.offerId === selectedOfferId) || scoredOffers[0];
 
   if (scoredOffers.length === 0) {
-    return <EmptyState icon={Shield} title="Pas de scores" description="Lancez d'abord le calcul a l'etape Resultats." />;
+    return (
+      <EmptyState
+        icon={Shield}
+        title="Pas de scores"
+        description="Lancez d'abord le calcul a l'etape Resultats."
+      />
+    );
   }
 
   return (
@@ -937,13 +1323,17 @@ function StepScoring({ scoredOffers, recommendation }) {
 
       {/* Offer selector */}
       <div className="flex gap-2 flex-wrap">
-        {scoredOffers.map(s => (
-          <button key={s.offerId}
+        {scoredOffers.map((s) => (
+          <button
+            key={s.offerId}
             onClick={() => setSelectedOfferId(s.offerId)}
             className={`px-3 py-1.5 rounded-lg text-sm font-medium transition border
-              ${(selected?.offerId === s.offerId) ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-gray-200 text-gray-600 hover:border-gray-300'}`}>
+              ${selected?.offerId === s.offerId ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-gray-200 text-gray-600 hover:border-gray-300'}`}
+          >
             {s.supplierName}
-            {s.offerId === recommendation?.bestOfferId && <Star size={12} className="inline ml-1 text-blue-500" />}
+            {s.offerId === recommendation?.bestOfferId && (
+              <Star size={12} className="inline ml-1 text-blue-500" />
+            )}
           </button>
         ))}
       </div>
@@ -956,7 +1346,7 @@ function StepScoring({ scoredOffers, recommendation }) {
             { key: 'transparency', label: 'Transparence', icon: Eye },
             { key: 'contractRisk', label: 'Risque Contractuel', icon: Lock },
             { key: 'dataReadiness', label: 'Donnees & Readiness', icon: BarChart3 },
-          ].map(axis => {
+          ].map((axis) => {
             const score = selected.scores[axis.key];
             if (!score) return null;
             const Icon = axis.icon;
@@ -983,7 +1373,10 @@ function StepScoring({ scoredOffers, recommendation }) {
                   <div className="mt-2 pt-2 border-t border-current/10">
                     <p className="text-[10px] font-medium mb-1">Evidence:</p>
                     {score.evidence.map((e, i) => (
-                      <span key={i} className="inline-block mr-1 mb-1 px-1.5 py-0.5 bg-white/50 rounded text-[10px]">
+                      <span
+                        key={i}
+                        className="inline-block mr-1 mb-1 px-1.5 py-0.5 bg-white/50 rounded text-[10px]"
+                      >
                         {e.ruleId}: {e.field}={JSON.stringify(e.value)?.slice(0, 30)}
                       </span>
                     ))}
@@ -1004,15 +1397,23 @@ function StepScoring({ scoredOffers, recommendation }) {
               {selected.offer.breakdown.map((b, i) => (
                 <div key={i} className="flex items-center justify-between text-sm py-1">
                   <div className="flex items-center gap-2">
-                    <span className={`w-2 h-2 rounded-full ${b.status === 'KNOWN' ? 'bg-green-500' : b.status === 'ESTIMATED' ? 'bg-amber-500' : 'bg-red-500'}`} />
-                    <span className="text-gray-700">{BREAKDOWN_LABELS[b.component] || b.component}</span>
+                    <span
+                      className={`w-2 h-2 rounded-full ${b.status === 'KNOWN' ? 'bg-green-500' : b.status === 'ESTIMATED' ? 'bg-amber-500' : 'bg-red-500'}`}
+                    />
+                    <span className="text-gray-700">
+                      {BREAKDOWN_LABELS[b.component] || b.component}
+                    </span>
                   </div>
                   <div className="flex items-center gap-4 text-xs">
                     <span className="text-gray-500">{(b.sharePct * 100).toFixed(1)}%</span>
                     <span className="text-gray-700 font-medium w-20 text-right">
                       {b.eurPerMwh != null ? `${b.eurPerMwh.toFixed(2)} EUR/MWh` : 'est.'}
                     </span>
-                    <Badge variant={b.status === 'KNOWN' ? 'green' : b.status === 'ESTIMATED' ? 'yellow' : 'red'}>
+                    <Badge
+                      variant={
+                        b.status === 'KNOWN' ? 'green' : b.status === 'ESTIMATED' ? 'yellow' : 'red'
+                      }
+                    >
                       {b.status}
                     </Badge>
                   </div>
@@ -1030,17 +1431,33 @@ function StepScoring({ scoredOffers, recommendation }) {
 // STEP 8: Decision
 // ═══════════════════════════════════════════════════════════════════
 
-function StepDecision({ recommendation, scoredOffers, engineOutput, offers, wizard, selectedSitesData, isDemo, onShowAudit, toast }) {
+function StepDecision({
+  recommendation,
+  scoredOffers,
+  engineOutput,
+  offers,
+  wizard,
+  selectedSitesData,
+  isDemo,
+  onShowAudit,
+  toast,
+}) {
   if (!recommendation || !recommendation.bestOfferId) {
-    return <EmptyState icon={Target} title="Pas de recommandation" description="Lancez le calcul a l'etape Resultats." />;
+    return (
+      <EmptyState
+        icon={Target}
+        title="Pas de recommandation"
+        description="Lancez le calcul a l'etape Resultats."
+      />
+    );
   }
 
-  const bestScored = scoredOffers.find(s => s.offerId === recommendation.bestOfferId);
+  const bestScored = scoredOffers.find((s) => s.offerId === recommendation.bestOfferId);
 
   const handleExportCsv = () => {
     const csv = generateComparisonCsv(
       recommendation._scoredOffers || scoredOffers,
-      engineOutput?.results || [],
+      engineOutput?.results || []
     );
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
     const url = URL.createObjectURL(blob);
@@ -1108,7 +1525,9 @@ function StepDecision({ recommendation, scoredOffers, engineOutput, offers, wiza
 
       {/* Confidence badge */}
       <div className="flex items-center gap-3">
-        <span className={`px-3 py-1 rounded-full text-sm font-semibold ${CONFIDENCE_COLORS[recommendation.confidence]}`}>
+        <span
+          className={`px-3 py-1 rounded-full text-sm font-semibold ${CONFIDENCE_COLORS[recommendation.confidence]}`}
+        >
           Confiance: {recommendation.confidence}
         </span>
         <span className="text-sm text-gray-500">{recommendation.confidenceReason}</span>
@@ -1124,14 +1543,21 @@ function StepDecision({ recommendation, scoredOffers, engineOutput, offers, wiza
               </div>
               <div>
                 <h4 className="font-bold text-gray-900 text-lg">{bestScored.supplierName}</h4>
-                <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${STRUCTURE_COLORS[bestScored.structure]}`}>
+                <span
+                  className={`px-2 py-0.5 text-xs font-medium rounded-full ${STRUCTURE_COLORS[bestScored.structure]}`}
+                >
                   {STRUCTURE_LABELS[bestScored.structure]}
                 </span>
               </div>
             </div>
             <div className="text-right">
-              <div className="text-2xl font-bold text-gray-900">{bestScored.corridor.p50.toFixed(1)} <span className="text-sm font-normal text-gray-500">EUR/MWh</span></div>
-              <div className="text-sm text-gray-500">{Math.round(bestScored.annualCostP50).toLocaleString()} EUR/an</div>
+              <div className="text-2xl font-bold text-gray-900">
+                {bestScored.corridor.p50.toFixed(1)}{' '}
+                <span className="text-sm font-normal text-gray-500">EUR/MWh</span>
+              </div>
+              <div className="text-sm text-gray-500">
+                {Math.round(bestScored.annualCostP50).toLocaleString()} EUR/an
+              </div>
             </div>
           </div>
 
@@ -1170,7 +1596,7 @@ function StepDecision({ recommendation, scoredOffers, engineOutput, offers, wiza
           <CardBody>
             <div className="space-y-2">
               {Object.entries(recommendation.whyNotOthers).map(([offerId, reason]) => {
-                const other = scoredOffers.find(s => s.offerId === offerId);
+                const other = scoredOffers.find((s) => s.offerId === offerId);
                 return (
                   <div key={offerId} className="flex items-center justify-between py-1">
                     <span className="text-sm text-gray-700">{other?.supplierName || offerId}</span>
@@ -1247,14 +1673,19 @@ function AuditTrailView() {
         <div key={record.decisionId || i} className="border border-gray-200 rounded-lg p-3 text-xs">
           <div className="flex items-center justify-between mb-1">
             <span className="font-mono text-gray-400">{record.decisionId}</span>
-            <Badge variant={record.action === 'COMPUTE' ? 'blue' : record.action === 'ACCEPT' ? 'green' : 'gray'}>
+            <Badge
+              variant={
+                record.action === 'COMPUTE' ? 'blue' : record.action === 'ACCEPT' ? 'green' : 'gray'
+              }
+            >
               {record.action}
             </Badge>
           </div>
           <div className="text-gray-500">{new Date(record.timestamp).toLocaleString('fr-FR')}</div>
           <div className="text-gray-600 mt-1">
             {record.outputs?.bestOfferId && `Best: ${record.outputs.bestOfferId}`}
-            {record.recommendation?.confidence && ` | Confidence: ${record.recommendation.confidence}`}
+            {record.recommendation?.confidence &&
+              ` | Confidence: ${record.recommendation.confidence}`}
             {record.outputs?.offerCount && ` | ${record.outputs.offerCount} offres`}
           </div>
         </div>

--- a/frontend/src/pages/PurchasePage.jsx
+++ b/frontend/src/pages/PurchasePage.jsx
@@ -5,6 +5,7 @@
  * Brique 3: + Energy Gate, WOW datasets, A4 exports.
  */
 import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useScope } from '../contexts/ScopeContext';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { PageShell, EmptyState } from '../ui';
@@ -31,15 +32,45 @@ import {
   seedWowDirty,
 } from '../services/api';
 import {
-  ShoppingCart, Calculator, Settings2, CheckCircle2,
-  TrendingDown, Shield, Zap, Leaf, AlertTriangle,
-  Building2, Clock, History, Lock, Info, Database, AlertOctagon, Printer, FileText,
+  ShoppingCart,
+  Calculator,
+  Settings2,
+  CheckCircle2,
+  TrendingDown,
+  Shield,
+  Zap,
+  Leaf,
+  AlertTriangle,
+  Building2,
+  Clock,
+  History,
+  Lock,
+  Info,
+  Database,
+  AlertOctagon,
+  Printer,
+  FileText,
 } from 'lucide-react';
 
 const STRATEGY_META = {
-  fixe:   { label: 'Prix Fixe',  icon: Shield,       color: 'blue',   desc: 'Prix garanti sur toute la duree du contrat' },
-  indexe: { label: 'Indexe',     icon: TrendingDown,  color: 'green',  desc: 'Prix suit un indice marche avec plafond' },
-  spot:   { label: 'Spot',       icon: Zap,           color: 'orange', desc: 'Prix marche temps reel, economies max' },
+  fixe: {
+    label: 'Prix Fixe',
+    icon: Shield,
+    color: 'blue',
+    desc: 'Prix garanti sur toute la duree du contrat',
+  },
+  indexe: {
+    label: 'Indexe',
+    icon: TrendingDown,
+    color: 'green',
+    desc: 'Prix suit un indice marche avec plafond',
+  },
+  spot: {
+    label: 'Spot',
+    icon: Zap,
+    color: 'orange',
+    desc: 'Prix marche temps reel, economies max',
+  },
 };
 
 const RISK_COLORS = {
@@ -68,13 +99,45 @@ const TABS = [
   { key: 'historique', label: 'Historique', icon: History },
 ];
 
+/** Map deep-link ?filter= values to the corresponding tab key. */
+const FILTER_TO_TAB = {
+  renewal: 'echeances',
+  missing: 'portefeuille',
+};
+
 export default function PurchasePage() {
-  const { scopedSites } = useScope();
+  const { scopedSites, scope } = useScope();
   const { isExpert } = useExpertMode();
   const { toast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  // Tab state
-  const [activeTab, setActiveTab] = useState('simulation');
+  // Tab state — initialise from ?filter= deep-link if present
+  const [activeTab, setActiveTab] = useState(() => {
+    const filter = searchParams.get('filter');
+    return (filter && FILTER_TO_TAB[filter]) || 'simulation';
+  });
+
+  // Sync tab ↔ URL: when filter changes externally, update tab
+  useEffect(() => {
+    const filter = searchParams.get('filter');
+    const mapped = filter && FILTER_TO_TAB[filter];
+    if (mapped && mapped !== activeTab) setActiveTab(mapped);
+  }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When user clicks a tab, update URL to keep it in sync
+  const handleTabChange = useCallback(
+    (tabKey) => {
+      setActiveTab(tabKey);
+      const filterEntry = Object.entries(FILTER_TO_TAB).find(([, v]) => v === tabKey);
+      if (filterEntry) {
+        setSearchParams({ filter: filterEntry[0] }, { replace: true });
+      } else {
+        // Remove filter param for tabs without a deep-link alias
+        setSearchParams({}, { replace: true });
+      }
+    },
+    [setSearchParams]
+  );
 
   // Simulation state (V1)
   const [selectedSiteId, setSelectedSiteId] = useState(null);
@@ -176,9 +239,12 @@ export default function PurchasePage() {
   useEffect(() => {
     if (activeTab === 'echeances' && renewals.length === 0) {
       setRenewalsLoading(true);
-      getPurchaseRenewals().then(data => {
-        setRenewals(data.renewals || []);
-      }).catch(() => toast('Erreur lors du chargement des echeances', 'error')).finally(() => setRenewalsLoading(false));
+      getPurchaseRenewals()
+        .then((data) => {
+          setRenewals(data.renewals || []);
+        })
+        .catch(() => toast('Erreur lors du chargement des echeances', 'error'))
+        .finally(() => setRenewalsLoading(false));
     }
   }, [activeTab, renewals.length]);
 
@@ -186,22 +252,33 @@ export default function PurchasePage() {
   useEffect(() => {
     if (activeTab === 'historique' && selectedSiteId) {
       setHistoryLoading(true);
-      getPurchaseHistory(selectedSiteId).then(data => {
-        setHistory(data.runs || []);
-      }).catch(() => toast('Erreur lors du chargement de l\'historique', 'error')).finally(() => setHistoryLoading(false));
+      getPurchaseHistory(selectedSiteId)
+        .then((data) => {
+          setHistory(data.runs || []);
+        })
+        .catch(() => toast("Erreur lors du chargement de l'historique", 'error'))
+        .finally(() => setHistoryLoading(false));
     }
   }, [activeTab, selectedSiteId]);
 
   const handleSaveAssumptions = async () => {
     if (!selectedSiteId) return;
     setSavingAssumptions(true);
-    try { await putPurchaseAssumptions(selectedSiteId, assumptions); } catch { toast('Erreur lors de la sauvegarde des hypotheses', 'error'); }
+    try {
+      await putPurchaseAssumptions(selectedSiteId, assumptions);
+    } catch {
+      toast('Erreur lors de la sauvegarde des hypotheses', 'error');
+    }
     setSavingAssumptions(false);
   };
 
   const handleSavePreferences = async () => {
     setSavingPrefs(true);
-    try { await putPurchasePreferences(preferences); } catch { toast('Erreur lors de la sauvegarde des preferences', 'error'); }
+    try {
+      await putPurchasePreferences(preferences);
+    } catch {
+      toast('Erreur lors de la sauvegarde des preferences', 'error');
+    }
     setSavingPrefs(false);
   };
 
@@ -214,7 +291,9 @@ export default function PurchasePage() {
       const result = await computePurchaseScenarios(selectedSiteId);
       setScenarios(result.scenarios || []);
       setAcceptedId(null);
-    } catch { toast('Erreur lors du calcul des scenarios', 'error'); }
+    } catch {
+      toast('Erreur lors du calcul des scenarios', 'error');
+    }
     setComputing(false);
   };
 
@@ -222,535 +301,732 @@ export default function PurchasePage() {
     try {
       await acceptPurchaseResult(resultId);
       setAcceptedId(resultId);
-      setScenarios(prev => prev.map(s =>
-        s.id === resultId ? { ...s, reco_status: 'accepted' } : s
-      ));
-    } catch { toast('Erreur lors de l\'acceptation du scenario', 'error'); }
+      setScenarios((prev) =>
+        prev.map((s) => (s.id === resultId ? { ...s, reco_status: 'accepted' } : s))
+      );
+    } catch {
+      toast("Erreur lors de l'acceptation du scenario", 'error');
+    }
   };
 
   const handleComputePortfolio = async () => {
     setPortfolioLoading(true);
     try {
-      const data = await computePortfolio(1);
+      const data = await computePortfolio(scope.orgId);
       setPortfolioData(data);
-    } catch { toast('Erreur lors du calcul du portefeuille', 'error'); }
+    } catch {
+      toast('Erreur lors du calcul du portefeuille', 'error');
+    }
     setPortfolioLoading(false);
   };
 
   const handleLoadPortfolio = async () => {
     setPortfolioLoading(true);
     try {
-      const data = await getPortfolioResults(1);
+      const data = await getPortfolioResults(scope.orgId);
       setPortfolioData(data);
-    } catch { toast('Erreur lors du chargement du portefeuille', 'error'); }
+    } catch {
+      toast('Erreur lors du chargement du portefeuille', 'error');
+    }
     setPortfolioLoading(false);
   };
 
   return (
     <PurchaseErrorBoundary>
-    <PageShell
-      icon={ShoppingCart}
-      title="Achats énergie"
-      subtitle="Simuler & arbitrer vos stratégies d'achat"
-    >
-      {/* Tab bar */}
-      <div className="flex border-b border-gray-200">
-        {TABS.map(tab => (
-          <button
-            key={tab.key}
-            onClick={() => setActiveTab(tab.key)}
-            className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition ${
-              activeTab === tab.key
-                ? 'border-blue-600 text-blue-600'
-                : 'border-transparent text-gray-500 hover:text-gray-700'
-            }`}
-          >
-            <tab.icon size={16} />
-            {tab.label}
-          </button>
-        ))}
-      </div>
+      <PageShell
+        icon={ShoppingCart}
+        title="Achats énergie"
+        subtitle="Simuler & arbitrer vos stratégies d'achat"
+      >
+        {/* Tab bar */}
+        <div className="flex border-b border-gray-200">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => handleTabChange(tab.key)}
+              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition ${
+                activeTab === tab.key
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              <tab.icon size={16} />
+              {tab.label}
+            </button>
+          ))}
+        </div>
 
-      {/* ══ TAB: Simulation (V1) ══ */}
-      {activeTab === 'simulation' && (
-        <>
-          {/* Section 1: Site selection + Estimation */}
-          <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
-              <Calculator size={18} /> Selection du site & Estimation
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Site</label>
-                <select
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
-                  value={selectedSiteId || ''}
-                  onChange={(e) => setSelectedSiteId(Number(e.target.value))}
-                >
-                  <option value="">Choisir un site...</option>
-                  {scopedSites.map(s => (
-                    <option key={s.id} value={s.id}>{s.nom} — {s.ville}</option>
-                  ))}
-                </select>
-              </div>
-              {estimate && (
-                <>
-                  <div className="bg-blue-50 rounded-lg p-4">
-                    <div className="text-xs text-blue-600 font-medium uppercase">Volume estime</div>
-                    <div className="text-2xl font-bold text-blue-900">
-                      {Math.round(estimate.volume_kwh_an).toLocaleString()} kWh/an
-                    </div>
-                    <div className="text-xs text-blue-500 mt-1">
-                      Source: {estimate.source} ({estimate.months_covered} mois)
-                    </div>
-                  </div>
-                  <div className="bg-purple-50 rounded-lg p-4">
-                    <div className="text-xs text-purple-600 font-medium uppercase">Profil de charge</div>
-                    <div className="text-2xl font-bold text-purple-900">
-                      {estimate.profile_factor?.toFixed(2)}
-                    </div>
-                    <div className="text-xs text-purple-500 mt-1">
-                      {estimate.profile_factor > 1 ? 'Profil pointe' : estimate.profile_factor < 1 ? 'Profil plat' : 'Standard'}
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
-          </div>
-
-          {/* Section 2: Hypotheses */}
-          <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
-              <Settings2 size={18} /> Hypotheses
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Volume (kWh/an)</label>
-                <input
-                  type="number"
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
-                  value={assumptions.volume_kwh_an}
-                  onChange={(e) => setAssumptions(prev => ({ ...prev, volume_kwh_an: Number(e.target.value) }))}
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Horizon (mois)</label>
-                <select
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
-                  value={assumptions.horizon_months}
-                  onChange={(e) => setAssumptions(prev => ({ ...prev, horizon_months: Number(e.target.value) }))}
-                >
-                  <option value={12}>12 mois</option>
-                  <option value={24}>24 mois</option>
-                  <option value={36}>36 mois</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Energie</label>
-                <div className="w-full border border-gray-200 bg-gray-50 rounded-lg px-3 py-2 text-sm flex items-center gap-2 text-gray-700">
-                  <Zap size={14} className="text-blue-500" />
-                  <span className="font-medium">Electricite</span>
-                  <Lock size={12} className="text-gray-400 ml-auto" />
-                </div>
-                <p className="text-xs text-gray-400 mt-1 flex items-center gap-1">
-                  <Info size={10} /> Post-ARENH — elec uniquement
-                </p>
-              </div>
-              <div className="flex items-end">
-                <button
-                  onClick={handleSaveAssumptions}
-                  disabled={savingAssumptions}
-                  className="w-full bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200 transition disabled:opacity-50"
-                >
-                  {savingAssumptions ? 'Sauvegarde...' : 'Sauvegarder'}
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Section 3: Preferences */}
-          <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-lg font-semibold text-gray-800 mb-4">Preferences</h3>
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Tolerance au risque</label>
-                <div className="flex gap-2">
-                  {['low', 'medium', 'high'].map(level => (
-                    <button
-                      key={level}
-                      onClick={() => setPreferences(prev => ({ ...prev, risk_tolerance: level }))}
-                      className={`px-3 py-1.5 rounded-lg text-sm font-medium transition ${
-                        preferences.risk_tolerance === level
-                          ? RISK_COLORS[level] + ' ring-2 ring-offset-1 ring-current'
-                          : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                      }`}
-                    >
-                      {level === 'low' ? 'Faible' : level === 'medium' ? 'Moyen' : 'Eleve'}
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Priorite budget: {Math.round(preferences.budget_priority * 100)}%
-                </label>
-                <input
-                  type="range" min="0" max="1" step="0.1"
-                  value={preferences.budget_priority}
-                  onChange={(e) => setPreferences(prev => ({ ...prev, budget_priority: Number(e.target.value) }))}
-                  className="w-full"
-                />
-                <div className="flex justify-between text-xs text-gray-400">
-                  <span>Securite</span>
-                  <span>Economies</span>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <input type="checkbox" id="green" checked={preferences.green_preference}
-                  onChange={(e) => setPreferences(prev => ({ ...prev, green_preference: e.target.checked }))}
-                  className="rounded" />
-                <label htmlFor="green" className="text-sm text-gray-700 flex items-center gap-1">
-                  <Leaf size={14} className="text-green-500" /> Offre verte
-                </label>
-              </div>
-              <div className="flex gap-2">
-                <button onClick={handleSavePreferences} disabled={savingPrefs}
-                  className="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200 transition disabled:opacity-50">
-                  {savingPrefs ? '...' : 'Sauvegarder'}
-                </button>
-                <button onClick={handleCompute} disabled={computing || !selectedSiteId}
-                  className="flex-1 bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 transition disabled:opacity-50 flex items-center justify-center gap-2">
-                  {computing ? 'Calcul...' : 'Calculer les scenarios'}
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Section 4: Scenario Results */}
-          {scenarios.length > 0 && (
-            <div>
-              <h3 className="text-lg font-semibold text-gray-800 mb-4">Resultats des scenarios</h3>
+        {/* ══ TAB: Simulation (V1) ══ */}
+        {activeTab === 'simulation' && (
+          <>
+            {/* Section 1: Site selection + Estimation */}
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
+                <Calculator size={18} /> Selection du site & Estimation
+              </h3>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                {scenarios.map((s) => {
-                  const meta = STRATEGY_META[s.strategy] || STRATEGY_META.fixe;
-                  const Icon = meta.icon;
-                  const risk = riskLevel(s.risk_score);
-                  const isReco = s.is_recommended;
-                  const isAccepted = s.reco_status === 'accepted' || acceptedId === s.id;
-                  return (
-                    <div key={s.strategy}
-                      className={`bg-white rounded-xl shadow-md p-6 border-2 transition ${isReco ? 'border-blue-500 ring-2 ring-blue-100' : 'border-gray-200'}`}>
-                      <div className="flex items-center justify-between mb-4">
-                        <div className="flex items-center gap-2">
-                          <div className={`p-2 rounded-lg bg-${meta.color}-50`}>
-                            <Icon size={20} className={`text-${meta.color}-600`} />
-                          </div>
-                          <div>
-                            <h4 className="font-semibold text-gray-900">{meta.label}</h4>
-                            <p className="text-xs text-gray-500">{meta.desc}</p>
-                          </div>
-                        </div>
-                        {isReco && <span className="px-2 py-1 text-xs font-bold bg-blue-100 text-blue-700 rounded-full">Recommande</span>}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Site</label>
+                  <select
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+                    value={selectedSiteId || ''}
+                    onChange={(e) => setSelectedSiteId(Number(e.target.value))}
+                  >
+                    <option value="">Choisir un site...</option>
+                    {scopedSites.map((s) => (
+                      <option key={s.id} value={s.id}>
+                        {s.nom} — {s.ville}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                {estimate && (
+                  <>
+                    <div className="bg-blue-50 rounded-lg p-4">
+                      <div className="text-xs text-blue-600 font-medium uppercase">
+                        Volume estime
                       </div>
-                      <div className="mb-4">
-                        <div className="text-3xl font-bold text-gray-900">
-                          {s.price_eur_per_kwh?.toFixed(4)} <span className="text-sm font-normal text-gray-500">EUR/kWh</span>
-                        </div>
-                        <div className="text-sm text-gray-600 mt-1">{Math.round(s.total_annual_eur).toLocaleString()} EUR/an</div>
+                      <div className="text-2xl font-bold text-blue-900">
+                        {Math.round(estimate.volume_kwh_an).toLocaleString()} kWh/an
                       </div>
-                      {s.savings_vs_current_pct != null && (
-                        <div className={`text-sm font-medium mb-3 ${s.savings_vs_current_pct > 0 ? 'text-green-600' : 'text-red-600'}`}>
-                          {s.savings_vs_current_pct > 0 ? '-' : '+'}{Math.abs(s.savings_vs_current_pct)}% vs prix actuel
-                        </div>
-                      )}
-                      <div className="mb-3">
-                        <div className="flex justify-between text-xs text-gray-500 mb-1">
-                          <span>Risque</span>
-                          <span className={RISK_COLORS[risk]}>{s.risk_score}/100</span>
-                        </div>
-                        <div className="w-full bg-gray-200 rounded-full h-2">
-                          <div className={`h-2 rounded-full ${risk === 'low' ? 'bg-green-500' : risk === 'medium' ? 'bg-yellow-500' : 'bg-red-500'}`}
-                            style={{ width: `${s.risk_score}%` }} />
-                        </div>
+                      <div className="text-xs text-blue-500 mt-1">
+                        Source: {estimate.source} ({estimate.months_covered} mois)
                       </div>
-                      {s.p10_eur != null && s.p90_eur != null && (
-                        <div className="text-xs text-gray-500 mb-4">
-                          <AlertTriangle size={12} className="inline mr-1" />
-                          Fourchette: {Math.round(s.p10_eur).toLocaleString()} — {Math.round(s.p90_eur).toLocaleString()} EUR/an
-                        </div>
-                      )}
-                      {isReco && !isAccepted && (
-                        <button onClick={() => handleAccept(s.id)}
-                          className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 transition flex items-center justify-center gap-2">
-                          <CheckCircle2 size={16} /> Accepter
-                        </button>
-                      )}
-                      {isAccepted && (
-                        <div className="w-full bg-green-50 text-green-700 py-2 rounded-lg text-sm font-semibold text-center flex items-center justify-center gap-2">
-                          <CheckCircle2 size={16} /> Accepte
-                        </div>
-                      )}
                     </div>
-                  );
-                })}
+                    <div className="bg-purple-50 rounded-lg p-4">
+                      <div className="text-xs text-purple-600 font-medium uppercase">
+                        Profil de charge
+                      </div>
+                      <div className="text-2xl font-bold text-purple-900">
+                        {estimate.profile_factor?.toFixed(2)}
+                      </div>
+                      <div className="text-xs text-purple-500 mt-1">
+                        {estimate.profile_factor > 1
+                          ? 'Profil pointe'
+                          : estimate.profile_factor < 1
+                            ? 'Profil plat'
+                            : 'Standard'}
+                      </div>
+                    </div>
+                  </>
+                )}
               </div>
-              {scenarios.find(s => s.reasoning) && (
-                <div className="mt-4 bg-blue-50 rounded-lg p-4">
-                  <p className="text-sm text-blue-800">
-                    <strong>Analyse:</strong> {scenarios.find(s => s.reasoning)?.reasoning}
+            </div>
+
+            {/* Section 2: Hypotheses */}
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
+                <Settings2 size={18} /> Hypotheses
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Volume (kWh/an)
+                  </label>
+                  <input
+                    type="number"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+                    value={assumptions.volume_kwh_an}
+                    onChange={(e) =>
+                      setAssumptions((prev) => ({ ...prev, volume_kwh_an: Number(e.target.value) }))
+                    }
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Horizon (mois)
+                  </label>
+                  <select
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+                    value={assumptions.horizon_months}
+                    onChange={(e) =>
+                      setAssumptions((prev) => ({
+                        ...prev,
+                        horizon_months: Number(e.target.value),
+                      }))
+                    }
+                  >
+                    <option value={12}>12 mois</option>
+                    <option value={24}>24 mois</option>
+                    <option value={36}>36 mois</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Energie</label>
+                  <div className="w-full border border-gray-200 bg-gray-50 rounded-lg px-3 py-2 text-sm flex items-center gap-2 text-gray-700">
+                    <Zap size={14} className="text-blue-500" />
+                    <span className="font-medium">Electricite</span>
+                    <Lock size={12} className="text-gray-400 ml-auto" />
+                  </div>
+                  <p className="text-xs text-gray-400 mt-1 flex items-center gap-1">
+                    <Info size={10} /> Post-ARENH — elec uniquement
                   </p>
                 </div>
-              )}
-            </div>
-          )}
-          {scenarios.length > 0 && (
-            <div className="flex justify-end">
-              <button onClick={() => setShowNoteDecision(true)}
-                className="flex items-center gap-1.5 bg-white border border-blue-200 text-blue-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-50 transition">
-                <Printer size={14} /> Exporter Note de Decision (A4)
-              </button>
-            </div>
-          )}
-          {loading && <div className="grid grid-cols-1 md:grid-cols-3 gap-4"><SkeletonCard /><SkeletonCard /><SkeletonCard /></div>}
-        </>
-      )}
-
-      {/* ══ TAB: Portefeuille (V1.1) ══ */}
-      {activeTab === 'portefeuille' && (
-        <div className="space-y-6">
-          <div className="flex items-center gap-4 flex-wrap">
-            <button onClick={handleComputePortfolio} disabled={portfolioLoading}
-              className="bg-blue-600 text-white px-5 py-2.5 rounded-lg text-sm font-semibold hover:bg-blue-700 transition disabled:opacity-50">
-              {portfolioLoading ? 'Calcul...' : 'Calculer le portefeuille'}
-            </button>
-            <button onClick={handleLoadPortfolio} disabled={portfolioLoading}
-              className="bg-gray-100 text-gray-700 px-5 py-2.5 rounded-lg text-sm font-medium hover:bg-gray-200 transition disabled:opacity-50">
-              Charger résultats existants
-            </button>
-            <div className="ml-auto flex items-center gap-2">
-              <span className="text-xs text-gray-400 uppercase font-medium">Datasets demo</span>
-              <button onClick={() => handleSeedWow('happy')} disabled={!!seedingWow}
-                className="flex items-center gap-1.5 bg-emerald-50 text-emerald-700 border border-emerald-200 px-3 py-2 rounded-lg text-xs font-medium hover:bg-emerald-100 transition disabled:opacity-50">
-                <Database size={13} />
-                {seedingWow === 'happy' ? 'Chargement...' : '15 sites (happy)'}
-              </button>
-              <button onClick={() => handleSeedWow('dirty')} disabled={!!seedingWow}
-                className="flex items-center gap-1.5 bg-orange-50 text-orange-700 border border-orange-200 px-3 py-2 rounded-lg text-xs font-medium hover:bg-orange-100 transition disabled:opacity-50">
-                <AlertOctagon size={13} />
-                {seedingWow === 'dirty' ? 'Chargement...' : '15 sites (dirty)'}
-              </button>
-            </div>
-          </div>
-          {seedResult && (
-            <div className={`rounded-lg p-3 text-sm ${seedResult.error ? 'bg-red-50 text-red-700' : 'bg-blue-50 text-blue-700'}`}>
-              {seedResult.error
-                ? `Erreur: ${seedResult.error}`
-                : `Dataset "${seedResult.mode}" charge: ${seedResult.sites_created} sites, ${seedResult.scenarios_created} scenarios, ${seedResult.contracts_created} contrats (org: ${seedResult.org_nom})`
-              }
-            </div>
-          )}
-          {portfolioData?.portfolio && (
-            <>
-              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                <div className="bg-white rounded-lg shadow p-5">
-                  <div className="text-xs text-gray-500 uppercase font-medium">Sites analyses</div>
-                  <div className="text-3xl font-bold text-gray-900 mt-1">{portfolioData.portfolio.sites_count}</div>
-                </div>
-                <div className="bg-white rounded-lg shadow p-5">
-                  <div className="text-xs text-gray-500 uppercase font-medium">Cout annuel total</div>
-                  <div className="text-3xl font-bold text-blue-700 mt-1">
-                    {Math.round(portfolioData.portfolio.total_annual_cost_eur).toLocaleString()} EUR
-                  </div>
-                </div>
-                <div className="bg-white rounded-lg shadow p-5">
-                  <div className="text-xs text-gray-500 uppercase font-medium">Risque moyen pondere</div>
-                  <div className="text-3xl font-bold text-orange-600 mt-1">{portfolioData.portfolio.weighted_risk_score}/100</div>
-                </div>
-                <div className="bg-white rounded-lg shadow p-5">
-                  <div className="text-xs text-gray-500 uppercase font-medium">Economies potentielles</div>
-                  <div className={`text-3xl font-bold mt-1 ${portfolioData.portfolio.weighted_savings_pct > 0 ? 'text-green-600' : 'text-red-600'}`}>
-                    {portfolioData.portfolio.weighted_savings_pct > 0 ? '-' : ''}{portfolioData.portfolio.weighted_savings_pct}%
-                  </div>
+                <div className="flex items-end">
+                  <button
+                    onClick={handleSaveAssumptions}
+                    disabled={savingAssumptions}
+                    className="w-full bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200 transition disabled:opacity-50"
+                  >
+                    {savingAssumptions ? 'Sauvegarde...' : 'Sauvegarder'}
+                  </button>
                 </div>
               </div>
-              {portfolioData.sites?.length > 0 && (
-                <div className="bg-white rounded-lg shadow overflow-hidden">
-                  <table className="w-full text-sm">
-                    <thead className="bg-gray-50 text-gray-500 uppercase text-xs">
-                      <tr>
-                        <th className="px-4 py-3 text-left">Site</th>
-                        <th className="px-4 py-3 text-left">Strategie</th>
-                        <th className="px-4 py-3 text-right">Cout annuel</th>
-                        <th className="px-4 py-3 text-right">Risque</th>
-                        <th className="px-4 py-3 text-right">Economies</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100">
-                      {portfolioData.sites.map(site => {
-                        const reco = site.scenarios?.find(s => s.is_recommended);
-                        return (
-                          <tr key={site.site_id} className="hover:bg-gray-50">
-                            <td className="px-4 py-3 font-medium text-gray-900">Site {site.site_id}</td>
-                            <td className="px-4 py-3">{reco ? <span className="px-2 py-1 text-xs font-semibold bg-blue-50 text-blue-700 rounded capitalize">{reco.strategy}</span> : '—'}</td>
-                            <td className="px-4 py-3 text-right">{reco ? `${Math.round(reco.total_annual_eur).toLocaleString()} EUR` : '—'}</td>
-                            <td className="px-4 py-3 text-right">{reco ? `${reco.risk_score}/100` : '—'}</td>
-                            <td className="px-4 py-3 text-right">{reco?.savings_vs_current_pct != null ? <span className={reco.savings_vs_current_pct > 0 ? 'text-green-600 font-medium' : 'text-red-600'}>{reco.savings_vs_current_pct > 0 ? '-' : '+'}{Math.abs(reco.savings_vs_current_pct)}%</span> : '—'}</td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
+            </div>
+
+            {/* Section 3: Preferences */}
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4">Preferences</h3>
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Tolerance au risque
+                  </label>
+                  <div className="flex gap-2">
+                    {['low', 'medium', 'high'].map((level) => (
+                      <button
+                        key={level}
+                        onClick={() =>
+                          setPreferences((prev) => ({ ...prev, risk_tolerance: level }))
+                        }
+                        className={`px-3 py-1.5 rounded-lg text-sm font-medium transition ${
+                          preferences.risk_tolerance === level
+                            ? RISK_COLORS[level] + ' ring-2 ring-offset-1 ring-current'
+                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                        }`}
+                      >
+                        {level === 'low' ? 'Faible' : level === 'medium' ? 'Moyen' : 'Eleve'}
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              )}
-              <div className="flex justify-end mt-4">
-                <button onClick={() => setShowPackRFP(true)}
-                  className="flex items-center gap-1.5 bg-white border border-blue-200 text-blue-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-50 transition">
-                  <FileText size={14} /> Exporter Pack RFP (A4)
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Priorite budget: {Math.round(preferences.budget_priority * 100)}%
+                  </label>
+                  <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.1"
+                    value={preferences.budget_priority}
+                    onChange={(e) =>
+                      setPreferences((prev) => ({
+                        ...prev,
+                        budget_priority: Number(e.target.value),
+                      }))
+                    }
+                    className="w-full"
+                  />
+                  <div className="flex justify-between text-xs text-gray-400">
+                    <span>Securite</span>
+                    <span>Economies</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="green"
+                    checked={preferences.green_preference}
+                    onChange={(e) =>
+                      setPreferences((prev) => ({ ...prev, green_preference: e.target.checked }))
+                    }
+                    className="rounded"
+                  />
+                  <label htmlFor="green" className="text-sm text-gray-700 flex items-center gap-1">
+                    <Leaf size={14} className="text-green-500" /> Offre verte
+                  </label>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleSavePreferences}
+                    disabled={savingPrefs}
+                    className="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200 transition disabled:opacity-50"
+                  >
+                    {savingPrefs ? '...' : 'Sauvegarder'}
+                  </button>
+                  <button
+                    onClick={handleCompute}
+                    disabled={computing || !selectedSiteId}
+                    className="flex-1 bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 transition disabled:opacity-50 flex items-center justify-center gap-2"
+                  >
+                    {computing ? 'Calcul...' : 'Calculer les scenarios'}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Section 4: Scenario Results */}
+            {scenarios.length > 0 && (
+              <div>
+                <h3 className="text-lg font-semibold text-gray-800 mb-4">
+                  Resultats des scenarios
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  {scenarios.map((s) => {
+                    const meta = STRATEGY_META[s.strategy] || STRATEGY_META.fixe;
+                    const Icon = meta.icon;
+                    const risk = riskLevel(s.risk_score);
+                    const isReco = s.is_recommended;
+                    const isAccepted = s.reco_status === 'accepted' || acceptedId === s.id;
+                    return (
+                      <div
+                        key={s.strategy}
+                        className={`bg-white rounded-xl shadow-md p-6 border-2 transition ${isReco ? 'border-blue-500 ring-2 ring-blue-100' : 'border-gray-200'}`}
+                      >
+                        <div className="flex items-center justify-between mb-4">
+                          <div className="flex items-center gap-2">
+                            <div className={`p-2 rounded-lg bg-${meta.color}-50`}>
+                              <Icon size={20} className={`text-${meta.color}-600`} />
+                            </div>
+                            <div>
+                              <h4 className="font-semibold text-gray-900">{meta.label}</h4>
+                              <p className="text-xs text-gray-500">{meta.desc}</p>
+                            </div>
+                          </div>
+                          {isReco && (
+                            <span className="px-2 py-1 text-xs font-bold bg-blue-100 text-blue-700 rounded-full">
+                              Recommande
+                            </span>
+                          )}
+                        </div>
+                        <div className="mb-4">
+                          <div className="text-3xl font-bold text-gray-900">
+                            {s.price_eur_per_kwh?.toFixed(4)}{' '}
+                            <span className="text-sm font-normal text-gray-500">EUR/kWh</span>
+                          </div>
+                          <div className="text-sm text-gray-600 mt-1">
+                            {Math.round(s.total_annual_eur).toLocaleString()} EUR/an
+                          </div>
+                        </div>
+                        {s.savings_vs_current_pct != null && (
+                          <div
+                            className={`text-sm font-medium mb-3 ${s.savings_vs_current_pct > 0 ? 'text-green-600' : 'text-red-600'}`}
+                          >
+                            {s.savings_vs_current_pct > 0 ? '-' : '+'}
+                            {Math.abs(s.savings_vs_current_pct)}% vs prix actuel
+                          </div>
+                        )}
+                        <div className="mb-3">
+                          <div className="flex justify-between text-xs text-gray-500 mb-1">
+                            <span>Risque</span>
+                            <span className={RISK_COLORS[risk]}>{s.risk_score}/100</span>
+                          </div>
+                          <div className="w-full bg-gray-200 rounded-full h-2">
+                            <div
+                              className={`h-2 rounded-full ${risk === 'low' ? 'bg-green-500' : risk === 'medium' ? 'bg-yellow-500' : 'bg-red-500'}`}
+                              style={{ width: `${s.risk_score}%` }}
+                            />
+                          </div>
+                        </div>
+                        {s.p10_eur != null && s.p90_eur != null && (
+                          <div className="text-xs text-gray-500 mb-4">
+                            <AlertTriangle size={12} className="inline mr-1" />
+                            Fourchette: {Math.round(s.p10_eur).toLocaleString()} —{' '}
+                            {Math.round(s.p90_eur).toLocaleString()} EUR/an
+                          </div>
+                        )}
+                        {isReco && !isAccepted && (
+                          <button
+                            onClick={() => handleAccept(s.id)}
+                            className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 transition flex items-center justify-center gap-2"
+                          >
+                            <CheckCircle2 size={16} /> Accepter
+                          </button>
+                        )}
+                        {isAccepted && (
+                          <div className="w-full bg-green-50 text-green-700 py-2 rounded-lg text-sm font-semibold text-center flex items-center justify-center gap-2">
+                            <CheckCircle2 size={16} /> Accepte
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                {scenarios.find((s) => s.reasoning) && (
+                  <div className="mt-4 bg-blue-50 rounded-lg p-4">
+                    <p className="text-sm text-blue-800">
+                      <strong>Analyse:</strong> {scenarios.find((s) => s.reasoning)?.reasoning}
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+            {scenarios.length > 0 && (
+              <div className="flex justify-end">
+                <button
+                  onClick={() => setShowNoteDecision(true)}
+                  className="flex items-center gap-1.5 bg-white border border-blue-200 text-blue-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-50 transition"
+                >
+                  <Printer size={14} /> Exporter Note de Decision (A4)
                 </button>
               </div>
-            </>
-          )}
-          {!portfolioData && !portfolioLoading && (
-            <div className="text-center py-12 text-gray-400">Cliquez sur "Calculer le portefeuille" pour lancer l'analyse multi-site</div>
-          )}
-        </div>
-      )}
+            )}
+            {loading && (
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <SkeletonCard />
+                <SkeletonCard />
+                <SkeletonCard />
+              </div>
+            )}
+          </>
+        )}
 
-      {/* ══ Export modals ══ */}
-      {showNoteDecision && (
-        <ExportNoteDecision
-          data={{
-            site_id: selectedSiteId,
-            site_nom: scopedSites.find(s => s.id === selectedSiteId)?.nom,
-            volume_kwh_an: assumptions.volume_kwh_an,
-            horizon_months: assumptions.horizon_months,
-            scenarios,
-          }}
-          onClose={() => setShowNoteDecision(false)}
-        />
-      )}
-      {showPackRFP && portfolioData && (
-        <ExportPackRFP
-          portfolio={portfolioData.portfolio}
-          sites={portfolioData.sites}
-          orgName="PROMEOS"
-          onClose={() => setShowPackRFP(false)}
-        />
-      )}
-
-      {/* ══ TAB: Echeances (V1.1) ══ */}
-      {activeTab === 'echeances' && (
-        <div className="space-y-4">
-          {renewalsLoading ? (
-            <div className="text-center py-12 text-gray-400">Chargement...</div>
-          ) : renewals.length === 0 ? (
-            <div className="text-center py-12 text-gray-400">Aucun contrat avec echeance a venir</div>
-          ) : (
-            <div className="bg-white rounded-lg shadow overflow-hidden">
-              <table className="w-full text-sm">
-                <thead className="bg-gray-50 text-gray-500 uppercase text-xs">
-                  <tr>
-                    <th className="px-4 py-3 text-left">Urgence</th>
-                    <th className="px-4 py-3 text-left">Site</th>
-                    <th className="px-4 py-3 text-left">Fournisseur</th>
-                    <th className="px-4 py-3 text-left">Energie</th>
-                    <th className="px-4 py-3 text-left">Fin contrat</th>
-                    <th className="px-4 py-3 text-left">Deadline preavis</th>
-                    <th className="px-4 py-3 text-right">Jours restants</th>
-                    <th className="px-4 py-3 text-center">Auto-renew</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-100">
-                  {renewals.map(r => (
-                    <tr key={r.contract_id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3">
-                        <span className={`px-2 py-1 text-xs font-bold rounded ${URGENCY_STYLES[r.urgency] || URGENCY_STYLES.gray}`}>
-                          {r.urgency === 'red' ? 'Urgent' : r.urgency === 'orange' ? 'Bientot' : r.urgency === 'yellow' ? 'A planifier' : 'OK'}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 font-medium text-gray-900">{r.site_nom || `Site ${r.site_id}`}</td>
-                      <td className="px-4 py-3">{r.supplier_name}</td>
-                      <td className="px-4 py-3 capitalize">{r.energy_type}</td>
-                      <td className="px-4 py-3">{new Date(r.end_date).toLocaleDateString('fr-FR')}</td>
-                      <td className="px-4 py-3">{new Date(r.notice_deadline).toLocaleDateString('fr-FR')}</td>
-                      <td className="px-4 py-3 text-right font-semibold">{r.days_until_expiry}j</td>
-                      <td className="px-4 py-3 text-center">{r.auto_renew ? <span className="text-green-600 text-xs font-medium">Oui</span> : <span className="text-gray-400 text-xs">Non</span>}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+        {/* ══ TAB: Portefeuille (V1.1) ══ */}
+        {activeTab === 'portefeuille' && (
+          <div className="space-y-6">
+            <div className="flex items-center gap-4 flex-wrap">
+              <button
+                onClick={handleComputePortfolio}
+                disabled={portfolioLoading}
+                className="bg-blue-600 text-white px-5 py-2.5 rounded-lg text-sm font-semibold hover:bg-blue-700 transition disabled:opacity-50"
+              >
+                {portfolioLoading ? 'Calcul...' : 'Calculer le portefeuille'}
+              </button>
+              <button
+                onClick={handleLoadPortfolio}
+                disabled={portfolioLoading}
+                className="bg-gray-100 text-gray-700 px-5 py-2.5 rounded-lg text-sm font-medium hover:bg-gray-200 transition disabled:opacity-50"
+              >
+                Charger résultats existants
+              </button>
+              <div className="ml-auto flex items-center gap-2">
+                <span className="text-xs text-gray-400 uppercase font-medium">Datasets demo</span>
+                <button
+                  onClick={() => handleSeedWow('happy')}
+                  disabled={!!seedingWow}
+                  className="flex items-center gap-1.5 bg-emerald-50 text-emerald-700 border border-emerald-200 px-3 py-2 rounded-lg text-xs font-medium hover:bg-emerald-100 transition disabled:opacity-50"
+                >
+                  <Database size={13} />
+                  {seedingWow === 'happy' ? 'Chargement...' : '15 sites (happy)'}
+                </button>
+                <button
+                  onClick={() => handleSeedWow('dirty')}
+                  disabled={!!seedingWow}
+                  className="flex items-center gap-1.5 bg-orange-50 text-orange-700 border border-orange-200 px-3 py-2 rounded-lg text-xs font-medium hover:bg-orange-100 transition disabled:opacity-50"
+                >
+                  <AlertOctagon size={13} />
+                  {seedingWow === 'dirty' ? 'Chargement...' : '15 sites (dirty)'}
+                </button>
+              </div>
             </div>
-          )}
-        </div>
-      )}
-
-      {/* ══ TAB: Historique (V1.1) ══ */}
-      {activeTab === 'historique' && (
-        <div className="space-y-4">
-          <div className="bg-white rounded-lg shadow p-4">
-            <label className="block text-sm font-medium text-gray-700 mb-1">Site</label>
-            <select className="w-full max-w-sm border border-gray-300 rounded-lg px-3 py-2 text-sm"
-              value={selectedSiteId || ''} onChange={(e) => setSelectedSiteId(Number(e.target.value))}>
-              <option value="">Choisir un site...</option>
-              {scopedSites.map(s => <option key={s.id} value={s.id}>{s.nom} — {s.ville}</option>)}
-            </select>
-          </div>
-          {historyLoading ? (
-            <div className="text-center py-12 text-gray-400">Chargement...</div>
-          ) : history.length === 0 ? (
-            <div className="text-center py-12 text-gray-400">Aucun historique de calcul pour ce site</div>
-          ) : (
-            <div className="space-y-3">
-              {history.map((run, idx) => (
-                <div key={run.run_id || idx}
-                  className={`bg-white rounded-lg shadow p-4 cursor-pointer transition border-2 ${selectedRun?.run_id === run.run_id ? 'border-blue-500' : 'border-transparent hover:border-gray-300'}`}
-                  onClick={() => setSelectedRun(selectedRun?.run_id === run.run_id ? null : run)}>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="text-sm font-semibold text-gray-900">
-                        {run.computed_at ? new Date(run.computed_at).toLocaleString('fr-FR') : 'Date inconnue'}
-                      </div>
-                      <div className="text-xs text-gray-500 mt-0.5">
-                        {run.run_id ? `Run: ${run.run_id.substring(0, 8)}...` : 'Run legacy'}
-                        {run.inputs_hash && ` | Hash: ${run.inputs_hash.substring(0, 8)}...`}
-                      </div>
+            {seedResult && (
+              <div
+                className={`rounded-lg p-3 text-sm ${seedResult.error ? 'bg-red-50 text-red-700' : 'bg-blue-50 text-blue-700'}`}
+              >
+                {seedResult.error
+                  ? `Erreur: ${seedResult.error}`
+                  : `Dataset "${seedResult.mode}" charge: ${seedResult.sites_created} sites, ${seedResult.scenarios_created} scenarios, ${seedResult.contracts_created} contrats (org: ${seedResult.org_nom})`}
+              </div>
+            )}
+            {portfolioData?.portfolio && (
+              <>
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                  <div className="bg-white rounded-lg shadow p-5">
+                    <div className="text-xs text-gray-500 uppercase font-medium">
+                      Sites analyses
                     </div>
-                    <div className="text-right">
-                      {run.summary?.recommended_strategy && (
-                        <span className="px-2 py-1 text-xs font-semibold bg-blue-50 text-blue-700 rounded capitalize">{run.summary.recommended_strategy}</span>
-                      )}
-                      {run.summary?.recommended_total_eur && (
-                        <div className="text-sm font-medium text-gray-700 mt-1">{Math.round(run.summary.recommended_total_eur).toLocaleString()} EUR/an</div>
-                      )}
+                    <div className="text-3xl font-bold text-gray-900 mt-1">
+                      {portfolioData.portfolio.sites_count}
                     </div>
                   </div>
-                  {selectedRun?.run_id === run.run_id && run.scenarios && (
-                    <div className="mt-4 pt-4 border-t border-gray-100 grid grid-cols-3 gap-3">
-                      {run.scenarios.map(s => (
-                        <div key={s.id} className={`p-3 rounded-lg border ${s.is_recommended ? 'border-blue-300 bg-blue-50' : 'border-gray-200'}`}>
-                          <div className="text-xs font-semibold uppercase text-gray-500 capitalize">{s.strategy}</div>
-                          <div className="text-lg font-bold text-gray-900 mt-1">{s.price_eur_per_kwh?.toFixed(4)} EUR/kWh</div>
-                          <div className="text-xs text-gray-500">{Math.round(s.total_annual_eur).toLocaleString()} EUR/an | Risque: {s.risk_score}</div>
-                          {s.is_recommended && <span className="inline-block mt-1 px-2 py-0.5 text-xs font-bold bg-blue-100 text-blue-700 rounded-full">Recommande</span>}
-                        </div>
-                      ))}
+                  <div className="bg-white rounded-lg shadow p-5">
+                    <div className="text-xs text-gray-500 uppercase font-medium">
+                      Cout annuel total
                     </div>
-                  )}
+                    <div className="text-3xl font-bold text-blue-700 mt-1">
+                      {Math.round(portfolioData.portfolio.total_annual_cost_eur).toLocaleString()}{' '}
+                      EUR
+                    </div>
+                  </div>
+                  <div className="bg-white rounded-lg shadow p-5">
+                    <div className="text-xs text-gray-500 uppercase font-medium">
+                      Risque moyen pondere
+                    </div>
+                    <div className="text-3xl font-bold text-orange-600 mt-1">
+                      {portfolioData.portfolio.weighted_risk_score}/100
+                    </div>
+                  </div>
+                  <div className="bg-white rounded-lg shadow p-5">
+                    <div className="text-xs text-gray-500 uppercase font-medium">
+                      Economies potentielles
+                    </div>
+                    <div
+                      className={`text-3xl font-bold mt-1 ${portfolioData.portfolio.weighted_savings_pct > 0 ? 'text-green-600' : 'text-red-600'}`}
+                    >
+                      {portfolioData.portfolio.weighted_savings_pct > 0 ? '-' : ''}
+                      {portfolioData.portfolio.weighted_savings_pct}%
+                    </div>
+                  </div>
                 </div>
-              ))}
+                {portfolioData.sites?.length > 0 && (
+                  <div className="bg-white rounded-lg shadow overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-gray-50 text-gray-500 uppercase text-xs">
+                        <tr>
+                          <th className="px-4 py-3 text-left">Site</th>
+                          <th className="px-4 py-3 text-left">Strategie</th>
+                          <th className="px-4 py-3 text-right">Cout annuel</th>
+                          <th className="px-4 py-3 text-right">Risque</th>
+                          <th className="px-4 py-3 text-right">Economies</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {portfolioData.sites.map((site) => {
+                          const reco = site.scenarios?.find((s) => s.is_recommended);
+                          return (
+                            <tr key={site.site_id} className="hover:bg-gray-50">
+                              <td className="px-4 py-3 font-medium text-gray-900">
+                                Site {site.site_id}
+                              </td>
+                              <td className="px-4 py-3">
+                                {reco ? (
+                                  <span className="px-2 py-1 text-xs font-semibold bg-blue-50 text-blue-700 rounded capitalize">
+                                    {reco.strategy}
+                                  </span>
+                                ) : (
+                                  '—'
+                                )}
+                              </td>
+                              <td className="px-4 py-3 text-right">
+                                {reco
+                                  ? `${Math.round(reco.total_annual_eur).toLocaleString()} EUR`
+                                  : '—'}
+                              </td>
+                              <td className="px-4 py-3 text-right">
+                                {reco ? `${reco.risk_score}/100` : '—'}
+                              </td>
+                              <td className="px-4 py-3 text-right">
+                                {reco?.savings_vs_current_pct != null ? (
+                                  <span
+                                    className={
+                                      reco.savings_vs_current_pct > 0
+                                        ? 'text-green-600 font-medium'
+                                        : 'text-red-600'
+                                    }
+                                  >
+                                    {reco.savings_vs_current_pct > 0 ? '-' : '+'}
+                                    {Math.abs(reco.savings_vs_current_pct)}%
+                                  </span>
+                                ) : (
+                                  '—'
+                                )}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+                <div className="flex justify-end mt-4">
+                  <button
+                    onClick={() => setShowPackRFP(true)}
+                    className="flex items-center gap-1.5 bg-white border border-blue-200 text-blue-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-50 transition"
+                  >
+                    <FileText size={14} /> Exporter Pack RFP (A4)
+                  </button>
+                </div>
+              </>
+            )}
+            {!portfolioData && !portfolioLoading && (
+              <div className="text-center py-12 text-gray-400">
+                Cliquez sur "Calculer le portefeuille" pour lancer l'analyse multi-site
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ══ Export modals ══ */}
+        {showNoteDecision && (
+          <ExportNoteDecision
+            data={{
+              site_id: selectedSiteId,
+              site_nom: scopedSites.find((s) => s.id === selectedSiteId)?.nom,
+              volume_kwh_an: assumptions.volume_kwh_an,
+              horizon_months: assumptions.horizon_months,
+              scenarios,
+            }}
+            onClose={() => setShowNoteDecision(false)}
+          />
+        )}
+        {showPackRFP && portfolioData && (
+          <ExportPackRFP
+            portfolio={portfolioData.portfolio}
+            sites={portfolioData.sites}
+            orgName="PROMEOS"
+            onClose={() => setShowPackRFP(false)}
+          />
+        )}
+
+        {/* ══ TAB: Echeances (V1.1) ══ */}
+        {activeTab === 'echeances' && (
+          <div className="space-y-4">
+            {renewalsLoading ? (
+              <div className="text-center py-12 text-gray-400">Chargement...</div>
+            ) : renewals.length === 0 ? (
+              <div className="text-center py-12 text-gray-400">
+                Aucun contrat avec echeance a venir
+              </div>
+            ) : (
+              <div className="bg-white rounded-lg shadow overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50 text-gray-500 uppercase text-xs">
+                    <tr>
+                      <th className="px-4 py-3 text-left">Urgence</th>
+                      <th className="px-4 py-3 text-left">Site</th>
+                      <th className="px-4 py-3 text-left">Fournisseur</th>
+                      <th className="px-4 py-3 text-left">Energie</th>
+                      <th className="px-4 py-3 text-left">Fin contrat</th>
+                      <th className="px-4 py-3 text-left">Deadline preavis</th>
+                      <th className="px-4 py-3 text-right">Jours restants</th>
+                      <th className="px-4 py-3 text-center">Auto-renew</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {renewals.map((r) => (
+                      <tr key={r.contract_id} className="hover:bg-gray-50">
+                        <td className="px-4 py-3">
+                          <span
+                            className={`px-2 py-1 text-xs font-bold rounded ${URGENCY_STYLES[r.urgency] || URGENCY_STYLES.gray}`}
+                          >
+                            {r.urgency === 'red'
+                              ? 'Urgent'
+                              : r.urgency === 'orange'
+                                ? 'Bientot'
+                                : r.urgency === 'yellow'
+                                  ? 'A planifier'
+                                  : 'OK'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 font-medium text-gray-900">
+                          {r.site_nom || `Site ${r.site_id}`}
+                        </td>
+                        <td className="px-4 py-3">{r.supplier_name}</td>
+                        <td className="px-4 py-3 capitalize">{r.energy_type}</td>
+                        <td className="px-4 py-3">
+                          {new Date(r.end_date).toLocaleDateString('fr-FR')}
+                        </td>
+                        <td className="px-4 py-3">
+                          {new Date(r.notice_deadline).toLocaleDateString('fr-FR')}
+                        </td>
+                        <td className="px-4 py-3 text-right font-semibold">
+                          {r.days_until_expiry}j
+                        </td>
+                        <td className="px-4 py-3 text-center">
+                          {r.auto_renew ? (
+                            <span className="text-green-600 text-xs font-medium">Oui</span>
+                          ) : (
+                            <span className="text-gray-400 text-xs">Non</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ══ TAB: Historique (V1.1) ══ */}
+        {activeTab === 'historique' && (
+          <div className="space-y-4">
+            <div className="bg-white rounded-lg shadow p-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">Site</label>
+              <select
+                className="w-full max-w-sm border border-gray-300 rounded-lg px-3 py-2 text-sm"
+                value={selectedSiteId || ''}
+                onChange={(e) => setSelectedSiteId(Number(e.target.value))}
+              >
+                <option value="">Choisir un site...</option>
+                {scopedSites.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.nom} — {s.ville}
+                  </option>
+                ))}
+              </select>
             </div>
-          )}
-        </div>
-      )}
-    <PurchaseDebugDrawer
-      assumptions={assumptions}
-      preferences={preferences}
-      scenarios={scenarios}
-      portfolioData={portfolioData}
-      selectedSiteId={selectedSiteId}
-      seedResult={seedResult}
-    />
-    </PageShell>
+            {historyLoading ? (
+              <div className="text-center py-12 text-gray-400">Chargement...</div>
+            ) : history.length === 0 ? (
+              <div className="text-center py-12 text-gray-400">
+                Aucun historique de calcul pour ce site
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {history.map((run, idx) => (
+                  <div
+                    key={run.run_id || idx}
+                    className={`bg-white rounded-lg shadow p-4 cursor-pointer transition border-2 ${selectedRun?.run_id === run.run_id ? 'border-blue-500' : 'border-transparent hover:border-gray-300'}`}
+                    onClick={() => setSelectedRun(selectedRun?.run_id === run.run_id ? null : run)}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="text-sm font-semibold text-gray-900">
+                          {run.computed_at
+                            ? new Date(run.computed_at).toLocaleString('fr-FR')
+                            : 'Date inconnue'}
+                        </div>
+                        <div className="text-xs text-gray-500 mt-0.5">
+                          {run.run_id ? `Run: ${run.run_id.substring(0, 8)}...` : 'Run legacy'}
+                          {run.inputs_hash && ` | Hash: ${run.inputs_hash.substring(0, 8)}...`}
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        {run.summary?.recommended_strategy && (
+                          <span className="px-2 py-1 text-xs font-semibold bg-blue-50 text-blue-700 rounded capitalize">
+                            {run.summary.recommended_strategy}
+                          </span>
+                        )}
+                        {run.summary?.recommended_total_eur && (
+                          <div className="text-sm font-medium text-gray-700 mt-1">
+                            {Math.round(run.summary.recommended_total_eur).toLocaleString()} EUR/an
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                    {selectedRun?.run_id === run.run_id && run.scenarios && (
+                      <div className="mt-4 pt-4 border-t border-gray-100 grid grid-cols-3 gap-3">
+                        {run.scenarios.map((s) => (
+                          <div
+                            key={s.id}
+                            className={`p-3 rounded-lg border ${s.is_recommended ? 'border-blue-300 bg-blue-50' : 'border-gray-200'}`}
+                          >
+                            <div className="text-xs font-semibold uppercase text-gray-500 capitalize">
+                              {s.strategy}
+                            </div>
+                            <div className="text-lg font-bold text-gray-900 mt-1">
+                              {s.price_eur_per_kwh?.toFixed(4)} EUR/kWh
+                            </div>
+                            <div className="text-xs text-gray-500">
+                              {Math.round(s.total_annual_eur).toLocaleString()} EUR/an | Risque:{' '}
+                              {s.risk_score}
+                            </div>
+                            {s.is_recommended && (
+                              <span className="inline-block mt-1 px-2 py-0.5 text-xs font-bold bg-blue-100 text-blue-700 rounded-full">
+                                Recommande
+                              </span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        <PurchaseDebugDrawer
+          assumptions={assumptions}
+          preferences={preferences}
+          scenarios={scenarios}
+          portfolioData={portfolioData}
+          selectedSiteId={selectedSiteId}
+          seedResult={seedResult}
+        />
+      </PageShell>
     </PurchaseErrorBoundary>
   );
 }

--- a/frontend/src/pages/__tests__/purchaseP0.test.js
+++ b/frontend/src/pages/__tests__/purchaseP0.test.js
@@ -1,0 +1,127 @@
+/**
+ * PROMEOS — P0 Purchase Fixes
+ * Tests for:
+ *   P0-1: No hardcoded org_id=1 in PurchasePage
+ *   P0-2: Deep-link ?filter= maps to correct tab
+ *   P0-3: PurchaseAssistantPage triggers API call
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const SRC = path.resolve(__dirname, '../..');
+
+function readSrc(relPath) {
+  return fs.readFileSync(path.join(SRC, relPath), 'utf-8');
+}
+
+// ════════════════════════════════════════════════════════════════════
+// P0-1: org_id must NOT be hardcoded in PurchasePage
+// ════════════════════════════════════════════════════════════════════
+
+describe('P0-1: PurchasePage — dynamic org_id', () => {
+  const src = readSrc('pages/PurchasePage.jsx');
+
+  it('does not contain computePortfolio(1) — hardcoded org_id', () => {
+    expect(src).not.toContain('computePortfolio(1)');
+  });
+
+  it('does not contain getPortfolioResults(1) — hardcoded org_id', () => {
+    expect(src).not.toContain('getPortfolioResults(1)');
+  });
+
+  it('uses scope.orgId for computePortfolio', () => {
+    expect(src).toContain('computePortfolio(scope.orgId)');
+  });
+
+  it('uses scope.orgId for getPortfolioResults', () => {
+    expect(src).toContain('getPortfolioResults(scope.orgId)');
+  });
+
+  it('destructures scope from useScope()', () => {
+    expect(src).toMatch(/const\s*\{[^}]*scope[^}]*\}\s*=\s*useScope\(\)/);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// P0-2: Deep-link ?filter= is read and mapped to correct tab
+// ════════════════════════════════════════════════════════════════════
+
+describe('P0-2: PurchasePage — deep-link filter support', () => {
+  const src = readSrc('pages/PurchasePage.jsx');
+
+  it('imports useSearchParams from react-router-dom', () => {
+    expect(src).toContain('useSearchParams');
+    expect(src).toContain('react-router-dom');
+  });
+
+  it('defines FILTER_TO_TAB mapping', () => {
+    expect(src).toContain('FILTER_TO_TAB');
+  });
+
+  it('maps filter=renewal to echeances tab', () => {
+    expect(src).toContain("renewal: 'echeances'");
+  });
+
+  it('maps filter=missing to portefeuille tab', () => {
+    expect(src).toContain("missing: 'portefeuille'");
+  });
+
+  it('reads filter from searchParams on init', () => {
+    expect(src).toContain("searchParams.get('filter')");
+  });
+
+  it('syncs tab changes back to URL', () => {
+    expect(src).toContain('setSearchParams');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// P0-3: PurchaseAssistantPage calls the API
+// ════════════════════════════════════════════════════════════════════
+
+describe('P0-3: PurchaseAssistantPage — API integration', () => {
+  const src = readSrc('pages/PurchaseAssistantPage.jsx');
+
+  it('imports getPurchaseAssistantData from api', () => {
+    expect(src).toContain('getPurchaseAssistantData');
+    expect(src).toContain("from '../services/api'");
+  });
+
+  it('imports useScope for dynamic org context', () => {
+    expect(src).toContain('useScope');
+    expect(src).toContain("from '../contexts/ScopeContext'");
+  });
+
+  it('calls getPurchaseAssistantData in useEffect', () => {
+    expect(src).toContain('getPurchaseAssistantData(');
+  });
+
+  it('sets isDemo from API response', () => {
+    expect(src).toContain('data.is_demo');
+  });
+
+  it('uses apiAssistantData when available', () => {
+    expect(src).toContain('apiAssistantData');
+  });
+
+  it('falls back to getAllDemoSites when API fails', () => {
+    expect(src).toContain('getAllDemoSites()');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// P0-3: API service exports the assistant endpoint
+// ════════════════════════════════════════════════════════════════════
+
+describe('P0-3: services/api.js — getPurchaseAssistantData', () => {
+  const src = readSrc('services/api.js');
+
+  it('exports getPurchaseAssistantData', () => {
+    expect(src).toContain('export const getPurchaseAssistantData');
+  });
+
+  it('calls /purchase/assistant endpoint', () => {
+    expect(src).toContain("'/purchase/assistant'");
+  });
+});

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -42,28 +42,36 @@ function _cachedGet(url, config = {}) {
 
   if (entry) {
     if (entry.inflight) return entry.promise; // dedup in-flight
-    if (now - entry.ts < GET_CACHE_TTL_MS) {  // cache hit
+    if (now - entry.ts < GET_CACHE_TTL_MS) {
+      // cache hit
       return Promise.resolve({ data: entry.data, status: 200, _cached: true });
     }
   }
 
-  const promise = api.get(url, config).then(response => {
-    _getCache.set(key, { data: response.data, ts: Date.now(), inflight: false });
-    return response;
-  }).catch(err => {
-    _getCache.delete(key);
-    throw err;
-  });
+  const promise = api
+    .get(url, config)
+    .then((response) => {
+      _getCache.set(key, { data: response.data, ts: Date.now(), inflight: false });
+      return response;
+    })
+    .catch((err) => {
+      _getCache.delete(key);
+      throw err;
+    });
 
   _getCache.set(key, { promise, inflight: true });
   return promise;
 }
 
 /** Clear the GET cache (for tests or after mutations). */
-export function clearApiCache() { _getCache.clear(); }
+export function clearApiCache() {
+  _getCache.clear();
+}
 
 /** @returns {number} Current cache size (for DevPanel / tests). */
-export function getApiCacheSize() { return _getCache.size; }
+export function getApiCacheSize() {
+  return _getCache.size;
+}
 
 // Periodic cleanup of expired entries
 if (typeof setInterval !== 'undefined') {
@@ -141,7 +149,9 @@ export function isDemoPath(url) {
   let path = url;
   try {
     if (/^https?:\/\//i.test(url)) path = new URL(url).pathname;
-  } catch { /* keep as-is */ }
+  } catch {
+    /* keep as-is */
+  }
   path = path.split('?')[0].split('#')[0];
   // Match /demo/* or /api/demo/*
   return /\/demo\//.test(path);
@@ -164,7 +174,9 @@ export function normalizePathFromAxiosConfig(config) {
     if (/^https?:\/\//i.test(raw)) {
       raw = new URL(raw).pathname;
     }
-  } catch { /* keep raw as-is */ }
+  } catch {
+    /* keep raw as-is */
+  }
   // Strip querystring and hash
   raw = raw.split('?')[0].split('#')[0];
   // Ensure leading slash
@@ -174,17 +186,25 @@ export function normalizePathFromAxiosConfig(config) {
 
 export const isSilentUrl = (urlOrConfig) => {
   // Accept either a string (legacy) or an axios config object
-  const path = typeof urlOrConfig === 'object' && urlOrConfig !== null
-    ? normalizePathFromAxiosConfig(urlOrConfig)
-    : String(urlOrConfig || '');
-  return SILENT_URLS.some(u => path.endsWith(u) || path.includes(u + '?') || path.includes(u + '#') || path === u);
+  const path =
+    typeof urlOrConfig === 'object' && urlOrConfig !== null
+      ? normalizePathFromAxiosConfig(urlOrConfig)
+      : String(urlOrConfig || '');
+  return SILENT_URLS.some(
+    (u) => path.endsWith(u) || path.includes(u + '?') || path.includes(u + '#') || path === u
+  );
 };
 
 api.interceptors.response.use(
   (response) => {
     // Guard: detect non-JSON responses (HTML from missing proxy / wrong prefix)
     const ct = response.headers?.['content-type'] || '';
-    if (ct && !ct.includes('application/json') && !ct.includes('text/plain') && response.config.responseType !== 'blob') {
+    if (
+      ct &&
+      !ct.includes('application/json') &&
+      !ct.includes('text/plain') &&
+      response.config.responseType !== 'blob'
+    ) {
       const msg = `[PROMEOS] API returned non-JSON (content-type: ${ct}). Vérifiez le proxy Vite ou le préfixe /api.`;
       console.error(msg, { url: response.config.url, status: response.status });
       return Promise.reject(new Error(msg));
@@ -206,8 +226,18 @@ api.interceptors.response.use(
     if (import.meta.env.DEV) {
       console.log(
         `%c[API] %c${entry.method} %c${entry.url} %c${entry.status} %c${duration}ms`,
-        'color:#6b7280', 'color:#2563eb', 'color:#059669', 'color:#6b7280', duration > 300 ? 'color:#ef4444;font-weight:bold' : 'color:#6b7280',
-        { page: window.location.pathname, orgId: _apiScope.orgId, endpoint: entry.url, ms: duration, requestId: entry.id },
+        'color:#6b7280',
+        'color:#2563eb',
+        'color:#059669',
+        'color:#6b7280',
+        duration > 300 ? 'color:#ef4444;font-weight:bold' : 'color:#6b7280',
+        {
+          page: window.location.pathname,
+          orgId: _apiScope.orgId,
+          endpoint: entry.url,
+          ms: duration,
+          requestId: entry.id,
+        }
       );
     }
 
@@ -318,73 +348,95 @@ export const resolveAlerte = async (id) => {
 // DEMO MODE
 // ========================================
 
-export const getDemoStatus = () => api.get('/demo/status').then(r => r.data);
-export const enableDemo = () => api.post('/demo/enable').then(r => r.data);
-export const disableDemo = () => api.post('/demo/disable').then(r => r.data);
-export const getDemoTemplates = () => api.get('/demo/templates').then(r => r.data);
-export const getDemoPacks = () => api.get('/demo/packs').then(r => r.data);
+export const getDemoStatus = () => api.get('/demo/status').then((r) => r.data);
+export const enableDemo = () => api.post('/demo/enable').then((r) => r.data);
+export const disableDemo = () => api.post('/demo/disable').then((r) => r.data);
+export const getDemoTemplates = () => api.get('/demo/templates').then((r) => r.data);
+export const getDemoPacks = () => api.get('/demo/packs').then((r) => r.data);
 export const seedDemoPack = (pack, size, reset = false) =>
-  api.post('/demo/seed-pack', { pack, size, reset, rng_seed: 42 }).then(r => r.data);
-export const getDemoPackStatus = () => api.get('/demo/status-pack', { silent: true }).then(r => r.data);
+  api.post('/demo/seed-pack', { pack, size, reset, rng_seed: 42 }).then((r) => r.data);
+export const getDemoPackStatus = () =>
+  api.get('/demo/status-pack', { silent: true }).then((r) => r.data);
 export const resetDemoPack = (mode = 'soft', confirm = false) =>
-  api.post('/demo/reset-pack', { mode, confirm }).then(r => r.data);
-export const getDemoManifest = () => api.get('/demo/manifest', { silent: true }).then(r => r.data);
+  api.post('/demo/reset-pack', { mode, confirm }).then((r) => r.data);
+export const getDemoManifest = () =>
+  api.get('/demo/manifest', { silent: true }).then((r) => r.data);
 
 // ========================================
 // GUIDANCE (Action Plan + Readiness)
 // ========================================
 
-export const getActionPlan = (params = {}) => api.get('/guidance/action-plan', { params }).then(r => r.data);
-export const getReadiness = () => api.get('/guidance/readiness').then(r => r.data);
+export const getActionPlan = (params = {}) =>
+  api.get('/guidance/action-plan', { params }).then((r) => r.data);
+export const getReadiness = () => api.get('/guidance/readiness').then((r) => r.data);
 
 // ========================================
 // GUARDRAILS
 // ========================================
 
-export const getSiteGuardrails = (id) => api.get(`/sites/${id}/guardrails`).then(r => r.data);
+export const getSiteGuardrails = (id) => api.get(`/sites/${id}/guardrails`).then((r) => r.data);
 
 // ========================================
 // REGOPS
 // ========================================
 
-export const getRegOpsAssessment = (siteId) => api.get(`/regops/site/${siteId}`).then(r => r.data);
-export const getRegOpsCached = (siteId) => api.get(`/regops/site/${siteId}/cached`).then(r => r.data);
-export const recomputeRegOps = (params = {}) => api.post('/regops/recompute', null, { params }).then(r => r.data);
-export const getRegOpsDashboard = () => api.get('/regops/dashboard').then(r => r.data);
-export const getScoreExplain = (scopeType, scopeId) => api.get('/regops/score_explain', { params: { scope_type: scopeType, scope_id: scopeId } }).then(r => r.data);
-export const getDataQuality = (scopeType, scopeId) => api.get('/regops/data_quality', { params: { scope_type: scopeType, scope_id: scopeId } }).then(r => r.data);
-export const getDataQualitySpecs = () => api.get('/regops/data_quality/specs').then(r => r.data);
+export const getRegOpsAssessment = (siteId) =>
+  api.get(`/regops/site/${siteId}`).then((r) => r.data);
+export const getRegOpsCached = (siteId) =>
+  api.get(`/regops/site/${siteId}/cached`).then((r) => r.data);
+export const recomputeRegOps = (params = {}) =>
+  api.post('/regops/recompute', null, { params }).then((r) => r.data);
+export const getRegOpsDashboard = () => api.get('/regops/dashboard').then((r) => r.data);
+export const getScoreExplain = (scopeType, scopeId) =>
+  api
+    .get('/regops/score_explain', { params: { scope_type: scopeType, scope_id: scopeId } })
+    .then((r) => r.data);
+export const getDataQuality = (scopeType, scopeId) =>
+  api
+    .get('/regops/data_quality', { params: { scope_type: scopeType, scope_id: scopeId } })
+    .then((r) => r.data);
+export const getDataQualitySpecs = () => api.get('/regops/data_quality/specs').then((r) => r.data);
 
 // ========================================
 // CONNECTORS
 // ========================================
 
-export const listConnectors = () => api.get('/connectors/list').then(r => r.data);
-export const testConnector = (name) => api.post(`/connectors/${name}/test`).then(r => r.data);
+export const listConnectors = () => api.get('/connectors/list').then((r) => r.data);
+export const testConnector = (name) => api.post(`/connectors/${name}/test`).then((r) => r.data);
 export const syncConnector = (name, objectType, objectId) =>
-  api.post(`/connectors/${name}/sync`, null, { params: { object_type: objectType, object_id: objectId } }).then(r => r.data);
+  api
+    .post(`/connectors/${name}/sync`, null, {
+      params: { object_type: objectType, object_id: objectId },
+    })
+    .then((r) => r.data);
 
 // ========================================
 // WATCHERS
 // ========================================
 
-export const listWatchers = () => api.get('/watchers/list').then(r => r.data);
-export const runWatcher = (name) => api.post(`/watchers/${name}/run`).then(r => r.data);
+export const listWatchers = () => api.get('/watchers/list').then((r) => r.data);
+export const runWatcher = (name) => api.post(`/watchers/${name}/run`).then((r) => r.data);
 export const listRegEvents = (source = null, reviewed = null, status = null) =>
-  api.get('/watchers/events', { params: { source, reviewed, status } }).then(r => r.data);
+  api.get('/watchers/events', { params: { source, reviewed, status } }).then((r) => r.data);
 export const reviewRegEvent = (eventId, decision = 'apply', notes = '') =>
-  api.patch(`/watchers/events/${eventId}/review`, { decision, notes }).then(r => r.data);
-export const getRegEventDetail = (eventId) => api.get(`/watchers/events/${eventId}`).then(r => r.data);
+  api.patch(`/watchers/events/${eventId}/review`, { decision, notes }).then((r) => r.data);
+export const getRegEventDetail = (eventId) =>
+  api.get(`/watchers/events/${eventId}`).then((r) => r.data);
 
 // ========================================
 // AI AGENTS
 // ========================================
 
-export const getAiExplanation = (siteId) => api.get(`/ai/site/${siteId}/explain`).then(r => r.data);
-export const getAiRecommendations = (siteId) => api.get(`/ai/site/${siteId}/recommend`).then(r => r.data);
-export const getAiDataQuality = (siteId) => api.get(`/ai/site/${siteId}/data-quality`).then(r => r.data);
-export const getAiExecBrief = (orgId = 1) => api.get('/ai/org/brief', { params: { org_id: orgId } }).then(r => r.data);
-export const listAiInsights = (params = {}) => api.get('/ai/insights', { params }).then(r => r.data);
+export const getAiExplanation = (siteId) =>
+  api.get(`/ai/site/${siteId}/explain`).then((r) => r.data);
+export const getAiRecommendations = (siteId) =>
+  api.get(`/ai/site/${siteId}/recommend`).then((r) => r.data);
+export const getAiDataQuality = (siteId) =>
+  api.get(`/ai/site/${siteId}/data-quality`).then((r) => r.data);
+export const getAiExecBrief = (orgId = 1) =>
+  api.get('/ai/org/brief', { params: { org_id: orgId } }).then((r) => r.data);
+export const listAiInsights = (params = {}) =>
+  api.get('/ai/insights', { params }).then((r) => r.data);
 
 // ========================================
 // KB USAGES (Knowledge Base)
@@ -392,29 +444,36 @@ export const listAiInsights = (params = {}) => api.get('/ai/insights', { params 
 
 const KB_BASE = '/kb';
 
-export const pingKB = () => api.get(`${KB_BASE}/ping`).then(r => r.data);
-export const getKBArchetypes = () => api.get(`${KB_BASE}/archetypes`).then(r => r.data);
-export const getKBArchetype = (code) => api.get(`${KB_BASE}/archetypes/${code}`).then(r => r.data);
-export const getKBArchetypeByNaf = (naf) => api.get(`${KB_BASE}/archetypes/by-naf/${naf}`).then(r => r.data);
-export const getKBRules = () => api.get(`${KB_BASE}/rules`).then(r => r.data);
-export const getKBRecommendations = () => api.get(`${KB_BASE}/recommendations`).then(r => r.data);
-export const searchKB = (q, type = null) => api.get(`${KB_BASE}/search`, { params: { q, type } }).then(r => r.data);
-export const getKBProvenance = (itemType, code) => api.get(`${KB_BASE}/provenance/${itemType}/${code}`).then(r => r.data);
-export const getKBStats = () => api.get(`${KB_BASE}/usages-stats`).then(r => r.data);
-export const reloadKB = () => api.post(`${KB_BASE}/reload`).then(r => r.data);
-export const seedDemoKB = () => api.post(`${KB_BASE}/seed_demo`).then(r => r.data);
+export const pingKB = () => api.get(`${KB_BASE}/ping`).then((r) => r.data);
+export const getKBArchetypes = () => api.get(`${KB_BASE}/archetypes`).then((r) => r.data);
+export const getKBArchetype = (code) =>
+  api.get(`${KB_BASE}/archetypes/${code}`).then((r) => r.data);
+export const getKBArchetypeByNaf = (naf) =>
+  api.get(`${KB_BASE}/archetypes/by-naf/${naf}`).then((r) => r.data);
+export const getKBRules = () => api.get(`${KB_BASE}/rules`).then((r) => r.data);
+export const getKBRecommendations = () => api.get(`${KB_BASE}/recommendations`).then((r) => r.data);
+export const searchKB = (q, type = null) =>
+  api.get(`${KB_BASE}/search`, { params: { q, type } }).then((r) => r.data);
+export const getKBProvenance = (itemType, code) =>
+  api.get(`${KB_BASE}/provenance/${itemType}/${code}`).then((r) => r.data);
+export const getKBStats = () => api.get(`${KB_BASE}/usages-stats`).then((r) => r.data);
+export const reloadKB = () => api.post(`${KB_BASE}/reload`).then((r) => r.data);
+export const seedDemoKB = () => api.post(`${KB_BASE}/seed_demo`).then((r) => r.data);
 
 // KB Explorer (structured KB system - FTS5 search + apply engine)
-export const getKBItemsList = (params = {}) => api.get(`${KB_BASE}/items`, { params }).then(r => r.data);
-export const getKBItemDetail = (itemId) => api.get(`${KB_BASE}/items/${itemId}`).then(r => r.data);
-export const searchKBItems = (body) => api.post(`${KB_BASE}/search`, body).then(r => r.data);
-export const applyKB = (body) => api.post(`${KB_BASE}/apply`, body).then(r => r.data);
-export const getKBFullStats = () => api.get(`${KB_BASE}/stats`).then(r => {
-  const d = r.data;
-  // app/kb/router.py returns { kb: { total_items, by_status, by_domain, ... }, index: {...} }
-  // Normalize to flat shape expected by KBExplorerPage (stats.total_items, stats.by_status, ...)
-  return d && d.kb ? { ...d.kb } : d;
-});
+export const getKBItemsList = (params = {}) =>
+  api.get(`${KB_BASE}/items`, { params }).then((r) => r.data);
+export const getKBItemDetail = (itemId) =>
+  api.get(`${KB_BASE}/items/${itemId}`).then((r) => r.data);
+export const searchKBItems = (body) => api.post(`${KB_BASE}/search`, body).then((r) => r.data);
+export const applyKB = (body) => api.post(`${KB_BASE}/apply`, body).then((r) => r.data);
+export const getKBFullStats = () =>
+  api.get(`${KB_BASE}/stats`).then((r) => {
+    const d = r.data;
+    // app/kb/router.py returns { kb: { total_items, by_status, by_domain, ... }, index: {...} }
+    // Normalize to flat shape expected by KBExplorerPage (stats.total_items, stats.by_status, ...)
+    return d && d.kb ? { ...d.kb } : d;
+  });
 
 // KB Memobox V38 — Upload + Lifecycle
 export const uploadKBDoc = (file, title, domain = null, docType = 'pdf', actionId = null) => {
@@ -423,49 +482,60 @@ export const uploadKBDoc = (file, title, domain = null, docType = 'pdf', actionI
   const params = { title };
   if (domain) params.domain = domain;
   if (docType) params.doc_type = docType;
-  if (actionId) params.action_id = actionId;  // V48: auto-link to action
-  return api.post(`${KB_BASE}/upload`, fd, {
-    params,
-    headers: { 'Content-Type': 'multipart/form-data' },
-  }).then(r => r.data);
+  if (actionId) params.action_id = actionId; // V48: auto-link to action
+  return api
+    .post(`${KB_BASE}/upload`, fd, {
+      params,
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then((r) => r.data);
 };
 export const changeKBDocStatus = (docId, status) =>
-  api.post(`${KB_BASE}/docs/${docId}/status`, { status }).then(r => r.data);
+  api.post(`${KB_BASE}/docs/${docId}/status`, { status }).then((r) => r.data);
 export const getKBDocs = (params = {}) =>
-  api.get(`${KB_BASE}/docs`, { params }).then(r => r.data);
+  api.get(`${KB_BASE}/docs`, { params }).then((r) => r.data);
 
 // ========================================
 // ENERGY (Import & Analysis)
 // ========================================
 
-export const getMeters = (siteId = null) => api.get('/energy/meters', { params: { site_id: siteId } }).then(r => r.data);
-export const createMeter = (data) => api.post('/energy/meters', data).then(r => r.data);
+export const getMeters = (siteId = null) =>
+  api.get('/energy/meters', { params: { site_id: siteId } }).then((r) => r.data);
+export const createMeter = (data) => api.post('/energy/meters', data).then((r) => r.data);
 export const uploadConsumptionData = (file, meterId, frequency = 'hourly') => {
   const formData = new FormData();
   formData.append('file', file);
-  return api.post('/energy/import/upload', formData, {
-    params: { meter_id: meterId, frequency },
-    headers: { 'Content-Type': 'multipart/form-data' }
-  }).then(r => r.data);
+  return api
+    .post('/energy/import/upload', formData, {
+      params: { meter_id: meterId, frequency },
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then((r) => r.data);
 };
-export const getImportJobs = (meterId = null) => api.get('/energy/import/jobs', { params: { meter_id: meterId } }).then(r => r.data);
-export const runAnalysis = (meterId) => api.post('/energy/analysis/run', null, { params: { meter_id: meterId } }).then(r => r.data);
-export const getAnalysisSummary = (meterId) => api.get('/energy/analysis/summary', { params: { meter_id: meterId } }).then(r => r.data);
-export const generateDemoEnergy = (data) => api.post('/energy/demo/generate', data).then(r => r.data);
+export const getImportJobs = (meterId = null) =>
+  api.get('/energy/import/jobs', { params: { meter_id: meterId } }).then((r) => r.data);
+export const runAnalysis = (meterId) =>
+  api.post('/energy/analysis/run', null, { params: { meter_id: meterId } }).then((r) => r.data);
+export const getAnalysisSummary = (meterId) =>
+  api.get('/energy/analysis/summary', { params: { meter_id: meterId } }).then((r) => r.data);
+export const generateDemoEnergy = (data) =>
+  api.post('/energy/demo/generate', data).then((r) => r.data);
 
 // ========================================
 // ONBOARDING
 // ========================================
 
-export const createOnboarding = (data) => api.post('/onboarding', data).then(r => r.data);
+export const createOnboarding = (data) => api.post('/onboarding', data).then((r) => r.data);
 export const importSitesCsv = (file) => {
   const fd = new FormData();
   fd.append('file', file);
-  return api.post('/onboarding/import-csv', fd, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  }).then(r => r.data);
+  return api
+    .post('/onboarding/import-csv', fd, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then((r) => r.data);
 };
-export const getOnboardingStatus = () => api.get('/onboarding/status').then(r => r.data);
+export const getOnboardingStatus = () => api.get('/onboarding/status').then((r) => r.data);
 
 // ========================================
 // IMPORT STANDALONE
@@ -474,287 +544,430 @@ export const getOnboardingStatus = () => api.get('/onboarding/status').then(r =>
 export const importSitesStandalone = (file) => {
   const fd = new FormData();
   fd.append('file', file);
-  return api.post('/import/sites', fd, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  }).then(r => r.data);
+  return api
+    .post('/import/sites', fd, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then((r) => r.data);
 };
-export const getImportTemplate = () => api.get('/import/template').then(r => r.data);
+export const getImportTemplate = () => api.get('/import/template').then((r) => r.data);
 
 // ========================================
 // DEMO SEED
 // ========================================
 
-export const seedDemo = () => api.post('/demo/seed').then(r => r.data);
+export const seedDemo = () => api.post('/demo/seed').then((r) => r.data);
 
 // ========================================
 // CRUD (Sites + Compteurs)
 // ========================================
 
-export const createSite = (data) => api.post('/sites', data).then(r => r.data);
-export const createCompteur = (data) => api.post('/compteurs', data).then(r => r.data);
+export const createSite = (data) => api.post('/sites', data).then((r) => r.data);
+export const createCompteur = (data) => api.post('/compteurs', data).then((r) => r.data);
 
 // ========================================
 // DASHBOARD 2 MINUTES
 // ========================================
 
-export const getDashboard2min = () => api.get('/dashboard/2min').then(r => r.data);
+export const getDashboard2min = () => api.get('/dashboard/2min').then((r) => r.data);
 
 // ========================================
 // SEGMENTATION
 // ========================================
 
-export const getSegmentationQuestions = () => api.get('/segmentation/questions').then(r => r.data);
-export const submitSegmentationAnswers = (answers) => api.post('/segmentation/answers', { answers }).then(r => r.data);
-export const getSegmentationProfile = () => api.get('/segmentation/profile').then(r => r.data);
+export const getSegmentationQuestions = () =>
+  api.get('/segmentation/questions').then((r) => r.data);
+export const submitSegmentationAnswers = (answers) =>
+  api.post('/segmentation/answers', { answers }).then((r) => r.data);
+export const getSegmentationProfile = () => api.get('/segmentation/profile').then((r) => r.data);
 
 // ========================================
 // COMPLIANCE (Rules-based)
 // ========================================
 
-export const getComplianceSummary = (params = {}) => api.get('/compliance/summary', { params }).then(r => r.data);
-export const getComplianceSites = (params = {}) => api.get('/compliance/sites', { params }).then(r => r.data);
-export const getComplianceBundle = (params = {}) => _cachedGet('/compliance/bundle', { params }).then(r => r.data);
-export const recomputeComplianceRules = (orgId = null) => api.post('/compliance/recompute-rules', null, { params: { org_id: orgId } }).then(r => r.data);
-export const getComplianceRules = () => api.get('/compliance/rules').then(r => r.data);
+export const getComplianceSummary = (params = {}) =>
+  api.get('/compliance/summary', { params }).then((r) => r.data);
+export const getComplianceSites = (params = {}) =>
+  api.get('/compliance/sites', { params }).then((r) => r.data);
+export const getComplianceBundle = (params = {}) =>
+  _cachedGet('/compliance/bundle', { params }).then((r) => r.data);
+export const recomputeComplianceRules = (orgId = null) =>
+  api.post('/compliance/recompute-rules', null, { params: { org_id: orgId } }).then((r) => r.data);
+export const getComplianceRules = () => api.get('/compliance/rules').then((r) => r.data);
 
 // Sprint 9: Compliance OPS workflow
-export const getComplianceFindings = (params = {}) => api.get('/compliance/findings', { params }).then(r => r.data);
-export const patchComplianceFinding = (id, data) => api.patch(`/compliance/findings/${id}`, data).then(r => r.data);
-export const getComplianceBatches = (orgId = null) => api.get('/compliance/batches', { params: { org_id: orgId } }).then(r => r.data);
-export const getFindingDetail = (findingId) => api.get(`/compliance/findings/${findingId}`).then(r => r.data);
+export const getComplianceFindings = (params = {}) =>
+  api.get('/compliance/findings', { params }).then((r) => r.data);
+export const patchComplianceFinding = (id, data) =>
+  api.patch(`/compliance/findings/${id}`, data).then((r) => r.data);
+export const getComplianceBatches = (orgId = null) =>
+  api.get('/compliance/batches', { params: { org_id: orgId } }).then((r) => r.data);
+export const getFindingDetail = (findingId) =>
+  api.get(`/compliance/findings/${findingId}`).then((r) => r.data);
 
 // Dev Tools
-export const resetDb = () => api.post('/dev/reset_db').then(r => r.data);
+export const resetDb = () => api.post('/dev/reset_db').then((r) => r.data);
 
 // Health
-export const getApiHealth = () => api.get('/health').then(r => r.data);
+export const getApiHealth = () => api.get('/health').then((r) => r.data);
 
 // ========================================
 // CONSUMPTION DIAGNOSTIC
 // ========================================
 
-export const getConsumptionInsights = (orgId = null) => api.get('/consumption/insights', { params: { org_id: orgId } }).then(r => r.data);
-export const getConsumptionSite = (siteId) => api.get(`/consumption/site/${siteId}`).then(r => r.data);
-export const runConsumptionDiagnose = (orgId = null, days = 30) => api.post('/consumption/diagnose', null, { params: { org_id: orgId, days } }).then(r => r.data);
-export const seedDemoConsumption = (siteId = null, days = 30) => api.post('/consumption/seed-demo', null, { params: { site_id: siteId, days } }).then(r => r.data);
-export const patchConsumptionInsight = (insightId, data) => api.patch(`/consumption/insights/${insightId}`, data).then(r => r.data);
+export const getConsumptionInsights = (orgId = null) =>
+  api.get('/consumption/insights', { params: { org_id: orgId } }).then((r) => r.data);
+export const getConsumptionSite = (siteId) =>
+  api.get(`/consumption/site/${siteId}`).then((r) => r.data);
+export const runConsumptionDiagnose = (orgId = null, days = 30) =>
+  api.post('/consumption/diagnose', null, { params: { org_id: orgId, days } }).then((r) => r.data);
+export const seedDemoConsumption = (siteId = null, days = 30) =>
+  api
+    .post('/consumption/seed-demo', null, { params: { site_id: siteId, days } })
+    .then((r) => r.data);
+export const patchConsumptionInsight = (insightId, data) =>
+  api.patch(`/consumption/insights/${insightId}`, data).then((r) => r.data);
 
 // ========================================
 // FLEX MINI
 // ========================================
 export const getFlexMini = (siteId, start, end) =>
-  api.get(`/sites/${siteId}/flex/mini`, { params: { start, end } }).then(r => r.data);
+  api.get(`/sites/${siteId}/flex/mini`, { params: { start, end } }).then((r) => r.data);
 
 // ========================================
 // CONSUMPTION EXPLORER (V10 World-Class)
 // ========================================
 
 // Availability check (V10.1 handshake)
-export const getConsumptionAvailability = (siteId, energyType = 'electricity') => _cachedGet('/consumption/availability', { params: { site_id: siteId, energy_type: energyType } }).then(r => r.data);
+export const getConsumptionAvailability = (siteId, energyType = 'electricity') =>
+  _cachedGet('/consumption/availability', {
+    params: { site_id: siteId, energy_type: energyType },
+  }).then((r) => r.data);
 
 // Tunnel (envelope P10-P90)
-export const getConsumptionTunnel = (siteId, days = 90, energyType = 'electricity') => api.get('/consumption/tunnel', { params: { site_id: siteId, days, energy_type: energyType } }).then(r => r.data);
-export const getConsumptionTunnelV2 = (siteId, days = 90, energyType = 'electricity', mode = 'energy') => _cachedGet('/consumption/tunnel_v2', { params: { site_id: siteId, days, energy_type: energyType, mode } }).then(r => r.data);
+export const getConsumptionTunnel = (siteId, days = 90, energyType = 'electricity') =>
+  api
+    .get('/consumption/tunnel', { params: { site_id: siteId, days, energy_type: energyType } })
+    .then((r) => r.data);
+export const getConsumptionTunnelV2 = (
+  siteId,
+  days = 90,
+  energyType = 'electricity',
+  mode = 'energy'
+) =>
+  _cachedGet('/consumption/tunnel_v2', {
+    params: { site_id: siteId, days, energy_type: energyType, mode },
+  }).then((r) => r.data);
 
 // Targets (objectifs & budgets)
-export const getConsumptionTargets = (siteId, energyType = 'electricity', year = null) => _cachedGet('/consumption/targets', { params: { site_id: siteId, energy_type: energyType, year } }).then(r => r.data);
-export const createConsumptionTarget = (data) => api.post('/consumption/targets', data).then(r => r.data);
-export const patchConsumptionTarget = (id, data) => api.patch(`/consumption/targets/${id}`, data).then(r => r.data);
-export const deleteConsumptionTarget = (id) => api.delete(`/consumption/targets/${id}`).then(r => r.data);
-export const getTargetsProgression = (siteId, energyType = 'electricity', year = null) => api.get('/consumption/targets/progression', { params: { site_id: siteId, energy_type: energyType, year } }).then(r => r.data);
-export const getTargetsProgressionV2 = (siteId, energyType = 'electricity', year = null) => _cachedGet('/consumption/targets/progress_v2', { params: { site_id: siteId, energy_type: energyType, year } }).then(r => r.data);
+export const getConsumptionTargets = (siteId, energyType = 'electricity', year = null) =>
+  _cachedGet('/consumption/targets', {
+    params: { site_id: siteId, energy_type: energyType, year },
+  }).then((r) => r.data);
+export const createConsumptionTarget = (data) =>
+  api.post('/consumption/targets', data).then((r) => r.data);
+export const patchConsumptionTarget = (id, data) =>
+  api.patch(`/consumption/targets/${id}`, data).then((r) => r.data);
+export const deleteConsumptionTarget = (id) =>
+  api.delete(`/consumption/targets/${id}`).then((r) => r.data);
+export const getTargetsProgression = (siteId, energyType = 'electricity', year = null) =>
+  api
+    .get('/consumption/targets/progression', {
+      params: { site_id: siteId, energy_type: energyType, year },
+    })
+    .then((r) => r.data);
+export const getTargetsProgressionV2 = (siteId, energyType = 'electricity', year = null) =>
+  _cachedGet('/consumption/targets/progress_v2', {
+    params: { site_id: siteId, energy_type: energyType, year },
+  }).then((r) => r.data);
 
 // TOU Schedules (grilles HP/HC)
-export const getTOUSchedules = (siteId, meterId = null, activeOnly = true) => api.get('/consumption/tou_schedules', { params: { site_id: siteId, meter_id: meterId, active_only: activeOnly } }).then(r => r.data);
-export const getActiveTOUSchedule = (siteId, meterId = null, refDate = null) => api.get('/consumption/tou_schedules/active', { params: { site_id: siteId, meter_id: meterId, ref_date: refDate } }).then(r => r.data);
-export const createTOUSchedule = (data) => api.post('/consumption/tou_schedules', data).then(r => r.data);
-export const patchTOUSchedule = (id, data) => api.patch(`/consumption/tou_schedules/${id}`, data).then(r => r.data);
-export const deleteTOUSchedule = (id) => api.delete(`/consumption/tou_schedules/${id}`).then(r => r.data);
+export const getTOUSchedules = (siteId, meterId = null, activeOnly = true) =>
+  api
+    .get('/consumption/tou_schedules', {
+      params: { site_id: siteId, meter_id: meterId, active_only: activeOnly },
+    })
+    .then((r) => r.data);
+export const getActiveTOUSchedule = (siteId, meterId = null, refDate = null) =>
+  api
+    .get('/consumption/tou_schedules/active', {
+      params: { site_id: siteId, meter_id: meterId, ref_date: refDate },
+    })
+    .then((r) => r.data);
+export const createTOUSchedule = (data) =>
+  api.post('/consumption/tou_schedules', data).then((r) => r.data);
+export const patchTOUSchedule = (id, data) =>
+  api.patch(`/consumption/tou_schedules/${id}`, data).then((r) => r.data);
+export const deleteTOUSchedule = (id) =>
+  api.delete(`/consumption/tou_schedules/${id}`).then((r) => r.data);
 
 // HP/HC Ratio
-export const getHPHCRatio = (siteId, meterId = null, days = 30) => api.get('/consumption/hp_hc', { params: { site_id: siteId, meter_id: meterId, days } }).then(r => r.data);
-export const getHPHCBreakdownV2 = (siteId, days = 30, calendarId = null, simulate = false) => _cachedGet('/consumption/hphc_breakdown_v2', { params: { site_id: siteId, days, calendar_id: calendarId, simulate } }).then(r => r.data);
+export const getHPHCRatio = (siteId, meterId = null, days = 30) =>
+  api
+    .get('/consumption/hp_hc', { params: { site_id: siteId, meter_id: meterId, days } })
+    .then((r) => r.data);
+export const getHPHCBreakdownV2 = (siteId, days = 30, calendarId = null, simulate = false) =>
+  _cachedGet('/consumption/hphc_breakdown_v2', {
+    params: { site_id: siteId, days, calendar_id: calendarId, simulate },
+  }).then((r) => r.data);
 
 // Gas Summary (beta)
-export const getGasSummary = (siteId, days = 90) => _cachedGet('/consumption/gas/summary', { params: { site_id: siteId, days } }).then(r => r.data);
-export const getGasWeatherNormalized = (siteId, days = 90) => _cachedGet('/consumption/gas/weather_normalized', { params: { site_id: siteId, days } }).then(r => r.data);
+export const getGasSummary = (siteId, days = 90) =>
+  _cachedGet('/consumption/gas/summary', { params: { site_id: siteId, days } }).then((r) => r.data);
+export const getGasWeatherNormalized = (siteId, days = 90) =>
+  _cachedGet('/consumption/gas/weather_normalized', { params: { site_id: siteId, days } }).then(
+    (r) => r.data
+  );
 
 // ========================================
 // SITE CONFIG (Schedule + Tariff)
 // ========================================
 
-export const getSiteSchedule = (siteId) => api.get(`/site/${siteId}/schedule`).then(r => r.data);
-export const putSiteSchedule = (siteId, data) => api.put(`/site/${siteId}/schedule`, data).then(r => r.data);
-export const getSiteTariff = (siteId) => api.get(`/site/${siteId}/tariff`).then(r => r.data);
-export const putSiteTariff = (siteId, data) => api.put(`/site/${siteId}/tariff`, data).then(r => r.data);
+export const getSiteSchedule = (siteId) => api.get(`/site/${siteId}/schedule`).then((r) => r.data);
+export const putSiteSchedule = (siteId, data) =>
+  api.put(`/site/${siteId}/schedule`, data).then((r) => r.data);
+export const getSiteTariff = (siteId) => api.get(`/site/${siteId}/tariff`).then((r) => r.data);
+export const putSiteTariff = (siteId, data) =>
+  api.put(`/site/${siteId}/tariff`, data).then((r) => r.data);
 
 // ========================================
 // BILL INTELLIGENCE
 // ========================================
 
-export const getBillingSummary = () => api.get('/billing/summary').then(r => r.data);
-export const getBillingInsights = (params = {}) => api.get('/billing/insights', { params }).then(r => r.data);
-export const getInsightDetail = (insightId) => api.get(`/billing/insights/${insightId}`).then(r => r.data);
-export const getBillingInvoices = (params = {}) => api.get('/billing/invoices', { params }).then(r => r.data);
-export const getSiteBilling = (siteId) => api.get(`/billing/site/${siteId}`).then(r => r.data);
-export const getBillingRules = () => api.get('/billing/rules').then(r => r.data);
-export const auditInvoice = (invoiceId) => api.post(`/billing/audit/${invoiceId}`).then(r => r.data);
-export const auditAllInvoices = () => api.post('/billing/audit-all').then(r => r.data);
-export const seedBillingDemo = () => api.post('/billing/seed-demo').then(r => r.data);
+export const getBillingSummary = () => api.get('/billing/summary').then((r) => r.data);
+export const getBillingInsights = (params = {}) =>
+  api.get('/billing/insights', { params }).then((r) => r.data);
+export const getInsightDetail = (insightId) =>
+  api.get(`/billing/insights/${insightId}`).then((r) => r.data);
+export const getBillingInvoices = (params = {}) =>
+  api.get('/billing/invoices', { params }).then((r) => r.data);
+export const getSiteBilling = (siteId) => api.get(`/billing/site/${siteId}`).then((r) => r.data);
+export const getBillingRules = () => api.get('/billing/rules').then((r) => r.data);
+export const auditInvoice = (invoiceId) =>
+  api.post(`/billing/audit/${invoiceId}`).then((r) => r.data);
+export const auditAllInvoices = () => api.post('/billing/audit-all').then((r) => r.data);
+export const seedBillingDemo = () => api.post('/billing/seed-demo').then((r) => r.data);
 export const importInvoicesCsv = (file) => {
   const fd = new FormData();
   fd.append('file', file);
-  return api.post('/billing/import-csv', fd, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  }).then(r => r.data);
+  return api
+    .post('/billing/import-csv', fd, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then((r) => r.data);
 };
-export const patchBillingInsight = (insightId, data) => api.patch(`/billing/insights/${insightId}`, data).then(r => r.data);
-export const resolveBillingInsight = (insightId, notes = null) => api.post(`/billing/insights/${insightId}/resolve`, null, { params: notes ? { notes } : {} }).then(r => r.data);
-export const getImportBatches = (params = {}) => api.get('/billing/import/batches', { params }).then(r => r.data);
+export const patchBillingInsight = (insightId, data) =>
+  api.patch(`/billing/insights/${insightId}`, data).then((r) => r.data);
+export const resolveBillingInsight = (insightId, notes = null) =>
+  api
+    .post(`/billing/insights/${insightId}/resolve`, null, { params: notes ? { notes } : {} })
+    .then((r) => r.data);
+export const getImportBatches = (params = {}) =>
+  api.get('/billing/import/batches', { params }).then((r) => r.data);
 
 // V66 — PDF import + action creation + billing anomalies
 export const importInvoicesPdf = (siteId, file) => {
   const fd = new FormData();
   fd.append('file', file);
-  return api.post('/billing/import-pdf', fd, {
-    params: { site_id: siteId },
-    headers: { 'Content-Type': 'multipart/form-data' },
-  }).then(r => r.data);
+  return api
+    .post('/billing/import-pdf', fd, {
+      params: { site_id: siteId },
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then((r) => r.data);
 };
 
 export const createActionFromBillingInsight = (insightId, title, siteId) =>
-  api.post('/actions', {
-    source_type: 'manual',
-    source_id: String(insightId),
-    source_key: `billing-insight:${insightId}`,
-    idempotency_key: `billing-insight:${insightId}`,
-    title,
-    site_id: siteId,
-  }).then(r => r.data);
+  api
+    .post('/actions', {
+      source_type: 'manual',
+      source_id: String(insightId),
+      source_key: `billing-insight:${insightId}`,
+      idempotency_key: `billing-insight:${insightId}`,
+      title,
+      site_id: siteId,
+    })
+    .then((r) => r.data);
 
 export const getBillingAnomaliesScoped = () =>
-  api.get('/billing/anomalies-scoped').then(r => r.data);
+  api.get('/billing/anomalies-scoped').then((r) => r.data);
 
 /* ── V67 — Timeline & Coverage ── */
 export const getBillingPeriods = (params = {}) =>
-  api.get('/billing/periods', { params }).then(r => r.data);
+  api.get('/billing/periods', { params }).then((r) => r.data);
 
 export const getCoverageSummary = (params = {}) =>
-  api.get('/billing/coverage-summary', { params }).then(r => r.data);
+  api.get('/billing/coverage-summary', { params }).then((r) => r.data);
 
 export const getMissingPeriods = (params = {}) =>
-  api.get('/billing/missing-periods', { params }).then(r => r.data);
+  api.get('/billing/missing-periods', { params }).then((r) => r.data);
 
 export const getNormalizedInvoices = (params = {}) =>
-  api.get('/billing/invoices/normalized', { params }).then(r => r.data);
+  api.get('/billing/invoices/normalized', { params }).then((r) => r.data);
 
 // ========================================
 // ACHAT ENERGIE
 // ========================================
 
-export const getPurchaseEstimate = (siteId) => api.get(`/purchase/estimate/${siteId}`).then(r => r.data);
-export const getPurchaseAssumptions = (siteId) => api.get(`/purchase/assumptions/${siteId}`).then(r => r.data);
-export const putPurchaseAssumptions = (siteId, data) => api.put(`/purchase/assumptions/${siteId}`, data).then(r => r.data);
-export const getPurchasePreferences = (params = {}) => api.get('/purchase/preferences', { params }).then(r => r.data);
-export const putPurchasePreferences = (data) => api.put('/purchase/preferences', data).then(r => r.data);
-export const computePurchaseScenarios = (siteId) => api.post(`/purchase/compute/${siteId}`).then(r => r.data);
-export const getPurchaseResults = (siteId) => api.get(`/purchase/results/${siteId}`).then(r => r.data);
-export const acceptPurchaseResult = (resultId) => api.patch(`/purchase/results/${resultId}/accept`).then(r => r.data);
-export const seedPurchaseDemo = () => api.post('/purchase/seed-demo').then(r => r.data);
+export const getPurchaseEstimate = (siteId) =>
+  api.get(`/purchase/estimate/${siteId}`).then((r) => r.data);
+export const getPurchaseAssumptions = (siteId) =>
+  api.get(`/purchase/assumptions/${siteId}`).then((r) => r.data);
+export const putPurchaseAssumptions = (siteId, data) =>
+  api.put(`/purchase/assumptions/${siteId}`, data).then((r) => r.data);
+export const getPurchasePreferences = (params = {}) =>
+  api.get('/purchase/preferences', { params }).then((r) => r.data);
+export const putPurchasePreferences = (data) =>
+  api.put('/purchase/preferences', data).then((r) => r.data);
+export const computePurchaseScenarios = (siteId) =>
+  api.post(`/purchase/compute/${siteId}`).then((r) => r.data);
+export const getPurchaseResults = (siteId) =>
+  api.get(`/purchase/results/${siteId}`).then((r) => r.data);
+export const acceptPurchaseResult = (resultId) =>
+  api.patch(`/purchase/results/${resultId}/accept`).then((r) => r.data);
+export const seedPurchaseDemo = () => api.post('/purchase/seed-demo').then((r) => r.data);
+
+// Brique 3: Assistant wizard data
+export const getPurchaseAssistantData = (orgId = null) =>
+  _cachedGet('/purchase/assistant', { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
 
 // Brique 3: WOW multi-site datasets
-export const seedWowHappy = () => api.post('/purchase/seed-wow-happy').then(r => r.data);
-export const seedWowDirty = () => api.post('/purchase/seed-wow-dirty').then(r => r.data);
+export const seedWowHappy = () => api.post('/purchase/seed-wow-happy').then((r) => r.data);
+export const seedWowDirty = () => api.post('/purchase/seed-wow-dirty').then((r) => r.data);
 
 // Sprint 8.1: Portfolio, Renewals, History, Actions
-export const computePortfolio = (orgId) => api.post('/purchase/compute', null, { params: { org_id: orgId, scope: 'org' } }).then(r => r.data);
-export const getPortfolioResults = (orgId) => api.get('/purchase/results', { params: { org_id: orgId } }).then(r => r.data);
-export const getPurchaseRenewals = (orgId = null) => api.get('/purchase/renewals', { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
-export const getPurchaseHistory = (siteId) => api.get(`/purchase/history/${siteId}`).then(r => r.data);
-export const getPurchaseActions = (orgId = null) => api.get('/purchase/actions', { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
+export const computePortfolio = (orgId) =>
+  api
+    .post('/purchase/compute', null, { params: { org_id: orgId, scope: 'org' } })
+    .then((r) => r.data);
+export const getPortfolioResults = (orgId) =>
+  api.get('/purchase/results', { params: { org_id: orgId } }).then((r) => r.data);
+export const getPurchaseRenewals = (orgId = null) =>
+  api.get('/purchase/renewals', { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
+export const getPurchaseHistory = (siteId) =>
+  api.get(`/purchase/history/${siteId}`).then((r) => r.data);
+export const getPurchaseActions = (orgId = null) =>
+  api.get('/purchase/actions', { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
 
 // ========================================
 // ACTION HUB (Sprint 10)
 // ========================================
 
-export const createAction = (data) => api.post('/actions', data).then(r => r.data);
-export const syncActions = (orgId = null) => api.post('/actions/sync', null, { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
-export const getActionsList = (params = {}) => _cachedGet('/actions/list', { params }).then(r => r.data);
-export const getActionsSummary = (orgId = null) => _cachedGet('/actions/summary', { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
-export const patchAction = (id, data) => api.patch(`/actions/${id}`, data).then(r => r.data);
-export const getActionBatches = (orgId = null) => api.get('/actions/batches', { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
-export const exportActionsCSV = (params = {}) => api.get('/actions/export.csv', { params, responseType: 'blob' });
+export const createAction = (data) => api.post('/actions', data).then((r) => r.data);
+export const syncActions = (orgId = null) =>
+  api.post('/actions/sync', null, { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
+export const getActionsList = (params = {}) =>
+  _cachedGet('/actions/list', { params }).then((r) => r.data);
+export const getActionsSummary = (orgId = null) =>
+  _cachedGet('/actions/summary', { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
+export const patchAction = (id, data) => api.patch(`/actions/${id}`, data).then((r) => r.data);
+export const getActionBatches = (orgId = null) =>
+  api.get('/actions/batches', { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
+export const exportActionsCSV = (params = {}) =>
+  api.get('/actions/export.csv', { params, responseType: 'blob' });
 
 // Action Detail + Sub-resources (V5.0)
-export const getActionDetail = (id) => api.get(`/actions/${id}`).then(r => r.data);
-export const getActionComments = (id) => api.get(`/actions/${id}/comments`).then(r => r.data);
-export const addActionComment = (id, data) => api.post(`/actions/${id}/comments`, data).then(r => r.data);
-export const getActionEvidence = (id) => api.get(`/actions/${id}/evidence`).then(r => r.data);
-export const addActionEvidence = (id, data) => api.post(`/actions/${id}/evidence`, data).then(r => r.data);
-export const getActionEvents = (id) => api.get(`/actions/${id}/events`).then(r => r.data);
-export const getROISummary = (orgId) => api.get('/actions/roi_summary', { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
+export const getActionDetail = (id) => api.get(`/actions/${id}`).then((r) => r.data);
+export const getActionComments = (id) => api.get(`/actions/${id}/comments`).then((r) => r.data);
+export const addActionComment = (id, data) =>
+  api.post(`/actions/${id}/comments`, data).then((r) => r.data);
+export const getActionEvidence = (id) => api.get(`/actions/${id}/evidence`).then((r) => r.data);
+export const addActionEvidence = (id, data) =>
+  api.post(`/actions/${id}/evidence`, data).then((r) => r.data);
+export const getActionEvents = (id) => api.get(`/actions/${id}/events`).then((r) => r.data);
+export const getROISummary = (orgId) =>
+  api.get('/actions/roi_summary', { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
 
 // V48: Action ↔ Proof persistence
-export const getActionProofs = (actionId) => api.get(`/actions/${actionId}/proofs`).then(r => r.data);
-export const linkProofToAction = (actionId, kbDocId) => api.post(`/actions/${actionId}/proofs/${kbDocId}`).then(r => r.data);
+export const getActionProofs = (actionId) =>
+  api.get(`/actions/${actionId}/proofs`).then((r) => r.data);
+export const linkProofToAction = (actionId, kbDocId) =>
+  api.post(`/actions/${actionId}/proofs/${kbDocId}`).then((r) => r.data);
 
 // V49: Action closeability check
-export const checkActionCloseability = (actionId) => api.get(`/actions/${actionId}/closeability`).then(r => r.data);
+export const checkActionCloseability = (actionId) =>
+  api.get(`/actions/${actionId}/closeability`).then((r) => r.data);
 
 // ========================================
 // REPORTS (Sprint 10.1)
 // ========================================
 
-export const getAuditReportJSON = (orgId = null) => api.get('/reports/audit.json', { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
-export const downloadAuditPDF = (orgId = null) => api.get('/reports/audit.pdf', { params: orgId ? { org_id: orgId } : {}, responseType: 'blob' });
+export const getAuditReportJSON = (orgId = null) =>
+  api.get('/reports/audit.json', { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
+export const downloadAuditPDF = (orgId = null) =>
+  api.get('/reports/audit.pdf', { params: orgId ? { org_id: orgId } : {}, responseType: 'blob' });
 
 // ========================================
 // NOTIFICATIONS (Sprint 10.2)
 // ========================================
 
-export const syncNotifications = (orgId = null) => api.post('/notifications/sync', null, { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
-export const getNotificationsList = (params = {}) => api.get('/notifications/list', { params }).then(r => r.data);
-export const getNotificationsSummary = (orgId = null) => _cachedGet('/notifications/summary', { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
-export const patchNotification = (id, data) => api.patch(`/notifications/${id}`, data).then(r => r.data);
-export const getNotificationPreferences = (orgId = null) => api.get('/notifications/preferences', { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
-export const putNotificationPreferences = (data, orgId = null) => api.put('/notifications/preferences', data, { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
+export const syncNotifications = (orgId = null) =>
+  api
+    .post('/notifications/sync', null, { params: orgId ? { org_id: orgId } : {} })
+    .then((r) => r.data);
+export const getNotificationsList = (params = {}) =>
+  api.get('/notifications/list', { params }).then((r) => r.data);
+export const getNotificationsSummary = (orgId = null) =>
+  _cachedGet('/notifications/summary', { params: orgId ? { org_id: orgId } : {} }).then(
+    (r) => r.data
+  );
+export const patchNotification = (id, data) =>
+  api.patch(`/notifications/${id}`, data).then((r) => r.data);
+export const getNotificationPreferences = (orgId = null) =>
+  api
+    .get('/notifications/preferences', { params: orgId ? { org_id: orgId } : {} })
+    .then((r) => r.data);
+export const putNotificationPreferences = (data, orgId = null) =>
+  api
+    .put('/notifications/preferences', data, { params: orgId ? { org_id: orgId } : {} })
+    .then((r) => r.data);
 
 // ========================================
 // IAM — Auth (Sprint 11)
 // ========================================
 
-export const loginAuth = (email, password) => api.post('/auth/login', { email, password }).then(r => r.data);
-export const refreshAuth = () => api.post('/auth/refresh').then(r => r.data);
-export const getAuthMe = () => api.get('/auth/me').then(r => r.data);
-export const logoutAuth = () => api.post('/auth/logout').then(r => r.data);
-export const changePassword = (currentPassword, newPassword) => api.put('/auth/password', { current_password: currentPassword, new_password: newPassword }).then(r => r.data);
-export const switchOrg = (orgId) => api.post('/auth/switch-org', { org_id: orgId }).then(r => r.data);
+export const loginAuth = (email, password) =>
+  api.post('/auth/login', { email, password }).then((r) => r.data);
+export const refreshAuth = () => api.post('/auth/refresh').then((r) => r.data);
+export const getAuthMe = () => api.get('/auth/me').then((r) => r.data);
+export const logoutAuth = () => api.post('/auth/logout').then((r) => r.data);
+export const changePassword = (currentPassword, newPassword) =>
+  api
+    .put('/auth/password', { current_password: currentPassword, new_password: newPassword })
+    .then((r) => r.data);
+export const switchOrg = (orgId) =>
+  api.post('/auth/switch-org', { org_id: orgId }).then((r) => r.data);
 
 // ========================================
 // IAM — Admin Users (Sprint 11)
 // ========================================
 
-export const getAdminUsers = () => api.get('/admin/users').then(r => r.data);
-export const createAdminUser = (data) => api.post('/admin/users', data).then(r => r.data);
-export const getAdminUser = (id) => api.get(`/admin/users/${id}`).then(r => r.data);
-export const patchAdminUser = (id, data) => api.patch(`/admin/users/${id}`, data).then(r => r.data);
-export const changeAdminRole = (id, role) => api.put(`/admin/users/${id}/role`, { role }).then(r => r.data);
-export const setAdminScopes = (id, scopes) => api.put(`/admin/users/${id}/scopes`, { scopes }).then(r => r.data);
-export const deleteAdminUser = (id) => api.delete(`/admin/users/${id}`).then(r => r.data);
-export const getAdminRoles = () => api.get('/admin/roles').then(r => r.data);
-export const getEffectiveAccess = (id) => api.get(`/admin/users/${id}/effective-access`).then(r => r.data);
+export const getAdminUsers = () => api.get('/admin/users').then((r) => r.data);
+export const createAdminUser = (data) => api.post('/admin/users', data).then((r) => r.data);
+export const getAdminUser = (id) => api.get(`/admin/users/${id}`).then((r) => r.data);
+export const patchAdminUser = (id, data) =>
+  api.patch(`/admin/users/${id}`, data).then((r) => r.data);
+export const changeAdminRole = (id, role) =>
+  api.put(`/admin/users/${id}/role`, { role }).then((r) => r.data);
+export const setAdminScopes = (id, scopes) =>
+  api.put(`/admin/users/${id}/scopes`, { scopes }).then((r) => r.data);
+export const deleteAdminUser = (id) => api.delete(`/admin/users/${id}`).then((r) => r.data);
+export const getAdminRoles = () => api.get('/admin/roles').then((r) => r.data);
+export const getEffectiveAccess = (id) =>
+  api.get(`/admin/users/${id}/effective-access`).then((r) => r.data);
 
 // ========================================
 // IAM — Audit Log (Sprint 11)
 // ========================================
 
-export const getAuditLogs = (params = {}) => api.get('/auth/audit', { params }).then(r => r.data);
+export const getAuditLogs = (params = {}) => api.get('/auth/audit', { params }).then((r) => r.data);
 
 // ========================================
 // IAM — Demo Mode (Sprint 11)
 // ========================================
 
-export const impersonateUser = (email) => api.post('/auth/impersonate', { email }).then(r => r.data);
+export const impersonateUser = (email) =>
+  api.post('/auth/impersonate', { email }).then((r) => r.data);
 
 // ========================================
 // PATRIMOINE STAGING (DIAMANT)
@@ -763,161 +976,304 @@ export const impersonateUser = (email) => api.post('/auth/impersonate', { email 
 export const stagingImport = (file, mode = 'import') => {
   const fd = new FormData();
   fd.append('file', file);
-  return api.post('/patrimoine/staging/import', fd, {
-    params: { mode },
-    headers: { 'Content-Type': 'multipart/form-data' },
-  }).then(r => r.data);
+  return api
+    .post('/patrimoine/staging/import', fd, {
+      params: { mode },
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then((r) => r.data);
 };
-export const stagingImportInvoices = (invoices) => api.post('/patrimoine/staging/import-invoices', { invoices }).then(r => r.data);
-export const stagingSummary = (batchId) => api.get(`/patrimoine/staging/${batchId}/summary`).then(r => r.data);
-export const stagingRows = (batchId, params = {}) => api.get(`/patrimoine/staging/${batchId}/rows`, { params }).then(r => r.data);
-export const stagingIssues = (batchId, params = {}) => api.get(`/patrimoine/staging/${batchId}/issues`, { params }).then(r => r.data);
-export const stagingValidate = (batchId) => api.post(`/patrimoine/staging/${batchId}/validate`).then(r => r.data);
-export const stagingFix = (batchId, fixType, params) => api.put(`/patrimoine/staging/${batchId}/fix`, { fix_type: fixType, params }).then(r => r.data);
-export const stagingFixBulk = (batchId, fixes) => api.put(`/patrimoine/staging/${batchId}/fix/bulk`, { fixes }).then(r => r.data);
-export const stagingAutofix = (batchId) => api.post(`/patrimoine/staging/${batchId}/autofix`).then(r => r.data);
-export const stagingActivate = (batchId, portefeuilleId) => api.post(`/patrimoine/staging/${batchId}/activate`, { portefeuille_id: portefeuilleId }).then(r => r.data);
-export const stagingResult = (batchId) => api.get(`/patrimoine/staging/${batchId}/result`).then(r => r.data);
-export const stagingAbandon = (batchId) => api.delete(`/patrimoine/staging/${batchId}`).then(r => r.data);
-export const loadPatrimoineDemo = () => api.post('/patrimoine/demo/load').then(r => r.data);
-export const getImportTemplateColumns = () => api.get('/patrimoine/import/template/columns').then(r => r.data);
+export const stagingImportInvoices = (invoices) =>
+  api.post('/patrimoine/staging/import-invoices', { invoices }).then((r) => r.data);
+export const stagingSummary = (batchId) =>
+  api.get(`/patrimoine/staging/${batchId}/summary`).then((r) => r.data);
+export const stagingRows = (batchId, params = {}) =>
+  api.get(`/patrimoine/staging/${batchId}/rows`, { params }).then((r) => r.data);
+export const stagingIssues = (batchId, params = {}) =>
+  api.get(`/patrimoine/staging/${batchId}/issues`, { params }).then((r) => r.data);
+export const stagingValidate = (batchId) =>
+  api.post(`/patrimoine/staging/${batchId}/validate`).then((r) => r.data);
+export const stagingFix = (batchId, fixType, params) =>
+  api.put(`/patrimoine/staging/${batchId}/fix`, { fix_type: fixType, params }).then((r) => r.data);
+export const stagingFixBulk = (batchId, fixes) =>
+  api.put(`/patrimoine/staging/${batchId}/fix/bulk`, { fixes }).then((r) => r.data);
+export const stagingAutofix = (batchId) =>
+  api.post(`/patrimoine/staging/${batchId}/autofix`).then((r) => r.data);
+export const stagingActivate = (batchId, portefeuilleId) =>
+  api
+    .post(`/patrimoine/staging/${batchId}/activate`, { portefeuille_id: portefeuilleId })
+    .then((r) => r.data);
+export const stagingResult = (batchId) =>
+  api.get(`/patrimoine/staging/${batchId}/result`).then((r) => r.data);
+export const stagingAbandon = (batchId) =>
+  api.delete(`/patrimoine/staging/${batchId}`).then((r) => r.data);
+export const loadPatrimoineDemo = () => api.post('/patrimoine/demo/load').then((r) => r.data);
+export const getImportTemplateColumns = () =>
+  api.get('/patrimoine/import/template/columns').then((r) => r.data);
 export const portfolioSync = (portfolioId, file, dryRun = true) => {
   const fd = new FormData();
   fd.append('file', file);
-  return api.post(`/patrimoine/${portfolioId}/sync`, fd, {
-    params: { dry_run: dryRun },
-    headers: { 'Content-Type': 'multipart/form-data' },
-  }).then(r => r.data);
+  return api
+    .post(`/patrimoine/${portfolioId}/sync`, fd, {
+      params: { dry_run: dryRun },
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then((r) => r.data);
 };
-export const mappingPreview = (headers) => api.post('/patrimoine/mapping/preview', { headers }).then(r => r.data);
+export const mappingPreview = (headers) =>
+  api.post('/patrimoine/mapping/preview', { headers }).then((r) => r.data);
 
 // PATRIMOINE CRUD (WORLD CLASS)
-export const patrimoineSites = (params = {}) => api.get('/patrimoine/sites', { params }).then(r => r.data);
-export const patrimoineSiteDetail = (id) => api.get(`/patrimoine/sites/${id}`).then(r => r.data);
-export const patrimoineSiteUpdate = (id, data) => api.patch(`/patrimoine/sites/${id}`, data).then(r => r.data);
-export const patrimoineSiteArchive = (id) => api.post(`/patrimoine/sites/${id}/archive`).then(r => r.data);
-export const patrimoineSiteRestore = (id) => api.post(`/patrimoine/sites/${id}/restore`).then(r => r.data);
-export const patrimoineSiteMerge = (sourceId, targetId) => api.post('/patrimoine/sites/merge', { source_site_id: sourceId, target_site_id: targetId }).then(r => r.data);
-export const patrimoineCompteurs = (params = {}) => api.get('/patrimoine/compteurs', { params }).then(r => r.data);
-export const patrimoineCompteurUpdate = (id, data) => api.patch(`/patrimoine/compteurs/${id}`, data).then(r => r.data);
-export const patrimoineCompteurMove = (id, targetSiteId) => api.post(`/patrimoine/compteurs/${id}/move`, { target_site_id: targetSiteId }).then(r => r.data);
-export const patrimoineCompteurDetach = (id) => api.post(`/patrimoine/compteurs/${id}/detach`).then(r => r.data);
-export const patrimoineContracts = (params = {}) => api.get('/patrimoine/contracts', { params }).then(r => r.data);
-export const patrimoineContractCreate = (data) => api.post('/patrimoine/contracts', data).then(r => r.data);
-export const patrimoineContractUpdate = (id, data) => api.patch(`/patrimoine/contracts/${id}`, data).then(r => r.data);
-export const patrimoineContractDelete = (id) => api.delete(`/patrimoine/contracts/${id}`).then(r => r.data);
+export const patrimoineSites = (params = {}) =>
+  api.get('/patrimoine/sites', { params }).then((r) => r.data);
+export const patrimoineSiteDetail = (id) => api.get(`/patrimoine/sites/${id}`).then((r) => r.data);
+export const patrimoineSiteUpdate = (id, data) =>
+  api.patch(`/patrimoine/sites/${id}`, data).then((r) => r.data);
+export const patrimoineSiteArchive = (id) =>
+  api.post(`/patrimoine/sites/${id}/archive`).then((r) => r.data);
+export const patrimoineSiteRestore = (id) =>
+  api.post(`/patrimoine/sites/${id}/restore`).then((r) => r.data);
+export const patrimoineSiteMerge = (sourceId, targetId) =>
+  api
+    .post('/patrimoine/sites/merge', { source_site_id: sourceId, target_site_id: targetId })
+    .then((r) => r.data);
+export const patrimoineCompteurs = (params = {}) =>
+  api.get('/patrimoine/compteurs', { params }).then((r) => r.data);
+export const patrimoineCompteurUpdate = (id, data) =>
+  api.patch(`/patrimoine/compteurs/${id}`, data).then((r) => r.data);
+export const patrimoineCompteurMove = (id, targetSiteId) =>
+  api
+    .post(`/patrimoine/compteurs/${id}/move`, { target_site_id: targetSiteId })
+    .then((r) => r.data);
+export const patrimoineCompteurDetach = (id) =>
+  api.post(`/patrimoine/compteurs/${id}/detach`).then((r) => r.data);
+export const patrimoineContracts = (params = {}) =>
+  api.get('/patrimoine/contracts', { params }).then((r) => r.data);
+export const patrimoineContractCreate = (data) =>
+  api.post('/patrimoine/contracts', data).then((r) => r.data);
+export const patrimoineContractUpdate = (id, data) =>
+  api.patch(`/patrimoine/contracts/${id}`, data).then((r) => r.data);
+export const patrimoineContractDelete = (id) =>
+  api.delete(`/patrimoine/contracts/${id}`).then((r) => r.data);
 
 // Patrimoine — compléments audit V51
 export const stagingExportReport = (batchId) =>
   api.get(`/patrimoine/staging/${batchId}/export/report.csv`, { responseType: 'blob' });
 export const patrimoineDeliveryPoints = (siteId) =>
-  api.get(`/patrimoine/sites/${siteId}/delivery-points`).then(r => r.data);
+  api.get(`/patrimoine/sites/${siteId}/delivery-points`).then((r) => r.data);
 export const patrimoineKpis = (params = {}) =>
-  api.get('/patrimoine/kpis', { params }).then(r => r.data);
+  api.get('/patrimoine/kpis', { params }).then((r) => r.data);
 export const patrimoineSitesExport = (params = {}) =>
   api.get('/patrimoine/sites/export.csv', { params, responseType: 'blob' });
 
 // Patrimoine — V58 Snapshot & Anomalies (V59: enriched with impact)
 export const getPatrimoineSnapshot = (siteId) =>
-  api.get(`/patrimoine/sites/${siteId}/snapshot`).then(r => r.data);
+  api.get(`/patrimoine/sites/${siteId}/snapshot`).then((r) => r.data);
 export const getPatrimoineAnomalies = (siteId) =>
-  api.get(`/patrimoine/sites/${siteId}/anomalies`).then(r => r.data);
+  api.get(`/patrimoine/sites/${siteId}/anomalies`).then((r) => r.data);
 export const listPatrimoineAnomalies = (params = {}) =>
-  api.get('/patrimoine/anomalies', { params }).then(r => r.data);
+  api.get('/patrimoine/anomalies', { params }).then((r) => r.data);
 // V59: hypothèses de calcul en lecture seule
 export const getPatrimoineAssumptions = () =>
-  api.get('/patrimoine/assumptions').then(r => r.data);
+  api.get('/patrimoine/assumptions').then((r) => r.data);
 // V60: résumé portfolio — risque global, framework breakdown, top sites
 export const getPatrimoinePortfolioSummary = (params = {}) =>
-  _cachedGet('/patrimoine/portfolio-summary', { params }).then(r => r.data);
+  _cachedGet('/patrimoine/portfolio-summary', { params }).then((r) => r.data);
 
 // ========================================
 // SMART INTAKE (DIAMANT)
 // ========================================
 
-export const getIntakeQuestions = (siteId) => api.get(`/intake/${siteId}/questions`).then(r => r.data);
+export const getIntakeQuestions = (siteId) =>
+  api.get(`/intake/${siteId}/questions`).then((r) => r.data);
 export const submitIntakeAnswer = (siteId, fieldPath, value, source = 'user') =>
-  api.post(`/intake/${siteId}/answers`, { field_path: fieldPath, value, source }).then(r => r.data);
+  api
+    .post(`/intake/${siteId}/answers`, { field_path: fieldPath, value, source })
+    .then((r) => r.data);
 export const applyIntakeSuggestions = (siteId, fieldPaths) =>
-  api.post(`/intake/${siteId}/apply-suggestions`, { field_paths: fieldPaths }).then(r => r.data);
-export const intakeDemoAutofill = (siteId) => api.post(`/intake/${siteId}/demo-autofill`).then(r => r.data);
-export const completeIntake = (siteId) => api.post(`/intake/${siteId}/complete`).then(r => r.data);
-export const getIntakeSession = (sessionId) => api.get(`/intake/session/${sessionId}`).then(r => r.data);
-export const purgeIntakeDemo = () => api.delete('/intake/demo/purge').then(r => r.data);
+  api.post(`/intake/${siteId}/apply-suggestions`, { field_paths: fieldPaths }).then((r) => r.data);
+export const intakeDemoAutofill = (siteId) =>
+  api.post(`/intake/${siteId}/demo-autofill`).then((r) => r.data);
+export const completeIntake = (siteId) =>
+  api.post(`/intake/${siteId}/complete`).then((r) => r.data);
+export const getIntakeSession = (sessionId) =>
+  api.get(`/intake/session/${sessionId}`).then((r) => r.data);
+export const purgeIntakeDemo = () => api.delete('/intake/demo/purge').then((r) => r.data);
 
 // ========================================
 // MONITORING (Electric Performance)
 // ========================================
 
-export const getMonitoringKpis = (siteId) => api.get('/monitoring/kpis', { params: { site_id: siteId } }).then(r => r.data);
-export const runMonitoring = (siteId, days = 90) => api.post('/monitoring/run', { site_id: siteId, days }).then(r => r.data);
-export const getMonitoringSnapshots = (siteId, limit = 10) => api.get('/monitoring/snapshots', { params: { site_id: siteId, limit } }).then(r => r.data);
-export const getMonitoringAlerts = (siteId, status = null, limit = 50) => api.get('/monitoring/alerts', { params: { site_id: siteId, status, limit } }).then(r => r.data);
-export const ackMonitoringAlert = (id) => api.post(`/monitoring/alerts/${id}/ack`, { acknowledged_by: 'user' }).then(r => r.data);
-export const resolveMonitoringAlert = (id, note = null) => api.post(`/monitoring/alerts/${id}/resolve`, { resolved_by: 'user', resolution_note: note }).then(r => r.data);
-export const generateMonitoringDemo = (siteId, days = 90, profile = 'office') => api.post('/monitoring/demo/generate', { site_id: siteId, days, profile }).then(r => r.data);
-export const getMonitoringKpisCompare = (siteId, mode = 'previous', customStart = null, customEnd = null) =>
-  api.get('/monitoring/kpis/compare', { params: { site_id: siteId, mode, custom_start: customStart, custom_end: customEnd } }).then(r => r.data);
+export const getMonitoringKpis = (siteId) =>
+  api.get('/monitoring/kpis', { params: { site_id: siteId } }).then((r) => r.data);
+export const runMonitoring = (siteId, days = 90) =>
+  api.post('/monitoring/run', { site_id: siteId, days }).then((r) => r.data);
+export const getMonitoringSnapshots = (siteId, limit = 10) =>
+  api.get('/monitoring/snapshots', { params: { site_id: siteId, limit } }).then((r) => r.data);
+export const getMonitoringAlerts = (siteId, status = null, limit = 50) =>
+  api.get('/monitoring/alerts', { params: { site_id: siteId, status, limit } }).then((r) => r.data);
+export const ackMonitoringAlert = (id) =>
+  api.post(`/monitoring/alerts/${id}/ack`, { acknowledged_by: 'user' }).then((r) => r.data);
+export const resolveMonitoringAlert = (id, note = null) =>
+  api
+    .post(`/monitoring/alerts/${id}/resolve`, { resolved_by: 'user', resolution_note: note })
+    .then((r) => r.data);
+export const generateMonitoringDemo = (siteId, days = 90, profile = 'office') =>
+  api.post('/monitoring/demo/generate', { site_id: siteId, days, profile }).then((r) => r.data);
+export const getMonitoringKpisCompare = (
+  siteId,
+  mode = 'previous',
+  customStart = null,
+  customEnd = null
+) =>
+  api
+    .get('/monitoring/kpis/compare', {
+      params: { site_id: siteId, mode, custom_start: customStart, custom_end: customEnd },
+    })
+    .then((r) => r.data);
 
 // ========================================
 // Emissions / CO2e (Sprint V9 Decarbonation)
 // ========================================
 
-export const getEmissions = (siteId) => api.get('/monitoring/emissions', { params: { site_id: siteId } }).then(r => r.data);
-export const getEmissionFactors = () => api.get('/monitoring/emission-factors').then(r => r.data);
-export const seedEmissionFactors = () => api.post('/monitoring/emission-factors/seed').then(r => r.data);
+export const getEmissions = (siteId) =>
+  api.get('/monitoring/emissions', { params: { site_id: siteId } }).then((r) => r.data);
+export const getEmissionFactors = () => api.get('/monitoring/emission-factors').then((r) => r.data);
+export const seedEmissionFactors = () =>
+  api.post('/monitoring/emission-factors/seed').then((r) => r.data);
 
 // ========================================
 // BACS Expert (Decret n°2020-887)
 // ========================================
 
-export const getBacsAssessment = (siteId) => api.get(`/regops/bacs/site/${siteId}`).then(r => r.data);
-export const recomputeBacs = (siteId) => api.post(`/regops/bacs/recompute/${siteId}`).then(r => r.data);
-export const getBacsScoreExplain = (siteId) => api.get(`/regops/bacs/score_explain/${siteId}`).then(r => r.data);
-export const getBacsDataQuality = (siteId) => api.get(`/regops/bacs/data_quality/${siteId}`).then(r => r.data);
+export const getBacsAssessment = (siteId) =>
+  api.get(`/regops/bacs/site/${siteId}`).then((r) => r.data);
+export const recomputeBacs = (siteId) =>
+  api.post(`/regops/bacs/recompute/${siteId}`).then((r) => r.data);
+export const getBacsScoreExplain = (siteId) =>
+  api.get(`/regops/bacs/score_explain/${siteId}`).then((r) => r.data);
+export const getBacsDataQuality = (siteId) =>
+  api.get(`/regops/bacs/data_quality/${siteId}`).then((r) => r.data);
 export const createBacsAsset = (siteId, isTertiary = true, pcDate = null) =>
-  api.post('/regops/bacs/asset', null, { params: { site_id: siteId, is_tertiary: isTertiary, pc_date: pcDate } }).then(r => r.data);
+  api
+    .post('/regops/bacs/asset', null, {
+      params: { site_id: siteId, is_tertiary: isTertiary, pc_date: pcDate },
+    })
+    .then((r) => r.data);
 export const addCvcSystem = (assetId, systemType, architecture, unitsJson = '[]') =>
-  api.post(`/regops/bacs/asset/${assetId}/system`, null, { params: { system_type: systemType, architecture, units_json: unitsJson } }).then(r => r.data);
+  api
+    .post(`/regops/bacs/asset/${assetId}/system`, null, {
+      params: { system_type: systemType, architecture, units_json: unitsJson },
+    })
+    .then((r) => r.data);
 export const updateCvcSystem = (systemId, unitsJson = null, architecture = null) =>
-  api.put(`/regops/bacs/system/${systemId}`, null, { params: { units_json: unitsJson, architecture } }).then(r => r.data);
-export const deleteCvcSystem = (systemId) => api.delete(`/regops/bacs/system/${systemId}`).then(r => r.data);
-export const seedBacsDemo = () => api.post('/regops/bacs/seed_demo').then(r => r.data);
-export const getBacsOpsPanel = (siteId) => api.get(`/regops/bacs/site/${siteId}/ops`).then(r => r.data);
+  api
+    .put(`/regops/bacs/system/${systemId}`, null, {
+      params: { units_json: unitsJson, architecture },
+    })
+    .then((r) => r.data);
+export const deleteCvcSystem = (systemId) =>
+  api.delete(`/regops/bacs/system/${systemId}`).then((r) => r.data);
+export const seedBacsDemo = () => api.post('/regops/bacs/seed_demo').then((r) => r.data);
+export const getBacsOpsPanel = (siteId) =>
+  api.get(`/regops/bacs/site/${siteId}/ops`).then((r) => r.data);
 
 // ========================================
 // EMS Consumption Explorer
 // ========================================
 
-export const getEmsTimeseries = (params) => _cachedGet('/ems/timeseries', { params }).then(r => r.data);
-export const getEmsTimeseriesSuggest = (dateFrom, dateTo) => _cachedGet('/ems/timeseries/suggest', { params: { date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
-export const getEmsWeather = (siteId, dateFrom, dateTo) => api.get('/ems/weather', { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
-export const getEmsWeatherMulti = (siteIds, dateFrom, dateTo) => api.get('/ems/weather', { params: { site_ids: siteIds.join(','), date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
-export const getEmsReferenceProfile = (siteId, dateFrom, dateTo, famille, puissance, granularity = 'daily') => api.get('/ems/reference_profile', { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo, famille, puissance, granularity } }).then(r => r.data);
-export const getEmsWeatherHourly = (siteId, dateFrom, dateTo) => api.get('/ems/weather_hourly', { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
-export const runEmsSignature = (siteId, dateFrom, dateTo, meterIds = null) => api.post('/ems/signature/run', null, { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo, meter_ids: meterIds } }).then(r => r.data);
-export const runEmsSignaturePortfolio = (siteIds, dateFrom, dateTo) => api.post('/ems/signature/portfolio', null, { params: { site_ids: siteIds.join(','), date_from: dateFrom, date_to: dateTo } }).then(r => r.data);
-export const getEmsViews = (userId = null) => api.get('/ems/views', { params: userId ? { user_id: userId } : {} }).then(r => r.data);
-export const createEmsView = (name, configJson, userId = null) => api.post('/ems/views', null, { params: { name, config_json: configJson, user_id: userId } }).then(r => r.data);
-export const updateEmsView = (id, params) => api.put(`/ems/views/${id}`, null, { params }).then(r => r.data);
-export const deleteEmsView = (id) => api.delete(`/ems/views/${id}`).then(r => r.data);
+export const getEmsTimeseries = (params) =>
+  _cachedGet('/ems/timeseries', { params }).then((r) => r.data);
+export const getEmsTimeseriesSuggest = (dateFrom, dateTo) =>
+  _cachedGet('/ems/timeseries/suggest', { params: { date_from: dateFrom, date_to: dateTo } }).then(
+    (r) => r.data
+  );
+export const getEmsWeather = (siteId, dateFrom, dateTo) =>
+  api
+    .get('/ems/weather', { params: { site_id: siteId, date_from: dateFrom, date_to: dateTo } })
+    .then((r) => r.data);
+export const getEmsWeatherMulti = (siteIds, dateFrom, dateTo) =>
+  api
+    .get('/ems/weather', {
+      params: { site_ids: siteIds.join(','), date_from: dateFrom, date_to: dateTo },
+    })
+    .then((r) => r.data);
+export const getEmsReferenceProfile = (
+  siteId,
+  dateFrom,
+  dateTo,
+  famille,
+  puissance,
+  granularity = 'daily'
+) =>
+  api
+    .get('/ems/reference_profile', {
+      params: {
+        site_id: siteId,
+        date_from: dateFrom,
+        date_to: dateTo,
+        famille,
+        puissance,
+        granularity,
+      },
+    })
+    .then((r) => r.data);
+export const getEmsWeatherHourly = (siteId, dateFrom, dateTo) =>
+  api
+    .get('/ems/weather_hourly', {
+      params: { site_id: siteId, date_from: dateFrom, date_to: dateTo },
+    })
+    .then((r) => r.data);
+export const runEmsSignature = (siteId, dateFrom, dateTo, meterIds = null) =>
+  api
+    .post('/ems/signature/run', null, {
+      params: { site_id: siteId, date_from: dateFrom, date_to: dateTo, meter_ids: meterIds },
+    })
+    .then((r) => r.data);
+export const runEmsSignaturePortfolio = (siteIds, dateFrom, dateTo) =>
+  api
+    .post('/ems/signature/portfolio', null, {
+      params: { site_ids: siteIds.join(','), date_from: dateFrom, date_to: dateTo },
+    })
+    .then((r) => r.data);
+export const getEmsViews = (userId = null) =>
+  api.get('/ems/views', { params: userId ? { user_id: userId } : {} }).then((r) => r.data);
+export const createEmsView = (name, configJson, userId = null) =>
+  api
+    .post('/ems/views', null, { params: { name, config_json: configJson, user_id: userId } })
+    .then((r) => r.data);
+export const updateEmsView = (id, params) =>
+  api.put(`/ems/views/${id}`, null, { params }).then((r) => r.data);
+export const deleteEmsView = (id) => api.delete(`/ems/views/${id}`).then((r) => r.data);
 
 // Collections (paniers de sites)
-export const getEmsCollections = () => api.get('/ems/collections').then(r => r.data);
+export const getEmsCollections = () => api.get('/ems/collections').then((r) => r.data);
 export const createEmsCollection = (name, siteIds, scopeType = 'custom', isFavorite = false) =>
-  api.post('/ems/collections', null, { params: { name, site_ids: siteIds.join(','), scope_type: scopeType, is_favorite: isFavorite } }).then(r => r.data);
-export const updateEmsCollection = (id, params) => api.put(`/ems/collections/${id}`, null, { params }).then(r => r.data);
-export const deleteEmsCollection = (id) => api.delete(`/ems/collections/${id}`).then(r => r.data);
+  api
+    .post('/ems/collections', null, {
+      params: { name, site_ids: siteIds.join(','), scope_type: scopeType, is_favorite: isFavorite },
+    })
+    .then((r) => r.data);
+export const updateEmsCollection = (id, params) =>
+  api.put(`/ems/collections/${id}`, null, { params }).then((r) => r.data);
+export const deleteEmsCollection = (id) => api.delete(`/ems/collections/${id}`).then((r) => r.data);
 
 // Usage suggest & benchmark
-export const getUsageSuggest = (siteId) => api.get('/ems/usage_suggest', { params: { site_id: siteId } }).then(r => r.data);
-export const getEmsBenchmark = (siteId) => api.get('/ems/benchmark', { params: { site_id: siteId } }).then(r => r.data);
-export const getScheduleSuggest = (siteId, days = 90) => api.get('/ems/schedule_suggest', { params: { site_id: siteId, days } }).then(r => r.data);
+export const getUsageSuggest = (siteId) =>
+  api.get('/ems/usage_suggest', { params: { site_id: siteId } }).then((r) => r.data);
+export const getEmsBenchmark = (siteId) =>
+  api.get('/ems/benchmark', { params: { site_id: siteId } }).then((r) => r.data);
+export const getScheduleSuggest = (siteId, days = 90) =>
+  api.get('/ems/schedule_suggest', { params: { site_id: siteId, days } }).then((r) => r.data);
 
 // Demo data
 export const generateEmsDemo = (portfolioSize = 12, days = 365, seed = 123, force = false) =>
-  api.post('/ems/demo/generate', null, { params: { portfolio_size: portfolioSize, days, seed, force } }).then(r => r.data);
-export const purgeEmsDemo = () => api.post('/ems/demo/purge').then(r => r.data);
+  api
+    .post('/ems/demo/generate', null, {
+      params: { portfolio_size: portfolioSize, days, seed, force },
+    })
+    .then((r) => r.data);
+export const purgeEmsDemo = () => api.post('/ems/demo/purge').then((r) => r.data);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Tertiaire / OPERAT V39
@@ -925,78 +1281,89 @@ export const purgeEmsDemo = () => api.post('/ems/demo/purge').then(r => r.data);
 const TERT_BASE = '/tertiaire';
 
 export const getTertiaireEfas = (params = {}) =>
-  api.get(`${TERT_BASE}/efa`, { params }).then(r => r.data);
-export const createTertiaireEfa = (body) =>
-  api.post(`${TERT_BASE}/efa`, body).then(r => r.data);
-export const getTertiaireEfa = (efaId) =>
-  api.get(`${TERT_BASE}/efa/${efaId}`).then(r => r.data);
+  api.get(`${TERT_BASE}/efa`, { params }).then((r) => r.data);
+export const createTertiaireEfa = (body) => api.post(`${TERT_BASE}/efa`, body).then((r) => r.data);
+export const getTertiaireEfa = (efaId) => api.get(`${TERT_BASE}/efa/${efaId}`).then((r) => r.data);
 export const updateTertiaireEfa = (efaId, body) =>
-  api.patch(`${TERT_BASE}/efa/${efaId}`, body).then(r => r.data);
+  api.patch(`${TERT_BASE}/efa/${efaId}`, body).then((r) => r.data);
 export const deleteTertiaireEfa = (efaId) =>
-  api.delete(`${TERT_BASE}/efa/${efaId}`).then(r => r.data);
+  api.delete(`${TERT_BASE}/efa/${efaId}`).then((r) => r.data);
 
 export const addTertiaireBuilding = (efaId, body) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/buildings`, body).then(r => r.data);
+  api.post(`${TERT_BASE}/efa/${efaId}/buildings`, body).then((r) => r.data);
 export const addTertiaireResponsibility = (efaId, body) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/responsibilities`, body).then(r => r.data);
+  api.post(`${TERT_BASE}/efa/${efaId}/responsibilities`, body).then((r) => r.data);
 export const addTertiaireEvent = (efaId, body) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/events`, body).then(r => r.data);
+  api.post(`${TERT_BASE}/efa/${efaId}/events`, body).then((r) => r.data);
 export const addTertiaireEfaLink = (efaId, body) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/links`, body).then(r => r.data);
+  api.post(`${TERT_BASE}/efa/${efaId}/links`, body).then((r) => r.data);
 
 export const runTertiaireControls = (efaId, year = null) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/controls`, null, { params: year ? { year } : {} }).then(r => r.data);
+  api
+    .post(`${TERT_BASE}/efa/${efaId}/controls`, null, { params: year ? { year } : {} })
+    .then((r) => r.data);
 export const precheckTertiaireDeclaration = (efaId, year) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/precheck`, null, { params: { year } }).then(r => r.data);
+  api.post(`${TERT_BASE}/efa/${efaId}/precheck`, null, { params: { year } }).then((r) => r.data);
 export const exportTertiairePack = (efaId, year) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/export-pack`, null, { params: { year } }).then(r => r.data);
+  api.post(`${TERT_BASE}/efa/${efaId}/export-pack`, null, { params: { year } }).then((r) => r.data);
 
 export const getTertiaireIssues = (params = {}) =>
-  api.get(`${TERT_BASE}/issues`, { params }).then(r => r.data);
+  api.get(`${TERT_BASE}/issues`, { params }).then((r) => r.data);
 export const updateTertiaireIssue = (issueId, body) =>
-  api.patch(`${TERT_BASE}/issues/${issueId}`, body).then(r => r.data);
+  api.patch(`${TERT_BASE}/issues/${issueId}`, body).then((r) => r.data);
 
 export const getTertiaireDashboard = (orgId = null) =>
-  api.get(`${TERT_BASE}/dashboard`, { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
+  api.get(`${TERT_BASE}/dashboard`, { params: orgId ? { org_id: orgId } : {} }).then((r) => r.data);
 
 // V42: Site signals for auto-qualification
 export const getTertiaireSiteSignals = (orgId = null) =>
-  api.get(`${TERT_BASE}/site-signals`, { params: orgId ? { org_id: orgId } : {} }).then(r => r.data);
+  api
+    .get(`${TERT_BASE}/site-signals`, { params: orgId ? { org_id: orgId } : {} })
+    .then((r) => r.data);
 
 // V41: Patrimoine building catalog for wizard
 export const getTertiaireCatalog = (orgId = 1) =>
-  api.get(`${TERT_BASE}/catalog`, { params: { org_id: orgId } }).then(r => r.data);
+  api.get(`${TERT_BASE}/catalog`, { params: { org_id: orgId } }).then((r) => r.data);
 
 // V45 — Proof catalog + status
 export const getTertiaireProofCatalog = () =>
-  api.get(`${TERT_BASE}/proof-catalog`).then(r => r.data);
+  api.get(`${TERT_BASE}/proof-catalog`).then((r) => r.data);
 
 export const getTertiaireEfaProofs = (efaId, year = null) =>
-  api.get(`${TERT_BASE}/efa/${efaId}/proofs`, { params: year ? { year } : {} }).then(r => r.data);
+  api.get(`${TERT_BASE}/efa/${efaId}/proofs`, { params: year ? { year } : {} }).then((r) => r.data);
 
 export const linkTertiaireProof = (efaId, body) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/proofs/link`, body).then(r => r.data);
+  api.post(`${TERT_BASE}/efa/${efaId}/proofs/link`, body).then((r) => r.data);
 
 // V50: Proof Catalog V2 + Issue mapping + Template generation
 export const getOperatProofCatalogV2 = () =>
-  api.get(`${TERT_BASE}/proofs/catalog`).then(r => r.data);
+  api.get(`${TERT_BASE}/proofs/catalog`).then((r) => r.data);
 
 export const getIssueProofs = (issueCode) =>
-  api.get(`${TERT_BASE}/issues/${issueCode}/proofs`).then(r => r.data);
+  api.get(`${TERT_BASE}/issues/${issueCode}/proofs`).then((r) => r.data);
 
 export const createOperatProofTemplates = (efaId, year, body) =>
-  api.post(`${TERT_BASE}/efa/${efaId}/proofs/templates`, body, { params: { year } }).then(r => r.data);
+  api
+    .post(`${TERT_BASE}/efa/${efaId}/proofs/templates`, body, { params: { year } })
+    .then((r) => r.data);
 
 // ========================================
 // PORTFOLIO CONSUMPTION (V1)
 // ========================================
 
 // skipSiteHeader: portfolio = multi-sites, never filter by single site scope
-export const getPortfolioSummary = (params = {}) => _cachedGet('/portfolio/consumption/summary', { params, skipSiteHeader: true }).then(r => r.data);
-export const getPortfolioSites = (params = {}) => _cachedGet('/portfolio/consumption/sites', { params, skipSiteHeader: true }).then(r => r.data);
+export const getPortfolioSummary = (params = {}) =>
+  _cachedGet('/portfolio/consumption/summary', { params, skipSiteHeader: true }).then(
+    (r) => r.data
+  );
+export const getPortfolioSites = (params = {}) =>
+  _cachedGet('/portfolio/consumption/sites', { params, skipSiteHeader: true }).then((r) => r.data);
 
 // V69: Meta version (sha + branch) — Expert mode display
 export const getMetaVersion = () =>
-  api.get('/meta/version').then(r => r.data).catch(() => null);
+  api
+    .get('/meta/version')
+    .then((r) => r.data)
+    .catch(() => null);
 
 export default api;


### PR DESCRIPTION
P0-1: Replace hardcoded org_id=1 with scope.orgId from useScope()
      in computePortfolio() and getPortfolioResults() calls.

P0-2: Add useSearchParams to PurchasePage — ?filter=renewal maps to
      echeances tab, ?filter=missing maps to portefeuille tab.
      Tab changes sync back to URL for bookmarkable state.

P0-3: Create GET /api/purchase/assistant backend endpoint returning
      portfolio sites (real or demo seed). Connect PurchaseAssistantPage
      via getPurchaseAssistantData() API call on mount.

Tests: 19 vitest + 4 pytest covering all 3 fixes.

https://claude.ai/code/session_01L4NDk9ML8NT3gRsy58XAW2