### PR TITLE
fix(consumption): correction guard siteIds.length pour aggregateLabel (#49)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -142,6 +142,7 @@ export default function ExplorerChart({
   siteIds = [],
   siteColors = {},
   siteLabels = {},
+  aggregateLabel = 'Agrégé',
   height = 300,
   onSlotClick,
   showBrush = true,
@@ -228,7 +229,7 @@ export default function ExplorerChart({
               stroke="#3b82f6"
               fill="#93c5fd"
               fillOpacity={0.3}
-              name="Agrégé"
+              name={aggregateLabel}
             />
           )}
 

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -406,7 +406,9 @@ export default function TimeseriesPanel({
     : siteIds.slice(0, 1);
   // When a single site is displayed in agrege mode, show its name instead of "Agrégé"
   const aggregateLabel =
-    seriesData.length === 1 ? (siteLabels[chartSiteIds[0]] ?? 'Agrégé') : 'Agrégé';
+    seriesData.length === 1
+      ? (_sites.find((s) => s.id === chartSiteIds[0])?.nom ?? siteLabels[chartSiteIds[0]] ?? 'Agrégé')
+      : 'Agrégé';
 
   return (
     <ChartFrame>

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -404,6 +404,9 @@ export default function TimeseriesPanel({
   const chartSiteIds = overlayValueKeys.length
     ? overlayValueKeys.map((k) => parseInt(k.replace('site_', ''), 10)).filter((id) => !isNaN(id))
     : siteIds.slice(0, 1);
+  // When a single site is displayed in agrege mode, show its name instead of "Agrégé"
+  const aggregateLabel =
+    seriesData.length === 1 ? (siteLabels[chartSiteIds[0]] ?? 'Agrégé') : 'Agrégé';
 
   return (
     <ChartFrame>
@@ -423,6 +426,7 @@ export default function TimeseriesPanel({
           siteIds={chartSiteIds}
           siteColors={effectiveSiteColors}
           siteLabels={siteLabels}
+          aggregateLabel={aggregateLabel}
           height={360}
           showBrush
           summaryData={{

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -406,8 +406,8 @@ export default function TimeseriesPanel({
     : siteIds.slice(0, 1);
   // When a single site is displayed in agrege mode, show its name instead of "Agrégé"
   const aggregateLabel =
-    seriesData.length === 1
-      ? (_sites.find((s) => s.id === chartSiteIds[0])?.nom ?? siteLabels[chartSiteIds[0]] ?? 'Agrégé')
+    siteIds.length === 1
+      ? (_sites.find((s) => s.id === siteIds[0])?.nom ?? siteLabels[siteIds[0]] ?? 'Agrégé')
       : 'Agrégé';
 
   return (


### PR DESCRIPTION
## Summary
- Corrige la régression introduite en PR #55 (fermée)
- `seriesData.length === 1` était `true` pour N sites agrégés (le backend retourne toujours 1 série `key='total'`), affichant le nom du premier site au lieu de "Agrégé"
- Guard corrigé : `siteIds.length === 1` — discriminant correct basé sur le nombre de sites **sélectionnés par l'utilisateur**

## Verification matrix
| Scénario | siteIds.length | Légende attendue |
|----------|----------------|-----------------|
| 1 site, mode agrégé | 1 | `s.nom` (ex: "Bureau Paris") |
| 2+ sites, mode agrégé | >1 | "Agrégé" |
| 2+ sites, superposé/empilé/séparé | >1 | noms par série (non concerné par aggregateLabel) |

## Test plan
- [ ] Sélectionner 1 seul site → vérifier que la légende affiche le nom du site
- [ ] Sélectionner 2+ sites en mode agrégé → vérifier que la légende affiche "Agrégé"
- [ ] Tests unitaires : 12/12 ✅ (`ExplorerChartBrush.test.js`)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)