### PR TITLE
fix(consumption): séparé mode shows correct per-site data and real site names (#33)

### DIFF
--- a/frontend/src/pages/__tests__/V143Timeseries.test.js
+++ b/frontend/src/pages/__tests__/V143Timeseries.test.js
@@ -28,8 +28,8 @@ describe('MODE_MAP: PROMEOS → EMS API modes', () => {
     expect(MODE_MAP.empile).toBe('stack');
   });
 
-  it('separe → split', () => {
-    expect(MODE_MAP.separe).toBe('split');
+  it('separe → overlay (fix #33: split returns meter keys, overlay returns site_<id> keys)', () => {
+    expect(MODE_MAP.separe).toBe('overlay');
   });
 
   it('all 4 modes are defined', () => {

--- a/frontend/src/pages/__tests__/V20TimeseriesFix.test.js
+++ b/frontend/src/pages/__tests__/V20TimeseriesFix.test.js
@@ -182,6 +182,6 @@ describe('MODE_MAP', () => {
     expect(MODE_MAP.agrege).toBe('aggregate');
     expect(MODE_MAP.superpose).toBe('overlay');
     expect(MODE_MAP.empile).toBe('stack');
-    expect(MODE_MAP.separe).toBe('split');
+    expect(MODE_MAP.separe).toBe('overlay'); // fix #33: overlay returns site_<id> keys; split returns meter_<id> keys
   });
 });

--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -88,13 +88,14 @@ function InsufficientDataPlaceholder({ count = 0 }) {
   );
 }
 
-function SepareGrid({ siteIds, data, xKey, valueKey, unit, height, children }) {
+function SepareGrid({ siteIds, data, xKey, valueKey, unit, height, siteLabels = {}, children }) {
   const colCount = Math.min(siteIds.length, 3);
   return (
     <div className={`grid gap-3`} style={{ gridTemplateColumns: `repeat(${colCount}, 1fr)` }}>
       {siteIds.map((sid, idx) => {
         const color = colorForSite(sid, idx);
-        const siteData = data.map((p) => ({ ...p, kwh: p[`site_${sid}`] ?? p.value ?? null }));
+        const siteData = data.map((p) => ({ ...p, kwh: p[`site_${sid}`] ?? null }));
+        const label = siteLabels[sid] ?? `Site ${idx + 1}`;
         return (
           <div key={sid}>
             <ResponsiveContainer width="100%" height={Math.round(height * 0.6)}>
@@ -119,12 +120,12 @@ function SepareGrid({ siteIds, data, xKey, valueKey, unit, height, children }) {
                   stroke={color}
                   fill={color}
                   fillOpacity={0.2}
-                  name={`Site ${idx + 1}`}
+                  name={label}
                 />
                 {children}
               </ComposedChart>
             </ResponsiveContainer>
-            <p className="text-center text-xs text-gray-500 mt-1">Site {idx + 1}</p>
+            <p className="text-center text-xs text-gray-500 mt-1">{label}</p>
           </div>
         );
       })}
@@ -140,6 +141,7 @@ export default function ExplorerChart({
   unit = 'kwh',
   siteIds = [],
   siteColors = {},
+  siteLabels = {},
   height = 300,
   onSlotClick,
   showBrush = true,
@@ -185,6 +187,7 @@ export default function ExplorerChart({
           valueKey={valueKey}
           unit={unit}
           height={height}
+          siteLabels={siteLabels}
         >
           {children}
         </SepareGrid>

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -316,6 +316,13 @@ export default function TimeseriesPanel({
   // V20-B (RC3 fix): effectiveValueKey must match what ExplorerChart will use
   const effectiveValueKey = overlayValueKeys.length ? overlayValueKeys[0] : 'value';
 
+  // Issue #33: site name labels for SepareGrid sub-graph titles
+  const siteLabels = Object.fromEntries(
+    seriesData
+      .filter((s) => s.key?.startsWith('site_'))
+      .map((s) => [parseInt(s.key.replace('site_', ''), 10), s.label])
+  );
+
   // Debug panel — shown in ALL states when ?debug=1 (after overlayValueKeys so chartMeta is available)
   const isDebug =
     typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('debug');
@@ -413,6 +420,7 @@ export default function TimeseriesPanel({
           unit={unit}
           siteIds={chartSiteIds}
           siteColors={effectiveSiteColors}
+          siteLabels={siteLabels}
           height={360}
           showBrush
           summaryData={{

--- a/frontend/src/pages/consumption/useEmsTimeseries.js
+++ b/frontend/src/pages/consumption/useEmsTimeseries.js
@@ -21,7 +21,7 @@ export const MODE_MAP = {
   agrege: 'aggregate',
   superpose: 'overlay',
   empile: 'stack',
-  separe: 'split',
+  separe: 'overlay', // one series per site (site_<id> keys) — same as superpose, displayed differently
 };
 
 // ── Date formatting by granularity (French) ───────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause (bug a)**: `MODE_MAP` mapped `separe` → `'split'` (API mode). The `split` mode returns series keyed as `meter_<id>`, but `SepareGrid` reconstructs `site_<id>` keys for lookups. `parseInt('meter_5'.replace('site_', ''), 10)` → `NaN`, so every chart fell back to `p.value` (first site's data). The `overlay` mode (already used by `superpose`) correctly returns `site_<id>` keys — `separe` needs the same.
- **Root cause (bug b)**: No site label map was threaded from `TimeseriesPanel` → `ExplorerChart` → `SepareGrid`, so sub-graph titles defaulted to `Site 1`, `Site 2`, etc. The API already returns `label` per series; we just needed to build and pass the map.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/useEmsTimeseries.js` | `separe: 'split'` → `separe: 'overlay'` in `MODE_MAP` |
| `frontend/src/pages/consumption/TimeseriesPanel.jsx` | Build `siteLabels` map from `seriesData`; pass as prop to `ExplorerChart` |
| `frontend/src/pages/consumption/ExplorerChart.jsx` | Accept `siteLabels` prop; thread to `SepareGrid`; use label for `Area name` and `<p>` title; remove erroneous `?? p.value` fallback |
| `frontend/src/pages/__tests__/V143Timeseries.test.js` | Update `separe` assertion from `'split'` → `'overlay'` |
| `frontend/src/pages/__tests__/V20TimeseriesFix.test.js` | Same |

## Test plan

**Automated tests**
```bash
cd frontend
npx vitest run src/pages/__tests__/ExplorerChartBrush.test.js src/pages/__tests__/V143Timeseries.test.js src/pages/__tests__/V20TimeseriesFix.test.js
# 53 tests, all passing
```

**Steps to reproduce the bug**
1. Go to Consommations → Explorer
2. Select 3+ sites from the left panel
3. Switch display mode to **Séparé**
4. Observe all sub-graphs showing identical data (site 1) and titles "Site 1", "Site 2"

**Steps to verify the fix**
1. Same steps as above
2. Each sub-graph now shows its own site's data (distinct curves)
3. Sub-graph titles show real site names (e.g. "Entrepôt Lyon", "Siège Paris")

Closes #33