### PR TITLE
fix(consumption): légende affiche le nom du site sur sélection unique (#49)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -142,6 +142,7 @@ export default function ExplorerChart({
   siteIds = [],
   siteColors = {},
   siteLabels = {},
+  aggregateLabel = 'Agrégé',
   height = 300,
   onSlotClick,
   showBrush = true,
@@ -228,7 +229,7 @@ export default function ExplorerChart({
               stroke="#3b82f6"
               fill="#93c5fd"
               fillOpacity={0.3}
-              name="Agrégé"
+              name={aggregateLabel}
             />
           )}
 

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -404,6 +404,9 @@ export default function TimeseriesPanel({
   const chartSiteIds = overlayValueKeys.length
     ? overlayValueKeys.map((k) => parseInt(k.replace('site_', ''), 10)).filter((id) => !isNaN(id))
     : siteIds.slice(0, 1);
+  // When a single site is displayed in agrege mode, show its name instead of "Agrégé"
+  const aggregateLabel =
+    seriesData.length === 1 ? (siteLabels[chartSiteIds[0]] ?? 'Agrégé') : 'Agrégé';
 
   return (
     <ChartFrame>
@@ -423,6 +426,7 @@ export default function TimeseriesPanel({
           siteIds={chartSiteIds}
           siteColors={effectiveSiteColors}
           siteLabels={siteLabels}
+          aggregateLabel={aggregateLabel}
           height={360}
           showBrush
           summaryData={{


### PR DESCRIPTION
## Summary

- **Root cause**: `ExplorerChart` hardcodait `name="Agrégé"` pour la série agrege; `TimeseriesPanel` forçait `chartMode='agrege'` pour un seul site sans passer de label contextuel.
- **Fix**: ajout d'une prop `aggregateLabel` dans `ExplorerChart` (défaut `"Agrégé"`); `TimeseriesPanel` dérive `aggregateLabel` depuis `siteLabels` quand `seriesData.length === 1`.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/ExplorerChart.jsx` | Ajout prop `aggregateLabel = 'Agrégé'`; utilisation en lieu de la valeur hardcodée |
| `frontend/src/pages/consumption/TimeseriesPanel.jsx` | Calcul de `aggregateLabel` depuis `siteLabels` quand un seul site; transmission à `<ExplorerChart>` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/ExplorerChartBrush.test.js --reporter=verbose
```

**Steps to reproduce the bug**
1. Ouvrir l'explorateur de consommation
2. Sélectionner un seul site
3. Observer la légende du graphique → affiche "Agrégé"

**Steps to verify the fix**
1. Sélectionner un seul site → la légende affiche le nom du site
2. Sélectionner plusieurs sites en mode Agrégé → la légende affiche "Agrégé"
3. Sélectionner plusieurs sites en mode Superposé/Empilé/Séparé → la légende affiche les noms des sites

Closes #49