### PR TITLE
fix(ui): premium portal overlays — hook scroll/resize/zoom + z-index + testids

### DIFF
--- a/docs/ux-overlays.md
+++ b/docs/ux-overlays.md
@@ -1,43 +1,43 @@
-# UX Overlays — Audit & Règles (V1)
+# UX Overlays — Audit, Règles & Hook Premium (V2)
 
 > **But :** Référence pour tous les dropdowns, tooltips, popovers et modals du projet.
-> Garantit qu'aucun overlay ne se retrouve clippé derrière un contenu voisin.
+> Garantit qu'aucun overlay n'est clippé derrière du contenu, ne dérive au scroll, ni ne sort du viewport.
 
 ---
 
 ## 1. Inventaire des composants overlay
 
-| Composant | Fichier | Portal | Z-index | Risque | Statut |
-|-----------|---------|--------|---------|--------|--------|
-| `UserMenu` dropdown | `layout/AppShell.jsx` | ✅ `document.body` | `z-[120]` | — | ✅ OK |
-| `ScopeSwitcher` dropdown | `layout/ScopeSwitcher.jsx` | ✅ `document.body` | `z-[120]` | — | ✅ OK |
-| `NavPanel` (sidebar) | `layout/NavPanel.jsx` | ❌ non-portal | `z-30` | Faible — toujours à gauche | ✅ OK |
-| `CommandPalette` | `ui/CommandPalette.jsx` | ✅ (overlay plein écran) | `z-[200]` | — | ✅ OK |
-| `Modal` | `ui/Modal.jsx` | ✅ `document.body` | `z-[200]` | — | ✅ OK |
-| `Drawer` | `ui/Drawer.jsx` | ✅ `document.body` | `z-[200]` | — | ✅ OK |
-| `TooltipPortal` | `ui/TooltipPortal.jsx` | ✅ `document.body` | `z-[9999]` | — | ✅ OK |
-| `InfoTip` | `ui/InfoTip.jsx` | ✅ `document.body` | `z-[120]` | — | ✅ OK |
-| `InfoTooltip` (consumption) | `pages/consumption/InfoTooltip.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute` dans sticky+blur | ✅ **Fixed V1** |
-| `SiteSearchDropdown` | `pages/consumption/StickyFilterBar.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute z-40` dans sticky+blur | ✅ **Fixed V1** |
-| Presets dropdown | `pages/consumption/StickyFilterBar.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute z-30` dans sticky+blur | ✅ **Fixed V1** |
-| `SitePicker` dropdown | `components/SitePicker.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute z-50` | ✅ **Fixed V1** |
-| `InsightBadge` detail | `pages/consumption/InsightsStrip.jsx` | ✅ `document.body` | `z-[120]` | Était `absolute z-30` | ✅ **Fixed V1** |
+| Composant | Fichier | Portal | Z-index | scroll/resize | Statut |
+|-----------|---------|--------|---------|---------------|--------|
+| `UserMenu` dropdown | `layout/AppShell.jsx` | ✅ body | `z-[120]` | — | ✅ OK |
+| `ScopeSwitcher` dropdown | `layout/ScopeSwitcher.jsx` | ✅ body | `z-[120]` | ✅ hook | ✅ Premium V2 |
+| `NavPanel` (sidebar) | `layout/NavPanel.jsx` | ❌ non-portal | `z-30` | — | ✅ OK (sidebar fixe) |
+| `CommandPalette` | `ui/CommandPalette.jsx` | ✅ body | `z-[200]` | — | ✅ OK |
+| `Modal` | `ui/Modal.jsx` | ✅ body | `z-[200]` | — | ✅ OK |
+| `Drawer` | `ui/Drawer.jsx` | ✅ body | `z-[200]` | — | ✅ OK |
+| `TooltipPortal` | `ui/TooltipPortal.jsx` | ✅ body | `z-[120]` ✅ | — | ✅ **z-[9999]→z-[120] V2** |
+| `InfoTip` | `ui/InfoTip.jsx` | ✅ body | `z-[120]` | — | ✅ OK |
+| `InfoTooltip` (consumption) | `pages/consumption/InfoTooltip.jsx` | ✅ body | `z-[120]` | — | ✅ Fixed V1 |
+| `SiteSearchDropdown` | `pages/consumption/StickyFilterBar.jsx` | ✅ body | `z-[120]` | ✅ hook | ✅ Premium V2 |
+| Presets dropdown | `pages/consumption/StickyFilterBar.jsx` | ✅ body | `z-[120]` | ✅ hook | ✅ Premium V2 |
+| `SitePicker` dropdown | `components/SitePicker.jsx` | ✅ body | `z-[120]` | ✅ hook | ✅ Premium V2 |
+| `InsightBadge` detail | `pages/consumption/InsightsStrip.jsx` | ✅ body | `z-[120]` | — | ✅ Fixed V1 |
 
 ---
 
-## 2. Carte des couches Z-index
+## 2. Carte Z-index canonique
 
 ```
-z-[200]  Modals, Drawer, CommandPalette  (pleins écrans — portal body)
-z-[120]  Dropdowns, tooltips, popovers  (portal body — tous overlays)
-z-40     Header sticky                   (AppShell — backdrop-blur-md)
-z-30     Sidebar aside                   (sticky left column)
-z-20     StickyFilterBar                 (sticky top — backdrop-blur)
+z-[200]  Modals, Drawer, CommandPalette   (plein écran — portal body)
+z-[120]  Dropdowns, tooltips, popovers   (portal body — TOUS les overlays)
+z-40     Header sticky                    (AppShell — backdrop-blur-md)
+z-30     Sidebar aside                    (sticky left column)
+z-20     StickyFilterBar                  (sticky top — backdrop-blur)
 z-auto   Contenu de page normal
 ```
 
