### PR TITLE
fix: period picker reverts on first click (#23)

### DIFF
--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -256,6 +256,10 @@ export default function ConsumptionExplorerPage() {
     loading,
   } = motor;
 
+  // ── User-initiated period flag (issue #23) ────────────────────────────
+  // Prevents auto-calibration from overwriting a period the user explicitly chose.
+  const userPickedDaysRef = useRef(false);
+
   // ── Portfolio mode (V12-A): all sites, aggregated view ────────────────
   const [isPortfolioMode, setIsPortfolioMode] = useState(false);
   const [portfolioBannerDismissed, setPortfolioBannerDismissed] = useState(false);
@@ -319,7 +323,8 @@ export default function ConsumptionExplorerPage() {
   // ── Auto-calibrate period from availability ────────────────────────────
   useEffect(() => {
     const avail = primaryAvailability;
-    if (avail?.has_data && avail.first_ts && avail.last_ts) {
+    // Only auto-calibrate when the user hasn't explicitly picked a period
+    if (!userPickedDaysRef.current && avail?.has_data && avail.first_ts && avail.last_ts) {
       const autoDays = computeAutoRange(avail.first_ts, avail.last_ts);
       if (autoDays !== days) setDays(autoDays);
     }
@@ -328,6 +333,11 @@ export default function ConsumptionExplorerPage() {
       setActiveTab('gas');
     }
   }, [primaryAvailability]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Reset user-picked flag on site change so auto-calibration resumes ──
+  useEffect(() => {
+    userPickedDaysRef.current = false;
+  }, [siteIds]);
 
   // ── Track previous selectedSiteId to detect explicit scope changes ────────
   const prevSelectedSiteIdRef = useRef(selectedSiteId);
@@ -450,6 +460,14 @@ export default function ConsumptionExplorerPage() {
     },
     [navigate]
   );
+  const handleDaysChange = useCallback(
+    (d) => {
+      userPickedDaysRef.current = true;
+      setDays(d);
+    },
+    [setDays],
+  );
+
   const handleSwitchEnergy = useCallback(
     (type) => {
       setEnergyType(type);
@@ -504,7 +522,7 @@ export default function ConsumptionExplorerPage() {
         setEnergyType={setEnergyType}
         availableTypes={availability?.energy_types}
         days={days}
-        setDays={setDays}
+        setDays={handleDaysChange}
         startDate={startDate}
         setStartDate={setStartDate}
         endDate={endDate}

--- a/frontend/src/pages/consumption/useExplorerMotor.js
+++ b/frontend/src/pages/consumption/useExplorerMotor.js
@@ -187,7 +187,10 @@ export default function useExplorerMotor({
     activeSiteIds,
     // Primary site (single-site backward compat)
     primarySiteId,
-    primaryAvailability: availabilityBySite[primarySiteId] || null,
+    primaryAvailability: useMemo(
+      () => availabilityBySite[primarySiteId] || null,
+      [availabilityBySite, primarySiteId], // eslint-disable-line react-hooks/exhaustive-deps
+    ),
     primaryTunnel: tunnelBySite[primarySiteId] || null,
     primaryProgression: progressionBySite[primarySiteId] || null,
     primaryTargets: targetsBySite[primarySiteId] || [],


### PR DESCRIPTION
## Problem

In `ConsumptionExplorerPage`, the auto-calibration `useEffect` fires whenever `primaryAvailability` changes object reference. Since `primaryAvailability` was not memoized in `useExplorerMotor`, every fetch (triggered by a `days` change) produced a new reference → re-triggered the effect → `computeAutoRange` returned 90 → overwrote the user's selection with `setDays(90)`.

## Fix

**`ConsumptionExplorerPage.jsx`**
- Added `userPickedDaysRef` (`useRef(false)`) to track whether the user explicitly chose a period
- Auto-calibration effect now gates on `!userPickedDaysRef.current` — skips if user already picked
- Added `handleDaysChange` callback that sets the flag before calling `setDays`; passed to `StickyFilterBar` instead of raw `setDays`
- Added `useEffect([siteIds])` that resets the flag on site change, so auto-calibration resumes for new sites

**`useExplorerMotor.js`**
- Memoized `primaryAvailability` with `useMemo([availabilityBySite, primarySiteId])` to reduce spurious effect triggers from reference churn

## Verified manually

- Clicking "30j" → chart updates and stays at 30 days
- Clicking "12m" → same
- Adding/removing a site → period resets to `computeAutoRange` result (expected)

## Test plan

- [x] Click "30j" on a site with ≥90d of data — period stays at 30 days
- [x] Click "12m" — period stays at 12 months
- [x] Change site — period resets to auto-calibrated value
- [x] `npx vitest run` — 4333 tests pass (4 pre-existing failures in `demoCoherence.test.js` are unrelated, hardcoded Windows paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)