### PR TITLE
fix(ui): supprimer l'espace vide de ~80 px entre onglets et pills (#51)

### DIFF
--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -578,21 +578,6 @@ export default function ConsumptionExplorerPage() {
         </div>
       )}
 
-      {/* UI Mode toggle — persisted in localStorage, never in URL */}
-      <div className="flex justify-end">
-        <button
-          onClick={toggleUiMode}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border transition text-gray-600 border-gray-200 bg-white hover:bg-gray-50"
-          title={
-            isClassic
-              ? 'Passer en mode Expert (contrôles avancés)'
-              : 'Passer en mode Classique (vue standard)'
-          }
-        >
-          {isClassic ? '⚙ Mode Expert' : '← Mode Classique'}
-        </button>
-      </div>
-
       {/* Unified sticky filter bar */}
       <StickyFilterBar
         uiMode={uiMode}
@@ -633,6 +618,7 @@ export default function ConsumptionExplorerPage() {
         samplingMinutes={samplingMinutes}
         compareYoy={compareYoy}
         setCompareYoy={setCompareYoy}
+        onToggleUiMode={toggleUiMode}
       />
 
       {/* Portfolio info banner — non-blocking, dismissible */}

--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -299,6 +299,8 @@ export default function StickyFilterBar({
   // YoY comparison toggle (Step 10 — F1)
   compareYoy = false,
   setCompareYoy,
+  // UI mode toggle (issue #51 — moved from standalone row)
+  onToggleUiMode,
 }) {
   const isClassic = uiMode === 'classic';
 
@@ -521,6 +523,21 @@ export default function StickyFilterBar({
               </option>
             ))}
           </select>
+        )}
+
+        {/* UI mode toggle — pushed to right side of Row 1 (issue #51) */}
+        {onToggleUiMode && (
+          <button
+            onClick={onToggleUiMode}
+            className="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border transition text-gray-600 border-gray-200 bg-white hover:bg-gray-50"
+            title={
+              isClassic
+                ? 'Passer en mode Expert (contrôles avancés)'
+                : 'Passer en mode Classique (vue standard)'
+            }
+          >
+            {isClassic ? '⚙ Mode Expert' : '← Mode Classique'}
+          </button>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- **Root cause**: Le bouton Mode Expert/Classique occupait sa propre rangée (`div.flex.justify-end`, ~36 px) dans `ConsumptionExplorerPage`, avec un `space-y-5` de 20 px avant la `StickyFilterBar` — cumulé aux 24 px du `space-y-6` de `PageShell`, cela créait ~80 px de vide entre les onglets et les pills de sites.
- **Fix**: Le bouton est déplacé dans la Row 1 de `StickyFilterBar` (extrémité droite via `ml-auto`) au moyen d'un nouveau prop `onToggleUiMode`. La `div` autonome est supprimée de `ConsumptionExplorerPage`, économisant ~56 px de hauteur effective.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/StickyFilterBar.jsx` | Ajout du prop `onToggleUiMode` ; rendu conditionnel du bouton Mode Expert/Classique avec `ml-auto` à la fin de Row 1 |
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Suppression de la `div.flex.justify-end` autonome ; passage de `onToggleUiMode={toggleUiMode}` à `StickyFilterBar` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```
5336 tests pass (17 échecs pré-existants non liés, chemins Windows d'un autre dev).

**Steps to reproduce the bug**
1. Ouvrir la page Consommations > Explorer
2. Observer l'espace entre la barre d'onglets et la première rangée de pills de sites (~80 px)

**Steps to verify the fix**
1. Ouvrir la page Consommations > Explorer
2. Vérifier que la `StickyFilterBar` apparaît immédiatement sous les onglets sans espace mort
3. Vérifier que le bouton Mode Expert / Mode Classique est visible à droite de la Row 1 de la `StickyFilterBar`
4. Vérifier que le toggle fonctionne (bascule entre mode Classic et Expert)

Closes #51