-> **Règle absolue :** aucun overlay ne peut exister à moins de `z-[120]` rendu dans `document.body`.
-> Un overlay dans un élément `z-20` sera toujours caché derrière un élément frère `z-21`.
+> **Règle absolue :** aucun overlay à moins de `z-[120]`, rendu dans `document.body`.
+> Ne jamais utiliser de valeurs ad-hoc (z-50, z-[9999], z-9999) — elles cassent la cohérence.
 
 ---
 
@@ -45,24 +45,22 @@ z-auto   Contenu de page normal
 
 ### Règle 1 — Tout overlay = Portal + `position: fixed`
 
-Un overlay (dropdown, tooltip, popover) **doit** être rendu dans `document.body` via `createPortal`.
-Sa position est calculée depuis `element.getBoundingClientRect()` et appliquée en `style={{ top, left }}` avec `position: fixed`.
+Un overlay **doit** être rendu dans `document.body` via `createPortal`.
+Sa position est calculée en `position: fixed` — jamais en `position: absolute`.
 
 ```jsx
-// ✅ Correct
-const [coords, setCoords] = useState(null);
-const triggerRef = useRef(null);
+// ✅ CORRECT — portal + fixed + hook
+import useFloatingPortalPosition from '@/hooks/useFloatingPortalPosition';
 
-const open = () => {
-  const r = triggerRef.current.getBoundingClientRect();
-  setCoords({ top: r.bottom + 4, left: r.left });
-};
+const triggerRef = useRef(null);
+const dropRef    = useRef(null);
+const { style } = useFloatingPortalPosition({ isOpen, triggerRef, portalRef: dropRef });
 
 return (
   <>
-    <button ref={triggerRef} onClick={open}>Ouvrir</button>
-    {visible && coords && createPortal(
-      <div className="fixed z-[120]" style={{ top: coords.top, left: coords.left }}>
+    <button ref={triggerRef} onClick={() => setOpen(true)}>Ouvrir</button>
+    {isOpen && createPortal(
+      <div ref={dropRef} className="fixed z-[120] w-64 bg-white ..." style={style}>
         Contenu overlay
       </div>,
       document.body,
@@ -70,58 +68,98 @@ return (
   </>
 );
 
-// ❌ Interdit — absolute piégé dans un stacking context ancêtre
-<div className="relative">
-  <button>Trigger</button>
-  <div className="absolute top-full z-50">Overlay clippé !</div>
+// ❌ INTERDIT — absolute piégé dans stacking context ancêtre
+<div className="relative backdrop-blur-md sticky top-0 z-20">
+  <div className="absolute top-full z-50">Overlay invisible !</div>
 </div>
 ```
 
-### Règle 2 — Outside-click doit vérifier les deux refs
+### Règle 2 — Utiliser `useFloatingPortalPosition` (scroll/resize/zoom)
 
-Quand le dropdown est dans un portal, les clics sur le dropdown ne tombent **pas** dans le `triggerRef`. L'handler `mousedown` doit vérifier les deux :
+Le hook `src/hooks/useFloatingPortalPosition.js` fournit :
+- Position initiale calculée via `getBoundingClientRect()` **avant** le premier paint (no-flicker)
+- Repositionnement automatique sur `scroll`, `resize`, `visualViewport` (pinch-zoom mobile)
+- Throttling via `requestAnimationFrame` (max 60 fps)
+- Cleanup automatique à la fermeture
+
+```js
+const { style, updatePosition } = useFloatingPortalPosition({
+  isOpen,           // boolean — attache/détache les listeners
+  triggerRef,       // ref vers le bouton déclencheur
+  portalRef,        // ref vers le div portalisé
+  placement,        // 'bottom-start' | 'bottom-end' | 'top-start'  (default: 'bottom-start')
+  offset,           // gap px entre trigger et overlay               (default: 8)
+  clampPadding,     // distance min aux bords du viewport            (default: 8)
+});
+// style = { top, left } — spread sur le div portalisé
+// updatePosition() — forcer un recalcul immédiat (ex: contenu dynamique)
+```
+
+### Règle 3 — Outside-click doit vérifier les deux refs (cross-portal)
 
 ```jsx
 useEffect(() => {
+  if (!open) return;
   function handler(e) {
-    if (
-      triggerRef.current && !triggerRef.current.contains(e.target) &&
-      dropRef.current   && !dropRef.current.contains(e.target)
-    ) {
-      setOpen(false);
-    }
+    if (triggerRef.current?.contains(e.target)) return;
+    if (dropRef.current?.contains(e.target)) return;
+    setOpen(false);
   }
+  function onEsc(e) { if (e.key === 'Escape') setOpen(false); }
   document.addEventListener('mousedown', handler);
-  return () => document.removeEventListener('mousedown', handler);
-}, []);
+  document.addEventListener('keydown', onEsc);
+  return () => {
+    document.removeEventListener('mousedown', handler);
+    document.removeEventListener('keydown', onEsc);
+  };
+}, [open]);
 ```
-
-### Règle 3 — Contextes de stacking qui piègent les enfants
-
-Ces propriétés CSS créent un nouveau stacking context — les `z-index` des enfants ne peuvent **pas** dépasser le z-index du conteneur :
-
-| Propriété CSS | Crée un stacking context |
-|--------------|--------------------------|
-| `position: sticky/fixed/absolute/relative` + `z-index ≠ auto` | ✅ Oui |
-| `backdrop-filter: blur(...)` | ✅ Oui (tous navigateurs modernes) |
-| `opacity < 1` | ✅ Oui |
-| `transform` | ✅ Oui |
-| `filter` | ✅ Oui |
-| `will-change: transform/opacity` | ✅ Oui |
-
-**Corollaire :** Toute combinaison `sticky + z-XX + backdrop-blur` (comme `StickyFilterBar`) piège ses enfants absolus. La seule issue est le portal.
 
 ---
 
