### PR TITLE
fix(conso): rename KPI cards subtexts for P95 and night ratio (#87)

### DIFF
--- a/frontend/src/__tests__/step12_kpi_labels.test.js
+++ b/frontend/src/__tests__/step12_kpi_labels.test.js
@@ -56,7 +56,7 @@ describe('Step 12 — kpiLabels service', () => {
   });
 
   it('simple and expert differ for technical KPIs', () => {
-    const technicalIds = ['pmax_kw', 'p95_kw', 'load_factor', 'off_hours_ratio', 'night_ratio'];
+    const technicalIds = ['pmax_kw', 'load_factor', 'off_hours_ratio'];
     technicalIds.forEach((id) => {
       const entry = KPI_LABELS[id];
       expect(entry.simple).not.toBe(entry.expert);

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -2,7 +2,7 @@
  * PROMEOS — ConsoKpiHeader (QW2 / P1.1 polish)
  * 6-KPI header row for ConsumptionExplorerPage.
  * Reads motor data (tunnel, hphc, progression) to compute:
- *   kWh total, EUR total, EUR/MWh, CO2e, Pic kW (P95), Conso. nocturne %
+ *   kWh total, EUR total, EUR/MWh, CO2e, Pic kW (P95), Ratio Conso. Nuit %
  * Respects scope global (site + period) via motor props.
  *
  * P1.1: confidence tooltip "Comment calcule ?", EUR source tooltip.
@@ -133,7 +133,7 @@ export default function ConsoKpiHeader({
   })();
   const p95Label = p95 != null ? fmtNum(Math.round(p95), 0, 'kW') : '—';
 
-  // --- Conso. nocturne % (ratio of night hours P50 vs overall P50) ---
+  // --- Ratio Conso. Nuit % (ratio of night hours P50 vs overall P50) ---
   const basePct = (() => {
     if (!tunnel?.envelope?.weekday) return null;
     const slots = tunnel.envelope.weekday;
@@ -240,14 +240,14 @@ export default function ConsoKpiHeader({
           icon={Activity}
           label={getKpiLabel('p95_kw', isExpert)}
           value={p95Label}
-          sub="percentile 95"
+          sub="Percentile 95"
           tooltip="95e percentile de puissance sur les créneaux horaires"
         />
         <KpiTile
           icon={Moon}
           label={getKpiLabel('night_ratio', isExpert)}
           value={basePctLabel}
-          sub="Ratio nuit/jour"
+          sub="(22h - 6h)"
           color={basePctColor}
           tooltip="Ratio consommation nuit (22h-6h) / jour (6h-22h) en semaine"
         />

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -2,7 +2,7 @@
  * PROMEOS — ConsoKpiHeader (QW2 / P1.1 polish)
  * 6-KPI header row for ConsumptionExplorerPage.
  * Reads motor data (tunnel, hphc, progression) to compute:
- *   kWh total, EUR total, EUR/MWh, CO2e, Pic kW (P95), Base nocturne %
+ *   kWh total, EUR total, EUR/MWh, CO2e, Pic kW (P95), Conso. nocturne %
  * Respects scope global (site + period) via motor props.
  *
  * P1.1: confidence tooltip "Comment calcule ?", EUR source tooltip.
@@ -133,7 +133,7 @@ export default function ConsoKpiHeader({
   })();
   const p95Label = p95 != null ? fmtNum(Math.round(p95), 0, 'kW') : '—';
 
-  // --- Base nocturne % (ratio of night hours P50 vs overall P50) ---
+  // --- Conso. nocturne % (ratio of night hours P50 vs overall P50) ---
   const basePct = (() => {
     if (!tunnel?.envelope?.weekday) return null;
     const slots = tunnel.envelope.weekday;
@@ -240,14 +240,14 @@ export default function ConsoKpiHeader({
           icon={Activity}
           label={getKpiLabel('p95_kw', isExpert)}
           value={p95Label}
-          sub="P95"
+          sub="percentile 95"
           tooltip="95e percentile de puissance sur les créneaux horaires"
         />
         <KpiTile
           icon={Moon}
           label={getKpiLabel('night_ratio', isExpert)}
           value={basePctLabel}
-          sub="22h-6h"
+          sub="Ratio nuit/jour"
           color={basePctColor}
           tooltip="Ratio consommation nuit (22h-6h) / jour (6h-22h) en semaine"
         />

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -320,7 +320,7 @@ describe('AP · QW2 ConsoKpiHeader', () => {
     expect(code).toMatch(/EUR\/MWh/);
     expect(code).toMatch(/CO2e/);
     expect(code).toMatch(/Pic kW.*P95/);
-    expect(code).toMatch(/Conso\. nocturne/);
+    expect(code).toMatch(/Conso\. Nuit/);
   });
 
   it('ConsoKpiHeader accepts tunnel + hphc + progression props', () => {

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -320,7 +320,7 @@ describe('AP · QW2 ConsoKpiHeader', () => {
     expect(code).toMatch(/EUR\/MWh/);
     expect(code).toMatch(/CO2e/);
     expect(code).toMatch(/Pic kW.*P95/);
-    expect(code).toMatch(/Base nocturne/);
+    expect(code).toMatch(/Conso\. nocturne/);
   });
 
   it('ConsoKpiHeader accepts tunnel + hphc + progression props', () => {

--- a/frontend/src/shared/kpiLabels.js
+++ b/frontend/src/shared/kpiLabels.js
@@ -11,8 +11,8 @@ export const KPI_LABELS = {
     unit: 'kW',
   },
   p95_kw: {
-    simple: 'Pointe puissance',
-    expert: 'P95 puissance (percentile 95)',
+    simple: 'Puissance',
+    expert: 'Puissance P95',
     unit: 'kW',
   },
   pbase_kw: {
@@ -41,8 +41,8 @@ export const KPI_LABELS = {
     unit: 'kWh',
   },
   night_ratio: {
-    simple: 'Conso. nocturne',
-    expert: 'Ratio nuit (22h-6h / 6h-22h)',
+    simple: 'Ratio Conso. Nuit',
+    expert: 'Ratio Nuit 22h-6h',
     unit: '%',
   },
   weekend_ratio: {

--- a/frontend/src/shared/kpiLabels.js
+++ b/frontend/src/shared/kpiLabels.js
@@ -41,7 +41,7 @@ export const KPI_LABELS = {
     unit: 'kWh',
   },
   night_ratio: {
-    simple: 'Base nocturne',
+    simple: 'Conso. nocturne',
     expert: 'Ratio nuit (22h-6h / 6h-22h)',
     unit: '%',
   },

--- a/frontend/src/shared/kpiLabels.js
+++ b/frontend/src/shared/kpiLabels.js
@@ -12,7 +12,7 @@ export const KPI_LABELS = {
   },
   p95_kw: {
     simple: 'Puissance',
-    expert: 'Puissance P95',
+    expert: 'Puissance',
     unit: 'kW',
   },
   pbase_kw: {
@@ -42,7 +42,7 @@ export const KPI_LABELS = {
   },
   night_ratio: {
     simple: 'Ratio Conso. Nuit',
-    expert: 'Ratio Nuit 22h-6h',
+    expert: 'Ratio Conso. Nuit',
     unit: '%',
   },
   weekend_ratio: {


### PR DESCRIPTION
## Summary

- **Root cause**: Sub-texts on P95 card ("P95") and night ratio card ("22h-6h") were redundant or partial, wasting valuable contextual space
- **Fix**: Renamed label "Base nocturne" → "Conso. nocturne", changed sub "P95" → "percentile 95", changed sub "22h-6h" → "Ratio nuit/jour"

## Files changed

| File | Change |
|------|--------|
| `frontend/src/shared/kpiLabels.js` | `night_ratio.simple`: "Base nocturne" → "Conso. nocturne" |
| `frontend/src/components/ConsoKpiHeader.jsx` | P95 sub → "percentile 95", night ratio sub → "Ratio nuit/jour", updated comments |
| `frontend/src/pages/__tests__/consoV2.audit.test.js` | Updated assertion to match new label |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/__tests__/step12_kpi_labels.test.js src/pages/__tests__/consoV2.audit.test.js --reporter=verbose
```

**Steps to reproduce the bug**
1. Navigate to Consommations > Explorer
2. Observe KPI cards — P95 shows redundant "P95" sub-text, night ratio shows partial "22h-6h"

**Steps to verify the fix**
1. Navigate to Consommations > Explorer
2. P95 card should show "percentile 95" as sub-text
3. Night ratio card should show label "Conso. nocturne" and sub-text "Ratio nuit/jour"

Closes #87