### PR TITLE
fix(ui): overlay portals + z-index audit + smoke tests (V16)

### DIFF
--- a/docs/ux-overlays.md
+++ b/docs/ux-overlays.md
@@ -1,0 +1,127 @@
+# UX Overlays — Audit & Règles (V1)
+
+> **But :** Référence pour tous les dropdowns, tooltips, popovers et modals du projet.
+> Garantit qu'aucun overlay ne se retrouve clippé derrière un contenu voisin.
+
+---
+
+## 1. Inventaire des composants overlay
+
+| Composant | Fichier | Portal | Z-index | Risque | Statut |
+|-----------|---------|--------|---------|--------|--------|
+| `UserMenu` dropdown | `layout/AppShell.jsx` | ✅ `document.body` | `z-[120]` | — | ✅ OK |
+| `ScopeSwitcher` dropdown | `layout/ScopeSwitcher.jsx` | ✅ `document.body` | `z-[120]` | — | ✅ OK |
+| `NavPanel` (sidebar) | `layout/NavPanel.jsx` | ❌ non-portal | `z-30` | Faible — toujours à gauche | ✅ OK |
+| `CommandPalette` | `ui/CommandPalette.jsx` | ✅ (overlay plein écran) | `z-[200]` | — | ✅ OK |
+| `Modal` | `ui/Modal.jsx` | ✅ `document.body` | `z-[200]` | — | ✅ OK |
+| `Drawer` | `ui/Drawer.jsx` | ✅ `document.body` | `z-[200]` | — | ✅ OK |
+| `TooltipPortal` | `ui/TooltipPortal.jsx` | ✅ `document.body` | `z-[9999]` | — | ✅ OK |
+| `InfoTip` | `ui/InfoTip.jsx` | ✅ `document.body` | `z-[120]` | — | ✅ OK |
+| `InfoTooltip` (consumption) | `pages/consumption/InfoTooltip.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute` dans sticky+blur | ✅ **Fixed V1** |
+| `SiteSearchDropdown` | `pages/consumption/StickyFilterBar.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute z-40` dans sticky+blur | ✅ **Fixed V1** |
+| Presets dropdown | `pages/consumption/StickyFilterBar.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute z-30` dans sticky+blur | ✅ **Fixed V1** |
+| `SitePicker` dropdown | `components/SitePicker.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute z-50` | ✅ **Fixed V1** |
+| `InsightBadge` detail | `pages/consumption/InsightsStrip.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute z-30` | ✅ **Fixed V1** |
+
+---
+
+## 2. Carte des couches Z-index
+
+```
+z-[200]  Modals, Drawer, CommandPalette  (pleins écrans — portal body)
+z-[120]  Dropdowns, tooltips, popovers  (portal body — tous overlays)
+z-40     Header sticky                   (AppShell — backdrop-blur-md)
+z-30     Sidebar aside                   (sticky left column)
+z-20     StickyFilterBar                 (sticky top — backdrop-blur)
+z-auto   Contenu de page normal
+```
+
+> **Règle absolue :** aucun overlay ne peut exister à moins de `z-[120]` rendu dans `document.body`.
+> Un overlay dans un élément `z-20` sera toujours caché derrière un élément frère `z-21`.
+
+---
+
+## 3. Les 3 règles du développeur
+
+### Règle 1 — Tout overlay = Portal + `position: fixed`
+
+Un overlay (dropdown, tooltip, popover) **doit** être rendu dans `document.body` via `createPortal`.
+Sa position est calculée depuis `element.getBoundingClientRect()` et appliquée en `style={{ top, left }}` avec `position: fixed`.
+
+```jsx
+// ✅ Correct
+const [coords, setCoords] = useState(null);
+const triggerRef = useRef(null);
+
+const open = () => {
+  const r = triggerRef.current.getBoundingClientRect();
+  setCoords({ top: r.bottom + 4, left: r.left });
+};
+
+return (
+  <>
+    <button ref={triggerRef} onClick={open}>Ouvrir</button>
+    {visible && coords && createPortal(
+      <div className="fixed z-[120]" style={{ top: coords.top, left: coords.left }}>
+        Contenu overlay
+      </div>,
+      document.body,
+    )}
+  </>
+);
+
+// ❌ Interdit — absolute piégé dans un stacking context ancêtre
+<div className="relative">
+  <button>Trigger</button>
+  <div className="absolute top-full z-50">Overlay clippé !</div>
+</div>
+```
+
+### Règle 2 — Outside-click doit vérifier les deux refs
+
+Quand le dropdown est dans un portal, les clics sur le dropdown ne tombent **pas** dans le `triggerRef`. L'handler `mousedown` doit vérifier les deux :
+
+```jsx
+useEffect(() => {
+  function handler(e) {
+    if (
+      triggerRef.current && !triggerRef.current.contains(e.target) &&
+      dropRef.current   && !dropRef.current.contains(e.target)
+    ) {
+      setOpen(false);
+    }
+  }
+  document.addEventListener('mousedown', handler);
+  return () => document.removeEventListener('mousedown', handler);
+}, []);
+```
+
+### Règle 3 — Contextes de stacking qui piègent les enfants
+
+Ces propriétés CSS créent un nouveau stacking context — les `z-index` des enfants ne peuvent **pas** dépasser le z-index du conteneur :
+
+| Propriété CSS | Crée un stacking context |
+|--------------|--------------------------|
+| `position: sticky/fixed/absolute/relative` + `z-index ≠ auto` | ✅ Oui |
+| `backdrop-filter: blur(...)` | ✅ Oui (tous navigateurs modernes) |
+| `opacity < 1` | ✅ Oui |
+| `transform` | ✅ Oui |
+| `filter` | ✅ Oui |
+| `will-change: transform/opacity` | ✅ Oui |
+
+**Corollaire :** Toute combinaison `sticky + z-XX + backdrop-blur` (comme `StickyFilterBar`) piège ses enfants absolus. La seule issue est le portal.
+
+---
+
+## 4. Diagnostic rapide
+
+Si un overlay se retrouve derrière du contenu :
+
+1. Inspecter l'ancêtre le plus proche avec `position: sticky/fixed` ou `backdrop-filter`
+2. Vérifier si cet ancêtre a un `z-index` explicite → stacking context confirmé
+3. Migrer l'overlay vers un portal (`createPortal` + `position: fixed`)
+4. Assigner `z-[120]` au overlay (ou `z-[200]` pour les modals)
+
+---
+
+*Dernière mise à jour : V1 — audit complet overlays (Sprint WOW)*

