### PR TITLE
fix(ui): remove horizontal scroll on multi-site badge container

### DIFF
--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -389,7 +389,7 @@ export default function StickyFilterBar({
           <div className="flex items-center gap-1.5">
             {effectiveSiteIds.length > 0 ? (
               /* Selected site chips */
-              <div className="flex gap-1.5 overflow-x-auto max-w-xs" style={{ scrollbarWidth: 'thin' }}>
+              <div className="flex gap-1.5 min-w-0">
                 {effectiveSiteIds.map((id, idx) => {
                   const site = sites.find(s => s.id === id);
                   const color = colorForSite(id, idx);


### PR DESCRIPTION
Replaced `max-w-xs overflow-x-auto` with `min-w-0` on the site badge container in StickyFilterBar. The 320px hard cap was causing a scrollbar when 2+ sites were selected. Badges now expand freely; Row 1's existing `flex-wrap` handles overflow gracefully.

Closes #24