### PR TITLE
fix(explorer): afficher le nom des sites en mode superposé/empilé (#44)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -258,7 +258,7 @@ export default function ExplorerChart({
                   stroke={color}
                   dot={false}
                   strokeWidth={2}
-                  name={`Site ${idx + 1}`}
+                  name={siteLabels[sid] ?? `Site ${idx + 1}`}
                 />,
                 hasPrev && (
                   <Line
@@ -270,7 +270,7 @@ export default function ExplorerChart({
                     strokeOpacity={0.4}
                     dot={false}
                     strokeWidth={1.5}
-                    name={`Site ${idx + 1} (N-1)`}
+                    name={`${siteLabels[sid] ?? `Site ${idx + 1}`} (N-1)`}
                   />
                 ),
               ];
@@ -288,7 +288,7 @@ export default function ExplorerChart({
                   stroke={color}
                   fill={color}
                   fillOpacity={0.4}
-                  name={`Site ${idx + 1}`}
+                  name={siteLabels[sid] ?? `Site ${idx + 1}`}
                 />
               );
             })}


### PR DESCRIPTION
## Summary

- **Root cause**: les blocs `superpose` et `empile` de `ExplorerChart.jsx` codaient en dur `` `Site ${idx + 1}` `` au lieu d'utiliser le prop `siteLabels` déjà disponible.
- **Fix**: remplacement par `` siteLabels[sid] ?? `Site ${idx + 1}` `` aux trois occurrences (ligne principale, N-1, et mode empilé), avec fallback gracieux si le label est absent.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/ExplorerChart.jsx` | 3 substitutions : hard-coded `Site N` → `siteLabels[sid] ?? \`Site N\`` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/ExplorerChartBrush.test.js src/pages/__tests__/ConsumptionExplorerPage.test.js src/pages/__tests__/ExplorerHelpers.test.js
```

**Steps to reproduce the bug**
1. Ouvrir Consommations › Explorer
2. Sélectionner plusieurs sites
3. Passer en mode Superposé ou Empilé
4. Observer la légende et les tooltips : ils affichent `Site 1`, `Site 2`…

**Steps to verify the fix**
1. Mêmes étapes — la légende et les tooltips doivent afficher le nom réel du site (ex. `Site Bordeaux Bacalan`)
2. Le mode Séparé (déjà correct) doit continuer à fonctionner identiquement

Closes #44