--- a/e2e/overlays.spec.js
+++ b/e2e/overlays.spec.js
@@ -1,0 +1,162 @@
+/**
+ * PROMEOS — Overlay Layering Smoke Tests
+ * Validates that portal-based overlays are:
+ *   - Rendered as direct children of <body> (createPortal)
+ *   - Using position:fixed (not absolute — immune to stacking-context trapping)
+ *   - Carrying z-index ≥ 120 (above sticky header z-40 and sidebar z-30)
+ *   - Occupying visible screen space (not clipped behind other layers)
+ *
+ * Regressions guarded:
+ *   1. ScopeSwitcher dropdown clipped on /consommations behind sticky+backdrop-blur
+ *   2. InfoTip rendering empty black dots when content prop was undefined
+ *
+ * Requires: backend on :8000, frontend on :5173, demo data seeded.
+ */
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCREENSHOTS = path.join(__dirname, 'screenshots');
+
+async function login(page) {
+  await page.goto('/login');
+  await page.fill('input[type="email"]', 'sophie@atlas.demo');
+  await page.fill('input[type="password"]', 'demo2024');
+  await page.click('button[type="submit"]');
+  await page.waitForURL((url) => !url.pathname.includes('/login'), {
+    timeout: 10_000,
+  });
+}
+
+test.beforeAll(() => {
+  fs.mkdirSync(SCREENSHOTS, { recursive: true });
+});
+
+test.describe('Overlay layering — portal + z-index regression', () => {
+
+  // ── Test 1: ScopeSwitcher dropdown ──────────────────────────────────────────
+  test(
+    'Consommations explorer: ScopeSwitcher dropdown is portaled, position:fixed, z≥120',
+    async ({ page }) => {
+      await login(page);
+      await page.goto('/consommations');
+
+      // Wait for the page to stabilize (data fetch + React hydration)
+      await page.waitForTimeout(2000);
+
+      // Locate the ScopeSwitcher trigger (the scope pill in the header)
+      const trigger = page.locator('button[aria-haspopup="listbox"]');
+      await expect(trigger).toBeVisible({ timeout: 8_000 });
+
+      // Open the dropdown
+      await trigger.click();
+
+      // Dropdown must appear
+      const listbox = page.locator('[role="listbox"]');
+      await expect(listbox).toBeVisible({ timeout: 5_000 });
+
+      // ── Portal assertion: must be a direct child of <body> ─────────────────
+      const parentTag = await listbox.evaluate((el) =>
+        el.parentElement?.tagName ?? 'UNKNOWN',
+      );
+      expect(parentTag, 'Listbox must be portaled to <body>').toBe('BODY');
+
+      // ── position:fixed — immune to ancestor stacking-context trapping ──────
+      const position = await listbox.evaluate((el) =>
+        window.getComputedStyle(el).position,
+      );
+      expect(position, 'Listbox must use position:fixed').toBe('fixed');
+
+      // ── z-index ≥ 120 — above sticky header (z-40) and sidebar (z-30) ──────
+      const zIndex = await listbox.evaluate((el) =>
+        parseInt(window.getComputedStyle(el).zIndex, 10),
+      );
+      expect(zIndex, 'Listbox z-index must be ≥ 120').toBeGreaterThanOrEqual(120);
+
+      // ── Visible bounding box (not zero-size, not off-screen) ───────────────
+      const box = await listbox.boundingBox();
+      expect(box, 'Listbox must have a non-null bounding box').not.toBeNull();
+      expect(box.width, 'Listbox must have visible width').toBeGreaterThan(100);
+      expect(box.height, 'Listbox must have visible height').toBeGreaterThan(20);
+
+      // ── Contains expected content ───────────────────────────────────────────
+      await expect(listbox.locator('text=Organisation')).toBeVisible();
+
+      // Regression screenshot — dropdown visible above page content
+      await page.screenshot({
+        path: path.join(SCREENSHOTS, 'scope-switcher-open.png'),
+        fullPage: false,
+      });
+
+      await page.keyboard.press('Escape');
+    },
+  );
+
+  // ── Test 2: InfoTip on Vue exécutive ────────────────────────────────────────
+  test(
+    'Vue exécutive: InfoTip icons show non-empty tooltip, no ghost bubbles',
+    async ({ page }) => {
+      await login(page);
+      await page.goto('/cockpit');
+
+      // Wait for ImpactDecisionPanel to finish loading (billing summary fetch)
+      await page.waitForSelector('[data-testid="impact-decision-panel"]', {
+        timeout: 15_000,
+      });
+      // Extra wait for async billing data
+      await page.waitForTimeout(1500);
+
+      // ── No ghost tooltip rendered before any hover ──────────────────────────
+      await expect(
+        page.locator('[role="tooltip"]'),
+        'No tooltip should be visible without hover',
+      ).toHaveCount(0);
+
+      // ── At least one InfoTip icon exists on the executive view ─────────────
+      const infotips = page.locator('button[aria-label="Aide contextuelle"]');
+      const count = await infotips.count();
+      expect(count, 'At least one InfoTip button must be rendered').toBeGreaterThan(0);
+      await expect(infotips.first()).toBeVisible({ timeout: 5_000 });
+
+      // ── Hover → tooltip appears with non-empty text content ─────────────────
+      await infotips.first().hover();
+      const tooltip = page.locator('[role="tooltip"]');
+      await expect(tooltip, 'Tooltip must appear on hover').toBeVisible({
+        timeout: 3_000,
+      });
+
+      const text = (await tooltip.textContent()).trim();
+      expect(
+        text.length,
+        'Tooltip must contain meaningful text (no empty bubble)',
+      ).toBeGreaterThan(5);
+
+      // ── Portal assertion: tooltip must be in <body> ─────────────────────────
+      const parentTag = await tooltip.evaluate((el) =>
+        el.parentElement?.tagName ?? 'UNKNOWN',
+      );
+      expect(parentTag, 'Tooltip must be portaled to <body>').toBe('BODY');
+
+      // ── position:fixed ──────────────────────────────────────────────────────
+      const position = await tooltip.evaluate((el) =>
+        window.getComputedStyle(el).position,
+      );
+      expect(position, 'Tooltip must use position:fixed').toBe('fixed');
+
+      // Regression screenshot — tooltip visible above executive content
+      await page.screenshot({
+        path: path.join(SCREENSHOTS, 'infotip-tooltip-visible.png'),
+        fullPage: false,
+      });
+
+      // ── Move away — tooltip must disappear (no lingering phantom ────────────
+      await page.mouse.move(0, 0);
+      await expect(
+        page.locator('[role="tooltip"]'),
+        'Tooltip must disappear after mouse leaves',
+      ).toHaveCount(0, { timeout: 2_000 });
+    },
+  );
+});

