### PR TITLE
fix(ems): stack mode aggregates per site with site_ keys (#34)

### DIFF
--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -190,7 +190,19 @@ def query_timeseries(
                 )
             )
     elif mode == "stack":
-        series = [_query_single(db, m, bucket_expr, date_from, date_to, granularity, metric) for m in meters]
+        site_meter_map = {}
+        for m in meters:
+            site_meter_map.setdefault(m.site_id, []).append(m)
+        site_names = {s.id: s.nom for s in db.query(Site).filter(Site.id.in_(list(site_meter_map.keys()))).all()}
+        series = []
+        for sid, ms in sorted(site_meter_map.items()):
+            m_ids = [m.id for m in ms]
+            label = site_names.get(sid, f"Site {sid}")
+            series.append(
+                _query_aggregate(
+                    db, m_ids, bucket_expr, date_from, date_to, granularity, metric, key=f"site_{sid}", label=label
+                )
+            )
     else:  # split
         MAX_SPLIT = 8
         sorted_meters = sorted(meters, key=lambda m: m.id)

--- a/backend/tests/test_ems_timeseries.py
+++ b/backend/tests/test_ems_timeseries.py
@@ -104,16 +104,17 @@ class TestTimeseriesContract:
 
     def test_stack_two_series(self, env):
         client, db = env
-        site = _seed_site(db)
-        m1 = _seed_meter(db, site.id, "M1")
-        m2 = _seed_meter(db, site.id, "M2")
+        site1 = _seed_site(db, "Site A")
+        site2 = _seed_site(db, "Site B")
+        m1 = _seed_meter(db, site1.id, "M1")
+        m2 = _seed_meter(db, site2.id, "M2")
         _seed_readings(db, m1.id, days=3, kwh=10)
         _seed_readings(db, m2.id, days=3, kwh=5)
 
         r = client.get(
             "/api/ems/timeseries",
             params={
-                "site_ids": str(site.id),
+                "site_ids": f"{site1.id},{site2.id}",
                 "date_from": "2025-01-01",
                 "date_to": "2025-01-04",
                 "granularity": "daily",
@@ -121,7 +122,10 @@ class TestTimeseriesContract:
             },
         )
         assert r.status_code == 200
-        assert len(r.json()["series"]) == 2
+        series = r.json()["series"]
+        assert len(series) == 2
+        keys = {s["key"] for s in series}
+        assert keys == {f"site_{site1.id}", f"site_{site2.id}"}
 
     def test_split_max_8_plus_others(self, env):
         client, db = env

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -400,7 +400,7 @@ export default function TimeseriesPanel({
   const MULTI_SITE_MODES = ['superpose', 'empile', 'separe'];
   const chartMode = seriesData.length > 1 && MULTI_SITE_MODES.includes(mode) ? mode : 'agrege';
   const chartSiteIds = overlayValueKeys.length
-    ? overlayValueKeys.map((k) => parseInt(k.replace('site_', ''), 10))
+    ? overlayValueKeys.map((k) => parseInt(k.replace('site_', ''), 10)).filter((id) => !isNaN(id))
     : siteIds.slice(0, 1);
 
   return (


### PR DESCRIPTION
## Summary

- **Backend**: `stack` mode in `timeseries_service.py` now aggregates meters per site (using `_query_aggregate` with `site_<id>` keys) instead of producing per-meter series with `meter_<id>` keys, mirroring the `overlay` mode pattern
- **Frontend**: Added `.filter((id) => !isNaN(id))` guard in `TimeseriesPanel.jsx` to prevent NaN from non-`site_` keys breaking chart rendering
- **Tests**: Updated `test_stack_two_series` to create 2 sites (1 meter each) and assert `site_<id>` key format

Closes #34

## Test plan

- [x] `pytest backend/tests/test_ems_timeseries.py -v` — all 13 tests pass
- [x] Open Consommations → Explorer, select 2+ sites, switch to **Empile** → stacked areas render correctly
- [x] Verify `GET /api/ems/timeseries?site_ids=1,2&mode=stack` returns `site_1`, `site_2` keys
- [x] Confirm **Superpose** and **Séparé** modes still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)