### PR TITLE
fix(readiness): skip connector check in demo mode (#76)

### DIFF
--- a/frontend/src/components/DataReadinessBadge.jsx
+++ b/frontend/src/components/DataReadinessBadge.jsx
@@ -52,7 +52,7 @@ export default function DataReadinessBadge() {
     return { total, conformes, nonConformes, aRisque, couvertureDonnees };
   }, [scopedSites]);
 
-  const { readinessState, loading } = useDataReadiness(kpis);
+  const { readinessState, loading } = useDataReadiness(kpis, { demoEnabled });
 
   // Snapshot scope
   const snapshotScope = useMemo(
@@ -98,7 +98,7 @@ export default function DataReadinessBadge() {
     return () => document.removeEventListener('keydown', handleKey);
   }, [open]);
 
-  if (!kpis.total || loading || !readinessState || demoEnabled) return null;
+  if (!kpis.total || loading || !readinessState) return null;
 
   return (
     <div ref={ref} className="relative" data-testid="data-readiness-badge">

--- a/frontend/src/hooks/useDataReadiness.js
+++ b/frontend/src/hooks/useDataReadiness.js
@@ -13,7 +13,10 @@ import { computeDataReadinessState } from '../models/dataReadinessModel';
  * @param {{ operatModuleActive?: boolean }} options
  * @returns {{ readinessState: ReadinessState|null, activation: ActivationResult, loading: boolean }}
  */
-export default function useDataReadiness(kpis, { operatModuleActive = false } = {}) {
+export default function useDataReadiness(
+  kpis,
+  { operatModuleActive = false, demoEnabled = false } = {}
+) {
   const { billingSummary, purchaseSignals, efaDashboard, connectors, loading } = useActivationData(
     kpis?.total
   );
@@ -31,6 +34,7 @@ export default function useDataReadiness(kpis, { operatModuleActive = false } = 
       connectors: Array.isArray(connectors) ? connectors : [],
       operatModuleActive,
       hasManualImport: (activation?.activatedCount ?? 0) > 1,
+      demoEnabled,
     });
   }, [activation, billingSummary, efaDashboard, connectors, operatModuleActive, loading]);
 

--- a/frontend/src/models/dataReadinessModel.js
+++ b/frontend/src/models/dataReadinessModel.js
@@ -113,6 +113,9 @@ function evalOperat(_activation, signals) {
 }
 
 function evalConnectors(activation, signals) {
+  // In demo mode, connector absence is expected (Enedis stub) — skip evaluation
+  if (signals?.demoEnabled) return { status: 'ok' };
+
   const connectors = signals?.connectors;
   const hasConnector =
     Array.isArray(connectors) && connectors.some((c) => c.status === 'active' || c.enabled);


### PR DESCRIPTION
## Summary

- **Root cause**: `evalConnectors` retourne `partial`/`ko` quand aucun connecteur Enedis n'est actif — ce qui est toujours le cas en POC/démo (stub uniquement). Le badge affiche donc un état AMBER/RED permanent dans le header.
- **Fix**: Passe le flag `demoEnabled` à travers `useDataReadiness` → `computeDataReadinessState` → `evalConnectors`. En mode démo, l'évaluation connecteurs est skippée (retourne `ok`). Le badge reste visible (suppression du `return null` sur `demoEnabled`) pour démontrer la feature.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/models/dataReadinessModel.js` | `evalConnectors` retourne `ok` quand `signals.demoEnabled` est `true` |
| `frontend/src/hooks/useDataReadiness.js` | Accepte `demoEnabled` en option et le passe dans `signals` |
| `frontend/src/components/DataReadinessBadge.jsx` | Passe `demoEnabled` au hook ; retire le `return null` blanket sur `demoEnabled` |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```
190 fichiers, 5587 tests — tous verts.

**Steps to verify the fix**
1. Activer le mode démo (toggle)
2. Vérifier que le badge DataReadiness s'affiche dans le header (il était masqué avant)
3. Vérifier que le badge est GREEN / "OK" (plus de penalité connecteur)
4. Désactiver le mode démo → le badge revient au comportement normal (AMBER si pas de connecteur)

Closes #76