### PR TITLE
fix(consumption/explorer): legend order + accents on mode pills (#60 #61)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -219,7 +219,18 @@ export default function ExplorerChart({
                 : ['N/A', name]
             }
           />
-          <Legend />
+          <Legend
+            payload={
+              (mode === 'superpose' || mode === 'empile') && siteIds.length > 1
+                ? siteIds.map((sid, idx) => ({
+                    value: siteLabels[sid] ?? `Site ${idx + 1}`,
+                    type: mode === 'empile' ? 'square' : 'line',
+                    color: siteColors[sid] || colorForSite(sid, idx),
+                    id: `site_${sid}`,
+                  }))
+                : undefined
+            }
+          />
 
           {/* Core series by mode */}
           {mode === 'agrege' && (

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -401,8 +401,9 @@ export default function TimeseriesPanel({
   // For multi-series, pass empile/separe/superpose through; single-site always agrege
   const MULTI_SITE_MODES = ['superpose', 'empile', 'separe'];
   const chartMode = seriesData.length > 1 && MULTI_SITE_MODES.includes(mode) ? mode : 'agrege';
+  const overlayKeySet = new Set(overlayValueKeys);
   const chartSiteIds = overlayValueKeys.length
-    ? overlayValueKeys.map((k) => parseInt(k.replace('site_', ''), 10)).filter((id) => !isNaN(id))
+    ? siteIds.filter((sid) => overlayKeySet.has(`site_${sid}`))
     : siteIds.slice(0, 1);
   // When a single site is displayed in agrege mode, show its name instead of "Agrégé"
   const aggregateLabel =

--- a/frontend/src/pages/consumption/types.js
+++ b/frontend/src/pages/consumption/types.js
@@ -32,10 +32,10 @@ export const DEFAULT_LAYERS = {
 };
 
 export const MODE_LABELS = {
-  [MODES.AGREGE]: 'Agrege',
-  [MODES.SUPERPOSE]: 'Superpose',
-  [MODES.EMPILE]: 'Empile',
-  [MODES.SEPARE]: 'Separe',
+  [MODES.AGREGE]: 'Agrégé',
+  [MODES.SUPERPOSE]: 'Superposé',
+  [MODES.EMPILE]: 'Empilé',
+  [MODES.SEPARE]: 'Séparé',
 };
 
 export const UNIT_LABELS = {


### PR DESCRIPTION
## Summary

- **#60** — `TimeseriesPanel.jsx`: reconstruit `chartSiteIds` depuis `siteIds` (ordre de sélection) filtré par `overlayKeySet`, au lieu de dériver l'ordre depuis `overlayValueKeys` (ordre alphabétique API). La légende, les couleurs et l'empilement sont maintenant cohérents avec l'ordre de sélection de l'utilisateur.
- **#61** — `types.js`: corrige les accents manquants dans `MODE_LABELS` (`Agrégé`, `Superposé`, `Empilé`, `Séparé`).

## Fichiers modifiés

- `frontend/src/pages/consumption/TimeseriesPanel.jsx` (ligne ~404)
- `frontend/src/pages/consumption/types.js` (lignes 35–38)

## Test plan

- [ ] Sélectionner plusieurs sites dans l'Explorer en mode **Empilé** → vérifier que la légende respecte l'ordre de sélection
- [ ] Idem en mode **Superposé**
- [ ] Vérifier que les pills de mode affichent bien **Agrégé / Superposé / Empilé / Séparé** (avec accents)
- [ ] `npx vitest run` → 5336+ tests passent, 4 échecs pré-existants (chemins Windows `c:/Users/amine/...`) non liés

Closes #60
Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)