### PR TITLE
fix(ux): clarify mode toggle button labels with verb-first CTA (#52)

### DIFF
--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -536,7 +536,7 @@ export default function StickyFilterBar({
                 : 'Passer en mode Classique (vue standard)'
             }
           >
-            {isClassic ? '⚙ Mode Expert' : '← Mode Classique'}
+            {isClassic ? 'Passer en mode Expert →' : '← Retour au mode Classique'}
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary

- **Root cause**: the button label `'⚙ Mode Expert'` reads as a status badge rather than a CTA, causing users to think they are already in Expert mode before clicking.
- **Fix**: applied Option A (verb-first CTA) from the issue — both states now use the same structure: explicit verb + directional arrow.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/StickyFilterBar.jsx` | Line 539: `'⚙ Mode Expert'` → `'Passer en mode Expert →'` / `'← Mode Classique'` → `'← Retour au mode Classique'` |

> Note: the button is rendered in `StickyFilterBar.jsx`, not in `ConsumptionExplorerPage.jsx` as stated in the issue.

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/UIModeParity.test.js
# 37/37 passed
```

**Steps to reproduce the bug**
1. Navigate to `/consommations/explorer`
2. Observe the pill button in the top-right corner — it shows `⚙ Mode Expert`, which reads as a status indicator

**Steps to verify the fix**
1. Navigate to `/consommations/explorer`
2. Button now shows `Passer en mode Expert →` — clearly an action
3. Click it — switches to Expert mode; button shows `← Retour au mode Classique` — same verb-first convention

Closes #52