### PR TITLE
fix(consumption): show date on X-axis for 15min/30min (#111)

### DIFF
--- a/frontend/src/pages/__tests__/V143Timeseries.test.js
+++ b/frontend/src/pages/__tests__/V143Timeseries.test.js
@@ -69,11 +69,12 @@ describe('formatDate: French locale formatting', () => {
     expect(result).toContain('15');
   });
 
-  it('default (15min/30min): returns time only (HH:MM)', () => {
+  it('15min/30min: returns day + month + time (same as hourly)', () => {
     const result = formatDate('2025-03-15T09:15:00Z', '15min');
     expect(result).toBeTruthy();
     expect(typeof result).toBe('string');
-    // Should be a time string with colon
+    // Should contain day ("15") and time with colon
+    expect(result).toContain('15');
     expect(result).toContain(':');
   });
 

--- a/frontend/src/pages/consumption/useEmsTimeseries.js
+++ b/frontend/src/pages/consumption/useEmsTimeseries.js
@@ -48,8 +48,13 @@ export function formatDate(isoStr, granularity) {
       minute: '2-digit',
     });
   }
-  // 15min / 30min
-  return d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+  // 15min / 30min — same day+month+time format as hourly
+  return d.toLocaleString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
 // ── Date computation from `days` ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause**: `formatDate()` in `useEmsTimeseries.js` used `toLocaleTimeString` for sub-hourly granularities (15min/30min), producing only `"10:15"` without any date context. The `hourly` branch already included `day` + `month`.
- **Fix**: Aligned the 15min/30min format with hourly — now uses `toLocaleString` with `{ day, month, hour, minute }`, producing e.g. `"14 mars, 10:15"`. Both the X-axis ticks and the Tooltip label benefit automatically since they rely on the pre-formatted `date` string.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/useEmsTimeseries.js` | `formatDate()` fallback branch: `toLocaleTimeString` → `toLocaleString` with day+month |
| `frontend/src/pages/__tests__/V143Timeseries.test.js` | Updated test description and assertion to match new behavior |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/V143Timeseries.test.js src/pages/__tests__/V20TimeseriesFix.test.js src/pages/__tests__/ExplorerChartBrush.test.js --reporter=verbose
```

**Steps to reproduce the bug**
1. Go to Consommations → Explorer
2. Select a multi-day date range and set granularity to 15 min
3. Observe X-axis labels show only time (e.g. "10:15") with no date

**Steps to verify the fix**
1. Same navigation as above
2. X-axis now shows day + month + time (e.g. "14 mars, 10:15")
3. Tooltip on hover also shows the date alongside the time

Closes #111