### PR TITLE
fix(header): supprimer l'affichage du SHA git en mode Expert (#74)

### DIFF
--- a/frontend/src/layout/AppShell.jsx
+++ b/frontend/src/layout/AppShell.jsx
@@ -16,7 +16,6 @@ import { ToastProvider } from '../ui/ToastProvider';
 import { ActionDrawerProvider } from '../contexts/ActionDrawerContext';
 import { Toggle } from '../ui';
 import { trackRouteChange } from '../services/tracker';
-import { getMetaVersion } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { resolveModule, MODULE_TINTS } from './NavRegistry';
@@ -167,13 +166,6 @@ export default function AppShell() {
   const location = useLocation();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const { isExpert, toggleExpert } = useExpertMode();
-  const [appVersion, setAppVersion] = useState(null);
-
-  useEffect(() => {
-    if (isExpert) getMetaVersion().then(setAppVersion);
-    else setAppVersion(null);
-  }, [isExpert]);
-
   useEffect(() => {
     trackRouteChange(location.pathname);
   }, [location.pathname]);
@@ -226,15 +218,6 @@ export default function AppShell() {
             <div title="Le mode Expert affiche la formule de score, les paramètres, les hypothèses et les références utilisées pour chaque évaluation.">
               <Toggle checked={isExpert} onChange={toggleExpert} label="Expert" size="sm" />
             </div>
-            {isExpert && appVersion && (
-              <span
-                className="text-xs font-mono text-slate-400 border border-slate-200 rounded px-1.5 py-0.5"
-                title={`branch: ${appVersion.branch} — ${appVersion.build_time}`}
-              >
-                {appVersion.sha}
-              </span>
-            )}
-
             <UserMenu />
           </div>
         </header>


### PR DESCRIPTION
## Summary

- **Root cause**: le bloc `{isExpert && appVersion && ...}` dans `AppShell.jsx` appelait `GET /api/meta/version` et rendait le SHA git court dans le bandeau header dès l'activation du mode Expert.
- **Fix**: suppression du rendu du SHA, du state `appVersion`, de l'effet de fetch et de l'import `getMetaVersion` devenu inutilisé.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/layout/AppShell.jsx` | Suppression du state, de l'effet, de l'import et du bloc JSX de rendu du SHA |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```
190 test files · 5586 tests — all pass.

**Steps to reproduce the bug**
1. Lancer l'app en dev
2. Activer le toggle **Expert** dans le header
3. Observer le rectangle gris avec un SHA comme `a3f9c12`

**Steps to verify the fix**
1. Activer le toggle Expert
2. Vérifier que le bandeau header ne contient aucun SHA ni artefact technique

Closes #74