### PR TITLE
fix(explorer): déplacer ContextBanner après les panels graphiques (#71)

### DIFF
--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -711,9 +711,6 @@ export default function ConsumptionExplorerPage() {
         </div>
       )}
 
-      {/* Context banner (site info + date range) — one row per site */}
-      <ContextBanner availabilityBySite={availabilityBySite} siteIds={siteIds} />
-
       {/* KPI Header — 6 KPIs respecting scope global */}
       {showContent && (
         <ConsoKpiHeader
@@ -977,6 +974,9 @@ export default function ConsumptionExplorerPage() {
           </button>
         </div>
       )}
+
+      {/* Context banner (site info + date range) — one row per site */}
+      <ContextBanner availabilityBySite={availabilityBySite} siteIds={siteIds} />
 
       {/* ── Evidence Drawer ("Pourquoi ce chiffre ?") ── */}
       <GenericEvidenceDrawer


### PR DESCRIPTION
## Summary

- **Root cause**: `<ContextBanner>` était rendu à la ligne 715, avant `<ConsoKpiHeader>` et tous les panels graphiques, interrompant le flux visuel vers les KPIs.
- **Fix**: déplacement du composant en bas de page, après les zones graphiques (PortfolioPanel, TimeseriesPanel, ExpertTabs, etc.) et le bloc "trop de sites", juste avant l'Evidence Drawer.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Déplacement du `<ContextBanner>` de la ligne 715 vers après la ligne 979 |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```
→ 5586 tests passed (190 files)

**Steps to reproduce the bug**
1. Ouvrir `/consommations/explorer`
2. Sélectionner un ou plusieurs sites
3. Observer les bandeaux bleus (ContextBanner) apparaître entre la barre de filtres et les KPIs

**Steps to verify the fix**
1. Ouvrir `/consommations/explorer`
2. Sélectionner un ou plusieurs sites
3. Vérifier que les bandeaux bleus apparaissent **en bas de page**, après les graphiques
4. Vérifier que les KPIs sont directement visibles sous la barre de filtres

Closes #71