### PR TITLE
fix(portfolio): filtrer les sites par portefeuille_id dans les endpoints conso (#83)

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -243,6 +243,7 @@ def _build_site_row(db, site, dt_from, dt_to, days):
 def get_portfolio_summary(
     date_from: Optional[str] = Query(None, alias="from"),
     date_to: Optional[str] = Query(None, alias="to"),
+    portefeuille_id: Optional[int] = Query(None),
     site_ids: Optional[str] = Query(None, description="Comma-separated site IDs"),
     db: Session = Depends(get_db),
 ):
@@ -257,6 +258,8 @@ def get_portfolio_summary(
 
     # Resolve sites
     q = db.query(Site).filter(Site.actif == True)
+    if portefeuille_id is not None:
+        q = q.filter(Site.portefeuille_id == portefeuille_id)
     if site_ids:
         ids = [int(x) for x in site_ids.split(",") if x.strip()]
         q = q.filter(Site.id.in_(ids))
@@ -345,6 +348,7 @@ def get_portfolio_summary(
 def get_portfolio_sites(
     date_from: Optional[str] = Query(None, alias="from"),
     date_to: Optional[str] = Query(None, alias="to"),
+    portefeuille_id: Optional[int] = Query(None),
     sort: str = Query(
         "impact_desc", description="impact_desc|kwh_desc|kwh_asc|name|peak|base_night|diagnostics|coverage"
     ),
@@ -369,6 +373,8 @@ def get_portfolio_sites(
     days = (d_to - d_from).days or 1
 
     q = db.query(Site).filter(Site.actif == True)
+    if portefeuille_id is not None:
+        q = q.filter(Site.portefeuille_id == portefeuille_id)
     if site_ids:
         ids = [int(x) for x in site_ids.split(",") if x.strip()]
         q = q.filter(Site.id.in_(ids))

--- a/frontend/src/pages/ConsumptionPortfolioPage.jsx
+++ b/frontend/src/pages/ConsumptionPortfolioPage.jsx
@@ -155,7 +155,7 @@ function TopListActions({ siteId, dates, navigate }) {
 export default function ConsumptionPortfolioPage() {
   const navigate = useNavigate();
   const { addToast } = useToast();
-  const { selectedSiteId, resetScope, scopeLabel } = useScope();
+  const { selectedSiteId, resetScope, scopeLabel, portefeuille } = useScope();
   const [searchParams] = useSearchParams();
   const dates = useMemo(() => {
     const f = searchParams.get('from');
@@ -202,12 +202,12 @@ export default function ConsumptionPortfolioPage() {
   // ─── Fetch summary ────────────────────────────────────────────────────
   useEffect(() => {
     setSummaryLoading(true);
-    getPortfolioSummary({ from: dates.from, to: dates.to })
+    getPortfolioSummary({ from: dates.from, to: dates.to, portefeuille_id: portefeuille?.id })
       .then(setSummary)
       .catch(() => addToast({ type: 'error', message: 'Erreur chargement resume portfolio' }))
       .finally(() => setSummaryLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dates.from, dates.to]);
+  }, [dates.from, dates.to, portefeuille?.id]);
 
   // ─── Fetch sites table ────────────────────────────────────────────────
   const fetchSites = useCallback(() => {
@@ -215,6 +215,7 @@ export default function ConsumptionPortfolioPage() {
     getPortfolioSites({
       from: dates.from,
       to: dates.to,
+      portefeuille_id: portefeuille?.id,
       sort,
       confidence: confidenceFilter || undefined,
       with_anomalies: anomalyFilter || undefined,
@@ -234,6 +235,7 @@ export default function ConsumptionPortfolioPage() {
   }, [
     dates.from,
     dates.to,
+    portefeuille?.id,
     sort,
     confidenceFilter,
     anomalyFilter,


### PR DESCRIPTION
## Summary

- **Root cause**: les endpoints `/portfolio/consumption/summary` et `/portfolio/consumption/sites` ne filtraient pas par portefeuille — la requête SQLAlchemy retournait tous les sites actifs de la base (135) au lieu des seuls sites du portefeuille sélectionné.
- **Fix**: ajout du paramètre `portefeuille_id: Optional[int] = Query(None)` aux deux endpoints avec filtre `.filter(Site.portefeuille_id == portefeuille_id)` ; côté frontend, extraction de `portefeuille` depuis `useScope()` et transmission de `portefeuille_id: portefeuille?.id` aux deux appels API ainsi qu'aux dépendances `useEffect`/`useCallback`.

## Files changed

| File | Change |
|------|--------|
| `backend/routes/portfolio.py` | Ajout de `portefeuille_id` query param + filtre SQLAlchemy dans `/summary` et `/sites` |
| `frontend/src/pages/ConsumptionPortfolioPage.jsx` | Extraction de `portefeuille` depuis `useScope()` + passage de `portefeuille_id` aux deux appels API |

## Test plan

**Automated tests**
```bash
cd "/Users/manocyprus/AI Projects/Promeos/promeos-poc" && ./backend/venv/bin/pytest backend/tests/test_portfolio.py -v
cd "/Users/manocyprus/AI Projects/Promeos/promeos-poc/frontend" && npx vitest run --reporter=verbose
```

**Steps to reproduce the bug**
1. Sélectionner le portefeuille "Démo Helios" (5 sites) dans le scope
2. Naviguer vers Consommations > Portefeuille
3. Observer 135 sites affichés (tous les sites actifs)

**Steps to verify the fix**
1. Sélectionner le portefeuille "Démo Helios" dans le scope
2. Naviguer vers Consommations > Portefeuille
3. Vérifier que seuls 5 sites apparaissent dans les indicateurs, le tableau et les tops

Closes #83