--- a/frontend/src/components/SitePicker.jsx
+++ b/frontend/src/components/SitePicker.jsx
@@ -3,6 +3,7 @@
  * Multi-site selector with search, chips, collections, and quick picks.
  */
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { Search, X, Star, FolderOpen, ChevronDown, Save, Check } from 'lucide-react';
 import { getEmsCollections, createEmsCollection } from '../services/api';
 
@@ -19,21 +20,27 @@ function saveRecent(ids) {
 export default function SitePicker({ sites, selectedIds, onChange, maxSelection = 8 }) {
   const [search, setSearch] = useState('');
   const [open, setOpen] = useState(false);
+  const [openCoords, setOpenCoords] = useState(null);
   const [collections, setCollections] = useState([]);
   const [showCollections, setShowCollections] = useState(false);
   const [saveName, setSaveName] = useState('');
   const [recent] = useState(loadRecent);
   const ref = useRef(null);
+  const triggerRef = useRef(null);
+  const dropRef = useRef(null);
 
   // Load collections on mount
   useEffect(() => {
     getEmsCollections().then(setCollections).catch(() => {});
   }, []);
 
-  // Close on outside click
+  // Close on outside click — check both trigger area and portaled dropdown
   useEffect(() => {
     function onClick(e) {
-      if (ref.current && !ref.current.contains(e.target)) {
+      if (
+        ref.current && !ref.current.contains(e.target) &&
+        !(dropRef.current && dropRef.current.contains(e.target))
+      ) {
         setOpen(false);
         setShowCollections(false);
       }
@@ -96,7 +103,14 @@ export default function SitePicker({ sites, selectedIds, onChange, maxSelection 
     <div ref={ref} className="relative">
       {/* Trigger button */}
       <button
-        onClick={() => setOpen(!open)}
+        ref={triggerRef}
+        onClick={() => {
+          if (!open && triggerRef.current) {
+            const r = triggerRef.current.getBoundingClientRect();
+            setOpenCoords({ top: r.bottom + 4, left: r.left });
+          }
+          setOpen(o => !o);
+        }}
         className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 rounded-lg bg-white
           hover:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition min-w-[180px]"
       >
@@ -123,9 +137,13 @@ export default function SitePicker({ sites, selectedIds, onChange, maxSelection 
         </div>
       )}
 
-      {/* Dropdown */}
-      {open && (
-        <div className="absolute z-50 top-full mt-1 left-0 w-80 bg-white border border-gray-200 rounded-xl shadow-xl max-h-[420px] flex flex-col">
+      {/* Dropdown — portaled to body to escape overflow/stacking-context clipping */}
+      {open && openCoords && createPortal(
+        <div
+          ref={dropRef}
+          className="fixed z-[120] w-80 bg-white border border-gray-200 rounded-xl shadow-xl max-h-[420px] flex flex-col"
+          style={{ top: openCoords.top, left: openCoords.left }}
+        >
           {/* Search */}
           <div className="p-2 border-b border-gray-100">
             <div className="relative">
@@ -239,7 +257,8 @@ export default function SitePicker({ sites, selectedIds, onChange, maxSelection 
               <Save size={14} />
             </button>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/frontend/src/layout/AppShell.jsx
+++ b/frontend/src/layout/AppShell.jsx
@@ -2,7 +2,8 @@
  * PROMEOS — AppShell Layout (Rail + Panel)
  * Sidebar (Rail+Panel) + Header + Content with module-tinted header bands.
  */
-import { useEffect, useState, useRef, useMemo } from 'react';
+import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Search, LogOut, ChevronDown, Building2, Command } from 'lucide-react';
 import Sidebar from './Sidebar';
@@ -35,15 +36,29 @@ const ROLE_LABELS = {
 function UserMenu() {
   const { user, org, role, orgs, logout, switchOrg, isAuthenticated } = useAuth();
   const [open, setOpen] = useState(false);
-  const ref = useRef(null);
+  const [dropCoords, setDropCoords] = useState(null);
+  const triggerRef = useRef(null);
+  const dropRef    = useRef(null);
 
+  // Close on outside click — checks both trigger and portal dropdown
   useEffect(() => {
+    if (!open) return;
     function onClickOutside(e) {
-      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+      if (triggerRef.current?.contains(e.target)) return;
+      if (dropRef.current?.contains(e.target)) return;
+      setOpen(false);
     }
     document.addEventListener('mousedown', onClickOutside);
     return () => document.removeEventListener('mousedown', onClickOutside);
-  }, []);
+  }, [open]);
+
+  const toggleOpen = useCallback(() => {
+    if (!open && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setDropCoords({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+    }
+    setOpen((prev) => !prev);
+  }, [open]);
 
   if (!isAuthenticated) {
     return (
@@ -56,9 +71,12 @@ function UserMenu() {
   const initials = `${(user.prenom || '')[0] || ''}${(user.nom || '')[0] || ''}`.toUpperCase() || 'U';
 
   return (
-    <div className="relative" ref={ref}>
+    <div>
       <button
-        onClick={() => setOpen(!open)}
+        ref={triggerRef}
+        onClick={toggleOpen}
+        aria-haspopup="menu"
+        aria-expanded={open}
         className="flex items-center gap-2 hover:bg-gray-50 rounded-lg px-2 py-1 transition"
       >
         <div className="w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center text-xs font-bold">
@@ -71,8 +89,14 @@ function UserMenu() {
         <ChevronDown size={14} className="text-gray-400" />
       </button>
 
-      {open && (
-        <div className="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
+      {/* Menu — portal to document.body, position:fixed right-aligned, z-[120] */}
+      {open && dropCoords && createPortal(
+        <div
+          ref={dropRef}
+          role="menu"
+          className="fixed w-64 bg-white rounded-lg shadow-xl border border-gray-200 py-2 z-[120]"
+          style={{ top: dropCoords.top, right: dropCoords.right }}
+        >
           <div className="px-4 py-2 border-b border-gray-100">
             <p className="text-sm font-medium text-gray-800">{user.prenom} {user.nom}</p>
             <p className="text-xs text-gray-400">{user.email}</p>
@@ -91,7 +115,7 @@ function UserMenu() {
 
           {orgs && orgs.length > 1 && (
             <div className="px-4 py-2 border-b border-gray-100">
-              <p className="text-[10px] uppercase text-gray-400 font-semibold tracking-wide mb-1">Changer d'org</p>
+              <p className="text-[10px] uppercase text-gray-400 font-semibold tracking-wide mb-1">Changer d&apos;org</p>
               {orgs.filter(o => o.id !== org?.id).map(o => (
                 <button
                   key={o.id}
@@ -111,7 +135,8 @@ function UserMenu() {
             <LogOut size={14} />
             Deconnexion
           </button>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );
@@ -153,7 +178,7 @@ export default function AppShell() {
       <Sidebar />
       <div className="flex-1 flex flex-col min-w-0">
         {/* Header — glass surface */}
-        <header className="bg-white/80 backdrop-blur-md border-b border-slate-200/70 px-6 py-3 flex items-center justify-between sticky top-0 z-10">
+        <header className="bg-white/80 backdrop-blur-md border-b border-slate-200/70 px-6 py-3 flex items-center justify-between sticky top-0 z-40">
           <div className="flex items-center gap-4">
             <Breadcrumb />
             <div className="relative">

--- a/frontend/src/layout/ScopeSwitcher.jsx
+++ b/frontend/src/layout/ScopeSwitcher.jsx
@@ -1,8 +1,12 @@
 /**
  * PROMEOS - Scope Switcher
  * Dropdown selectors: Org → Portefeuille → Site, plus a "scope pill" showing current scope.
+ *
+ * Dropdown rendered via createPortal (document.body, position:fixed, z-[120])
+ * to escape the header's backdrop-blur-md stacking context.
  */
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { Building2, ChevronDown, X, Briefcase, MapPin } from 'lucide-react';
 import { useScope } from '../contexts/ScopeContext';
 
@@ -12,21 +16,40 @@ export default function ScopeSwitcher() {
     setOrg, setPortefeuille, setSite, resetScope,
   } = useScope();
   const [open, setOpen] = useState(false);
-  const ref = useRef(null);
+  const [dropCoords, setDropCoords] = useState(null);
+  const triggerRef = useRef(null);
+  const dropRef    = useRef(null);
 
+  // Close on outside click — checks both the trigger pill and the portal dropdown
   useEffect(() => {
-    function handleClick(e) { if (ref.current && !ref.current.contains(e.target)) setOpen(false); }
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, []);
+    if (!open) return;
+    function onClickOutside(e) {
+      if (triggerRef.current?.contains(e.target)) return;
+      if (dropRef.current?.contains(e.target)) return;
+      setOpen(false);
+    }
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [open]);
+
+  const toggleOpen = useCallback(() => {
+    if (!open && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setDropCoords({ top: rect.bottom + 4, left: rect.left });
+    }
+    setOpen((prev) => !prev);
+  }, [open]);
 
   const hasSites = orgSites.length > 0;
 
   return (
-    <div className="flex items-center gap-2" ref={ref}>
-      {/* Scope pill */}
+    <div className="flex items-center gap-2">
+      {/* Scope pill trigger */}
       <button
-        onClick={() => setOpen(!open)}
+        ref={triggerRef}
+        onClick={toggleOpen}
+        aria-haspopup="listbox"
+        aria-expanded={open}
         className="flex items-center gap-2 px-3 py-1.5 bg-blue-50 border border-blue-200 rounded-full text-sm text-blue-700 hover:bg-blue-100 transition"
       >
         <Building2 size={14} />
@@ -52,9 +75,14 @@ export default function ScopeSwitcher() {
         </button>
       )}
 
-      {/* Dropdown */}
-      {open && (
-        <div className="absolute top-full left-0 mt-1 w-72 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-2 max-h-[80vh] overflow-y-auto">
+      {/* Dropdown — portal to document.body, position:fixed, z-[120] */}
+      {open && dropCoords && createPortal(
+        <div
+          ref={dropRef}
+          role="listbox"
+          className="fixed w-72 bg-white rounded-lg shadow-xl border border-gray-200 py-2 max-h-[80vh] overflow-y-auto z-[120]"
+          style={{ top: dropCoords.top, left: dropCoords.left }}
+        >
           {/* Org selector */}
           <div className="px-3 py-1.5">
             <p className="text-xs font-semibold text-gray-400 uppercase mb-1">Organisation</p>
@@ -127,7 +155,8 @@ export default function ScopeSwitcher() {
               </div>
             </>
           )}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/frontend/src/layout/Sidebar.jsx
+++ b/frontend/src/layout/Sidebar.jsx
@@ -88,10 +88,10 @@ export default function Sidebar() {
 
   return (
     // ── Z-index layer map ─────────────────────────────────────────────────────
-    // z-10     App header  (AppShell.jsx — sticky top-0 z-10 backdrop-blur-md)
-    // z-30     Sidebar aside — explicit stacking context, above header
-    // z-50     Modals, UserMenu, ScopeSwitcher dropdowns
-    // z-[9999] TooltipPortal  (document.body — always topmost)
+    // z-30     Sidebar aside   (sticky, left column)
+    // z-40     App header      (AppShell.jsx — sticky top-0 backdrop-blur-md)
+    // z-[120]  Overlays        (dropdowns/popovers/tooltips — portal to body)
+    // z-[200]  Modals          (full-screen overlays — portal to body)
     // ─────────────────────────────────────────────────────────────────────────
     <aside className="flex h-screen sticky top-0 z-30 shrink-0" aria-label="Navigation principale">
       <NavRail

--- a/frontend/src/pages/cockpit/DataActivationPanel.jsx
+++ b/frontend/src/pages/cockpit/DataActivationPanel.jsx
@@ -8,9 +8,10 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  Database, CheckCircle2, Circle, ArrowRight, Loader2, Info,
+  Database, CheckCircle2, Circle, ArrowRight, Loader2,
 } from 'lucide-react';
-import { Card, CardBody, Tooltip, Button, Progress } from '../../ui';
+import { Card, CardBody, InfoTip, Button, Progress } from '../../ui';
+import { TOOLTIPS } from '../../ui/tooltips';
 import { getBillingSummary, getPurchaseRenewals, patrimoineContracts } from '../../services/api';
 import { normalizePurchaseSignals } from '../../models/purchaseSignalsContract';
 import { buildActivationChecklist } from '../../models/dataActivationModel';
@@ -73,9 +74,7 @@ export default function DataActivationPanel({ kpis }) {
           <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
             Activation des données
           </h4>
-          <Tooltip text="Couverture des 5 briques de données nécessaires aux recommandations">
-            <Info size={12} className="text-gray-400 cursor-help" />
-          </Tooltip>
+          <InfoTip content={TOOLTIPS.executive.activationDonnees} />
         </div>
         <span className="text-xs font-medium text-gray-500">
           {activation.activatedCount}/{activation.totalDimensions} briques

--- a/frontend/src/pages/cockpit/DataActivationPanel.jsx
+++ b/frontend/src/pages/cockpit/DataActivationPanel.jsx
@@ -73,7 +73,7 @@ export default function DataActivationPanel({ kpis }) {
           <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
             Activation des données
           </h4>
-          <Tooltip content="Couverture des 5 briques de donnees necessaires aux recommandations">
+          <Tooltip text="Couverture des 5 briques de données nécessaires aux recommandations">
             <Info size={12} className="text-gray-400 cursor-help" />
           </Tooltip>
         </div>

--- a/frontend/src/pages/cockpit/ImpactDecisionPanel.jsx
+++ b/frontend/src/pages/cockpit/ImpactDecisionPanel.jsx
@@ -51,7 +51,7 @@ function ImpactKpiTile({ icon: Icon, label, value, available, tooltip, accent, o
             </span>
           )}
           {tooltip && (
-            <Tooltip content={tooltip}>
+            <Tooltip text={tooltip}>
               <Info size={12} className="text-gray-400 cursor-help" />
             </Tooltip>
           )}
@@ -168,7 +168,7 @@ export default function ImpactDecisionPanel({ kpis }) {
         <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
           Impact & Décision
         </h3>
-        <Tooltip content="Calculs V1 — règles déterministes basées sur vos données réelles">
+        <Tooltip text="Calculs V1 — règles déterministes basées sur vos données réelles">
           <span className="text-[10px] text-gray-400 border border-gray-200 rounded px-1.5 py-0.5 cursor-help">
             V1
           </span>
@@ -222,7 +222,7 @@ export default function ImpactDecisionPanel({ kpis }) {
           <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
             Achats d&apos;energie
           </h4>
-          <Tooltip content="Signaux d\u00e9riv\u00e9s des contrats renseign\u00e9s \u2014 heuristique V1">
+          <Tooltip text="Signaux dérivés des contrats renseignés — heuristique V1">
             <Info size={12} className="text-gray-400 cursor-help" />
           </Tooltip>
         </div>

--- a/frontend/src/pages/cockpit/ImpactDecisionPanel.jsx
+++ b/frontend/src/pages/cockpit/ImpactDecisionPanel.jsx
@@ -11,9 +11,10 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  ShieldAlert, Receipt, TrendingUp, ArrowRight, Info, Loader2, Zap, ShoppingCart,
+  ShieldAlert, Receipt, TrendingUp, ArrowRight, Loader2, Zap, ShoppingCart,
 } from 'lucide-react';
-import { Card, CardBody, Badge, Tooltip, Button } from '../../ui';
+import { Card, CardBody, Badge, InfoTip, Button } from '../../ui';
+import { TOOLTIPS } from '../../ui/tooltips';
 import { KPI_ACCENTS } from '../../ui/colorTokens';
 import { fmtEur } from '../../utils/format';
 import { getBillingSummary, getPurchaseRenewals, patrimoineContracts } from '../../services/api';
@@ -50,11 +51,7 @@ function ImpactKpiTile({ icon: Icon, label, value, available, tooltip, accent, o
               Prioritaire
             </span>
           )}
-          {tooltip && (
-            <Tooltip text={tooltip}>
-              <Info size={12} className="text-gray-400 cursor-help" />
-            </Tooltip>
-          )}
+          <InfoTip content={tooltip} />
         </div>
         <p className="text-lg font-bold text-gray-900 mt-0.5">
           {available ? fmtEur(value) : '—'}
@@ -168,11 +165,12 @@ export default function ImpactDecisionPanel({ kpis }) {
         <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
           Impact & Décision
         </h3>
-        <Tooltip text="Calculs V1 — règles déterministes basées sur vos données réelles">
-          <span className="text-[10px] text-gray-400 border border-gray-200 rounded px-1.5 py-0.5 cursor-help">
+        <div className="flex items-center gap-1">
+          <span className="text-[10px] text-gray-400 border border-gray-200 rounded px-1.5 py-0.5">
             V1
           </span>
-        </Tooltip>
+          <InfoTip content={TOOLTIPS.executive.calculsV1} />
+        </div>
       </div>
 
       {/* ── 3 KPIs ── */}
@@ -182,7 +180,7 @@ export default function ImpactDecisionPanel({ kpis }) {
           label="Risque conformité"
           value={impact.risqueConformite}
           available={impact.risqueAvailable}
-          tooltip="Somme des risques financiers des sites non conformes ou à risque dans le périmètre actif"
+          tooltip={TOOLTIPS.executive.risqueConformite}
           accent="risque"
           onClick={() => handleDrillDown('risque')}
           ariaLabel="Voir les sites à risque conformité"
@@ -194,7 +192,7 @@ export default function ImpactDecisionPanel({ kpis }) {
           label="Surcoût facture"
           value={impact.surcoutFacture}
           available={impact.surcoutAvailable}
-          tooltip="Total des pertes identifiées par le moteur d'audit facture (shadow billing)"
+          tooltip={TOOLTIPS.executive.surcoutFacture}
           accent="alertes"
           onClick={() => handleDrillDown('surcout')}
           ariaLabel="Voir les anomalies de facturation"
@@ -206,7 +204,7 @@ export default function ImpactDecisionPanel({ kpis }) {
           label="Opportunité optimisation"
           value={impact.opportuniteOptim}
           available={impact.optimAvailable}
-          tooltip="Heuristique V1 : 1 % du montant facturé total — affiné à mesure que les données s'enrichissent"
+          tooltip={TOOLTIPS.executive.opportuniteOptim}
           accent="conformite"
           onClick={() => handleDrillDown('optimisation')}
           ariaLabel="Voir les sites énergivores"
@@ -222,9 +220,7 @@ export default function ImpactDecisionPanel({ kpis }) {
           <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
             Achats d&apos;energie
           </h4>
-          <Tooltip text="Signaux dérivés des contrats renseignés — heuristique V1">
-            <Info size={12} className="text-gray-400 cursor-help" />
-          </Tooltip>
+          <InfoTip content={TOOLTIPS.executive.achatsEnergie} />
         </div>
         {isPurchaseAvailable(purchaseSignals) ? (
           <div className="grid grid-cols-3 gap-3">

--- a/frontend/src/pages/consumption/InfoTooltip.jsx
+++ b/frontend/src/pages/consumption/InfoTooltip.jsx
@@ -2,41 +2,59 @@
  * PROMEOS — InfoTooltip (Sprint V13)
  * Small "?" bubble with a hover tooltip in French.
  * Renders inline; works next to any label or button.
+ * V2: portal-based to escape sticky/backdrop-blur stacking contexts.
  *
  * Props:
  *   text       — tooltip text (required, French)
  *   position   — 'top' (default) | 'bottom'
  */
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 
 export default function InfoTooltip({ text, position = 'top' }) {
   const [show, setShow] = useState(false);
+  const [coords, setCoords] = useState(null);
+  const triggerRef = useRef(null);
+
+  const computeAndShow = useCallback(() => {
+    if (triggerRef.current) {
+      const r = triggerRef.current.getBoundingClientRect();
+      const cx = r.left + r.width / 2;
+      setCoords(
+        position === 'bottom'
+          ? { top: r.bottom + 4, left: cx, transform: 'translateX(-50%)' }
+          : { top: r.top - 4,    left: cx, transform: 'translate(-50%, -100%)' },
+      );
+    }
+    setShow(true);
+  }, [position]);
+
+  const hide = useCallback(() => setShow(false), []);
 
   return (
     <span className="relative inline-flex items-center">
       <button
+        ref={triggerRef}
         type="button"
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
-        onFocus={() => setShow(true)}
-        onBlur={() => setShow(false)}
+        onMouseEnter={computeAndShow}
+        onMouseLeave={hide}
+        onFocus={computeAndShow}
+        onBlur={hide}
         className="w-3.5 h-3.5 rounded-full bg-gray-200 text-gray-500 hover:bg-gray-300 text-[9px] font-bold flex items-center justify-center cursor-help leading-none"
         aria-label={text}
         tabIndex={0}
       >
         ?
       </button>
-      {show && (
+      {show && coords && createPortal(
         <span
           role="tooltip"
-          className={`absolute z-50 w-48 text-[10px] leading-snug bg-gray-800 text-white rounded-md px-2.5 py-1.5 shadow-lg pointer-events-none whitespace-normal
-            ${position === 'bottom'
-              ? 'top-full left-1/2 -translate-x-1/2 mt-1'
-              : 'bottom-full left-1/2 -translate-x-1/2 mb-1'
-            }`}
+          className="fixed z-[120] w-48 text-[10px] leading-snug bg-gray-800 text-white rounded-md px-2.5 py-1.5 shadow-lg pointer-events-none whitespace-normal"
+          style={{ top: coords.top, left: coords.left, transform: coords.transform }}
         >
           {text}
-        </span>
+        </span>,
+        document.body,
       )}
     </span>
   );

--- a/frontend/src/pages/consumption/InsightsStrip.jsx
+++ b/frontend/src/pages/consumption/InsightsStrip.jsx
@@ -2,12 +2,14 @@
  * PROMEOS — InsightsStrip
  * Horizontal scrollable strip of auto-generated insight badges.
  * Displayed below the tab bar, above the active panel.
+ * V2: detail popup portaled to body (escapes sticky/overflow clipping).
  *
  * Props:
  *   insights  {object[]}  array of { id, label, severity, detail }
  *                         severity: 'info' | 'warn' | 'crit'
  */
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { Info, AlertTriangle, AlertOctagon, X } from 'lucide-react';
 
 const SEVERITY_STYLES = {
@@ -33,14 +35,27 @@ const SEVERITY_STYLES = {
 
 function InsightBadge({ insight, onDismiss }) {
   const [expanded, setExpanded] = useState(false);
+  const [coords, setCoords] = useState(null);
+  const badgeRef = useRef(null);
   const style = SEVERITY_STYLES[insight.severity] || SEVERITY_STYLES.info;
   const Icon = style.Icon;
 
+  const handleToggle = () => {
+    if (!expanded && badgeRef.current) {
+      const r = badgeRef.current.getBoundingClientRect();
+      setCoords({ top: r.bottom + 4, left: r.left });
+    }
+    setExpanded(v => !v);
+  };
+
   return (
-    <div className={`relative flex-shrink-0 border rounded-lg px-3 py-1.5 ${style.bg} ${style.text} max-w-xs`}>
+    <div
+      ref={badgeRef}
+      className={`relative flex-shrink-0 border rounded-lg px-3 py-1.5 ${style.bg} ${style.text} max-w-xs`}
+    >
       <button
         className="flex items-center gap-1.5 text-xs font-medium"
-        onClick={() => setExpanded(v => !v)}
+        onClick={handleToggle}
         title="Voir le detail"
       >
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${style.dot}`} />
@@ -48,9 +63,12 @@ function InsightBadge({ insight, onDismiss }) {
         <span>{insight.label}</span>
       </button>
 
-      {/* Detail tooltip on click */}
-      {expanded && insight.detail && (
-        <div className="absolute top-full left-0 mt-1 z-30 bg-white border border-gray-200 rounded-lg shadow-lg p-3 text-xs text-gray-700 w-64">
+      {/* Detail popup on click — portaled to escape overflow/stacking clipping */}
+      {expanded && insight.detail && coords && createPortal(
+        <div
+          className="fixed z-[120] bg-white border border-gray-200 rounded-lg shadow-lg p-3 text-xs text-gray-700 w-64"
+          style={{ top: coords.top, left: coords.left }}
+        >
           {insight.detail}
           <button
             onClick={(e) => { e.stopPropagation(); setExpanded(false); }}
@@ -58,7 +76,8 @@ function InsightBadge({ insight, onDismiss }) {
           >
             <X size={12} />
           </button>
-        </div>
+        </div>,
+        document.body,
       )}
 
       {/* Dismiss */}

--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -36,6 +36,7 @@
  *   onDeletePreset(name)        delete preset callback
  */
 import { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { X, Zap, Flame, Save, RotateCcw, Link, ChevronDown, Trash2, Plus, LayoutGrid } from 'lucide-react';
 import { TrustBadge } from '../../ui';
 import { computeGranularity, colorForSite, getAvailableGranularities } from './helpers';
@@ -85,19 +86,50 @@ function todayISO() {
 }
 
 // ── Site Search Dropdown ──────────────────────────────────────────────────────
-function SiteSearchDropdown({ sites, selectedIds, onAdd, onClose }) {
+// Portaled to document.body — escapes the sticky+backdrop-blur stacking context.
+function SiteSearchDropdown({ sites, selectedIds, onAdd, onClose, anchorRef }) {
   const [query, setQuery] = useState('');
+  const [coords, setCoords] = useState(null);
   const inputRef = useRef(null);
+  const dropRef = useRef(null);
 
   useEffect(() => { inputRef.current?.focus(); }, []);
+
+  // Compute fixed position from the anchor element
+  useEffect(() => {
+    if (anchorRef?.current) {
+      const r = anchorRef.current.getBoundingClientRect();
+      setCoords({ top: r.bottom + 4, left: r.left });
+    }
+  }, [anchorRef]);
+
+  // Outside-click closes the dropdown (checks both anchor and portaled div)
+  useEffect(() => {
+    function handler(e) {
+      if (
+        dropRef.current && !dropRef.current.contains(e.target) &&
+        anchorRef?.current && !anchorRef.current.contains(e.target)
+      ) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onClose, anchorRef]);
 
   const available = sites.filter(
     s => !selectedIds.includes(s.id) &&
       s.nom.toLowerCase().includes(query.toLowerCase())
   );
 
-  return (
-    <div className="absolute top-full left-0 mt-1 w-60 bg-white rounded-lg shadow-lg border border-gray-200 z-40 py-1">
+  if (!coords) return null;
+
+  return createPortal(
+    <div
+      ref={dropRef}
+      className="fixed w-60 bg-white rounded-lg shadow-lg border border-gray-200 z-[120] py-1"
+      style={{ top: coords.top, left: coords.left }}
+    >
       <div className="px-2 py-1.5 border-b border-gray-100">
         <input
           ref={inputRef}
@@ -125,7 +157,8 @@ function SiteSearchDropdown({ sites, selectedIds, onAdd, onClose }) {
           );
         })}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -261,18 +294,24 @@ export default function StickyFilterBar({
   const [showAddSite, setShowAddSite] = useState(false);
 
   const addRef = useRef(null);
+  const presetsBtnRef = useRef(null);
+  const presetsDropRef = useRef(null);
+  const [presetsCoords, setPresetsCoords] = useState(null);
 
-  // Close site search on outside click
+  // Close presets dropdown on outside click
   useEffect(() => {
-    if (!showAddSite) return;
+    if (!showPresets) return;
     const handler = (e) => {
-      if (addRef.current && !addRef.current.contains(e.target)) {
-        setShowAddSite(false);
+      if (
+        presetsDropRef.current && !presetsDropRef.current.contains(e.target) &&
+        presetsBtnRef.current && !presetsBtnRef.current.contains(e.target)
+      ) {
+        setShowPresets(false);
       }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, [showAddSite]);
+  }, [showPresets]);
 
   const gran = computeGranularity(days);
   const confidence = availability?.has_data
@@ -376,7 +415,7 @@ export default function StickyFilterBar({
 
             {/* "+" add site button — only when more sites exist to add */}
             {effectiveSiteIds.length < MAX_SITES && sites.length > effectiveSiteIds.length && (
-              <div className="relative" ref={addRef}>
+              <div ref={addRef}>
                 <button
                   onClick={() => setShowAddSite(v => !v)}
                   className="flex items-center justify-center w-6 h-6 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 transition"
@@ -386,6 +425,7 @@ export default function StickyFilterBar({
                 </button>
                 {showAddSite && (
                   <SiteSearchDropdown
+                    anchorRef={addRef}
                     sites={sites}
                     selectedIds={effectiveSiteIds}
                     onAdd={(id) => { toggleSite(id); }}
@@ -626,16 +666,27 @@ export default function StickyFilterBar({
 
           {/* Presets dropdown */}
           {savedPresets.length > 0 && onLoadPreset && (
-            <div className="relative">
+            <div>
               <button
-                onClick={() => setShowPresets(v => !v)}
+                ref={presetsBtnRef}
+                onClick={() => {
+                  if (!showPresets && presetsBtnRef.current) {
+                    const r = presetsBtnRef.current.getBoundingClientRect();
+                    setPresetsCoords({ top: r.bottom + 4, left: r.left });
+                  }
+                  setShowPresets(v => !v);
+                }}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition"
               >
                 Presets ({savedPresets.length})
                 <ChevronDown size={11} />
               </button>
-              {showPresets && (
-                <div className="absolute top-full left-0 mt-1 w-52 bg-white rounded-lg shadow-lg border border-gray-200 z-30 py-1">
+              {showPresets && presetsCoords && createPortal(
+                <div
+                  ref={presetsDropRef}
+                  className="fixed w-52 bg-white rounded-lg shadow-lg border border-gray-200 z-[120] py-1"
+                  style={{ top: presetsCoords.top, left: presetsCoords.left }}
+                >
                   {savedPresets.map(p => (
                     <div key={p.name} className="flex items-center gap-1 px-2 py-1.5 hover:bg-gray-50 group">
                       <button
@@ -656,7 +707,8 @@ export default function StickyFilterBar({
                       )}
                     </div>
                   ))}
-                </div>
+                </div>,
+                document.body,
               )}
             </div>
           )}

--- a/frontend/src/ui/InfoTip.jsx
+++ b/frontend/src/ui/InfoTip.jsx
@@ -1,0 +1,110 @@
+/**
+ * PROMEOS Design System — InfoTip
+ * Self-contained info icon with portal tooltip.
+ *
+ * Features:
+ *   - Returns null when content is empty/undefined (no black dot, no empty bubble)
+ *   - Portal rendering in document.body (avoids stacking context / overflow clipping)
+ *   - max-width 280px, text wrapping, border, shadow, z-index 120
+ *   - aria-label, focus ring, keyboard accessible (Tab + Enter/Space)
+ *   - ~200ms hover delay (anti-flicker)
+ *
+ * Usage:
+ *   <InfoTip content="Explanation text" />
+ *   <InfoTip content={TOOLTIPS.executive.risqueConformite} position="bottom" />
+ */
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Info } from 'lucide-react';
+
+const DELAY_MS = 200;
+const OFFSET   = 8;   // px gap between icon and tooltip bubble
+
+function _getCoords(rect, position) {
+  const cx = rect.left + rect.width / 2;
+  const cy = rect.top  + rect.height / 2;
+  switch (position) {
+    case 'bottom': return { top: rect.bottom + OFFSET, left: cx,            transform: 'translateX(-50%)' };
+    case 'left':   return { top: cy,                   left: rect.left - OFFSET, transform: 'translate(-100%, -50%)' };
+    case 'right':  return { top: cy,                   left: rect.right + OFFSET, transform: 'translateY(-50%)' };
+    default:       return { top: rect.top - OFFSET,    left: cx,            transform: 'translate(-50%, -100%)' };
+  }
+}
+
+export default function InfoTip({
+  content,
+  position  = 'top',
+  size      = 12,
+  className = '',
+}) {
+  const [visible, setVisible] = useState(false);
+  const [coords,  setCoords]  = useState(null);
+  const triggerRef = useRef(null);
+  const timerRef   = useRef(null);
+  const tooltipId  = useRef(`it-${Math.random().toString(36).slice(2)}`);
+
+  const show = useCallback(() => {
+    if (!content) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      if (triggerRef.current) {
+        const rect = triggerRef.current.getBoundingClientRect();
+        const raw  = _getCoords(rect, position);
+        const vw   = typeof window !== 'undefined' ? window.innerWidth  : 1280;
+        const vh   = typeof window !== 'undefined' ? window.innerHeight : 800;
+        setCoords({
+          ...raw,
+          left: Math.max(8, Math.min(raw.left, vw - 296)),   // 280px + 16px margin
+          top:  Math.max(8, Math.min(raw.top,  vh - 80)),
+        });
+      }
+      setVisible(true);
+    }, DELAY_MS);
+  }, [position, content]);
+
+  const hide = useCallback(() => {
+    clearTimeout(timerRef.current);
+    setVisible(false);
+  }, []);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  // Guard: after hooks — no content → render nothing
+  if (!content) return null;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Aide contextuelle"
+        aria-describedby={visible ? tooltipId.current : undefined}
+        className={`inline-flex items-center justify-center shrink-0 text-gray-400
+          hover:text-gray-600 rounded cursor-help transition-colors
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1
+          ${className}`}
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+      >
+        <Info size={size} aria-hidden="true" />
+      </button>
+
+      {visible && coords && createPortal(
+        <div
+          id={tooltipId.current}
+          role="tooltip"
+          className="fixed pointer-events-none z-[120]"
+          style={{ top: coords.top, left: coords.left, transform: coords.transform }}
+        >
+          <div className="max-w-[280px] px-3 py-2 text-xs text-gray-700 leading-relaxed
+            bg-white border border-gray-200 rounded-lg shadow-lg">
+            {content}
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/frontend/src/ui/index.js
+++ b/frontend/src/ui/index.js
@@ -34,3 +34,7 @@ export { default as ScopeSummary } from './ScopeSummary';
 
 // Design System V5 — Conventions & UX standardisation
 export { LAYOUT, TYPO, LABELS_FR } from './conventions';
+
+// Design System V6 — InfoTip + Tooltip content map
+export { default as InfoTip } from './InfoTip';
+export { TOOLTIPS } from './tooltips';

--- a/frontend/src/ui/tooltips.js
+++ b/frontend/src/ui/tooltips.js
@@ -1,0 +1,23 @@
+/**
+ * PROMEOS — Tooltip content map
+ * Centralise les textes d'aide pour éviter les duplications inline.
+ *
+ * Convention: TOOLTIPS.<page>.<key>
+ */
+
+export const TOOLTIPS = {
+  executive: {
+    risqueConformite:
+      "Somme des risques financiers des sites non conformes ou à risque dans le périmètre actif.",
+    surcoutFacture:
+      "Total des pertes identifiées par le moteur d'audit facture (shadow billing).",
+    opportuniteOptim:
+      "Heuristique V1 : 1 % du montant facturé total — affiné à mesure que les données s'enrichissent.",
+    calculsV1:
+      "Calculs V1 — règles déterministes basées sur vos données réelles.",
+    achatsEnergie:
+      "Signaux dérivés des contrats renseignés — heuristique V1.",
+    activationDonnees:
+      "Couverture des 5 briques de données nécessaires aux recommandations.",
+  },
+};


### PR DESCRIPTION
## Summary

- **fix(cockpit)**: rename `content→text` prop on all Tooltip usages in Vue exécutive (`b51d719`)
- **fix(executive)**: create `InfoTip` component with portaled tooltip, fix empty ghost bubbles (`ec96814`)
- **fix(ui)**: portalize ScopeSwitcher topbar dropdown, establish z-index layer map (`b6b7d5c`)
- **chore(ui)**: systematic overlay audit — portalize StickyFilterBar (HIGH), SitePicker, InsightsStrip, InfoTooltip (MEDIUM); create `docs/ux-overlays.md` (`74a9cc9`)
- **test(ui)**: Playwright smoke tests for portal/z-index regression detection (`acbb676`)

## Why portals?
`backdrop-filter: blur()` + `position: sticky` create CSS stacking contexts that trap `position:absolute` children regardless of z-index. Solution: `createPortal` → `document.body` + `position:fixed` + `getBoundingClientRect()` coords.

## Z-index layer hierarchy
| Layer | Value |
|-------|-------|
| Modals/Drawers | `z-[200]` |
| Portal overlays | `z-[120]` |
| Header | `z-40` |
| Sidebar | `z-30` |
| StickyFilterBar | `z-20` |

## Test plan
- [ ] ScopeSwitcher dropdown opens over StickyFilterBar (no clipping)
- [ ] InfoTooltip/InfoTip hover shows tooltip text (no empty ghost bubble)
- [ ] SitePicker dropdown opens correctly from filter bar
- [ ] InsightsStrip badge detail popup visible
- [ ] `pnpm exec playwright test e2e/overlays.spec.js` passes
- [ ] No console z-index errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)