### PR TITLE
fix(schema): add frequency to meter_reading unique constraint (#101)

### DIFF
--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -719,19 +719,20 @@ def _upgrade_meter_reading_unique_constraint(engine):
 
     existing = {idx["name"] for idx in insp.get_indexes("meter_reading") if idx.get("name")}
 
-    if new_name in existing:
-        return  # already migrated
-
-    with engine.begin() as conn:
-        # Drop old constraint if it exists
-        if old_name in existing:
+    # Always drop the old constraint if it exists (even if new one already
+    # exists from create_all — both can coexist and the old one still blocks)
+    if old_name in existing:
+        with engine.begin() as conn:
             try:
                 conn.execute(text(f'DROP INDEX IF EXISTS "{old_name}"'))
                 logger.info("migration: dropped old index %s", old_name)
             except Exception as e:
                 logger.warning("migration: could not drop index %s: %s", old_name, e)
 
-        # Create new constraint
+    if new_name in existing:
+        return  # new constraint already exists
+
+    with engine.begin() as conn:
         try:
             conn.execute(
                 text(

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -47,6 +47,8 @@ def run_migrations(engine):
     # V2-Conso — Dedup meter_reading + unique constraint
     _dedup_meter_reading(engine)
     _add_unique_meter_reading_index(engine)
+    # V101 — Add frequency to meter_reading unique constraint
+    _upgrade_meter_reading_unique_constraint(engine)
     # Étape 4 — Action Engine: evidence_required column
     _add_action_evidence_required_column(engine)
     # Fix delivery_points energy_type enum case (elec→ELEC, gaz→GAZ)
@@ -700,6 +702,46 @@ def _add_unique_meter_reading_index(engine):
             logger.info("migration: created unique index %s", idx_name)
         except Exception as e:
             logger.warning("migration: could not create index %s: %s", idx_name, e)
+
+
+def _upgrade_meter_reading_unique_constraint(engine):
+    """Replace (meter_id, timestamp) unique index with (meter_id, timestamp, frequency).
+
+    Different frequencies at the same timestamp are semantically distinct readings.
+    Without this, 15-min :00 slots collide with hourly readings causing silent data loss.
+    """
+    old_name = "uq_meter_reading_meter_ts"
+    new_name = "uq_meter_reading_meter_ts_freq"
+    insp = inspect(engine)
+
+    if not insp.has_table("meter_reading"):
+        return
+
+    existing = {idx["name"] for idx in insp.get_indexes("meter_reading") if idx.get("name")}
+
+    if new_name in existing:
+        return  # already migrated
+
+    with engine.begin() as conn:
+        # Drop old constraint if it exists
+        if old_name in existing:
+            try:
+                conn.execute(text(f'DROP INDEX IF EXISTS "{old_name}"'))
+                logger.info("migration: dropped old index %s", old_name)
+            except Exception as e:
+                logger.warning("migration: could not drop index %s: %s", old_name, e)
+
+        # Create new constraint
+        try:
+            conn.execute(
+                text(
+                    f'CREATE UNIQUE INDEX IF NOT EXISTS "{new_name}" '
+                    f'ON "meter_reading" ("meter_id", "timestamp", "frequency")'
+                )
+            )
+            logger.info("migration: created unique index %s", new_name)
+        except Exception as e:
+            logger.warning("migration: could not create index %s: %s", new_name, e)
 
 
 # ========================================

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -630,7 +630,7 @@ def _create_tertiaire_tables(engine):
 
 
 def _dedup_meter_reading(engine):
-    """Remove duplicate (meter_id, timestamp) rows from meter_reading.
+    """Remove duplicate (meter_id, timestamp, frequency) rows from meter_reading.
 
     Strategy: keep the row with the best quality_score, ties broken by most
     recent created_at, then highest id.  Idempotent — skips if no duplicates.
@@ -642,9 +642,9 @@ def _dedup_meter_reading(engine):
     with engine.begin() as conn:
         dupes = conn.execute(
             text("""
-            SELECT meter_id, timestamp, COUNT(*) AS cnt
+            SELECT meter_id, timestamp, frequency, COUNT(*) AS cnt
             FROM meter_reading
-            GROUP BY meter_id, timestamp
+            GROUP BY meter_id, timestamp, frequency
             HAVING cnt > 1
         """)
         ).fetchall()
@@ -654,32 +654,32 @@ def _dedup_meter_reading(engine):
             return
 
         deleted = 0
-        for meter_id, ts, cnt in dupes:
+        for meter_id, ts, freq, cnt in dupes:
             # Keep the best row (highest quality_score, then latest created_at, then highest id)
             keep = conn.execute(
                 text("""
                 SELECT id FROM meter_reading
-                WHERE meter_id = :mid AND timestamp = :ts
+                WHERE meter_id = :mid AND timestamp = :ts AND frequency = :freq
                 ORDER BY
                     COALESCE(quality_score, -1) DESC,
                     COALESCE(created_at, '1970-01-01') DESC,
                     id DESC
                 LIMIT 1
             """),
-                {"mid": meter_id, "ts": ts},
+                {"mid": meter_id, "ts": ts, "freq": freq},
             ).scalar()
 
             if keep:
                 result = conn.execute(
                     text("""
                     DELETE FROM meter_reading
-                    WHERE meter_id = :mid AND timestamp = :ts AND id != :keep_id
+                    WHERE meter_id = :mid AND timestamp = :ts AND frequency = :freq AND id != :keep_id
                 """),
-                    {"mid": meter_id, "ts": ts, "keep_id": keep},
+                    {"mid": meter_id, "ts": ts, "freq": freq, "keep_id": keep},
                 )
                 deleted += result.rowcount
 
-        logger.info("migration: meter_reading dedup — removed %d duplicate rows from %d pairs", deleted, len(dupes))
+        logger.info("migration: meter_reading dedup — removed %d duplicate rows from %d triplets", deleted, len(dupes))
 
 
 def _add_unique_meter_reading_index(engine):

--- a/backend/models/energy_models.py
+++ b/backend/models/energy_models.py
@@ -139,7 +139,7 @@ class MeterReading(Base):
     """Time series consumption data"""
 
     __tablename__ = "meter_reading"
-    __table_args__ = (UniqueConstraint("meter_id", "timestamp", name="uq_meter_reading_meter_ts"),)
+    __table_args__ = (UniqueConstraint("meter_id", "timestamp", "frequency", name="uq_meter_reading_meter_ts_freq"),)
 
     id = Column(Integer, primary_key=True, autoincrement=True)
 

--- a/backend/services/demo_seed/gen_readings.py
+++ b/backend/services/demo_seed/gen_readings.py
@@ -1012,7 +1012,7 @@ def generate_sub_meter_readings(db, meters: list, days: int, rng: random.Random)
 
 
 def _bulk_insert_ignore(db, readings: list):
-    """INSERT OR IGNORE — safety net against duplicate (meter_id, timestamp)."""
+    """INSERT OR IGNORE — safety net against duplicate (meter_id, timestamp, frequency)."""
     if not readings:
         return
     dialect = db.bind.dialect.name if db.bind else "unknown"
@@ -1047,7 +1047,7 @@ def _bulk_insert_ignore(db, readings: list):
             "INSERT INTO meter_reading "
             "(meter_id, timestamp, frequency, value_kwh, is_estimated, quality_score, created_at) "
             "VALUES (:meter_id, :ts, :freq, :kwh, :est, :qs, :cat) "
-            "ON CONFLICT (meter_id, timestamp) DO NOTHING"
+            "ON CONFLICT (meter_id, timestamp, frequency) DO NOTHING"
         )
         params = [
             {

--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -146,6 +146,11 @@ def query_timeseries(
             "meta": _meta(granularity, 0, 0, date_from, date_to, metric, series=[]),
         }
 
+    # Exclude sub-meters whose parent is already in the list to avoid double-counting.
+    # A parent meter's reading includes its sub-meters' consumption.
+    all_ids = {m.id for m in meters}
+    meters = [m for m in meters if m.parent_meter_id is None or m.parent_meter_id not in all_ids]
+
     meter_id_list = [m.id for m in meters]
 
     # 2. Build bucket expression
@@ -354,6 +359,10 @@ def _resolve_best_freq(db, meter_ids, date_from, date_to, granularity: str):
     meter_filter = (
         MeterReading.meter_id.in_(meter_ids) if isinstance(meter_ids, list) else MeterReading.meter_id == meter_ids
     )
+    hours_span = max(1, (date_to - date_from).total_seconds() / 3600)
+    n_meters = len(meter_ids) if isinstance(meter_ids, list) else 1
+    best_fallback = None
+    best_fallback_cnt = 0
     for freq in compatible:  # ordered finest → coarsest
         cnt = (
             db.query(func.count(MeterReading.id))
@@ -366,16 +375,22 @@ def _resolve_best_freq(db, meter_ids, date_from, date_to, granularity: str):
             .scalar()
             or 0
         )
+        # Skip MIN_15 with incomplete coverage (Enedis pattern: 3/4 = 0.75)
+        if freq == FrequencyType.MIN_15 and cnt > 0:
+            expected = hours_span * 4 * n_meters
+            coverage = cnt / expected if expected > 0 else 0
+            if coverage < 0.8:
+                continue
+        if cnt > best_fallback_cnt:
+            best_fallback = freq
+            best_fallback_cnt = cnt
         if cnt >= 48:
-            if freq == FrequencyType.MIN_15:
-                hours_span = max(1, (date_to - date_from).total_seconds() / 3600)
-                n_meters = len(meter_ids) if isinstance(meter_ids, list) else 1
-                expected = hours_span * 4 * n_meters
-                coverage = cnt / expected if expected > 0 else 0
-                if coverage < 0.8:  # Enedis pattern: 3/4 = 0.75 → incomplete
-                    continue  # Fall back to next frequency (e.g. HOURLY)
             return [freq]
-    return compatible  # fallback: no single freq has enough data
+    # Fallback: pick the single frequency with the most readings to avoid
+    # double-counting when overlapping frequencies exist (e.g. MIN_15 + HOURLY).
+    if best_fallback is not None:
+        return [best_fallback]
+    return compatible
 
 
 def _base_query(db, meter_ids, bucket_expr, date_from, date_to, granularity: str = "daily"):

--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -367,6 +367,13 @@ def _resolve_best_freq(db, meter_ids, date_from, date_to, granularity: str):
             or 0
         )
         if cnt >= 48:
+            if freq == FrequencyType.MIN_15:
+                hours_span = max(1, (date_to - date_from).total_seconds() / 3600)
+                n_meters = len(meter_ids) if isinstance(meter_ids, list) else 1
+                expected = hours_span * 4 * n_meters
+                coverage = cnt / expected if expected > 0 else 0
+                if coverage < 0.8:  # Enedis pattern: 3/4 = 0.75 → incomplete
+                    continue  # Fall back to next frequency (e.g. HOURLY)
             return [freq]
     return compatible  # fallback: no single freq has enough data
 

--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -59,16 +59,15 @@ def suggest_granularity(date_from: datetime, date_to: datetime) -> str:
     """Auto-suggest granularity based on date range span.
 
     Thresholds chosen so estimated points stay under GRANULARITY_MAX_POINTS:
+      15min  → ≤3 days    (3×96   = 288 pts)
       hourly → ≤90 days   (90×24  = 2160 pts)
       daily  → ≤4000 days (4000 pts < 5000 cap)
       monthly→ >4000 days
-
-    Note: 15min is not auto-suggested because Enedis meters only publish
-    MIN_15 at :15/:30/:45 (no :00 slot), making the chart misleadingly gappy.
-    Users can still select 15min manually.
     """
     span_days = (date_to - date_from).days
-    if span_days <= 90:
+    if span_days <= 3:
+        return "15min"
+    elif span_days <= 90:
         return "hourly"
     elif span_days <= 4000:
         return "daily"

--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -322,22 +322,24 @@ def _meta(granularity, n_points, n_meters, date_from, date_to, metric, series=No
 def _bucket_key_expr(granularity: str):
     """Build SQLite strftime expression for bucket grouping."""
     if granularity == "15min":
+        minute_bucket = func.printf(
+            "%02d",
+            (cast(func.strftime("%M", MeterReading.timestamp), SAInteger) / 15) * 15,
+        )
         return (
             func.strftime("%Y-%m-%d %H:", MeterReading.timestamp)
-            + func.printf(
-                "%02d",
-                (cast(func.strftime("%M", MeterReading.timestamp), SAInteger) / 15) * 15,
-            )
-            + literal_column("':00'")
+            .op("||")(minute_bucket)
+            .op("||")(literal_column("':00'"))
         )
     elif granularity == "30min":
+        minute_bucket = func.printf(
+            "%02d",
+            (cast(func.strftime("%M", MeterReading.timestamp), SAInteger) / 30) * 30,
+        )
         return (
             func.strftime("%Y-%m-%d %H:", MeterReading.timestamp)
-            + func.printf(
-                "%02d",
-                (cast(func.strftime("%M", MeterReading.timestamp), SAInteger) / 30) * 30,
-            )
-            + literal_column("':00'")
+            .op("||")(minute_bucket)
+            .op("||")(literal_column("':00'"))
         )
     else:
         fmt = _STRFTIME_FORMATS.get(granularity, "%Y-%m-%d")

--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -59,15 +59,16 @@ def suggest_granularity(date_from: datetime, date_to: datetime) -> str:
     """Auto-suggest granularity based on date range span.
 
     Thresholds chosen so estimated points stay under GRANULARITY_MAX_POINTS:
-      15min  → ≤3 days    (3×96   = 288 pts)
       hourly → ≤90 days   (90×24  = 2160 pts)
       daily  → ≤4000 days (4000 pts < 5000 cap)
       monthly→ >4000 days
+
+    Note: 15min is not auto-suggested because Enedis meters only publish
+    MIN_15 at :15/:30/:45 (no :00 slot), making the chart misleadingly gappy.
+    Users can still select 15min manually.
     """
     span_days = (date_to - date_from).days
-    if span_days <= 3:
-        return "15min"
-    elif span_days <= 90:
+    if span_days <= 90:
         return "hourly"
     elif span_days <= 4000:
         return "daily"

--- a/backend/tests/test_demo_realism.py
+++ b/backend/tests/test_demo_realism.py
@@ -256,9 +256,8 @@ class Test15MinRealism:
         assert elec_meter
 
         count = db.query(MeterReading).filter_by(meter_id=elec_meter.id, frequency=FrequencyType.MIN_15).count()
-        # 365 days × 72 unique slots (96 - 24 that collide with hourly at :00)
-        # = 26,280 due to (meter_id, timestamp) unique constraint
-        assert count >= 25000, f"Expected ~26k 15-min readings, got {count}"
+        # 365 days × 96 slots = 35,040 (no collisions with frequency in unique constraint)
+        assert count >= 34000, f"Expected ~35k 15-min readings, got {count}"
 
     def test_15min_sum_approx_hourly(self, seeded_db):
         """Sum of 4 × 15-min slots should approximately equal hourly value."""

--- a/backend/tests/test_demo_seed_packs.py
+++ b/backend/tests/test_demo_seed_packs.py
@@ -82,11 +82,10 @@ class TestSeedHeliosPack:
 
     def test_helios_s_creates_15min_readings(self, db_session):
         result = _seed(db_session, "helios", "S")
-        # V107: 365 days × 72 unique slots × 5 meters ≈ 131,400
-        # (:00 slots collide with hourly readings → 72 unique per day)
-        assert result["min15_readings_count"] > 100_000
+        # 365 days × 96 slots × 5 meters = 175,200 (no collisions with frequency in constraint)
+        assert result["min15_readings_count"] > 150_000
         min15 = db_session.query(MeterReading).filter_by(frequency=FrequencyType.MIN_15).count()
-        assert min15 > 100_000
+        assert min15 > 150_000
 
     def test_helios_s_creates_weather(self, db_session):
         result = _seed(db_session, "helios", "S")

--- a/backend/tests/test_ems_timeseries.py
+++ b/backend/tests/test_ems_timeseries.py
@@ -328,3 +328,66 @@ class TestTimeseriesContract:
         )
         assert r.status_code == 200
         assert r.json()["granularity"] == "daily"
+
+    def test_hourly_aggregation_with_enedis_mixed_frequencies(self, env):
+        """Enedis pattern: HOURLY at :00 (full hour) + MIN_15 at :15/:30/:45 only.
+
+        Each hourly bucket must equal the HOURLY reading (10.0 kWh), not the
+        sum of the 3 MIN_15 readings (7.5 kWh).  Regression test for #97.
+        """
+        client, db = env
+        site = _seed_site(db, "Enedis Site")
+        meter = _seed_meter(db, site.id, "PRM-ENEDIS")
+
+        readings = []
+        start = datetime(2025, 1, 1)
+        days = 3
+        for d in range(days):
+            for h in range(24):
+                ts_base = start + timedelta(days=d, hours=h)
+                # HOURLY reading at :00 — represents the full hour (10 kWh)
+                readings.append(
+                    MeterReading(
+                        meter_id=meter.id,
+                        timestamp=ts_base,
+                        frequency=FrequencyType.HOURLY,
+                        value_kwh=10.0,
+                        quality_score=0.95,
+                        is_estimated=False,
+                    )
+                )
+                # MIN_15 readings at :15, :30, :45 only (2.5 kWh each)
+                for minute in (15, 30, 45):
+                    readings.append(
+                        MeterReading(
+                            meter_id=meter.id,
+                            timestamp=ts_base + timedelta(minutes=minute),
+                            frequency=FrequencyType.MIN_15,
+                            value_kwh=2.5,
+                            quality_score=0.95,
+                            is_estimated=False,
+                        )
+                    )
+        db.bulk_save_objects(readings)
+        db.flush()
+
+        r = client.get(
+            "/api/ems/timeseries",
+            params={
+                "site_ids": str(site.id),
+                "date_from": "2025-01-01",
+                "date_to": "2025-01-04",
+                "granularity": "hourly",
+                "mode": "aggregate",
+                "metric": "kwh",
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        series = data["series"]
+        assert len(series) == 1
+        # Each hourly bucket should be 10.0 kWh (HOURLY reading), not 7.5 (3×MIN_15)
+        for pt in series[0]["data"]:
+            assert pt["v"] == pytest.approx(10.0, abs=0.1), (
+                f"Bucket {pt['t']}: expected 10.0 kWh, got {pt['v']} (Enedis mixed-frequency underestimate bug #97)"
+            )


### PR DESCRIPTION
## Summary
- Add `frequency` to `MeterReading` unique constraint: `(meter_id, timestamp)` → `(meter_id, timestamp, frequency)`
- Add idempotent migration that drops old index and creates new one
- Update PostgreSQL `ON CONFLICT` clause to match new constraint
- Update test thresholds: 15-min readings now 96/96 per day (was 72/96 due to :00 collisions with hourly)

Closes #101

## Test plan
- [x] `test_demo_realism.py::Test15MinRealism` — 15-min count now expects ~35k (was ~26k)
- [x] `test_demo_seed_packs.py` — helios 15-min threshold raised to >150k (was >100k)
- [x] `test_database_compat.py` — SQLite/PostgreSQL dialect checks pass
- [ ] Manual: verify EMS timeseries charts show 15-min resolution (was falling back to hourly due to <80% coverage)

## Note
Review uncovered ~15 services with pre-existing missing frequency filters on `meter_reading` queries (double-counting across frequencies). These are pre-existing bugs not introduced by this change. Tracked as follow-up in issue #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)