### PR TITLE
fix(nav): clic icône Énergie navigue vers /consommations (#98)

### DIFF
--- a/frontend/src/layout/Sidebar.jsx
+++ b/frontend/src/layout/Sidebar.jsx
@@ -4,7 +4,7 @@
  * Manages shared state: active module, pins, badges, recents tracking.
  */
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import NavRail from './NavRail';
 import NavPanel from './NavPanel';
 import { resolveModule, matchRouteToModule, ALL_NAV_ITEMS } from './NavRegistry';
@@ -28,6 +28,7 @@ function saveJSON(key, value) {
 
 export default function Sidebar() {
   const location = useLocation();
+  const navigate = useNavigate();
 
   /* ── Active module (derived from route) ── */
   const activeModule = useMemo(() => resolveModule(location.pathname), [location.pathname]);
@@ -41,9 +42,18 @@ export default function Sidebar() {
     setOverrideModule(null);
   }, [activeModule]);
 
-  const handleSelectModule = useCallback((key) => {
-    setOverrideModule((prev) => (prev === key ? null : key));
-  }, []);
+  /* ── Module landing routes (icon click → navigate) ── */
+  const MODULE_LANDING = { energie: '/consommations' };
+
+  const handleSelectModule = useCallback(
+    (key) => {
+      if (key !== activeModule && MODULE_LANDING[key]) {
+        navigate(MODULE_LANDING[key]);
+      }
+      setOverrideModule((prev) => (prev === key ? null : key));
+    },
+    [activeModule, navigate]
+  );
 
   /* ── Pins ── */
   const [pins, setPins] = useState(() => loadJSON(PINS_KEY, []));


### PR DESCRIPTION
## Summary

- **Root cause**: `handleSelectModule` dans `Sidebar.jsx` ne faisait que toggle le panel latéral sans déclencher de navigation
- **Fix**: Ajout d'un `navigate('/consommations')` quand l'utilisateur clique sur l'icône Énergie depuis un autre module. Le comportement toggle du panel est conservé.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/layout/Sidebar.jsx` | Ajout `useNavigate` + navigation vers `/consommations` pour le module Énergie |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose
```
5608 tests pass, 0 regressions.

**Steps to reproduce the bug**
1. Naviguer vers `/cockpit`
2. Cliquer sur l'icône Énergie (⚡) dans la NavRail
3. Observer que seul le panel s'ouvre, sans navigation

**Steps to verify the fix**
1. Naviguer vers `/cockpit`
2. Cliquer sur l'icône Énergie (⚡) dans la NavRail
3. Vérifier que la page `/consommations/portfolio` s'affiche
4. Re-cliquer sur l'icône Énergie → le panel toggle (pas de re-navigation)

Closes #98