### PR TITLE
fix(consumption/explorer): accents manquants sur les pills de mode (#61)

### DIFF
--- a/frontend/src/pages/consumption/types.js
+++ b/frontend/src/pages/consumption/types.js
@@ -32,10 +32,10 @@ export const DEFAULT_LAYERS = {
 };
 
 export const MODE_LABELS = {
-  [MODES.AGREGE]: 'Agrege',
-  [MODES.SUPERPOSE]: 'Superpose',
-  [MODES.EMPILE]: 'Empile',
-  [MODES.SEPARE]: 'Separe',
+  [MODES.AGREGE]: 'Agrégé',
+  [MODES.SUPERPOSE]: 'Superposé',
+  [MODES.EMPILE]: 'Empilé',
+  [MODES.SEPARE]: 'Séparé',
 };
 
 export const UNIT_LABELS = {


### PR DESCRIPTION
## Summary

- **Root cause**: `MODE_LABELS` dans `frontend/src/pages/consumption/types.js` définissait les 4 labels de mode sans accents.
- **Fix**: remplacement des valeurs par les formes accentuées correctes (`Agrégé`, `Superposé`, `Empilé`, `Séparé`).

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/types.js` | Correction des 4 valeurs de `MODE_LABELS` (lignes 35–38) |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```

**Steps to reproduce the bug**
1. Aller sur la page Consommations › Explorer
2. Observer les pills de sélection du mode d'affichage : labels affichés sans accents (`Agrege`, `Superpose`, `Empile`, `Separe`)

**Steps to verify the fix**
1. Aller sur la page Consommations › Explorer
2. Vérifier que les pills affichent : `Agrégé`, `Superposé`, `Empilé`, `Séparé`

Closes #61