### PR TITLE
fix(consumption): remove OverviewRow grey banner (#47)

### DIFF
--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -36,7 +36,6 @@ import useExplorerURL from './consumption/useExplorerURL';
 import useExplorerPresets from './consumption/useExplorerPresets';
 import useExplorerMode from './consumption/useExplorerMode';
 import PortfolioPanel from './consumption/PortfolioPanel';
-import OverviewRow, { computeOverviewData } from './consumption/OverviewRow';
 import { MAX_SITES, nonApplicableTabs } from './consumption/types';
 import TimeseriesPanel from './consumption/TimeseriesPanel';
 import SignaturePanel from './consumption/SignaturePanel';
@@ -673,10 +672,6 @@ export default function ConsumptionExplorerPage() {
       {/* Portfolio mode — shown instead of tab panels */}
       {isPortfolioMode && (loading || (availability && hasData) || !loading) && (
         <>
-          {/* OverviewRow (aggregate) */}
-          {motor.primaryTunnel && (
-            <OverviewRow data={computeOverviewData(motor.primaryTunnel)} unit={unit} />
-          )}
           <PortfolioPanel motor={motor} sites={sites} unit={unit} />
         </>
       )}
@@ -684,11 +679,6 @@ export default function ConsumptionExplorerPage() {
       {/* Main content — non-portfolio, within site limit */}
       {!isPortfolioMode && siteIds.length <= MAX_SITES && (
         <>
-          {/* OverviewRow — only when real data is ready */}
-          {showContent && motor.primaryTunnel && (
-            <OverviewRow data={computeOverviewData(motor.primaryTunnel)} unit={unit} />
-          )}
-
           {isClassic ? (
             /* ── Classic mode: TimeseriesPanel ALWAYS rendered (handles own loading/empty/error) ── */
             <>


### PR DESCRIPTION
## Summary

- **Root cause**: `OverviewRow` was redundant with `ConsoKpiHeader`, showing inconsistent metrics (P50 estimates vs. real HPHC readings) without any explanation — confusing users.
- **Fix**: Remove `OverviewRow` entirely from `ConsumptionExplorerPage.jsx`. The `ConsoKpiHeader` (real data) stays and is sufficient.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Removed import and both render sites of `OverviewRow` (portfolio mode + single-site mode) |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/ExplorerPortfolio.test.js --reporter=verbose
```
All 25 tests pass. Pre-existing failures in 4 unrelated test files (hardcoded Windows paths) are unaffected.

**Steps to reproduce the bug**
1. Open Consumption Explorer on any site (e.g., Siège Helios Paris, 90-day view)
2. Observe grey banner below the filters/chart showing KPIs with different values than the KPI cards above

**Steps to verify the fix**
1. Open Consumption Explorer — grey banner is gone
2. Only `ConsoKpiHeader` KPI cards remain, no duplicate/conflicting metrics

Closes #47