### PR TITLE
fix(consumption): légende correcte sur un seul site — lookup via prop sites (#49)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -142,6 +142,7 @@ export default function ExplorerChart({
   siteIds = [],
   siteColors = {},
   siteLabels = {},
+  aggregateLabel = 'Agrégé',
   height = 300,
   onSlotClick,
   showBrush = true,
@@ -228,7 +229,7 @@ export default function ExplorerChart({
               stroke="#3b82f6"
               fill="#93c5fd"
               fillOpacity={0.3}
-              name="Agrégé"
+              name={aggregateLabel}
             />
           )}
 

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -406,7 +406,9 @@ export default function TimeseriesPanel({
     : siteIds.slice(0, 1);
   // When a single site is displayed in agrege mode, show its name instead of "Agrégé"
   const aggregateLabel =
-    seriesData.length === 1 ? (siteLabels[chartSiteIds[0]] ?? 'Agrégé') : 'Agrégé';
+    seriesData.length === 1
+      ? (_sites.find((s) => s.id === chartSiteIds[0])?.nom ?? siteLabels[chartSiteIds[0]] ?? 'Agrégé')
+      : 'Agrégé';
 
   return (
     <ChartFrame>

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -404,6 +404,9 @@ export default function TimeseriesPanel({
   const chartSiteIds = overlayValueKeys.length
     ? overlayValueKeys.map((k) => parseInt(k.replace('site_', ''), 10)).filter((id) => !isNaN(id))
     : siteIds.slice(0, 1);
+  // When a single site is displayed in agrege mode, show its name instead of "Agrégé"
+  const aggregateLabel =
+    seriesData.length === 1 ? (siteLabels[chartSiteIds[0]] ?? 'Agrégé') : 'Agrégé';
 
   return (
     <ChartFrame>
@@ -423,6 +426,7 @@ export default function TimeseriesPanel({
           siteIds={chartSiteIds}
           siteColors={effectiveSiteColors}
           siteLabels={siteLabels}
+          aggregateLabel={aggregateLabel}
           height={360}
           showBrush
           summaryData={{


### PR DESCRIPTION
## Root cause

En mode agrégé avec un seul site, le backend retourne une série avec `key='total'` (pas `key='site_<id>'`). `siteLabels` est donc toujours `{}` dans ce cas, et `aggregateLabel` tombait systématiquement sur `'Agrégé'`.

## Fix

`TimeseriesPanel.jsx:408-411` — `aggregateLabel` consulte maintenant `_sites.find((s) => s.id === chartSiteIds[0])?.nom` en priorité (prop déjà disponible), avec `siteLabels` et `'Agrégé'` comme fallbacks.

```js
// Before
const aggregateLabel =
  seriesData.length === 1 ? (siteLabels[chartSiteIds[0]] ?? 'Agrégé') : 'Agrégé';

// After
const aggregateLabel =
  seriesData.length === 1
    ? (_sites.find((s) => s.id === chartSiteIds[0])?.nom ?? siteLabels[chartSiteIds[0]] ?? 'Agrégé')
    : 'Agrégé';
```

## Test plan

- [ ] 1 site sélectionné → légende affiche `s.nom` (ex. "Bureau Paris")
- [ ] Multi-site agrégé → légende affiche "Agrégé"
- [ ] Multi-site superposé/empilé/séparé → noms par site inchangés
- [ ] `ExplorerChartBrush.test.js` — 12/12 tests passent

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)