### PR TITLE
fix(consumption): preserve user selection order in chart legend (#60)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -219,7 +219,7 @@ export default function ExplorerChart({
                 : ['N/A', name]
             }
           />
-          <Legend />
+          <Legend itemSorter={null} />
 
           {/* Core series by mode */}
           {mode === 'agrege' && (

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -401,8 +401,9 @@ export default function TimeseriesPanel({
   // For multi-series, pass empile/separe/superpose through; single-site always agrege
   const MULTI_SITE_MODES = ['superpose', 'empile', 'separe'];
   const chartMode = seriesData.length > 1 && MULTI_SITE_MODES.includes(mode) ? mode : 'agrege';
+  const overlayKeySet = new Set(overlayValueKeys);
   const chartSiteIds = overlayValueKeys.length
-    ? overlayValueKeys.map((k) => parseInt(k.replace('site_', ''), 10)).filter((id) => !isNaN(id))
+    ? siteIds.filter((sid) => overlayKeySet.has(`site_${sid}`))
     : siteIds.slice(0, 1);
   // When a single site is displayed in agrege mode, show its name instead of "Agrégé"
   const aggregateLabel =


### PR DESCRIPTION
## Summary

- **Root cause**: `chartSiteIds` was derived from `overlayValueKeys` (API response order = alphabetical by site name), instead of preserving the user's selection order from `siteIds`.
- **Fix**: Filter `siteIds` by overlay key membership (`Set` lookup) instead of rebuilding the array from `overlayValueKeys`. This preserves user selection order for legend, colors, and stacking.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/TimeseriesPanel.jsx` | Build `chartSiteIds` by filtering `siteIds` against `overlayKeySet` instead of deriving order from `overlayValueKeys` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```

**Steps to reproduce the bug**
1. Navigate to Consumption Explorer
2. Select 3+ sites in a specific order (e.g., Site C, Site A, Site B)
3. Switch to mode "Empilé" or "Superposé"
4. Observe the legend shows sites in alphabetical order (A, B, C) instead of selection order (C, A, B)

**Steps to verify the fix**
1. Same steps as above
2. Legend now shows sites in the order they were selected (C, A, B)
3. Legend order matches stacking order and color assignment

Closes #60