### PR TITLE
fix(consumption): fix multi-site ContextBanner showing first-site data only (#25)

### DIFF
--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -253,6 +253,7 @@ export default function ConsumptionExplorerPage() {
     mergedAvailability,
     primarySiteId,
     primaryAvailability,
+    data: { availabilityBySite },
     loading,
   } = motor;
 
@@ -573,8 +574,8 @@ export default function ConsumptionExplorerPage() {
         </div>
       )}
 
-      {/* Context banner (site info + date range) */}
-      <ContextBanner availability={availability} />
+      {/* Context banner (site info + date range) — one row per site */}
+      <ContextBanner availabilityBySite={availabilityBySite} siteIds={siteIds} />
 
       {/* KPI Header — 6 KPIs respecting scope global */}
       {showContent && (

--- a/frontend/src/pages/consumption/ContextBanner.jsx
+++ b/frontend/src/pages/consumption/ContextBanner.jsx
@@ -1,6 +1,6 @@
 /**
  * PROMEOS — ContextBanner (Consumption Explorer)
- * Info banner: site name, readings count, first/last date, energy types.
+ * Info banner: one row per selected site — name, readings count, energy types, date range.
  */
 import { CheckCircle } from 'lucide-react';
 
@@ -13,23 +13,32 @@ function fmtDate(ts) {
   });
 }
 
-export default function ContextBanner({ availability }) {
-  if (!availability?.has_data) return null;
+export default function ContextBanner({ availabilityBySite = {}, siteIds = [] }) {
+  const rows = siteIds
+    .map((sid) => availabilityBySite[sid])
+    .filter((a) => a?.has_data);
 
-  const { site_nom, readings_count, energy_types, first_ts, last_ts } = availability;
+  if (!rows.length) return null;
 
   return (
-    <div className="flex items-center gap-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-2.5 text-sm">
-      <CheckCircle size={16} className="text-blue-600 shrink-0" />
-      <span className="text-blue-800">
-        <strong>{site_nom || 'Site'}</strong> — {(readings_count || 0).toLocaleString()} releves
-        {energy_types?.length > 0 && ` (${energy_types.join(', ')})`}
-      </span>
-      {first_ts && last_ts && (
-        <span className="text-xs text-blue-500 ml-auto whitespace-nowrap">
-          {fmtDate(first_ts)} → {fmtDate(last_ts)}
-        </span>
-      )}
+    <div className="space-y-1.5">
+      {rows.map((a) => (
+        <div
+          key={a.site_nom}
+          className="flex items-center gap-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-2.5 text-sm"
+        >
+          <CheckCircle size={16} className="text-blue-600 shrink-0" />
+          <span className="text-blue-800">
+            <strong>{a.site_nom || 'Site'}</strong> — {(a.readings_count || 0).toLocaleString()} releves
+            {a.energy_types?.length > 0 && ` (${a.energy_types.join(', ')})`}
+          </span>
+          {a.first_ts && a.last_ts && (
+            <span className="text-xs text-blue-500 ml-auto whitespace-nowrap">
+              {fmtDate(a.first_ts)} → {fmtDate(a.last_ts)}
+            </span>
+          )}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `mergedAvailability` always used `avails[0]` for `site_nom`, `first_ts`, and `last_ts`, so in multi-site mode the banner always displayed the first site's name and dates regardless of which sites were selected.
- **Fix**: `ContextBanner` now accepts `availabilityBySite` (keyed by siteId) and `siteIds` (ordered array), and renders one clearly-labelled row per site using that site's own correct data. No aggregation ambiguity.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/ContextBanner.jsx` | Replaced flat `availability` prop with `availabilityBySite` + `siteIds`; renders one row per site with has_data |
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Destructures `data.availabilityBySite` from motor; passes `availabilityBySite` + `siteIds` to `ContextBanner` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/ConsumptionExplorerPage.test.js
```
18/18 pass.

**Steps to reproduce the bug**
1. Go to **Consommations → Explorer**
2. Select a first site — banner shows its name, readings, and date range
3. Add a second site — banner now shows only first site's name and dates (bug)

**Steps to verify the fix**
1. Go to **Consommations → Explorer**
2. Select a first site — banner shows one row with correct site info
3. Add a second site — banner shows two rows, each with its own name, readings count, energy types, and date range

Closes #25