-## 4. Diagnostic rapide
+## 4. Pièges — Stacking contexts créés automatiquement
+
+Ces propriétés CSS créent un nouveau stacking context — les `z-index` enfants ne peuvent **pas** dépasser le z-index du conteneur :
+
+| Propriété CSS | Stacking context |
+|--------------|-----------------|
+| `position: sticky/fixed/relative/absolute` + `z-index ≠ auto` | ✅ Oui |
+| `backdrop-filter: blur(...)` | ✅ Oui (tous navigateurs modernes) |
+| `opacity < 1` | ✅ Oui |
+| `transform: ...` | ✅ Oui |
+| `filter: ...` | ✅ Oui |
+| `will-change: transform/opacity` | ✅ Oui |
+| `isolation: isolate` | ✅ Oui |
+
+**Corollaire :** `StickyFilterBar` (`sticky + z-20 + backdrop-blur`) piège tout absolu enfant.
+La seule issue : portal (`createPortal` + `position: fixed`).
+
+---
+
+## 5. Diagnostic rapide
 
 Si un overlay se retrouve derrière du contenu :
 
-1. Inspecter l'ancêtre le plus proche avec `position: sticky/fixed` ou `backdrop-filter`
+1. Inspecter l'ancêtre avec `position: sticky/fixed` ou `backdrop-filter`
 2. Vérifier si cet ancêtre a un `z-index` explicite → stacking context confirmé
-3. Migrer l'overlay vers un portal (`createPortal` + `position: fixed`)
-4. Assigner `z-[120]` au overlay (ou `z-[200]` pour les modals)
+3. Migrer l'overlay vers `createPortal` + `position: fixed`
+4. Brancher `useFloatingPortalPosition` pour scroll/resize/zoom
+5. Assigner `z-[120]` (overlay) ou `z-[200]` (modal)
 
 ---
 
-*Dernière mise à jour : V1 — audit complet overlays (Sprint WOW)*
+## 6. data-testids stables (Playwright)
+
+| Élément | `data-testid` |
+|---------|--------------|
+| ScopeSwitcher trigger | `scope-switcher-trigger` |
+| ScopeSwitcher panel | `scope-switcher-panel` |
+| StickyFilterBar + site trigger | `sticky-sitesearch-trigger` |
+| StickyFilterBar + site panel | `sticky-sitesearch-panel` |
+| StickyFilterBar presets trigger | `sticky-presets-trigger` |
+| StickyFilterBar presets panel | `sticky-presets-panel` |
+| InfoTip icon button | `infotip` |
+
+---
+
+*Dernière mise à jour : V2 — hook premium scroll/resize/zoom + data-testids (Sprint WOW)*

--- a/e2e/overlays.spec.js
+++ b/e2e/overlays.spec.js
@@ -1,14 +1,17 @@
 /**
- * PROMEOS — Overlay Layering Smoke Tests
+ * PROMEOS — Overlay Premium Smoke Tests (V2)
  * Validates that portal-based overlays are:
  *   - Rendered as direct children of <body> (createPortal)
- *   - Using position:fixed (not absolute — immune to stacking-context trapping)
- *   - Carrying z-index ≥ 120 (above sticky header z-40 and sidebar z-30)
- *   - Occupying visible screen space (not clipped behind other layers)
+ *   - Using position:fixed (immune to stacking-context trapping)
+ *   - z-index ≥ 120 (above sticky header z-40, sidebar z-30, StickyFilterBar z-20)
+ *   - Correctly positioned relative to their trigger
+ *   - Stable after scroll + viewport resize (useFloatingPortalPosition hook)
  *
  * Regressions guarded:
- *   1. ScopeSwitcher dropdown clipped on /consommations behind sticky+backdrop-blur
- *   2. InfoTip rendering empty black dots when content prop was undefined
+ *   1. ScopeSwitcher dropdown clipped behind sticky+backdrop-blur (backdrop-filter stacking context)
+ *   2. InfoTip rendering empty black dots (content prop undefined)
+ *   3. Dropdowns drifting from trigger after scroll or viewport resize
+ *   4. TooltipPortal z-[9999] — now standardized to z-[120]
  *
  * Requires: backend on :8000, frontend on :5173, demo data seeded.
  */
@@ -25,138 +28,157 @@ async function login(page) {
   await page.fill('input[type="email"]', 'sophie@atlas.demo');
   await page.fill('input[type="password"]', 'demo2024');
   await page.click('button[type="submit"]');
-  await page.waitForURL((url) => !url.pathname.includes('/login'), {
-    timeout: 10_000,
-  });
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 10_000 });
+}
+
+/** Assert the overlay element is portaled to <body>, position:fixed, z >= 120. */
+async function assertPremiumPortal(el, label = 'overlay') {
+  const parentTag = await el.evaluate((node) => node.parentElement?.tagName ?? 'UNKNOWN');
+  expect(parentTag, `${label}: must be portaled to <body>`).toBe('BODY');
+
+  const position = await el.evaluate((node) => window.getComputedStyle(node).position);
+  expect(position, `${label}: must use position:fixed`).toBe('fixed');
+
+  const zIndex = await el.evaluate((node) => parseInt(window.getComputedStyle(node).zIndex, 10));
+  expect(zIndex, `${label}: z-index must be ≥ 120`).toBeGreaterThanOrEqual(120);
+}
+
+/** Assert panel bounding box is near the trigger (within tolerance px). */
+async function assertAlignedNear(trigger, panel, label = 'panel', tolerance = 40) {
+  const tBox = await trigger.boundingBox();
+  const pBox = await panel.boundingBox();
+  expect(tBox, `${label}: trigger must be visible`).not.toBeNull();
+  expect(pBox, `${label}: panel must have a bounding box`).not.toBeNull();
+
+  // Panel Y should be below the trigger bottom (within tolerance)
+  expect(pBox.y, `${label}: panel top should be near trigger bottom`)
+    .toBeGreaterThanOrEqual(tBox.y + tBox.height - tolerance);
+  expect(pBox.y, `${label}: panel should not be far below trigger`)
+    .toBeLessThan(tBox.y + tBox.height + tolerance + 200); // allow for panel height
+
+  // Panel X should be near the trigger X
+  expect(Math.abs(pBox.x - tBox.x), `${label}: panel X should be near trigger X`)
+    .toBeLessThan(tolerance);
 }
 
 test.beforeAll(() => {
   fs.mkdirSync(SCREENSHOTS, { recursive: true });
 });
 
