### PR TITLE
fix(consumption): granularity selector retains all options after selecting Mois (#26)

### DIFF
--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -401,9 +401,13 @@ export default function ConsumptionExplorerPage() {
   const [granularity, setGranularity] = useState('auto');
   // ── V22-B: Sampling minutes from backend meta (for data-frequency intersection) ──
   const [samplingMinutes, setSamplingMinutes] = useState(null);
+  // V26-fix: only update native sampling resolution from auto mode responses;
+  // forced-granularity responses return the aggregation window, not native resolution.
   const handleMeta = useCallback((m) => {
-    if (m?.sampling_minutes != null) setSamplingMinutes(m.sampling_minutes);
-  }, []);
+    if (m?.sampling_minutes != null && granularity === 'auto') {
+      setSamplingMinutes(m.sampling_minutes);
+    }
+  }, [granularity]);
 
   // ── V20-D / V21-F: Demo generation — generates MeterReading data for site, then forces refetch ──
   // Supports energy_vector param (V21-F: gas demo CTA)


### PR DESCRIPTION
## Summary

- `handleMeta` in `ConsumptionExplorerPage.jsx` was overwriting `samplingMinutes` with the **aggregation window** returned by the backend for monthly views (43 200 min), instead of the native meter reading interval (e.g. 1 440 min for daily meters).
- `getAvailableGranularities()` then filtered out `daily` because `1 440 < 43 200`, making the **1 j** pill disappear.
- Fix: guard `handleMeta` so it only updates `samplingMinutes` when `granularity === 'auto'` — the only mode where the backend resolution matches native meter data.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Add `granularity === 'auto'` guard in `handleMeta`; add `granularity` to `useCallback` deps |

## Test plan

### Automated
```
cd frontend && npm run test -- V22ConsommationsExpert
```
19/19 tests must pass.

### Manual — prerequisite
Start the dev stack (`uvicorn` + `vite`) and log in with a user that has at least one site with daily meter readings (any site from the synthetic dataset works — they all have daily readings by default).

### Steps to reproduce the bug (before the fix)
1. Go to **Consommations → Explorer**.
2. Select any site that shows **3 granularity pills**: Auto · 1 j · Mois.
3. Click **Mois**. The chart re-renders with monthly bars.
4. **Bug**: the **1 j** pill disappears — only Auto and Mois remain.

### Steps to verify the fix
1. Go to **Consommations → Explorer**.
2. Select a site — confirm **3 pills** are visible: Auto · 1 j · Mois.
3. Click **Mois** → chart updates to monthly bars → **1 j pill must still be visible**.
4. Click **1 j** → chart switches to daily bars → all 3 pills remain visible.
5. Click **Auto** → chart returns to auto-resolved view.
6. Open DevTools → Network → filter on the timeseries API call made after clicking **Auto**.
   Confirm the response JSON contains `"meta": { "sampling_minutes": 1440 }` (or the native interval for the selected site). This confirms `samplingMinutes` updated correctly from the auto-mode response.
7. Repeat steps 2–6 with a **multi-site selection** — granularity pills must behave consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)