### PR TITLE
fix(explorer): KPI Pic kW (P95) affiche 0 en mode multi-site (#41)

### DIFF
--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -282,7 +282,6 @@ export default function ConsumptionExplorerPage() {
         p10: arrays.reduce((s, arr) => s + (arr[i]?.p10 ?? 0), 0),
         p50: arrays.reduce((s, arr) => s + (arr[i]?.p50 ?? 0), 0),
         p90: arrays.reduce((s, arr) => s + (arr[i]?.p90 ?? 0), 0),
-        p95: arrays.reduce((s, arr) => s + (arr[i]?.p95 ?? 0), 0),
       }));
     };
     const weekdayArrays = entries.map((t) => t.envelope?.weekday).filter(Boolean);


### PR DESCRIPTION
## Summary

- **Root cause**: `sumSlots` in `ConsumptionExplorerPage.jsx` explicitly set `p95: 0` for every aggregated slot because the backend never returns a `p95` field (`undefined ?? 0 = 0`). `ConsoKpiHeader` then evaluated `s.p95 ?? s.p90` and got `0` — the `??` operator does **not** short-circuit on `0`, so the `p90` fallback was never reached.
- **Fix**: Removed the `p95` key from `sumSlots`. Aggregated slots now omit `p95` entirely (same as single-site slots), so `ConsoKpiHeader`'s `s.p95 ?? s.p90` correctly falls back to the summed `p90` value.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Deleted the `p95: arrays.reduce(...)` line from `sumSlots` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/ConsumptionExplorerPage.test.js
```
All 18 tests pass.

**Steps to reproduce the bug**
1. Open Consumption Explorer
2. Select 2+ sites
3. Observe "Pic kW (P95)" KPI tile shows **0 kW**

**Steps to verify the fix**
1. Open Consumption Explorer
2. Select 2+ sites
3. Observe "Pic kW (P95)" KPI tile shows the sum of per-site P90 peak values (non-zero)
4. Switch to single-site — value remains correct

Closes #41