### PR TITLE
fix(consumption): supprimer les métadonnées dupliquées du graphique (#46)

### DIFF
--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -425,37 +425,7 @@ export default function TimeseriesPanel({
           siteLabels={siteLabels}
           height={360}
           showBrush
-          summaryData={{
-            points: n_points,
-            series: seriesData.length,
-            meters: n_meters,
-            source: 'EMS',
-            quality: qualityPct,
-          }}
         />
-
-        {/* Granularity + date range info */}
-        {granularity && (
-          <p className="text-xs text-gray-400 text-right">
-            Granularité{'\u00a0'}: {GRAN_LABELS[granularity] || granularity}
-            {meta?.date_from && meta?.date_to && (
-              <span className="ml-2">
-                ·{' '}
-                {new Date(meta.date_from).toLocaleDateString('fr-FR', {
-                  day: '2-digit',
-                  month: 'short',
-                  year: '2-digit',
-                })}{' '}
-                →{' '}
-                {new Date(meta.date_to).toLocaleDateString('fr-FR', {
-                  day: '2-digit',
-                  month: 'short',
-                  year: '2-digit',
-                })}
-              </span>
-            )}
-          </p>
-        )}
       </div>
     </ChartFrame>
   );


### PR DESCRIPTION
## Summary

- **Root cause**: `summaryData` était passé à `<ExplorerChart>` depuis `TimeseriesPanel`, déclenchant le rendu de `SummaryRow` dans `ExplorerChart.jsx` (ligne 307), alors que `DataCoverageBadge` affichait déjà les mêmes informations (sites, compteurs, points, granularité, qualité, source) en haut du graphique.
- **Fix**: suppression de la prop `summaryData` et du paragraphe granularité/date-range dans `TimeseriesPanel.jsx`. `DataCoverageBadge` couvre déjà toutes ces informations. `SummaryRow` est conservé dans `ExplorerChart` pour d'éventuels usages sans `DataCoverageBadge`.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/TimeseriesPanel.jsx` | Suppression de la prop `summaryData` (lignes 428–434) et du bloc granularité/date-range (lignes 437–458) |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```
(160 fichiers passent — les 4 fichiers en échec utilisent des chemins Windows codés en dur, défaut pré-existant sans rapport avec ce fix)

**Steps to reproduce the bug**
1. Ouvrir Consommations > Explorer
2. Sélectionner un site et afficher le graphique
3. Observer les métadonnées affichées deux fois : une fois au-dessus (DataCoverageBadge), une fois en dessous (SummaryRow + ligne granularité)

**Steps to verify the fix**
1. Ouvrir Consommations > Explorer
2. Sélectionner un site et afficher le graphique
3. Vérifier que les métadonnées n'apparaissent qu'une seule fois, via la bande grise discrète au-dessus du graphique

Closes #46