### PR TITLE
feat(explorer): afficher la période filtrée en sous-titre du KPI Conso Totale (#73)

### DIFF
--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -90,6 +90,9 @@ export default function ConsoKpiHeader({
   confidence,
   onEvidence,
   compareSummary,
+  days,
+  startDate,
+  endDate,
 }) {
   const { isExpert } = useExpertMode();
   // --- kWh total ---
@@ -152,6 +155,17 @@ export default function ConsoKpiHeader({
           : 'text-green-600'
       : 'text-gray-900';
 
+  // --- Period label (dd/mm/yy → dd/mm/yy) ---
+  const periodLabel = (() => {
+    const fmt = (d) =>
+      d.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: '2-digit' });
+    const dateTo = endDate ? new Date(endDate) : new Date();
+    const dateFrom = startDate
+      ? new Date(startDate)
+      : new Date(dateTo.getTime() - (days ?? 30) * 86400000);
+    return `${fmt(dateFrom)} → ${fmt(dateTo)}`;
+  })();
+
   const confBadge = confidence
     ? {
         high: { label: 'Haute', variant: 'ok' },
@@ -187,7 +201,9 @@ export default function ConsoKpiHeader({
           sub={
             compareSummary?.delta_pct != null ? (
               <TrendDelta deltaPct={compareSummary.delta_pct} />
-            ) : undefined
+            ) : (
+              periodLabel
+            )
           }
           tooltip="Somme des relevés sur la période sélectionnée"
           evidenceId="conso-kwh-total"

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -720,6 +720,9 @@ export default function ConsumptionExplorerPage() {
           confidence={availability?.confidence}
           onEvidence={setEvidenceKpiOpen}
           compareSummary={compareYoy ? compareSummary : null}
+          days={days}
+          startDate={startDate}
+          endDate={endDate}
         />
       )}
 


### PR DESCRIPTION
## Summary

- **Root cause**: `ConsoKpiHeader` ne recevait pas `days`, `startDate`, `endDate` depuis `ConsumptionExplorerPage`, rendant impossible l'affichage de la plage temporelle dans le sous-titre du KPI kWh.
- **Fix**: passage des 3 props de période + calcul du label `dd/mm/yy → dd/mm/yy` dans `ConsoKpiHeader`. Priorité : `TrendDelta` si `compareYoy` actif, sinon plage de dates.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/components/ConsoKpiHeader.jsx` | Ajout props `days`/`startDate`/`endDate`, calcul `periodLabel`, `sub` du KpiTile kWh mis à jour |
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Passage de `days`, `startDate`, `endDate` à `<ConsoKpiHeader>` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```
5586 tests pass.

**Steps to reproduce the bug**
1. Aller sur `/consommations/explorer`
2. Observer le card KPI "Conso Totale (kWh)" — pas de sous-titre de période

**Steps to verify the fix**
1. Aller sur `/consommations/explorer`
2. Le sous-titre du KPI kWh affiche `01/02/25 → 03/03/25` (plage filtrée active)
3. Activer la comparaison N vs N-1 → le sous-titre bascule sur `TrendDelta`
4. Tester avec une plage custom via les date-pickers → le sous-titre se met à jour

Closes #73