-test.describe('Overlay layering — portal + z-index regression', () => {
+test.describe('Overlay premium — portal + z-index + scroll/resize regression', () => {
 
-  // ── Test 1: ScopeSwitcher dropdown ──────────────────────────────────────────
-  test(
-    'Consommations explorer: ScopeSwitcher dropdown is portaled, position:fixed, z≥120',
-    async ({ page }) => {
-      await login(page);
-      await page.goto('/consommations');
+  // ── Test 1: ScopeSwitcher dropdown — portal + fixed + z + scroll + resize ──
+  test('ScopeSwitcher: portaled, fixed, z≥120, stable on scroll and resize', async ({ page }) => {
+    await login(page);
+    await page.goto('/consommations');
+    await page.waitForTimeout(2000);
 
-      // Wait for the page to stabilize (data fetch + React hydration)
-      await page.waitForTimeout(2000);
+    const trigger = page.locator('[data-testid="scope-switcher-trigger"]');
+    await expect(trigger).toBeVisible({ timeout: 8_000 });
 
-      // Locate the ScopeSwitcher trigger (the scope pill in the header)
-      const trigger = page.locator('button[aria-haspopup="listbox"]');
-      await expect(trigger).toBeVisible({ timeout: 8_000 });
+    // Open dropdown
+    await trigger.click();
+    const panel = page.locator('[data-testid="scope-switcher-panel"]');
+    await expect(panel).toBeVisible({ timeout: 5_000 });
 
-      // Open the dropdown
-      await trigger.click();
+    // ── Premium assertions ───────────────────────────────────────────────────
+    await assertPremiumPortal(panel, 'ScopeSwitcher panel');
 
-      // Dropdown must appear
-      const listbox = page.locator('[role="listbox"]');
-      await expect(listbox).toBeVisible({ timeout: 5_000 });
+    // Bounding box: non-zero, visible
+    const box = await panel.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box.width).toBeGreaterThan(100);
+    expect(box.height).toBeGreaterThan(20);
 
-      // ── Portal assertion: must be a direct child of <body> ─────────────────
-      const parentTag = await listbox.evaluate((el) =>
-        el.parentElement?.tagName ?? 'UNKNOWN',
-      );
-      expect(parentTag, 'Listbox must be portaled to <body>').toBe('BODY');
+    // Content visible
+    await expect(panel.locator('text=Organisation')).toBeVisible();
 
-      // ── position:fixed — immune to ancestor stacking-context trapping ──────
-      const position = await listbox.evaluate((el) =>
-        window.getComputedStyle(el).position,
-      );
-      expect(position, 'Listbox must use position:fixed').toBe('fixed');
+    // Alignment: panel is near trigger
+    await assertAlignedNear(trigger, panel, 'ScopeSwitcher initial');
 
-      // ── z-index ≥ 120 — above sticky header (z-40) and sidebar (z-30) ──────
-      const zIndex = await listbox.evaluate((el) =>
-        parseInt(window.getComputedStyle(el).zIndex, 10),
-      );
-      expect(zIndex, 'Listbox z-index must be ≥ 120').toBeGreaterThanOrEqual(120);
+    await page.screenshot({ path: path.join(SCREENSHOTS, 'scope-switcher-open.png') });
 
-      // ── Visible bounding box (not zero-size, not off-screen) ───────────────
-      const box = await listbox.boundingBox();
-      expect(box, 'Listbox must have a non-null bounding box').not.toBeNull();
-      expect(box.width, 'Listbox must have visible width').toBeGreaterThan(100);
-      expect(box.height, 'Listbox must have visible height').toBeGreaterThan(20);
+    // ── Scroll 400px — panel must follow trigger (trigger is in sticky header) ─
+    await page.evaluate(() => window.scrollBy(0, 400));
+    await page.waitForTimeout(200); // rAF + visualViewport settle
 
-      // ── Contains expected content ───────────────────────────────────────────
-      await expect(listbox.locator('text=Organisation')).toBeVisible();
+    await expect(panel).toBeVisible({ timeout: 3_000 });
+    await assertAlignedNear(trigger, panel, 'ScopeSwitcher after scroll');
 
-      // Regression screenshot — dropdown visible above page content
-      await page.screenshot({
-        path: path.join(SCREENSHOTS, 'scope-switcher-open.png'),
-        fullPage: false,
-      });
+    await page.screenshot({ path: path.join(SCREENSHOTS, 'scope-switcher-after-scroll.png') });
 
-      await page.keyboard.press('Escape');
-    },
-  );
+    // ── Resize viewport — panel must clamp within new bounds ─────────────────
+    await page.setViewportSize({ width: 900, height: 600 });
+    await page.waitForTimeout(200);
 
-  // ── Test 2: InfoTip on Vue exécutive ────────────────────────────────────────
-  test(
-    'Vue exécutive: InfoTip icons show non-empty tooltip, no ghost bubbles',
-    async ({ page }) => {
-      await login(page);
-      await page.goto('/cockpit');
+    await expect(panel).toBeVisible({ timeout: 3_000 });
+    const panelBox = await panel.boundingBox();
+    expect(panelBox.x + panelBox.width).toBeLessThan(900 + 20); // within viewport (+ clamp margin)
 
-      // Wait for ImpactDecisionPanel to finish loading (billing summary fetch)
-      await page.waitForSelector('[data-testid="impact-decision-panel"]', {
-        timeout: 15_000,
-      });
-      // Extra wait for async billing data
-      await page.waitForTimeout(1500);
+    // ESC closes
+    await page.keyboard.press('Escape');
+    await expect(panel).not.toBeVisible({ timeout: 2_000 });
+  });
 
-      // ── No ghost tooltip rendered before any hover ──────────────────────────
-      await expect(
-        page.locator('[role="tooltip"]'),
-        'No tooltip should be visible without hover',
-      ).toHaveCount(0);
+  // ── Test 2: InfoTip — portal + fixed + z + non-empty text ──────────────────
+  test('InfoTip: portaled tooltip, z≥120, never empty', async ({ page }) => {
+    await login(page);
+    await page.goto('/cockpit');
 
-      // ── At least one InfoTip icon exists on the executive view ─────────────
-      const infotips = page.locator('button[aria-label="Aide contextuelle"]');
-      const count = await infotips.count();
-      expect(count, 'At least one InfoTip button must be rendered').toBeGreaterThan(0);
-      await expect(infotips.first()).toBeVisible({ timeout: 5_000 });
+    await page.waitForSelector('[data-testid="impact-decision-panel"]', { timeout: 15_000 });
+    await page.waitForTimeout(1500);
 
-      // ── Hover → tooltip appears with non-empty text content ─────────────────
-      await infotips.first().hover();
-      const tooltip = page.locator('[role="tooltip"]');
-      await expect(tooltip, 'Tooltip must appear on hover').toBeVisible({
-        timeout: 3_000,
-      });
+    // No ghost tooltip before hover
+    await expect(page.locator('[role="tooltip"]')).toHaveCount(0);
 
-      const text = (await tooltip.textContent()).trim();
-      expect(
-        text.length,
-        'Tooltip must contain meaningful text (no empty bubble)',
-      ).toBeGreaterThan(5);
+    // At least one InfoTip button
+    const infotips = page.locator('[data-testid="infotip"]');
+    expect(await infotips.count()).toBeGreaterThan(0);
+    await expect(infotips.first()).toBeVisible({ timeout: 5_000 });
 
-      // ── Portal assertion: tooltip must be in <body> ─────────────────────────
-      const parentTag = await tooltip.evaluate((el) =>
-        el.parentElement?.tagName ?? 'UNKNOWN',
-      );
-      expect(parentTag, 'Tooltip must be portaled to <body>').toBe('BODY');
+    // Hover → tooltip appears with non-empty text
+    await infotips.first().hover();
+    const tooltip = page.locator('[role="tooltip"]');
+    await expect(tooltip).toBeVisible({ timeout: 3_000 });
 
-      // ── position:fixed ──────────────────────────────────────────────────────
-      const position = await tooltip.evaluate((el) =>
-        window.getComputedStyle(el).position,
-      );
-      expect(position, 'Tooltip must use position:fixed').toBe('fixed');
+    const text = (await tooltip.textContent() ?? '').trim();
+    expect(text.length, 'Tooltip must contain meaningful text (no empty bubble)').toBeGreaterThan(5);
 
-      // Regression screenshot — tooltip visible above executive content
-      await page.screenshot({
-        path: path.join(SCREENSHOTS, 'infotip-tooltip-visible.png'),
-        fullPage: false,
-      });
+    // Premium assertions
+    await assertPremiumPortal(tooltip, 'InfoTip tooltip');
 
-      // ── Move away — tooltip must disappear (no lingering phantom ────────────
-      await page.mouse.move(0, 0);
-      await expect(
-        page.locator('[role="tooltip"]'),
-        'Tooltip must disappear after mouse leaves',
-      ).toHaveCount(0, { timeout: 2_000 });
-    },
-  );
+    await page.screenshot({ path: path.join(SCREENSHOTS, 'infotip-tooltip-visible.png') });
+
+    // Mouse away → tooltip disappears
+    await page.mouse.move(0, 0);
+    await expect(page.locator('[role="tooltip"]')).toHaveCount(0, { timeout: 2_000 });
+  });
+
+  // ── Test 3: StickyFilterBar dropdowns ───────────────────────────────────────
+  test('StickyFilterBar: presets dropdown portaled, fixed, z≥120', async ({ page }) => {
+    await login(page);
+
+    // Navigate to a consumption page with presets enabled
+    await page.goto('/consommations');
+    await page.waitForTimeout(3000);
+
+    // Locate presets trigger (only visible when savedPresets.length > 0)
+    const presetsTrigger = page.locator('[data-testid="sticky-presets-trigger"]');
+    const presetsVisible = await presetsTrigger.isVisible().catch(() => false);
+
+    if (!presetsVisible) {
+      test.skip(true, 'No saved presets available in this demo session — skip presets test');
+      return;
+    }
+
+    await presetsTrigger.click();
+    const presetsPanel = page.locator('[data-testid="sticky-presets-panel"]');
+    await expect(presetsPanel).toBeVisible({ timeout: 5_000 });
+
+    await assertPremiumPortal(presetsPanel, 'Presets panel');
+    await assertAlignedNear(presetsTrigger, presetsPanel, 'Presets panel');
+
+    await page.screenshot({ path: path.join(SCREENSHOTS, 'presets-panel-open.png') });
+  });
+
 });

--- a/frontend/src/components/SitePicker.jsx
+++ b/frontend/src/components/SitePicker.jsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Search, X, Star, FolderOpen, ChevronDown, Save, Check } from 'lucide-react';
 import { getEmsCollections, createEmsCollection } from '../services/api';
