### PR TITLE
fix(ui): renommer le pill "Date perso" en "Personnaliser" (#72)

### DIFF
--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -601,7 +601,7 @@ export default function StickyFilterBar({
                 : 'text-gray-600 hover:text-gray-900'
             }`}
           >
-            Date perso
+            Personnaliser
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

- **Root cause**: Libellé statique inline `Date perso` à la ligne 604 de `StickyFilterBar.jsx`.
- **Fix**: Remplacement de `Date perso` par `Personnaliser` — changement d'une seule ligne.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/StickyFilterBar.jsx` | `Date perso` → `Personnaliser` (l. 604) |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```
190 fichiers de test, 5 586 tests — tous passent.

**Steps to reproduce the bug**
1. Aller sur `/consommations/explorer`
2. Cliquer sur le pill de plage de dates personnalisée
3. Observer le libellé « Date perso »

**Steps to verify the fix**
1. Aller sur `/consommations/explorer`
2. Cliquer sur le pill de plage de dates personnalisée
3. Vérifier que le libellé affiche désormais « Personnaliser »

Closes #72