### PR TITLE
fix(explorer): enable YoY comparison for multi-site selection (#93)

### DIFF
--- a/frontend/src/__tests__/step10_compare_guard.test.js
+++ b/frontend/src/__tests__/step10_compare_guard.test.js
@@ -79,8 +79,8 @@ describe('C. StickyFilterBar compare toggle', () => {
     expect(src).toMatch(/Comparer N-1/);
   });
 
-  test('C4. single-site guard (effectiveSiteIds.length === 1)', () => {
-    expect(src).toMatch(/effectiveSiteIds\.length === 1/);
+  test('C4. not-portfolio guard (no single-site restriction)', () => {
+    expect(src).not.toMatch(/effectiveSiteIds\.length === 1/);
   });
 
   test('C5. not in portfolio mode guard', () => {

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -486,6 +486,13 @@ export default function ConsumptionExplorerPage() {
   const [compareYoy, setCompareYoy] = useState(false);
   const [compareSummary, setCompareSummary] = useState(null);
 
+  // Auto-disable YoY comparison when switching to multi-site (#93)
+  useEffect(() => {
+    if (siteIds.length > 1 && compareYoy) {
+      setCompareYoy(false);
+    }
+  }, [siteIds.length]); // eslint-disable-line react-hooks/exhaustive-deps
+
   useEffect(() => {
     if (!compareYoy || !siteIds.length) {
       setCompareSummary(null);

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -486,13 +486,6 @@ export default function ConsumptionExplorerPage() {
   const [compareYoy, setCompareYoy] = useState(false);
   const [compareSummary, setCompareSummary] = useState(null);
 
-  // Auto-disable YoY comparison when switching to multi-site (#93)
-  useEffect(() => {
-    if (siteIds.length > 1 && compareYoy) {
-      setCompareYoy(false);
-    }
-  }, [siteIds.length]); // eslint-disable-line react-hooks/exhaustive-deps
-
   useEffect(() => {
     if (!compareYoy || !siteIds.length) {
       setCompareSummary(null);

--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -631,8 +631,8 @@ export default function StickyFilterBar({
           </span>
         )}
 
-        {/* YoY comparison toggle (Step 10 — F1) — single-site only, not portfolio */}
-        {setCompareYoy && effectiveSiteIds.length === 1 && !isPortfolioMode && (
+        {/* YoY comparison toggle (Step 10 — F1) — not portfolio */}
+        {setCompareYoy && !isPortfolioMode && (
           <button
             onClick={() => setCompareYoy(!compareYoy)}
             className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium border transition-colors duration-100 ${


### PR DESCRIPTION
## Summary

- **Root cause**: the "Comparer N-1" button was gated behind `effectiveSiteIds.length === 1` in `StickyFilterBar.jsx`, hiding it in multi-site mode while `compareYoy` state stayed `true` — locking the user in comparison mode.
- **Fix**: removed the single-site guard — the backend (`_query_yoy_prev`), the hook (`useEmsTimeseries`), and the chart (`ExplorerChart`) already fully support multi-site YoY with aggregate (`total_prev`) and overlay (`site_{id}_prev`) series.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Removed auto-disable `useEffect` that reset `compareYoy` on multi-site |
| `frontend/src/pages/consumption/StickyFilterBar.jsx` | Removed `effectiveSiteIds.length === 1` guard from "Comparer N-1" button |
| `frontend/src/__tests__/step10_compare_guard.test.js` | Updated test C4 to assert single-site guard is absent |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/__tests__/step10_compare_guard.test.js --reporter=verbose
```

**Steps to verify**
1. Go to Consommations → Explorer
2. Select 1 site → activate "Comparer N-1" → dashed N-1 overlay appears
3. Add a 2nd site (aggregate mode) → button stays visible, `total_prev` dashed line shown
4. Switch to superpose mode → each site gets its own dashed `_prev` line
5. Toggle off "Comparer N-1" → all `_prev` lines disappear
6. Portfolio mode → button should NOT appear (guard preserved)

Closes #93