+import useFloatingPortalPosition from '../hooks/useFloatingPortalPosition';
 
 const MAX_RECENT = 5;
 const LS_KEY = 'promeos_ems_recent_sites';
@@ -20,7 +21,6 @@ function saveRecent(ids) {
 export default function SitePicker({ sites, selectedIds, onChange, maxSelection = 8 }) {
   const [search, setSearch] = useState('');
   const [open, setOpen] = useState(false);
-  const [openCoords, setOpenCoords] = useState(null);
   const [collections, setCollections] = useState([]);
   const [showCollections, setShowCollections] = useState(false);
   const [saveName, setSaveName] = useState('');
@@ -28,6 +28,13 @@ export default function SitePicker({ sites, selectedIds, onChange, maxSelection 
   const ref = useRef(null);
   const triggerRef = useRef(null);
   const dropRef = useRef(null);
+
+  // Premium positioning: scroll/resize/zoom auto-reposition
+  const { style: dropStyle } = useFloatingPortalPosition({
+    isOpen: open,
+    triggerRef,
+    portalRef: dropRef,
+  });
 
   // Load collections on mount
   useEffect(() => {
@@ -104,13 +111,7 @@ export default function SitePicker({ sites, selectedIds, onChange, maxSelection 
       {/* Trigger button */}
       <button
         ref={triggerRef}
-        onClick={() => {
-          if (!open && triggerRef.current) {
-            const r = triggerRef.current.getBoundingClientRect();
-            setOpenCoords({ top: r.bottom + 4, left: r.left });
-          }
-          setOpen(o => !o);
-        }}
+        onClick={() => setOpen(o => !o)}
         className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 rounded-lg bg-white
           hover:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition min-w-[180px]"
       >
@@ -137,12 +138,12 @@ export default function SitePicker({ sites, selectedIds, onChange, maxSelection 
         </div>
       )}
 
-      {/* Dropdown — portaled to body to escape overflow/stacking-context clipping */}
-      {open && openCoords && createPortal(
+      {/* Dropdown — portaled to body, auto-repositions on scroll/resize/zoom */}
+      {open && createPortal(
         <div
           ref={dropRef}
           className="fixed z-[120] w-80 bg-white border border-gray-200 rounded-xl shadow-xl max-h-[420px] flex flex-col"
-          style={{ top: openCoords.top, left: openCoords.left }}
+          style={dropStyle}
         >
           {/* Search */}
           <div className="p-2 border-b border-gray-100">

--- a/frontend/src/hooks/useFloatingPortalPosition.js
+++ b/frontend/src/hooks/useFloatingPortalPosition.js
@@ -1,0 +1,120 @@
+/**
+ * PROMEOS — useFloatingPortalPosition
+ * Premium portal positioning hook.
+ *
+ * Computes fixed top/left for a portaled overlay anchored to a trigger element.
+ * Auto-repositions on scroll, resize, and visualViewport zoom (mobile pinch).
+ * No flicker: useLayoutEffect fires synchronously before browser paint.
+ *
+ * @param {object} opts
+ * @param {boolean}  opts.isOpen       — when true, attach listeners and compute position
+ * @param {Ref}      opts.triggerRef   — ref to the trigger/anchor element
+ * @param {Ref}      opts.portalRef    — ref to the portaled overlay div
+ * @param {string}   opts.placement    — 'bottom-start' | 'bottom-end' | 'top-start' (default: 'bottom-start')
+ * @param {number}   opts.offset       — px gap between trigger and overlay (default: 8)
+ * @param {number}   opts.clampPadding — min distance from viewport edges (default: 8)
+ *
+ * @returns {{ style: {top, left}, updatePosition: () => void }}
+ *   style           — spread onto the overlay element (add className="fixed" separately)
+ *   updatePosition  — force immediate repositioning (e.g. after content resize)
+ *
+ * Usage:
+ *   const dropRef = useRef(null);
+ *   const { style } = useFloatingPortalPosition({ isOpen, triggerRef, portalRef: dropRef });
+ *   // In JSX: <div ref={dropRef} className="fixed z-[120] ..." style={style}>
+ */
+import { useState, useLayoutEffect, useCallback, useRef } from 'react';
+
+const OFF_SCREEN = Object.freeze({ top: -9999, left: -9999 });
+
+function _computePos(triggerEl, portalEl, placement, offset, pad) {
+  const tr = triggerEl.getBoundingClientRect();
+  const pw = portalEl.offsetWidth  || 200; // fallback if portal hasn't laid out yet
+  const ph = portalEl.offsetHeight || 40;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  let top, left;
+
+  switch (placement) {
+    case 'bottom-end':
+      top  = tr.bottom + offset;
+      left = tr.right - pw;
+      break;
+    case 'top-start':
+      top  = tr.top - ph - offset;
+      left = tr.left;
+      break;
+    default: // 'bottom-start'
+      top  = tr.bottom + offset;
+      left = tr.left;
+  }
+
+  // Auto-flip vertically when overflow
+  if (placement.startsWith('bottom') && top + ph > vh - pad && tr.top - ph - offset >= pad) {
+    top = tr.top - ph - offset;
+  } else if (placement.startsWith('top') && top < pad && tr.bottom + offset + ph <= vh - pad) {
+    top = tr.bottom + offset;
+  }
+
+  // Clamp to viewport
+  return {
+    top:  Math.max(pad, Math.min(top,  vh - ph - pad)),
+    left: Math.max(pad, Math.min(left, vw - pw - pad)),
+  };
+}
+
+export default function useFloatingPortalPosition({
+  isOpen,
+  triggerRef,
+  portalRef,
+  placement = 'bottom-start',
+  offset = 8,
+  clampPadding = 8,
+}) {
+  const [style, setStyle] = useState(OFF_SCREEN);
+  const rafRef = useRef(null);
+
+  const update = useCallback(() => {
+    const tEl = triggerRef?.current;
+    const pEl = portalRef?.current;
+    if (!tEl || !pEl) return;
+    setStyle(_computePos(tEl, pEl, placement, offset, clampPadding));
+  }, [triggerRef, portalRef, placement, offset, clampPadding]);
+
+  const rafUpdate = useCallback(() => {
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(update);
+  }, [update]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setStyle(OFF_SCREEN);
+      return;
+    }
+
+    // Synchronous initial position — before browser paint, no flicker
+    update();
+
+    const captOpts = { capture: true, passive: true };
+    window.addEventListener('scroll', rafUpdate, captOpts);
+    window.addEventListener('resize', rafUpdate, { passive: true });
+    // visualViewport: handles mobile pinch-zoom + address-bar resize
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('scroll', rafUpdate);
+      window.visualViewport.addEventListener('resize', rafUpdate);
+    }
+
+    return () => {
+      window.removeEventListener('scroll', rafUpdate, captOpts);
+      window.removeEventListener('resize', rafUpdate);
+      if (window.visualViewport) {
+        window.visualViewport.removeEventListener('scroll', rafUpdate);
+        window.visualViewport.removeEventListener('resize', rafUpdate);
+      }
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [isOpen, update, rafUpdate]);
+
+  return { style, updatePosition: update };
+}

--- a/frontend/src/layout/ScopeSwitcher.jsx
+++ b/frontend/src/layout/ScopeSwitcher.jsx
@@ -9,6 +9,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { Building2, ChevronDown, X, Briefcase, MapPin } from 'lucide-react';
 import { useScope } from '../contexts/ScopeContext';
+import useFloatingPortalPosition from '../hooks/useFloatingPortalPosition';
 
 export default function ScopeSwitcher() {
   const {
@@ -16,11 +17,17 @@ export default function ScopeSwitcher() {
     setOrg, setPortefeuille, setSite, resetScope,
   } = useScope();
   const [open, setOpen] = useState(false);
-  const [dropCoords, setDropCoords] = useState(null);
   const triggerRef = useRef(null);
   const dropRef    = useRef(null);
 
-  // Close on outside click — checks both the trigger pill and the portal dropdown
+  // Premium positioning: scroll/resize/zoom auto-reposition
+  const { style: dropStyle } = useFloatingPortalPosition({
+    isOpen: open,
+    triggerRef,
+    portalRef: dropRef,
+  });
+
+  // Close on outside click (cross-portal) + ESC
   useEffect(() => {
     if (!open) return;
     function onClickOutside(e) {
@@ -28,17 +35,18 @@ export default function ScopeSwitcher() {
       if (dropRef.current?.contains(e.target)) return;
       setOpen(false);
     }
+    function onKeyDown(e) {
+      if (e.key === 'Escape') setOpen(false);
+    }
     document.addEventListener('mousedown', onClickOutside);
-    return () => document.removeEventListener('mousedown', onClickOutside);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('keydown', onKeyDown);
+    };
   }, [open]);
 
-  const toggleOpen = useCallback(() => {
-    if (!open && triggerRef.current) {
-      const rect = triggerRef.current.getBoundingClientRect();
-      setDropCoords({ top: rect.bottom + 4, left: rect.left });
-    }
-    setOpen((prev) => !prev);
-  }, [open]);
+  const toggleOpen = useCallback(() => setOpen((prev) => !prev), []);
 
   const hasSites = orgSites.length > 0;
 
@@ -50,6 +58,7 @@ export default function ScopeSwitcher() {
         onClick={toggleOpen}
         aria-haspopup="listbox"
         aria-expanded={open}
+        data-testid="scope-switcher-trigger"
         className="flex items-center gap-2 px-3 py-1.5 bg-blue-50 border border-blue-200 rounded-full text-sm text-blue-700 hover:bg-blue-100 transition"
       >
         <Building2 size={14} />
@@ -75,13 +84,14 @@ export default function ScopeSwitcher() {
         </button>
       )}
 
-      {/* Dropdown — portal to document.body, position:fixed, z-[120] */}
-      {open && dropCoords && createPortal(
+      {/* Dropdown — portal to document.body, position:fixed, z-[120], auto-repositions on scroll/resize */}
+      {open && createPortal(
         <div
           ref={dropRef}
           role="listbox"
+          data-testid="scope-switcher-panel"
           className="fixed w-72 bg-white rounded-lg shadow-xl border border-gray-200 py-2 max-h-[80vh] overflow-y-auto z-[120]"
-          style={{ top: dropCoords.top, left: dropCoords.left }}
+          style={dropStyle}
         >
           {/* Org selector */}
           <div className="px-3 py-1.5">

--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -37,6 +37,7 @@
  */
 import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import useFloatingPortalPosition from '../../hooks/useFloatingPortalPosition';
 import { X, Zap, Flame, Save, RotateCcw, Link, ChevronDown, Trash2, Plus, LayoutGrid } from 'lucide-react';
 import { TrustBadge } from '../../ui';
 import { computeGranularity, colorForSite, getAvailableGranularities } from './helpers';
@@ -89,19 +90,17 @@ function todayISO() {
 // Portaled to document.body — escapes the sticky+backdrop-blur stacking context.
 function SiteSearchDropdown({ sites, selectedIds, onAdd, onClose, anchorRef }) {
   const [query, setQuery] = useState('');
-  const [coords, setCoords] = useState(null);
   const inputRef = useRef(null);
   const dropRef = useRef(null);
 
-  useEffect(() => { inputRef.current?.focus(); }, []);
+  // Premium positioning: component only mounts when visible → isOpen always true
+  const { style } = useFloatingPortalPosition({
+    isOpen: true,
+    triggerRef: anchorRef,
+    portalRef: dropRef,
+  });
 
-  // Compute fixed position from the anchor element
-  useEffect(() => {
-    if (anchorRef?.current) {
-      const r = anchorRef.current.getBoundingClientRect();
-      setCoords({ top: r.bottom + 4, left: r.left });
-    }
-  }, [anchorRef]);
+  useEffect(() => { inputRef.current?.focus(); }, []);
 
   // Outside-click closes the dropdown (checks both anchor and portaled div)
   useEffect(() => {
@@ -122,13 +121,12 @@ function SiteSearchDropdown({ sites, selectedIds, onAdd, onClose, anchorRef }) {
       s.nom.toLowerCase().includes(query.toLowerCase())
   );
 
-  if (!coords) return null;
-
   return createPortal(
     <div
       ref={dropRef}
+      data-testid="sticky-sitesearch-panel"
       className="fixed w-60 bg-white rounded-lg shadow-lg border border-gray-200 z-[120] py-1"
-      style={{ top: coords.top, left: coords.left }}
+      style={style}
     >
       <div className="px-2 py-1.5 border-b border-gray-100">
         <input
@@ -296,7 +294,13 @@ export default function StickyFilterBar({
   const addRef = useRef(null);
   const presetsBtnRef = useRef(null);
   const presetsDropRef = useRef(null);
-  const [presetsCoords, setPresetsCoords] = useState(null);
+
+  // Premium positioning for Presets dropdown
+  const { style: presetsStyle } = useFloatingPortalPosition({
+    isOpen: showPresets,
+    triggerRef: presetsBtnRef,
+    portalRef: presetsDropRef,
+  });
 
   // Close presets dropdown on outside click
   useEffect(() => {
@@ -417,6 +421,7 @@ export default function StickyFilterBar({
             {effectiveSiteIds.length < MAX_SITES && sites.length > effectiveSiteIds.length && (
               <div ref={addRef}>
                 <button
+                  data-testid="sticky-sitesearch-trigger"
                   onClick={() => setShowAddSite(v => !v)}
                   className="flex items-center justify-center w-6 h-6 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 transition"
                   title="Ajouter un site"
@@ -669,23 +674,19 @@ export default function StickyFilterBar({
             <div>
               <button
                 ref={presetsBtnRef}
-                onClick={() => {
-                  if (!showPresets && presetsBtnRef.current) {
-                    const r = presetsBtnRef.current.getBoundingClientRect();
-                    setPresetsCoords({ top: r.bottom + 4, left: r.left });
-                  }
-                  setShowPresets(v => !v);
-                }}
+                data-testid="sticky-presets-trigger"
+                onClick={() => setShowPresets(v => !v)}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition"
               >
                 Presets ({savedPresets.length})
                 <ChevronDown size={11} />
               </button>
-              {showPresets && presetsCoords && createPortal(
+              {showPresets && createPortal(
                 <div
                   ref={presetsDropRef}
+                  data-testid="sticky-presets-panel"
                   className="fixed w-52 bg-white rounded-lg shadow-lg border border-gray-200 z-[120] py-1"
-                  style={{ top: presetsCoords.top, left: presetsCoords.left }}
+                  style={presetsStyle}
                 >
                   {savedPresets.map(p => (
                     <div key={p.name} className="flex items-center gap-1 px-2 py-1.5 hover:bg-gray-50 group">

--- a/frontend/src/ui/InfoTip.jsx
+++ b/frontend/src/ui/InfoTip.jsx
@@ -79,6 +79,7 @@ export default function InfoTip({
         type="button"
         aria-label="Aide contextuelle"
         aria-describedby={visible ? tooltipId.current : undefined}
+        data-testid="infotip"
         className={`inline-flex items-center justify-center shrink-0 text-gray-400
           hover:text-gray-600 rounded cursor-help transition-colors
           focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1

--- a/frontend/src/ui/TooltipPortal.jsx
+++ b/frontend/src/ui/TooltipPortal.jsx
@@ -112,7 +112,7 @@ export default function TooltipPortal({
       {visible && coords && createPortal(
         <span
           id={tooltipId.current}
-          className="fixed z-[9999] px-2 py-1 text-xs text-white bg-gray-900 rounded shadow-lg whitespace-nowrap pointer-events-none transition-opacity duration-100 motion-reduce:transition-none"
+          className="fixed z-[120] px-2 py-1 text-xs text-white bg-gray-900 rounded shadow-lg whitespace-nowrap pointer-events-none transition-opacity duration-100 motion-reduce:transition-none"
           style={{ top: coords.top, left: coords.left, transform: coords.transform }}
           role="tooltip"
         >


### PR DESCRIPTION
## Summary

- **New hook** `useFloatingPortalPosition` — computes `position:fixed` top/left from `getBoundingClientRect()`, auto-repositions on `scroll`, `resize`, and `visualViewport` (mobile pinch-zoom), rAF-throttled at 60 fps, no flicker (`useLayoutEffect`)
- **Migrated** `ScopeSwitcher`, `StickyFilterBar` (site search + presets), `SitePicker` to use the hook — all portalized to `document.body`, immune to `backdrop-filter`/`sticky` stacking context trapping
- **Fixed** `TooltipPortal` z-[9999] → z-[120] (canonical overlay level)
- **Added** `data-testid` attributes: `scope-switcher-trigger/panel`, `sticky-sitesearch-trigger/panel`, `sticky-presets-trigger/panel`, `infotip`
- **Playwright** `e2e/overlays.spec.js` — 3 premium smoke tests asserting portal-to-body + position:fixed + z≥120 + alignment near trigger + scroll stability + resize clamping + ESC dismiss
- **Docs** `docs/ux-overlays.md` V2 — hook API reference, canonical z-index map, dev rules, stacking context pitfalls, testid table

## Regressions guarded

1. ScopeSwitcher dropdown clipped behind sticky header `backdrop-filter` stacking context
2. InfoTip empty black dot (content prop undefined)
3. Dropdowns drifting from trigger after scroll or viewport resize
4. TooltipPortal ad-hoc `z-[9999]`

## Test plan

- [ ] Open ScopeSwitcher → panel appears below trigger, follows on scroll, clamps on resize, closes on ESC
- [ ] Hover InfoTip icon on /cockpit → tooltip visible with text, no empty bubble
- [ ] Open site search on /consommations → panel follows trigger on scroll
- [ ] Run `npx playwright test e2e/overlays.spec.js` (requires demo seeded + servers up)
- [ ] `npm run build` — no TS/lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)