### PR TITLE
fix(explorer): palette 12 couleurs + index dropdown correct (#50)

### DIFF
--- a/frontend/src/pages/__tests__/ExplorerHelpers.test.js
+++ b/frontend/src/pages/__tests__/ExplorerHelpers.test.js
@@ -121,13 +121,13 @@ describe('colorForSite', () => {
     expect(colorForSite('s1', 0)).toMatch(/^#[0-9a-f]{6}$/i);
   });
 
-  it('wraps around after 5 sites', () => {
-    expect(colorForSite('s0', 0)).toBe(colorForSite('s5', 5));
+  it('wraps around after 12 sites', () => {
+    expect(colorForSite('s0', 0)).toBe(colorForSite('s12', 12));
   });
 
-  it('different indices get different colors (first 5)', () => {
-    const colors = [0, 1, 2, 3, 4].map((i) => colorForSite('s', i));
-    expect(new Set(colors).size).toBe(5);
+  it('different indices get different colors (first 12)', () => {
+    const colors = Array.from({ length: 12 }, (_, i) => colorForSite('s', i));
+    expect(new Set(colors).size).toBe(12);
   });
 });
 

--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -157,7 +157,7 @@ function SiteSearchDropdown({ sites, selectedIds, onAdd, onClose, anchorRef }) {
           <p className="text-xs text-gray-400 text-center py-3">Aucun site disponible</p>
         )}
         {available.map((s, idx) => {
-          const color = colorForSite(s.id, idx);
+          const color = colorForSite(s.id, selectedIds.length + idx);
           return (
             <button
               key={s.id}

--- a/frontend/src/pages/consumption/helpers.js
+++ b/frontend/src/pages/consumption/helpers.js
@@ -143,6 +143,13 @@ const SITE_COLORS = [
   '#f59e0b', // amber
   '#8b5cf6', // violet
   '#ef4444', // red
+  '#ec4899', // pink
+  '#06b6d4', // cyan
+  '#f97316', // orange
+  '#6366f1', // indigo
+  '#14b8a6', // teal
+  '#84cc16', // lime
+  '#d946ef', // fuchsia
 ];
 
 /**


### PR DESCRIPTION
## Summary

- **Root cause**: `SITE_COLORS` n'avait que 5 couleurs (doublons dès le 6ème site) et `SiteSearchDropdown` utilisait `idx` (0-based) au lieu de `selectedIds.length + idx`, produisant les mêmes couleurs dans le dropdown que les pills déjà sélectionnées.
- **Fix**: Palette élargie à 12 teintes couvrant le cercle chromatique complet ; index corrigé pour que la prévisualisation du dropdown corresponde à la couleur réellement attribuée.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/helpers.js` | `SITE_COLORS` : 5 → 12 couleurs (bleu, émeraude, ambre, violet, rouge, rose, cyan, orange, indigo, teal, lime, fuchsia) |
| `frontend/src/pages/consumption/StickyFilterBar.jsx` | `colorForSite(s.id, idx)` → `colorForSite(s.id, selectedIds.length + idx)` |
| `frontend/src/pages/__tests__/ExplorerHelpers.test.js` | Tests mis à jour pour refléter une palette de 12 couleurs |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose src/pages/__tests__/ExplorerHelpers.test.js
```

**Steps to reproduce the bug**
1. Ouvrir Consommations › Explorer
2. Sélectionner 3 sites (pills bleu, vert, ambre)
3. Ouvrir le menu déroulant de sélection de sites → observer les points de couleur bleu/vert en doublon

**Steps to verify the fix**
1. Reproduire les étapes ci-dessus
2. Les points du dropdown doivent afficher cyan, orange, indigo… (couleurs non encore utilisées)
3. Ajouter 6+ sites et vérifier l'absence de doublons visuels dans les graphiques

Closes #50