### PR TITLE
fix(explorer): aggregate multi-site KPIs in ConsoKpiHeader (#38)

### DIFF
--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -253,9 +253,59 @@ export default function ConsumptionExplorerPage() {
     mergedAvailability,
     primarySiteId,
     primaryAvailability,
-    data: { availabilityBySite },
+    data: { availabilityBySite, tunnelBySite, hphcBySite, progressionBySite },
     loading,
   } = motor;
+
+  // ── Multi-site KPI aggregation (issue #38) ────────────────────────────
+  // Aggregate hphc, tunnel, and progression across all selected sites so
+  // ConsoKpiHeader shows totals rather than only the primary site.
+  const aggregatedHphc = useMemo(() => {
+    const entries = siteIds.map((sid) => hphcBySite[sid]).filter(Boolean);
+    if (!entries.length) return null;
+    if (entries.length === 1) return entries[0];
+    return {
+      ...entries[0],
+      total_kwh: entries.reduce((s, h) => s + (h.total_kwh ?? 0), 0),
+      total_cost_eur: entries.reduce((s, h) => s + (h.total_cost_eur ?? 0), 0),
+    };
+  }, [siteIds, hphcBySite]);
+
+  const aggregatedTunnel = useMemo(() => {
+    const entries = siteIds.map((sid) => tunnelBySite[sid]).filter(Boolean);
+    if (!entries.length) return null;
+    if (entries.length === 1) return entries[0];
+    const sumSlots = (arrays) => {
+      if (!arrays.length) return null;
+      return arrays[0].map((slot, i) => ({
+        ...slot,
+        p10: arrays.reduce((s, arr) => s + (arr[i]?.p10 ?? 0), 0),
+        p50: arrays.reduce((s, arr) => s + (arr[i]?.p50 ?? 0), 0),
+        p90: arrays.reduce((s, arr) => s + (arr[i]?.p90 ?? 0), 0),
+        p95: arrays.reduce((s, arr) => s + (arr[i]?.p95 ?? 0), 0),
+      }));
+    };
+    const weekdayArrays = entries.map((t) => t.envelope?.weekday).filter(Boolean);
+    const weekendArrays = entries.map((t) => t.envelope?.weekend).filter(Boolean);
+    return {
+      ...entries[0],
+      total_kwh: entries.reduce((s, t) => s + (t.total_kwh ?? 0), 0),
+      envelope: {
+        weekday: sumSlots(weekdayArrays),
+        weekend: sumSlots(weekendArrays),
+      },
+    };
+  }, [siteIds, tunnelBySite]);
+
+  const aggregatedProgression = useMemo(() => {
+    const entries = siteIds.map((sid) => progressionBySite[sid]).filter(Boolean);
+    if (!entries.length) return null;
+    if (entries.length === 1) return entries[0];
+    return {
+      ...entries[0],
+      ytd_actual_kwh: entries.reduce((s, p) => s + (p.ytd_actual_kwh ?? 0), 0),
+    };
+  }, [siteIds, progressionBySite]);
 
   // ── User-initiated period flag (issue #23) ────────────────────────────
   // Prevents auto-calibration from overwriting a period the user explicitly chose.
@@ -580,9 +630,9 @@ export default function ConsumptionExplorerPage() {
       {/* KPI Header — 6 KPIs respecting scope global */}
       {showContent && (
         <ConsoKpiHeader
-          tunnel={motor.primaryTunnel}
-          hphc={motor.primaryHphc}
-          progression={motor.primaryProgression}
+          tunnel={aggregatedTunnel}
+          hphc={aggregatedHphc}
+          progression={aggregatedProgression}
           confidence={availability?.confidence}
           onEvidence={setEvidenceKpiOpen}
         />


### PR DESCRIPTION
## Summary

- **Root cause**: `ConsoKpiHeader` received `motor.primaryTunnel/primaryHphc/primaryProgression` which always pointed to `siteIds[0]`, silently ignoring all other selected sites in multi-site mode.
- **Fix**: Added three `useMemo` hooks (`aggregatedHphc`, `aggregatedTunnel`, `aggregatedProgression`) in `ConsumptionExplorerPage.jsx` that sum values across all selected sites. `ConsoKpiHeader` now receives these aggregated props. Single-site selection is a no-op passthrough (returns the original object unchanged).

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Destructure `tunnelBySite`, `hphcBySite`, `progressionBySite` from `motor.data`; add 3 `useMemo` aggregation hooks; pass aggregated props to `ConsoKpiHeader` |

## Aggregation logic

| KPI | Aggregation |
|-----|-------------|
| kWh total | Sum `hphc.total_kwh` across all sites |
| EUR total | Sum `hphc.total_cost_eur` across all sites |
| EUR/MWh | Derived from summed EUR / summed kWh (computed inside `ConsoKpiHeader`, unchanged) |
| CO2e | Derived from summed kWh × ADEME factor (computed inside `ConsoKpiHeader`, unchanged) |
| Pic kW (P95) | Sum `p95` per hour slot across all sites (total peak capacity) |
| Base nocturne % | Sum `p50` per slot → night/day ratio computed as before in `ConsoKpiHeader` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/ConsumptionExplorerPage.test.js
```

**Steps to reproduce the bug**
1. Go to `/consommations/explorer`
2. Select **Siege Helios Paris** — note the 6 KPI values
3. Add **Usine Helios Toulouse** — KPIs remain frozen on Siege Helios Paris values ❌

**Steps to verify the fix**
1. Go to `/consommations/explorer`
2. Select **Siege Helios Paris** — note the 6 KPI values
3. Add **Usine Helios Toulouse** — KPIs update to show aggregated totals for both sites ✅
4. Remove one site — KPIs revert to the single remaining site ✅

Closes #38