### PR TITLE
fix(explorer): restore empile/separe modes and fix site_N key mismatch (#22)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -94,7 +94,7 @@ function SepareGrid({ siteIds, data, xKey, valueKey, unit, height, children }) {
     <div className={`grid gap-3`} style={{ gridTemplateColumns: `repeat(${colCount}, 1fr)` }}>
       {siteIds.map((sid, idx) => {
         const color = colorForSite(sid, idx);
-        const siteData = data.map((p) => ({ ...p, kwh: p[`kwh_${sid}`] ?? p.kwh ?? null }));
+        const siteData = data.map((p) => ({ ...p, kwh: p[`site_${sid}`] ?? p.value ?? null }));
         return (
           <div key={sid}>
             <ResponsiveContainer width="100%" height={Math.round(height * 0.6)}>
@@ -115,7 +115,7 @@ function SepareGrid({ siteIds, data, xKey, valueKey, unit, height, children }) {
                 />
                 <Area
                   type="monotone"
-                  dataKey={valueKey}
+                  dataKey="kwh"
                   stroke={color}
                   fill={color}
                   fillOpacity={0.2}
@@ -160,7 +160,7 @@ export default function ExplorerChart({
   const hasAnySiteData =
     mode === 'superpose' || mode === 'empile'
       ? siteIds.some((sid) =>
-          stableData.some((p) => p[`kwh_${sid}`] != null && !isNaN(p[`kwh_${sid}`]))
+          stableData.some((p) => p[`site_${sid}`] != null && !isNaN(p[`site_${sid}`]))
         )
       : false;
 
@@ -236,7 +236,7 @@ export default function ExplorerChart({
                 <Line
                   key={sid}
                   type="monotone"
-                  dataKey={`kwh_${sid}`}
+                  dataKey={`site_${sid}`}
                   stroke={color}
                   dot={false}
                   strokeWidth={2}
@@ -252,7 +252,7 @@ export default function ExplorerChart({
                 <Area
                   key={sid}
                   type="monotone"
-                  dataKey={`kwh_${sid}`}
+                  dataKey={`site_${sid}`}
                   stackId="stack"
                   stroke={color}
                   fill={color}

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -389,8 +389,9 @@ export default function TimeseriesPanel({
     ? Math.min(100, Math.round((availability.readings_count / 500) * 100))
     : null;
 
-  // For multi-series overlay, ExplorerChart uses `superpose` mode with site keys
-  const chartMode = seriesData.length > 1 && mode === 'superpose' ? 'superpose' : 'agrege';
+  // For multi-series, pass empile/separe/superpose through; single-site always agrege
+  const MULTI_SITE_MODES = ['superpose', 'empile', 'separe'];
+  const chartMode = seriesData.length > 1 && MULTI_SITE_MODES.includes(mode) ? mode : 'agrege';
   const chartSiteIds = overlayValueKeys.length
     ? overlayValueKeys.map((k) => parseInt(k.replace('site_', ''), 10))
     : siteIds.slice(0, 1);


### PR DESCRIPTION
## Summary

- **Root cause (Bug 2)**: `TimeseriesPanel.jsx` line 393 — `chartMode` only passed `superpose` through; `empile` and `separe` were silently collapsed to `agrege`, so ExplorerChart never entered those branches.
- **Root cause (Bug 1)**: `ExplorerChart.jsx` read `dataKey=\`kwh_${sid}\`` in `superpose`/`empile` modes and `SepareGrid`, but `seriesToChartData()` stores per-site data under `site_${sid}` keys (as returned by the EMS API). Keys never matched → empty/wrong charts.
- **Fix**: `TimeseriesPanel` now passes all 4 modes through when `seriesData.length > 1`; `ExplorerChart` reads `site_${sid}` consistently across `superpose`, `empile`, and `SepareGrid`.

> Note: Bug 3 (KPI scorecards frozen on first site) is out of scope for this PR and will be addressed separately under the same issue #22.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/TimeseriesPanel.jsx` | `chartMode` now passes `empile` and `separe` through for multi-series |
| `frontend/src/pages/consumption/ExplorerChart.jsx` | `superpose`, `empile`, `hasAnySiteData` guard, and `SepareGrid` all use `site_${sid}` instead of `kwh_${sid}` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/ExplorerChartBrush.test.js src/pages/__tests__/V20TimeseriesFix.test.js src/pages/__tests__/V143Timeseries.test.js src/pages/__tests__/ConsumptionExplorerPage.test.js src/pages/__tests__/ExplorerMotor.test.js src/pages/__tests__/V22ConsommationsExpert.test.js
```
118/118 tests passing.

**Steps to reproduce the bug**
1. Go to `/consommations/explorer`
2. Select two sites (e.g. Siege Helios Paris + Usine Helios Toulouse)
3. Click **Superposé** → blank chart
4. Click **Empilé** → single site shown, labelled "Agrégé"
5. Click **Séparé** → same

**Steps to verify the fix**
1. Same setup as above
2. Click **Superposé** → both sites rendered as distinct lines with correct colors
3. Click **Empilé** → both sites stacked as areas
4. Click **Séparé** → two separate sub-charts, one per site

Closes #22 (stage 1/2 — Bugs 1 & 2 only)