### PR TITLE
fix(patrimoine): add org to useScope() destructuring (#63)

### DIFF
--- a/frontend/src/pages/Patrimoine.jsx
+++ b/frontend/src/pages/Patrimoine.jsx
@@ -129,7 +129,7 @@ export default function Patrimoine() {
   const navigate = useNavigate();
   const location = useLocation();
   const [sp, setSp] = useSearchParams();
-  const { scopedSites, sitesLoading, scope } = useScope();
+  const { scopedSites, sitesLoading, scope, org } = useScope();
   const { isExpert } = useExpertMode();
   const searchRef = useRef(null);
 


### PR DESCRIPTION
## Summary

- **Root cause**: `org` was used in the D.1 data-quality `useEffect` (lines 184–192) but never declared — it was missing from the `useScope()` destructuring at line 132, causing a `ReferenceError: Can't find variable: org` that crashed the page.
- **Fix**: Added `org` to the destructured properties from `useScope()` in `Patrimoine.jsx`. One-line change, confirmed by the existing `DataQualityWidget.jsx` pattern which does the same correctly.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/Patrimoine.jsx` | Added `org` to `useScope()` destructuring at line 132 |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose "src/pages/__tests__/patrimoineV63"
```
109 tests — all passing.

**Steps to reproduce the bug**
1. Start the dev server
2. Navigate to `/patrimoine`
3. Observe white page + `ReferenceError: Can't find variable: org` in the console

**Steps to verify the fix**
1. Navigate to `/patrimoine`
2. Page loads normally with the sites table and KPIs
3. D.1 data-quality scores load correctly per site

Closes #63