### PR TITLE
fix(ui): remove horizontal scroll on multi-site badge container (#24)

### DIFF
--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -410,10 +410,7 @@ export default function StickyFilterBar({
           <div className="flex items-center gap-1.5">
             {effectiveSiteIds.length > 0 ? (
               /* Selected site chips */
-              <div
-                className="flex gap-1.5 overflow-x-auto max-w-xs"
-                style={{ scrollbarWidth: 'thin' }}
-              >
+              <div className="flex gap-1.5 flex-wrap min-w-0">
                 {effectiveSiteIds.map((id, idx) => {
                   const site = sites.find((s) => s.id === id);
                   const color = colorForSite(id, idx);


### PR DESCRIPTION
## Summary
- Removes `max-w-xs` (320px cap) that caused the badge container to overflow with 2+ sites
- Removes `overflow-x-auto` horizontal scroll behaviour and the inline `scrollbarWidth` style
- Adds `flex-wrap` so badges wrap to the next line instead of scrolling
- Adds `min-w-0` so the flex container can shrink correctly within its parent

## Test plan
- [x] Start frontend dev server (`npm run dev` in `frontend/`)
- [ ] Navigate to the Consumption page
- [ ] Select 3+ sites in the StickyFilterBar
- [ ] Confirm badges wrap to a new line — no horizontal scrollbar
- [ ] Confirm no visual regression on the filter bar layout

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)