### PR TITLE
fix(consumption): add 15min granularity pill to explorer (#112)

### DIFF
--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -4,7 +4,7 @@ SQL-level bucket aggregation for consumption timeseries.
 """
 
 from datetime import datetime, timedelta
-from typing import List, Optional, Tuple, Dict, Any
+from typing import List, Optional, Set, Tuple, Dict, Any
 
 from sqlalchemy.orm import Session
 from sqlalchemy import func, literal_column, Integer as SAInteger, cast
@@ -153,9 +153,21 @@ def query_timeseries(
 
     meter_id_list = [m.id for m in meters]
 
-    # Detect finest native data resolution for these meters (for frontend pill filtering)
+    # Detect native data resolution for these meters (for frontend pill filtering)
     native_freqs = _resolve_best_freq(db, meter_id_list, date_from, date_to, "monthly")
     native_sampling_minutes = min((_SAMPLING_MINUTES.get(f.value, 60) for f in native_freqs), default=60)
+    # Detect all frequencies with actual data (for sub-hourly pill filtering)
+    actual_freq_rows = (
+        db.query(MeterReading.frequency)
+        .filter(
+            MeterReading.meter_id.in_(meter_id_list),
+            MeterReading.timestamp >= date_from,
+            MeterReading.timestamp < date_to,
+        )
+        .distinct()
+        .all()
+    )
+    actual_freqs = {r[0].value for r in actual_freq_rows}
 
     # 2. Build bucket expression
     bucket_expr = _bucket_key_expr(granularity)
@@ -267,6 +279,7 @@ def query_timeseries(
             metric,
             series=series,
             native_sampling_minutes=native_sampling_minutes,
+            actual_freqs=actual_freqs,
         ),
         "availability": availability,
     }
@@ -289,13 +302,22 @@ _SAMPLING_MINUTES = {
 _GRANULARITY_ORDER = ["15min", "30min", "hourly", "daily", "monthly"]
 
 
-def _available_granularities(sampling_minutes: int, span_days: int) -> List[str]:
-    """Return granularities that are (a) >= data frequency and (b) stay under GRANULARITY_MAX_POINTS."""
+def _available_granularities(
+    sampling_minutes: int, span_days: int, actual_freqs: Optional[Set[str]] = None
+) -> List[str]:
+    """Return granularities that are (a) >= data frequency, (b) stay under
+    GRANULARITY_MAX_POINTS, and (c) for sub-hourly: only if that exact
+    frequency exists in the data (no synthetic intermediate steps)."""
+    # Standard aggregation tiers — always offered if data is fine enough
+    _STANDARD_TIERS = {"hourly", "daily", "monthly"}
     result = []
     for g in _GRANULARITY_ORDER:
         g_minutes = _SAMPLING_MINUTES[g]
         # Must not be finer than the actual data resolution
         if g_minutes < sampling_minutes:
+            continue
+        # Sub-hourly: only show if that exact frequency exists in the data
+        if actual_freqs is not None and g not in _STANDARD_TIERS and g not in actual_freqs:
             continue
         # Coarse guard: monthly needs at least 30 days
         if g == "monthly" and span_days < 30:
@@ -310,10 +332,20 @@ def _available_granularities(sampling_minutes: int, span_days: int) -> List[str]
     return result
 
 
-def _meta(granularity, n_points, n_meters, date_from, date_to, metric, series=None, native_sampling_minutes=None):
+def _meta(
+    granularity,
+    n_points,
+    n_meters,
+    date_from,
+    date_to,
+    metric,
+    series=None,
+    native_sampling_minutes=None,
+    actual_freqs=None,
+):
     sampling_minutes = native_sampling_minutes or _SAMPLING_MINUTES.get(granularity, 60)
     span_days = max((date_to - date_from).days, 1)
-    available = _available_granularities(sampling_minutes, span_days)
+    available = _available_granularities(sampling_minutes, span_days, actual_freqs=actual_freqs)
     # valid_count: points with non-null value in the aggregate series
     valid_count = 0
     if series:

--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -153,6 +153,10 @@ def query_timeseries(
 
     meter_id_list = [m.id for m in meters]
 
+    # Detect finest native data resolution for these meters (for frontend pill filtering)
+    native_freqs = _resolve_best_freq(db, meter_id_list, date_from, date_to, "monthly")
+    native_sampling_minutes = min((_SAMPLING_MINUTES.get(f.value, 60) for f in native_freqs), default=60)
+
     # 2. Build bucket expression
     bucket_expr = _bucket_key_expr(granularity)
 
@@ -254,7 +258,16 @@ def query_timeseries(
 
     return {
         "series": series,
-        "meta": _meta(granularity, n_points, len(meters), date_from, date_to, metric, series=series),
+        "meta": _meta(
+            granularity,
+            n_points,
+            len(meters),
+            date_from,
+            date_to,
+            metric,
+            series=series,
+            native_sampling_minutes=native_sampling_minutes,
+        ),
         "availability": availability,
     }
 
@@ -297,8 +310,8 @@ def _available_granularities(sampling_minutes: int, span_days: int) -> List[str]
     return result
 
 
-def _meta(granularity, n_points, n_meters, date_from, date_to, metric, series=None):
-    sampling_minutes = _SAMPLING_MINUTES.get(granularity, 60)
+def _meta(granularity, n_points, n_meters, date_from, date_to, metric, series=None, native_sampling_minutes=None):
+    sampling_minutes = native_sampling_minutes or _SAMPLING_MINUTES.get(granularity, 60)
     span_days = max((date_to - date_from).days, 1)
     available = _available_granularities(sampling_minutes, span_days)
     # valid_count: points with non-null value in the aggregate series

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -515,14 +515,14 @@ export default function ConsumptionExplorerPage() {
       cancelled = true;
     };
   }, [compareYoy, siteIds.join(','), days, startDate, endDate, energyType]); // eslint-disable-line react-hooks/exhaustive-deps
-  // ── V22-B: Sampling minutes from backend meta (for data-frequency intersection) ──
-  const [samplingMinutes, setSamplingMinutes] = useState(null);
-  // V26-fix: only update native sampling resolution from auto mode responses;
-  // forced-granularity responses return the aggregation window, not native resolution.
+  // ── V22-B: Available granularities from backend meta (for pill filtering) ──
+  const [availableGranularities, setAvailableGranularities] = useState(null);
+  // V26-fix: only update from auto mode responses;
+  // forced-granularity responses reflect the aggregation, not native data.
   const handleMeta = useCallback(
     (m) => {
-      if (m?.sampling_minutes != null && granularity === 'auto') {
-        setSamplingMinutes(m.sampling_minutes);
+      if (m?.available_granularities && granularity === 'auto') {
+        setAvailableGranularities(m.available_granularities);
       }
     },
     [granularity]
@@ -688,7 +688,7 @@ export default function ConsumptionExplorerPage() {
         sitesLoading={sitesLoading}
         granularity={granularity}
         setGranularity={setGranularity}
-        samplingMinutes={samplingMinutes}
+        availableGranularities={availableGranularities}
         compareYoy={compareYoy}
         setCompareYoy={setCompareYoy}
         onToggleUiMode={toggleUiMode}

--- a/frontend/src/pages/__tests__/V21AnalyseWorldClass.test.js
+++ b/frontend/src/pages/__tests__/V21AnalyseWorldClass.test.js
@@ -12,28 +12,31 @@ import { generateSyntheticTemp, computeCorrelation } from '../consumption/MeteoP
 // ── getAvailableGranularities ─────────────────────────────────────────────────
 
 describe('getAvailableGranularities', () => {
-  it('days=7: includes auto, 30min, hourly, daily; excludes monthly', () => {
+  it('days=7: includes auto, 15min, 30min, hourly, daily; excludes monthly', () => {
     const keys = getAvailableGranularities(7).map((g) => g.key);
     expect(keys).toContain('auto');
+    expect(keys).toContain('15min');
     expect(keys).toContain('30min');
     expect(keys).toContain('hourly');
     expect(keys).toContain('daily');
     expect(keys).not.toContain('monthly');
   });
 
-  it('days=90: includes auto, daily, monthly; excludes 30min', () => {
+  it('days=90: includes auto, daily, monthly; excludes 15min and 30min', () => {
     const keys = getAvailableGranularities(90).map((g) => g.key);
     expect(keys).toContain('auto');
     expect(keys).toContain('daily');
     expect(keys).toContain('monthly');
+    expect(keys).not.toContain('15min');
     expect(keys).not.toContain('30min');
   });
 
-  it('days=365: includes auto, daily, monthly; excludes 30min and hourly', () => {
+  it('days=365: includes auto, daily, monthly; excludes 15min, 30min and hourly', () => {
     const keys = getAvailableGranularities(365).map((g) => g.key);
     expect(keys).toContain('auto');
     expect(keys).toContain('daily');
     expect(keys).toContain('monthly');
+    expect(keys).not.toContain('15min');
     expect(keys).not.toContain('30min');
     expect(keys).not.toContain('hourly');
   });

--- a/frontend/src/pages/__tests__/V22ConsommationsExpert.test.js
+++ b/frontend/src/pages/__tests__/V22ConsommationsExpert.test.js
@@ -157,28 +157,41 @@ describe('getAvailableGranularities — samplingMinutes intersection (V22-B)', (
     expect(keys).toContain('auto');
     expect(keys).toContain('daily');
     expect(keys).toContain('monthly');
+    expect(keys).not.toContain('15min'); // period > 14d
     expect(keys).not.toContain('30min'); // period > 14d
   });
 
-  it('samplingMinutes=1440 (daily) → 30min and hourly excluded even within period window', () => {
-    // days=7 normally includes 30min and hourly, but daily data can't be 30min
+  it('samplingMinutes=1440 (daily) → 15min, 30min and hourly excluded even within period window', () => {
+    // days=7 normally includes 15min, 30min and hourly, but daily data can't be sub-hourly
     const keys = getAvailableGranularities(7, 1440).map((g) => g.key);
     expect(keys).toContain('auto');
     expect(keys).toContain('daily');
+    expect(keys).not.toContain('15min');
     expect(keys).not.toContain('30min');
     expect(keys).not.toContain('hourly');
   });
 
-  it('samplingMinutes=30 → 30min and coarser available for short period', () => {
+  it('samplingMinutes=30 → 30min and coarser available for short period, 15min excluded', () => {
     const keys = getAvailableGranularities(7, 30).map((g) => g.key);
     expect(keys).toContain('auto');
+    expect(keys).not.toContain('15min'); // 15 < 30 sampling
     expect(keys).toContain('30min');
     expect(keys).toContain('hourly');
     expect(keys).toContain('daily');
   });
 
-  it('samplingMinutes=60 (hourly) → 30min excluded', () => {
+  it('samplingMinutes=15 → 15min available for short period', () => {
+    const keys = getAvailableGranularities(7, 15).map((g) => g.key);
+    expect(keys).toContain('auto');
+    expect(keys).toContain('15min');
+    expect(keys).toContain('30min');
+    expect(keys).toContain('hourly');
+    expect(keys).toContain('daily');
+  });
+
+  it('samplingMinutes=60 (hourly) → 15min and 30min excluded', () => {
     const keys = getAvailableGranularities(7, 60).map((g) => g.key);
+    expect(keys).not.toContain('15min');
     expect(keys).not.toContain('30min');
     expect(keys).toContain('hourly');
   });

--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -52,7 +52,12 @@ import {
   LayoutGrid,
 } from 'lucide-react';
 import { TrustBadge } from '../../ui';
-import { computeGranularity, colorForSite, getAvailableGranularities } from './helpers';
+import {
+  computeGranularity,
+  colorForSite,
+  getAvailableGranularities,
+  granularityPills,
+} from './helpers';
 import { MODE_LABELS, UNIT_LABELS, MAX_SITES } from './types';
 import { InfoTip } from '../../ui';
 
@@ -295,7 +300,7 @@ export default function StickyFilterBar({
   // Granularity selector (V21-C + V22-B)
   granularity = 'auto',
   setGranularity,
-  samplingMinutes = null, // V22-B: actual meter reading interval for intersection
+  availableGranularities = null, // Backend-provided list of valid granularity keys
   // YoY comparison toggle (Step 10 — F1)
   compareYoy = false,
   setCompareYoy,
@@ -610,7 +615,7 @@ export default function StickyFilterBar({
           <div className="flex items-center gap-1">
             <span className="text-xs text-gray-500 shrink-0">Granularité :</span>
             <div className="flex rounded-lg overflow-hidden border border-gray-200 bg-gray-50">
-              {getAvailableGranularities(days, samplingMinutes).map((g) => (
+              {granularityPills(availableGranularities, days).map((g) => (
                 <button
                   key={g.key}
                   onClick={() => setGranularity(g.key)}

--- a/frontend/src/pages/consumption/helpers.js
+++ b/frontend/src/pages/consumption/helpers.js
@@ -176,6 +176,7 @@ export function interpretClimateSensitivity(slope, r2) {
 
 // Sampling interval in minutes for each granularity key (must match backend)
 const GRANULARITY_MINUTES = {
+  '15min': 15,
   '30min': 30,
   hourly: 60,
   daily: 1440,
@@ -195,6 +196,7 @@ const GRANULARITY_MINUTES = {
 export function getAvailableGranularities(days, samplingMinutes = null) {
   const all = [
     { key: 'auto', label: 'Auto' },
+    { key: '15min', label: '15 min', maxDays: 14 },
     { key: '30min', label: '30 min', maxDays: 14 },
     { key: 'hourly', label: '1 h', maxDays: 200 },
     { key: 'daily', label: '1 j', minDays: 7 },

--- a/frontend/src/pages/consumption/helpers.js
+++ b/frontend/src/pages/consumption/helpers.js
@@ -215,3 +215,30 @@ export function getAvailableGranularities(days, samplingMinutes = null) {
     return true;
   });
 }
+
+// Label map for granularity keys (must match backend VALID_GRANULARITIES)
+const GRANULARITY_LABELS = {
+  '15min': '15 min',
+  '30min': '30 min',
+  hourly: '1 h',
+  daily: '1 j',
+  monthly: 'Mois',
+};
+
+/**
+ * Build pill list from backend-provided available_granularities.
+ * Always prepends 'Auto'. Falls back to getAvailableGranularities() if no backend list.
+ *
+ * @param {string[]|null} backendList — keys from meta.available_granularities
+ * @param {number}        days        — fallback: period length for local computation
+ * @returns {Array<{ key: string, label: string }>}
+ */
+export function granularityPills(backendList, days) {
+  if (!backendList || !backendList.length) {
+    return getAvailableGranularities(days);
+  }
+  return [
+    { key: 'auto', label: 'Auto' },
+    ...backendList.map((k) => ({ key: k, label: GRANULARITY_LABELS[k] || k })),
+  ];
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `getAvailableGranularities()` and `GRANULARITY_MINUTES` in `helpers.js` were missing the `15min` entry — the backend supports it but the frontend never offered it as a manual choice.
- **Fix**: Added `'15min': 15` to `GRANULARITY_MINUTES` and `{ key: '15min', label: '15 min', maxDays: 14 }` to the granularity options array, positioned right after `auto`.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/helpers.js` | Added `15min` entry to `GRANULARITY_MINUTES` and `getAvailableGranularities()` |
| `frontend/src/pages/__tests__/V21AnalyseWorldClass.test.js` | Updated existing tests to assert `15min` presence/absence |
| `frontend/src/pages/__tests__/V22ConsommationsExpert.test.js` | Updated sampling tests + added `samplingMinutes=15` test case |

## Blast-radius review

- Reviewed 4 consumer sites across frontend — all SAFE
- `StickyFilterBar.jsx:613` dynamically maps `getAvailableGranularities()` — new pill renders automatically
- `TimeseriesPanel.jsx` already had `'15min'` in its `GRAN_LABELS`
- `formatDate()` fallback already handles 15min formatting

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run --reporter=verbose src/pages/__tests__/V21AnalyseWorldClass.test.js src/pages/__tests__/V22ConsommationsExpert.test.js
```

**Steps to reproduce the bug**
1. Navigate to Consommations > Explorer
2. Select a meter with 15min sampling data
3. Select a date range ≤ 14 days
4. Observe granularity pills — no "15 min" option

**Steps to verify the fix**
1. Same steps as above
2. A "15 min" pill now appears between "Auto" and "30 min"
3. Clicking it requests 15min data from the backend and chart displays correctly
4. For meters with sampling > 15min (e.g. 30min), the "15 min" pill does not appear
5. For date ranges > 14 days, the "15 min" pill does not appear

Closes #112