### PR TITLE
fix(explorer): KPI cards refresh on custom date range change (#102)

### DIFF
--- a/backend/routes/consumption_diagnostic.py
+++ b/backend/routes/consumption_diagnostic.py
@@ -12,7 +12,7 @@ GET /api/consumption/gas/summary — resume gaz
 """
 
 from typing import Optional, List
-from datetime import date, timezone
+from datetime import date, datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -461,6 +461,8 @@ def get_tunnel_v2(
     days: int = Query(90, ge=7, le=365),
     energy_type: str = Query("electricity"),
     mode: str = Query("energy", description="energy (kWh) or power (kW)"),
+    start_date: Optional[date] = Query(None, description="Custom start date (overrides days)"),
+    end_date: Optional[date] = Query(None, description="Custom end date (overrides days)"),
     db: Session = Depends(get_db),
     auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
@@ -472,7 +474,9 @@ def get_tunnel_v2(
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
         raise HTTPException(status_code=404, detail="Site non trouve")
-    return compute_tunnel_v2(db, site_id, days=days, energy_type=energy_type, mode=mode)
+    sd = datetime.combine(start_date, datetime.min.time()) if start_date else None
+    ed = datetime.combine(end_date, datetime.max.time()) if end_date else None
+    return compute_tunnel_v2(db, site_id, days=days, energy_type=energy_type, mode=mode, start_date=sd, end_date=ed)
 
 
 # =============================================
@@ -807,12 +811,18 @@ def get_hphc_breakdown_v2(
     days: int = Query(30, ge=1, le=365),
     calendar_id: Optional[int] = Query(None),
     simulate: bool = Query(False),
+    start_date: Optional[date] = Query(None, description="Custom start date (overrides days)"),
+    end_date: Optional[date] = Query(None, description="Custom end date (overrides days)"),
     db: Session = Depends(get_db),
     auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
     """HP/HC V2 : breakdown + heatmap 7x24 + opportunite + simulation calendrier alternatif."""
     check_site_access(auth, site_id)
-    return compute_hphc_breakdown_v2(db, site_id, days=days, calendar_id=calendar_id, simulate=simulate)
+    sd = datetime.combine(start_date, datetime.min.time()) if start_date else None
+    ed = datetime.combine(end_date, datetime.max.time()) if end_date else None
+    return compute_hphc_breakdown_v2(
+        db, site_id, days=days, calendar_id=calendar_id, simulate=simulate, start_date=sd, end_date=ed
+    )
 
 
 # =============================================
@@ -824,6 +834,10 @@ def get_hphc_breakdown_v2(
 def gas_summary(
     site_id: int = Query(...),
     days: int = Query(90, ge=7, le=365),
+    start_date_param: Optional[date] = Query(
+        None, alias="start_date", description="Custom start date (overrides days)"
+    ),
+    end_date_param: Optional[date] = Query(None, alias="end_date", description="Custom end date (overrides days)"),
     db: Session = Depends(get_db),
     auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
@@ -831,11 +845,14 @@ def gas_summary(
     check_site_access(auth, site_id)
     from models import Meter, MeterReading
     from models.energy_models import EnergyVector
-    from datetime import datetime, timedelta
     from collections import defaultdict
 
-    end_date = datetime.now(timezone.utc)
-    start_date = end_date - timedelta(days=days)
+    if start_date_param and end_date_param:
+        start_date = datetime.combine(start_date_param, datetime.min.time(), tzinfo=timezone.utc)
+        end_date = datetime.combine(end_date_param, datetime.max.time(), tzinfo=timezone.utc)
+    else:
+        end_date = datetime.now(timezone.utc)
+        start_date = end_date - timedelta(days=days)
 
     meters = (
         db.query(Meter)
@@ -910,6 +927,8 @@ def gas_summary(
 def gas_weather_normalized(
     site_id: int = Query(...),
     days: int = Query(90, ge=7, le=365),
+    start_date: Optional[date] = Query(None, description="Custom start date (overrides days)"),
+    end_date: Optional[date] = Query(None, description="Custom end date (overrides days)"),
     db: Session = Depends(get_db),
     auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
@@ -917,4 +936,6 @@ def gas_weather_normalized(
     check_site_access(auth, site_id)
     from services.gas_weather_service import compute_weather_normalized
 
-    return compute_weather_normalized(db, site_id, days=days)
+    sd = datetime.combine(start_date, datetime.min.time()) if start_date else None
+    ed = datetime.combine(end_date, datetime.max.time()) if end_date else None
+    return compute_weather_normalized(db, site_id, days=days, start_date=sd, end_date=ed)

--- a/backend/services/gas_weather_service.py
+++ b/backend/services/gas_weather_service.py
@@ -59,6 +59,8 @@ def compute_weather_normalized(
     db: Session,
     site_id: int,
     days: int = 90,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
 ) -> Dict[str, Any]:
     """
     Gas weather normalization using DJU model.
@@ -70,8 +72,12 @@ def compute_weather_normalized(
         alerts: [{ type, severity, message }]
         confidence: str
     """
-    end_date = datetime.now(timezone.utc).replace(tzinfo=None)
-    start_date = end_date - timedelta(days=days)
+    if start_date and end_date:
+        start_date = start_date.replace(tzinfo=None) if start_date.tzinfo else start_date
+        end_date = end_date.replace(tzinfo=None) if end_date.tzinfo else end_date
+    else:
+        end_date = datetime.now(timezone.utc).replace(tzinfo=None)
+        start_date = end_date - timedelta(days=days)
 
     meters = (
         db.query(Meter)

--- a/backend/services/tou_service.py
+++ b/backend/services/tou_service.py
@@ -319,6 +319,8 @@ def compute_hphc_breakdown_v2(
     days: int = 30,
     calendar_id: Optional[int] = None,
     simulate: bool = False,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
 ) -> Dict[str, Any]:
     """
     HP/HC V2: breakdown + heatmap + opportunity + optional simulation.
@@ -361,8 +363,12 @@ def compute_hphc_breakdown_v2(
             price_hp, price_hc = DEFAULT_PRICE_ELEC_EUR_KWH, DEFAULT_PRICE_HC_EUR_KWH
 
     # Fetch readings
-    end_date = datetime.now(timezone.utc).replace(tzinfo=None)
-    start_date = end_date - timedelta(days=days)
+    if start_date and end_date:
+        start_date = start_date.replace(tzinfo=None) if start_date.tzinfo else start_date
+        end_date = end_date.replace(tzinfo=None) if end_date.tzinfo else end_date
+    else:
+        end_date = datetime.now(timezone.utc).replace(tzinfo=None)
+        start_date = end_date - timedelta(days=days)
 
     meters = (
         db.query(Meter)
@@ -461,7 +467,9 @@ def compute_hphc_breakdown_v2(
 
     # Simulation: compare with default schedule if calendar_id was used
     if simulate and calendar_id:
-        base = compute_hphc_breakdown_v2(db, site_id, days=days, calendar_id=None, simulate=False)
+        base = compute_hphc_breakdown_v2(
+            db, site_id, days=days, calendar_id=None, simulate=False, start_date=start_date, end_date=end_date
+        )
         result["simulation"] = {
             "base_calendar": base.get("calendar_name", "Defaut"),
             "base_cost_eur": base.get("total_cost_eur", 0),

--- a/backend/services/tunnel_service.py
+++ b/backend/services/tunnel_service.py
@@ -198,6 +198,8 @@ def compute_tunnel_v2(
     interval_minutes: int = 60,
     energy_type: str = "electricity",
     mode: str = "energy",
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
 ) -> Dict[str, Any]:
     """
     Tunnel V2: supports both energy (kWh) and power (kW) modes.
@@ -207,8 +209,12 @@ def compute_tunnel_v2(
 
     Returns same structure as V1 plus: mode, unit, reference_band_method, sample_size.
     """
-    end_date = datetime.now(timezone.utc).replace(tzinfo=None)
-    start_date = end_date - timedelta(days=days)
+    if start_date and end_date:
+        start_date = start_date.replace(tzinfo=None) if start_date.tzinfo else start_date
+        end_date = end_date.replace(tzinfo=None) if end_date.tzinfo else end_date
+    else:
+        end_date = datetime.now(timezone.utc).replace(tzinfo=None)
+        start_date = end_date - timedelta(days=days)
 
     meters = (
         db.query(Meter)

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -257,13 +257,17 @@ export default function ConsumptionExplorerPage() {
     initialSiteIds,
     initialEnergy: urlState.energy,
     initialDays: urlState.days,
+    initialStartDate: urlState.startDate || null,
+    initialEndDate: urlState.endDate || null,
   });
 
   const {
-    state: { siteIds, energyType, days, mode, unit, layers },
+    state: { siteIds, energyType, days, startDate, endDate, mode, unit, layers },
     setSiteIds,
     setEnergyType,
     setDays,
+    setStartDate,
+    setEndDate,
     setMode,
     setUnit,
     mergedAvailability,
@@ -362,9 +366,6 @@ export default function ConsumptionExplorerPage() {
       'conso-co2e': evidenceCO2e(scopeLabel, periodStr, co2Str),
     };
   }, [scopeLabel, days, motor.primaryHphc, motor.primaryTunnel]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const [startDate, setStartDate] = useState(urlState.startDate || null);
-  const [endDate, setEndDate] = useState(urlState.endDate || null);
 
   // Sync custom dates → URL
   useEffect(() => {
@@ -923,6 +924,8 @@ export default function ConsumptionExplorerPage() {
                     showSignature={layers.signature}
                     toast={toast}
                     initialTunnel={motor.primaryTunnel}
+                    startDate={startDate}
+                    endDate={endDate}
                   />
                 )}
                 {activeTab === 'targets' && showContent && (
@@ -941,6 +944,8 @@ export default function ConsumptionExplorerPage() {
                     days={days}
                     toast={toast}
                     initialBreakdown={motor.primaryHphc}
+                    startDate={startDate}
+                    endDate={endDate}
                   />
                 )}
                 {activeTab === 'gas' && showContent && (
@@ -951,6 +956,8 @@ export default function ConsumptionExplorerPage() {
                     toast={toast}
                     initialGas={motor.primaryGas}
                     initialWeather={motor.primaryWeather}
+                    startDate={startDate}
+                    endDate={endDate}
                   />
                 )}
               </div>

--- a/frontend/src/pages/consumption/GasPanel.jsx
+++ b/frontend/src/pages/consumption/GasPanel.jsx
@@ -38,6 +38,8 @@ export default function GasPanel({
   toast,
   initialGas,
   initialWeather,
+  startDate = null,
+  endDate = null,
 }) {
   const [gas, setGas] = useState(initialGas || null);
   const [weather, setWeather] = useState(initialWeather || null);
@@ -48,8 +50,8 @@ export default function GasPanel({
     setLoading(true);
     try {
       const [g, w] = await Promise.all([
-        getGasSummary(siteId, days),
-        getGasWeatherNormalized(siteId, days).catch(() => null),
+        getGasSummary(siteId, days, { startDate, endDate }),
+        getGasWeatherNormalized(siteId, days, { startDate, endDate }).catch(() => null),
       ]);
       setGas(g);
       setWeather(w);
@@ -59,7 +61,7 @@ export default function GasPanel({
     } finally {
       setLoading(false);
     }
-  }, [siteId, days, toast]);
+  }, [siteId, days, toast, startDate, endDate]);
 
   // Skip initial fetch if motor already provided data
   useEffect(() => {

--- a/frontend/src/pages/consumption/HPHCPanel.jsx
+++ b/frontend/src/pages/consumption/HPHCPanel.jsx
@@ -12,7 +12,14 @@ import HeatmapChart from './HeatmapChart';
 import { fmtKwh, fmtEur } from '../../utils/format';
 import { CONFIDENCE_BADGE } from './constants';
 
-export default function HPHCPanel({ siteId, days, toast, initialBreakdown }) {
+export default function HPHCPanel({
+  siteId,
+  days,
+  toast,
+  initialBreakdown,
+  startDate = null,
+  endDate = null,
+}) {
   const [breakdown, setBreakdown] = useState(initialBreakdown || null);
   const [schedule, setSchedule] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -30,7 +37,9 @@ export default function HPHCPanel({ siteId, days, toast, initialBreakdown }) {
     try {
       // Only fetch breakdown if not provided by motor; always fetch schedule
       const [bd, s] = await Promise.all([
-        initialBreakdown ? Promise.resolve(initialBreakdown) : getHPHCBreakdownV2(siteId, days),
+        initialBreakdown
+          ? Promise.resolve(initialBreakdown)
+          : getHPHCBreakdownV2(siteId, days, null, false, { startDate, endDate }),
         getActiveTOUSchedule(siteId),
       ]);
       setBreakdown(bd);
@@ -41,7 +50,7 @@ export default function HPHCPanel({ siteId, days, toast, initialBreakdown }) {
     } finally {
       setLoading(false);
     }
-  }, [siteId, days, initialBreakdown, toast]);
+  }, [siteId, days, initialBreakdown, toast, startDate, endDate]);
 
   useEffect(() => {
     load();

--- a/frontend/src/pages/consumption/TunnelPanel.jsx
+++ b/frontend/src/pages/consumption/TunnelPanel.jsx
@@ -23,6 +23,8 @@ export default function TunnelPanel({
   showSignature = false,
   toast,
   initialTunnel,
+  startDate = null,
+  endDate = null,
 }) {
   const [tunnel, setTunnel] = useState(initialTunnel || null);
   const [loading, setLoading] = useState(false);
@@ -36,7 +38,10 @@ export default function TunnelPanel({
     if (!siteId) return;
     setLoading(true);
     try {
-      const data = await getConsumptionTunnelV2(siteId, days, energyType, mode);
+      const data = await getConsumptionTunnelV2(siteId, days, energyType, mode, {
+        startDate,
+        endDate,
+      });
       setTunnel(data);
       track('tunnel_loaded', { site_id: siteId, days, energy_type: energyType, mode });
     } catch (e) {
@@ -44,7 +49,7 @@ export default function TunnelPanel({
     } finally {
       setLoading(false);
     }
-  }, [siteId, days, energyType, mode, toast]);
+  }, [siteId, days, energyType, mode, toast, startDate, endDate]);
 
   // Only fetch if no initial data OR mode changed from default 'energy'
   useEffect(() => {

--- a/frontend/src/pages/consumption/useExplorerMotor.js
+++ b/frontend/src/pages/consumption/useExplorerMotor.js
@@ -24,16 +24,22 @@ import {
  * @param {string[]} opts.initialSiteIds  — initial site IDs to load
  * @param {string}   opts.initialEnergy   — 'electricity' | 'gas'
  * @param {number}   opts.initialDays     — period in days
+ * @param {string|null} opts.initialStartDate — custom start date (ISO string)
+ * @param {string|null} opts.initialEndDate   — custom end date (ISO string)
  */
 export default function useExplorerMotor({
   initialSiteIds = [],
   initialEnergy = 'electricity',
   initialDays = 90,
+  initialStartDate = null,
+  initialEndDate = null,
 } = {}) {
   // ── Core filter state ──────────────────────────────────────────────────
   const [siteIds, setSiteIds] = useState(initialSiteIds);
   const [energyType, setEnergyType] = useState(initialEnergy);
   const [days, setDays] = useState(initialDays);
+  const [startDate, setStartDate] = useState(initialStartDate);
+  const [endDate, setEndDate] = useState(initialEndDate);
   const [mode, setMode] = useState(MODES.AGREGE);
   const [unit, setUnit] = useState(UNITS.KWH);
   const [layers, setLayers] = useState(DEFAULT_LAYERS);
@@ -73,12 +79,12 @@ export default function useExplorerMotor({
           const [avail, tunnel, progression, targets, hphc, gas, weather] =
             await Promise.allSettled([
               getConsumptionAvailability(sid, energyType),
-              getConsumptionTunnelV2(sid, days, energyType, 'energy'),
+              getConsumptionTunnelV2(sid, days, energyType, 'energy', { startDate, endDate }),
               getTargetsProgressionV2(sid, energyType, year),
               getConsumptionTargets(sid, energyType, year),
-              getHPHCBreakdownV2(sid, days),
-              getGasSummary(sid, days),
-              getGasWeatherNormalized(sid, days).catch(() => null),
+              getHPHCBreakdownV2(sid, days, null, false, { startDate, endDate }),
+              getGasSummary(sid, days, { startDate, endDate }),
+              getGasWeatherNormalized(sid, days, { startDate, endDate }).catch(() => null),
             ]);
           return {
             siteId: sid,
@@ -128,7 +134,7 @@ export default function useExplorerMotor({
     } finally {
       if (reqId === requestIdRef.current) setLoading(false);
     }
-  }, [siteIds, energyType, days]);
+  }, [siteIds, energyType, days, startDate, endDate]);
 
   useEffect(() => {
     fetchAll();
@@ -164,11 +170,13 @@ export default function useExplorerMotor({
 
   return {
     // State (controlled by FilterBar / URL hook)
-    state: { siteIds, energyType, days, mode, unit, layers },
+    state: { siteIds, energyType, days, startDate, endDate, mode, unit, layers },
     // Setters
     setSiteIds,
     setEnergyType,
     setDays,
+    setStartDate,
+    setEndDate,
     setMode,
     setUnit,
     toggleLayer,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -713,10 +713,18 @@ export const getConsumptionTunnelV2 = (
   siteId,
   days = 90,
   energyType = 'electricity',
-  mode = 'energy'
+  mode = 'energy',
+  { startDate, endDate } = {}
 ) =>
   _cachedGet('/consumption/tunnel_v2', {
-    params: { site_id: siteId, days, energy_type: energyType, mode },
+    params: {
+      site_id: siteId,
+      days,
+      energy_type: energyType,
+      mode,
+      start_date: startDate || undefined,
+      end_date: endDate || undefined,
+    },
   }).then((r) => r.data);
 
 // Targets (objectifs & budgets)
@@ -766,18 +774,43 @@ export const getHPHCRatio = (siteId, meterId = null, days = 30) =>
   api
     .get('/consumption/hp_hc', { params: { site_id: siteId, meter_id: meterId, days } })
     .then((r) => r.data);
-export const getHPHCBreakdownV2 = (siteId, days = 30, calendarId = null, simulate = false) =>
+export const getHPHCBreakdownV2 = (
+  siteId,
+  days = 30,
+  calendarId = null,
+  simulate = false,
+  { startDate, endDate } = {}
+) =>
   _cachedGet('/consumption/hphc_breakdown_v2', {
-    params: { site_id: siteId, days, calendar_id: calendarId, simulate },
+    params: {
+      site_id: siteId,
+      days,
+      calendar_id: calendarId,
+      simulate,
+      start_date: startDate || undefined,
+      end_date: endDate || undefined,
+    },
   }).then((r) => r.data);
 
 // Gas Summary (beta)
-export const getGasSummary = (siteId, days = 90) =>
-  _cachedGet('/consumption/gas/summary', { params: { site_id: siteId, days } }).then((r) => r.data);
-export const getGasWeatherNormalized = (siteId, days = 90) =>
-  _cachedGet('/consumption/gas/weather_normalized', { params: { site_id: siteId, days } }).then(
-    (r) => r.data
-  );
+export const getGasSummary = (siteId, days = 90, { startDate, endDate } = {}) =>
+  _cachedGet('/consumption/gas/summary', {
+    params: {
+      site_id: siteId,
+      days,
+      start_date: startDate || undefined,
+      end_date: endDate || undefined,
+    },
+  }).then((r) => r.data);
+export const getGasWeatherNormalized = (siteId, days = 90, { startDate, endDate } = {}) =>
+  _cachedGet('/consumption/gas/weather_normalized', {
+    params: {
+      site_id: siteId,
+      days,
+      start_date: startDate || undefined,
+      end_date: endDate || undefined,
+    },
+  }).then((r) => r.data);
 
 // ========================================
 // SITE CONFIG (Schedule + Tariff)


### PR DESCRIPTION
## Summary

- **Root cause**: `useExplorerMotor.fetchAll` dependency array missed `startDate`/`endDate`, and API calls only passed `days` — custom date ranges were ignored by KPI data feeds
- **Fix**: Added `startDate`/`endDate` as motor state, propagated through 4 backend endpoints and 3 panel components

## Files changed

| File | Change |
|------|--------|
| `backend/services/tunnel_service.py` | Optional `start_date`/`end_date` params in `compute_tunnel_v2` |
| `backend/services/tou_service.py` | Optional `start_date`/`end_date` params in `compute_hphc_breakdown_v2` + simulation recursive call |
| `backend/services/gas_weather_service.py` | Optional `start_date`/`end_date` params in `compute_weather_normalized` |
| `backend/routes/consumption_diagnostic.py` | Query params `start_date`/`end_date` on `tunnel_v2`, `hphc_breakdown_v2`, `gas/summary`, `gas/weather_normalized` |
| `frontend/src/services/api.js` | 4 API functions accept optional `{ startDate, endDate }` |
| `frontend/src/pages/consumption/useExplorerMotor.js` | `startDate`/`endDate` state + dep array + API propagation |
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Migrated date state from page to motor |
| `frontend/src/pages/consumption/TunnelPanel.jsx` | Accept + propagate `startDate`/`endDate` |
| `frontend/src/pages/consumption/HPHCPanel.jsx` | Accept + propagate `startDate`/`endDate` |
| `frontend/src/pages/consumption/GasPanel.jsx` | Accept + propagate `startDate`/`endDate` |

## Test plan

**Automated tests**
```bash
cd promeos-poc && ./backend/venv/bin/pytest backend/tests/ -x -v  # 929 passed
cd promeos-poc/frontend && npx vitest run --reporter=verbose       # 5608 passed
```

**Steps to reproduce the bug**
1. Go to Consommations > Explorer
2. Select a custom date range (startDate / endDate)
3. Observe KPI cards remain on the previous period values

**Steps to verify the fix**
1. Go to Consommations > Explorer
2. Select a custom date range
3. Verify KPI cards (kWh, cost, EUR/MWh, CO2e, peak kW, night ratio) refresh to match the selected period
4. Switch between preset periods (30d, 90d, 365d) and custom — KPIs should update each time
5. Open Tunnel, HP/HC, Gas tabs with custom date range — panels should display data for the custom period

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)