### PR TITLE
fix(explorer): compact sticky filter bar & reduce wasted space (#90)

### DIFF
--- a/frontend/src/__tests__/step10_compare_guard.test.js
+++ b/frontend/src/__tests__/step10_compare_guard.test.js
@@ -76,7 +76,8 @@ describe('C. StickyFilterBar compare toggle', () => {
   });
 
   test('C3. Comparer N-1 button text', () => {
-    expect(src).toMatch(/Comparer N-1/);
+    // Compact label "N-1" with full text in title attribute (#90)
+    expect(src).toMatch(/N-1/);
   });
 
   test('C4. not-portfolio guard (no single-site restriction)', () => {

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -176,82 +176,81 @@ export default function ConsoKpiHeader({
   const confTooltip = confidence ? CONFIDENCE_TOOLTIP[confidence] : null;
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <h3 className="text-sm font-semibold text-gray-600">KPIs Consommation</h3>
-        {confBadge && (
+    <div
+      className="flex flex-wrap items-baseline gap-x-5 gap-y-1 px-3 py-2 rounded-lg bg-gray-50 border border-gray-100 text-xs"
+      aria-label="KPIs Consommation"
+    >
+      <div className="flex flex-col" title="Somme des relevés sur la période sélectionnée">
+        <span className="text-gray-400">{getKpiLabel('total_kwh', isExpert)}</span>
+        <span className="font-semibold text-gray-700 whitespace-nowrap flex items-center gap-1">
+          {kwhLabel}
+          {compareSummary?.delta_pct != null && <TrendDelta deltaPct={compareSummary.delta_pct} />}
+          {onEvidence && (
+            <button
+              onClick={() => onEvidence('conso-kwh-total')}
+              className="text-gray-300 hover:text-blue-500 transition"
+              aria-label={`Pourquoi ce chiffre : ${getKpiLabel('total_kwh', isExpert)}`}
+              data-testid="evidence-open-conso-kwh-total"
+            >
+              <HelpCircle size={12} />
+            </button>
+          )}
+        </span>
+      </div>
+      <div
+        className="flex flex-col"
+        title={`Calcul : ${eurSource}. Basé sur les prix HP/HC du contrat ou estimés.`}
+      >
+        <span className="text-gray-400">Coût total</span>
+        <span className="font-semibold text-gray-700 whitespace-nowrap">{eurLabel}</span>
+      </div>
+      <div className="flex flex-col" title="Prix moyen = EUR total / MWh total (source HP/HC)">
+        <span className="text-gray-400">Prix moyen</span>
+        <span className="font-semibold text-gray-700 whitespace-nowrap">{eurMwhLabel}</span>
+      </div>
+      <div className="flex flex-col" title="Facteur ADEME 2024 : 0,052 kgCO₂e/kWh (mix France)">
+        <span className="text-gray-400">{getKpiLabel('total_kgco2e', isExpert)}</span>
+        <span className="font-semibold text-gray-700 whitespace-nowrap flex items-center gap-1">
+          {co2Label}
+          {onEvidence && (
+            <button
+              onClick={() => onEvidence('conso-co2e')}
+              className="text-gray-300 hover:text-blue-500 transition"
+              aria-label={`Pourquoi ce chiffre : ${getKpiLabel('total_kgco2e', isExpert)}`}
+              data-testid="evidence-open-conso-co2e"
+            >
+              <HelpCircle size={12} />
+            </button>
+          )}
+        </span>
+      </div>
+      <div className="flex flex-col" title="95e percentile de puissance sur les créneaux horaires">
+        <span className="text-gray-400">{getKpiLabel('p95_kw', isExpert)}</span>
+        <span className="font-semibold text-gray-700 whitespace-nowrap">{p95Label}</span>
+      </div>
+      <div
+        className="flex flex-col"
+        title="Ratio consommation nuit (22h-6h) / jour (6h-22h) en semaine"
+      >
+        <span className="text-gray-400">{getKpiLabel('night_ratio', isExpert)}</span>
+        <span className={`font-semibold whitespace-nowrap ${basePctColor}`}>{basePctLabel}</span>
+      </div>
+      {confBadge && (
+        <div className="flex flex-col ml-auto" title={`Comment calculé ? ${confTooltip}`}>
+          <span className="text-gray-400">Confiance</span>
           <span
-            className="inline-flex items-center gap-1"
-            title={`Comment calculé ? ${confTooltip}`}
+            className={`font-semibold whitespace-nowrap ${
+              confBadge.variant === 'ok'
+                ? 'text-green-600'
+                : confBadge.variant === 'warn'
+                  ? 'text-amber-600'
+                  : 'text-red-600'
+            }`}
           >
-            <TrustBadge
-              level={confBadge.variant}
-              label={`Confiance ${confBadge.label}`}
-              size="sm"
-            />
-            <HelpCircle size={12} className="text-gray-400 cursor-help" />
+            {confBadge.label}
           </span>
-        )}
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
-        <KpiTile
-          icon={Zap}
-          label={getKpiLabel('total_kwh', isExpert)}
-          value={kwhLabel}
-          sub={
-            compareSummary?.delta_pct != null ? (
-              <TrendDelta deltaPct={compareSummary.delta_pct} />
-            ) : (
-              periodLabel
-            )
-          }
-          tooltip="Somme des relevés sur la période sélectionnée"
-          evidenceId="conso-kwh-total"
-          onEvidence={onEvidence}
-        />
-        <KpiTile
-          icon={Euro}
-          label="Coût total"
-          value={eurLabel}
-          sub={eurSource}
-          tooltip={`Calcul : ${eurSource}. Basé sur les prix HP/HC du contrat ou estimés.`}
-        />
-        <KpiTile
-          icon={TrendingUp}
-          label="Prix moyen"
-          value={eurMwhLabel}
-          sub={
-            eurMwh != null
-              ? `${fmtNum(Math.round(totalEur), 0, '€')} / ${fmtKwh(hphcKwh)}`
-              : undefined
-          }
-          tooltip="Prix moyen = EUR total / MWh total (source HP/HC)"
-        />
-        <KpiTile
-          icon={Leaf}
-          label={getKpiLabel('total_kgco2e', isExpert)}
-          value={co2Label}
-          sub="ADEME 2024"
-          tooltip="Facteur ADEME 2024 : 0,052 kgCO₂e/kWh (mix France)"
-          evidenceId="conso-co2e"
-          onEvidence={onEvidence}
-        />
-        <KpiTile
-          icon={Activity}
-          label={getKpiLabel('p95_kw', isExpert)}
-          value={p95Label}
-          sub="Percentile 95"
-          tooltip="95e percentile de puissance sur les créneaux horaires"
-        />
-        <KpiTile
-          icon={Moon}
-          label={getKpiLabel('night_ratio', isExpert)}
-          value={basePctLabel}
-          sub="(22h - 6h)"
-          color={basePctColor}
-          tooltip="Ratio consommation nuit (22h-6h) / jour (6h-22h) en semaine"
-        />
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -177,7 +177,7 @@ export default function ConsoKpiHeader({
 
   return (
     <div
-      className="flex flex-wrap items-baseline gap-x-5 gap-y-1 px-3 py-2 rounded-lg bg-gray-50 border border-gray-100 text-xs"
+      className="flex flex-wrap items-baseline gap-x-8 gap-y-1 px-3 py-2 rounded-lg bg-gray-50 border border-gray-100 text-xs"
       aria-label="KPIs Consommation"
     >
       <div className="flex flex-col" title="Somme des relevés sur la période sélectionnée">

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -180,60 +180,92 @@ export default function ConsoKpiHeader({
       className="flex flex-wrap items-baseline gap-x-8 gap-y-1 px-3 py-2 rounded-lg bg-gray-50 border border-gray-100 text-xs"
       aria-label="KPIs Consommation"
     >
-      <div className="flex flex-col" title="Somme des relevés sur la période sélectionnée">
-        <span className="text-gray-400">{getKpiLabel('total_kwh', isExpert)}</span>
-        <span className="font-semibold text-gray-700 whitespace-nowrap flex items-center gap-1">
-          {kwhLabel}
-          {compareSummary?.delta_pct != null && <TrendDelta deltaPct={compareSummary.delta_pct} />}
-          {onEvidence && (
-            <button
-              onClick={() => onEvidence('conso-kwh-total')}
-              className="text-gray-300 hover:text-blue-500 transition"
-              aria-label={`Pourquoi ce chiffre : ${getKpiLabel('total_kwh', isExpert)}`}
-              data-testid="evidence-open-conso-kwh-total"
-            >
-              <HelpCircle size={12} />
-            </button>
-          )}
-        </span>
+      <div
+        className="flex items-center gap-2"
+        title="Somme des relevés sur la période sélectionnée"
+      >
+        <Zap size={14} className="text-gray-400 shrink-0" />
+        <div className="flex flex-col">
+          <span className="text-gray-400">{getKpiLabel('total_kwh', isExpert)}</span>
+          <span className="font-semibold text-gray-700 whitespace-nowrap flex items-center gap-1">
+            {kwhLabel}
+            {compareSummary?.delta_pct != null && (
+              <TrendDelta deltaPct={compareSummary.delta_pct} />
+            )}
+            {onEvidence && (
+              <button
+                onClick={() => onEvidence('conso-kwh-total')}
+                className="text-gray-300 hover:text-blue-500 transition"
+                aria-label={`Pourquoi ce chiffre : ${getKpiLabel('total_kwh', isExpert)}`}
+                data-testid="evidence-open-conso-kwh-total"
+              >
+                <HelpCircle size={12} />
+              </button>
+            )}
+          </span>
+        </div>
       </div>
       <div
-        className="flex flex-col"
+        className="flex items-center gap-2"
         title={`Calcul : ${eurSource}. Basé sur les prix HP/HC du contrat ou estimés.`}
       >
-        <span className="text-gray-400">Coût total</span>
-        <span className="font-semibold text-gray-700 whitespace-nowrap">{eurLabel}</span>
-      </div>
-      <div className="flex flex-col" title="Prix moyen = EUR total / MWh total (source HP/HC)">
-        <span className="text-gray-400">Prix moyen</span>
-        <span className="font-semibold text-gray-700 whitespace-nowrap">{eurMwhLabel}</span>
-      </div>
-      <div className="flex flex-col" title="Facteur ADEME 2024 : 0,052 kgCO₂e/kWh (mix France)">
-        <span className="text-gray-400">{getKpiLabel('total_kgco2e', isExpert)}</span>
-        <span className="font-semibold text-gray-700 whitespace-nowrap flex items-center gap-1">
-          {co2Label}
-          {onEvidence && (
-            <button
-              onClick={() => onEvidence('conso-co2e')}
-              className="text-gray-300 hover:text-blue-500 transition"
-              aria-label={`Pourquoi ce chiffre : ${getKpiLabel('total_kgco2e', isExpert)}`}
-              data-testid="evidence-open-conso-co2e"
-            >
-              <HelpCircle size={12} />
-            </button>
-          )}
-        </span>
-      </div>
-      <div className="flex flex-col" title="95e percentile de puissance sur les créneaux horaires">
-        <span className="text-gray-400">{getKpiLabel('p95_kw', isExpert)}</span>
-        <span className="font-semibold text-gray-700 whitespace-nowrap">{p95Label}</span>
+        <Euro size={14} className="text-gray-400 shrink-0" />
+        <div className="flex flex-col">
+          <span className="text-gray-400">Coût total</span>
+          <span className="font-semibold text-gray-700 whitespace-nowrap">{eurLabel}</span>
+        </div>
       </div>
       <div
-        className="flex flex-col"
+        className="flex items-center gap-2"
+        title="Prix moyen = EUR total / MWh total (source HP/HC)"
+      >
+        <TrendingUp size={14} className="text-gray-400 shrink-0" />
+        <div className="flex flex-col">
+          <span className="text-gray-400">Prix moyen</span>
+          <span className="font-semibold text-gray-700 whitespace-nowrap">{eurMwhLabel}</span>
+        </div>
+      </div>
+      <div
+        className="flex items-center gap-2"
+        title="Facteur ADEME 2024 : 0,052 kgCO₂e/kWh (mix France)"
+      >
+        <Leaf size={14} className="text-gray-400 shrink-0" />
+        <div className="flex flex-col">
+          <span className="text-gray-400">{getKpiLabel('total_kgco2e', isExpert)}</span>
+          <span className="font-semibold text-gray-700 whitespace-nowrap flex items-center gap-1">
+            {co2Label}
+            {onEvidence && (
+              <button
+                onClick={() => onEvidence('conso-co2e')}
+                className="text-gray-300 hover:text-blue-500 transition"
+                aria-label={`Pourquoi ce chiffre : ${getKpiLabel('total_kgco2e', isExpert)}`}
+                data-testid="evidence-open-conso-co2e"
+              >
+                <HelpCircle size={12} />
+              </button>
+            )}
+          </span>
+        </div>
+      </div>
+      <div
+        className="flex items-center gap-2"
+        title="95e percentile de puissance sur les créneaux horaires"
+      >
+        <Activity size={14} className="text-gray-400 shrink-0" />
+        <div className="flex flex-col">
+          <span className="text-gray-400">{getKpiLabel('p95_kw', isExpert)}</span>
+          <span className="font-semibold text-gray-700 whitespace-nowrap">{p95Label}</span>
+        </div>
+      </div>
+      <div
+        className="flex items-center gap-2"
         title="Ratio consommation nuit (22h-6h) / jour (6h-22h) en semaine"
       >
-        <span className="text-gray-400">{getKpiLabel('night_ratio', isExpert)}</span>
-        <span className={`font-semibold whitespace-nowrap ${basePctColor}`}>{basePctLabel}</span>
+        <Moon size={14} className="text-gray-400 shrink-0" />
+        <div className="flex flex-col">
+          <span className="text-gray-400">{getKpiLabel('night_ratio', isExpert)}</span>
+          <span className={`font-semibold whitespace-nowrap ${basePctColor}`}>{basePctLabel}</span>
+        </div>
       </div>
       {confBadge && (
         <div className="flex flex-col ml-auto" title={`Comment calculé ? ${confTooltip}`}>

--- a/frontend/src/pages/ConsommationsPage.jsx
+++ b/frontend/src/pages/ConsommationsPage.jsx
@@ -10,26 +10,24 @@ import { PageShell } from '../ui';
 const TABS = [
   { to: '/consommations/portfolio', label: 'Portefeuille', icon: Building2 },
   { to: '/consommations/explorer', label: 'Explorer', icon: BarChart3 },
-  { to: '/consommations/import', label: 'Import & Analyse', icon: Upload },
-  { to: '/consommations/kb', label: 'Mémobox', icon: Database },
+  { to: '/consommations/import', label: 'Import', icon: Upload },
+  { to: '/consommations/kb', label: 'Memobox', icon: Database },
 ];
 
 export default function ConsommationsPage() {
   const tabBar = (
-    <div className="flex gap-2">
+    <div className="flex gap-1 ml-4">
       {TABS.map(({ to, label, icon: Icon }) => (
         <NavLink
           key={to}
           to={to}
           className={({ isActive }) =>
-            `flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition ${
-              isActive
-                ? 'bg-blue-600 text-white'
-                : 'bg-white text-gray-600 hover:bg-gray-100 border'
+            `flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition ${
+              isActive ? 'bg-blue-600 text-white' : 'text-gray-500 bg-gray-100 hover:bg-gray-200'
             }`
           }
         >
-          <Icon size={16} />
+          <Icon size={13} />
           {label}
         </NavLink>
       ))}
@@ -37,7 +35,7 @@ export default function ConsommationsPage() {
   );
 
   return (
-    <PageShell icon={Zap} title="Consommations" actions={tabBar}>
+    <PageShell icon={Zap} title="Consommations" inlineActions={tabBar}>
       {/* Nested route content */}
       <Outlet />
     </PageShell>

--- a/frontend/src/pages/ConsommationsPage.jsx
+++ b/frontend/src/pages/ConsommationsPage.jsx
@@ -15,32 +15,29 @@ const TABS = [
 ];
 
 export default function ConsommationsPage() {
-  return (
-    <PageShell
-      icon={Zap}
-      title="Consommations"
-      subtitle="Explorer, importer & analyser vos données énergie"
-    >
-      {/* Tab bar */}
-      <div className="flex gap-2 -mt-2">
-        {TABS.map(({ to, label, icon: Icon }) => (
-          <NavLink
-            key={to}
-            to={to}
-            className={({ isActive }) =>
-              `flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition ${
-                isActive
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white text-gray-600 hover:bg-gray-100 border'
-              }`
-            }
-          >
-            <Icon size={16} />
-            {label}
-          </NavLink>
-        ))}
-      </div>
+  const tabBar = (
+    <div className="flex gap-2">
+      {TABS.map(({ to, label, icon: Icon }) => (
+        <NavLink
+          key={to}
+          to={to}
+          className={({ isActive }) =>
+            `flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition ${
+              isActive
+                ? 'bg-blue-600 text-white'
+                : 'bg-white text-gray-600 hover:bg-gray-100 border'
+            }`
+          }
+        >
+          <Icon size={16} />
+          {label}
+        </NavLink>
+      ))}
+    </div>
+  );
 
+  return (
+    <PageShell icon={Zap} title="Consommations" actions={tabBar}>
       {/* Nested route content */}
       <Outlet />
     </PageShell>

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -17,7 +17,6 @@ import {
   Zap,
   Database,
   Wifi,
-  Info,
   Grid3x3,
   Cloud,
   Lightbulb,
@@ -614,20 +613,17 @@ export default function ConsumptionExplorerPage() {
   const siteId = primarySiteId; // backward compat for panels
 
   return (
-    <div className="space-y-5">
-      {/* Page header + cross-nav */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-xl font-bold text-gray-900 flex items-center gap-2">
-            <BarChart3 size={20} className="text-blue-600" />
-            Explorateur de consommation
-          </h1>
-          <p className="text-sm text-gray-500 mt-0.5">
-            Visualisez et comparez les courbes de consommation de vos sites — par période, énergie
-            et granularité.
-          </p>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
+    <div className="space-y-3">
+      {/* Page header + scope badge + cross-nav — compact single row (#90) */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <h1 className="text-base font-semibold text-gray-900 flex items-center gap-2">
+          <BarChart3 size={18} className="text-blue-600" />
+          Explorateur de consommation
+        </h1>
+        {selectedSiteId && siteIds.length === 1 && (
+          <Badge status="info">{scopeLabel} — multi-sélection disponible</Badge>
+        )}
+        <div className="flex items-center gap-2 ml-auto shrink-0">
           <Link
             to={toConsoDiag()}
             className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition"
@@ -644,17 +640,6 @@ export default function ConsumptionExplorerPage() {
           </Link>
         </div>
       </div>
-
-      {/* V1.3: Scope coherence banner — single site indicator */}
-      {selectedSiteId && siteIds.length === 1 && (
-        <div className="flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-lg px-4 py-2.5 text-sm">
-          <Info size={14} className="text-blue-500 shrink-0" />
-          <span className="text-blue-700">
-            Vous explorez <strong>{scopeLabel}</strong>. La multi-selection est disponible via le
-            selecteur de sites ci-dessous.
-          </span>
-        </div>
-      )}
 
       {/* Unified sticky filter bar */}
       <StickyFilterBar
@@ -698,26 +683,9 @@ export default function ConsumptionExplorerPage() {
         compareYoy={compareYoy}
         setCompareYoy={setCompareYoy}
         onToggleUiMode={toggleUiMode}
+        portfolioBannerDismissed={portfolioBannerDismissed}
+        onDismissPortfolioBanner={() => setPortfolioBannerDismissed(true)}
       />
-
-      {/* Portfolio info banner — non-blocking, dismissible */}
-      {isPortfolioMode && !portfolioBannerDismissed && (
-        <div className="flex items-start gap-2 px-3 py-2 bg-indigo-50 border border-indigo-200 rounded-lg text-xs text-indigo-700">
-          <Info size={14} className="shrink-0 mt-0.5 text-indigo-500" />
-          <span className="flex-1">
-            <strong>Mode Portfolio</strong> — vue agrégée multi-sites (mode Agrégé uniquement).
-            Chaque site contribue à l&apos;enveloppe globale. Pour comparer des sites
-            individuellement, quittez le Portfolio.
-          </span>
-          <button
-            onClick={() => setPortfolioBannerDismissed(true)}
-            className="shrink-0 text-indigo-400 hover:text-indigo-600"
-            aria-label="Fermer la bannière Portfolio"
-          >
-            <X size={13} />
-          </button>
-        </div>
-      )}
 
       {/* KPI Header — 6 KPIs respecting scope global */}
       {showContent && (

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -593,11 +593,11 @@ describe('AU · P1.1 polish labels & tooltips', () => {
     expect(code).toMatch(/HelpCircle/);
   });
 
-  it('ConsoKpiHeader KPI tiles have tooltip prop', () => {
+  it('ConsoKpiHeader KPI items have tooltip via title attribute', () => {
     const code = readSrc('components', 'ConsoKpiHeader.jsx');
-    expect(code).toMatch(/tooltip=/);
-    // At least 6 tooltip props (one per tile) — some use template literals
-    const matches = code.match(/tooltip[=]/g);
+    // #90: inline strip uses title= on wrapper divs instead of tooltip= on KpiTile
+    expect(code).toMatch(/title=/);
+    const matches = code.match(/title=/g);
     expect(matches?.length).toBeGreaterThanOrEqual(6);
   });
 
@@ -1098,14 +1098,15 @@ describe('BH · Explorer scope coherence banner', () => {
     expect(code).toMatch(/scopeLabel/);
   });
 
-  it('shows scope banner when selectedSiteId and single site', () => {
+  it('shows scope indicator when selectedSiteId and single site', () => {
     expect(code).toMatch(/selectedSiteId && siteIds\.length === 1/);
-    expect(code).toMatch(/Vous explorez/);
+    // #90: replaced full-width banner with inline Badge
+    expect(code).toMatch(/multi-sélection disponible/);
     expect(code).toMatch(/scopeLabel/);
   });
 
   it('mentions multi-selection is available', () => {
-    expect(code).toMatch(/multi-selection/i);
+    expect(code).toMatch(/multi-s[eé]lection/i);
   });
 });
 

--- a/frontend/src/pages/__tests__/rescueUiUx.test.js
+++ b/frontend/src/pages/__tests__/rescueUiUx.test.js
@@ -158,7 +158,7 @@ describe('P0-6: French accent correctness', () => {
 describe('P0-6: ConsoKpiHeader responsive grid', () => {
   const code = src('components/ConsoKpiHeader.jsx');
 
-  it('uses xl:grid-cols-6 (not lg:) for comfortable display', () => {
-    expect(code).toMatch(/xl:grid-cols-6/);
+  it('uses flex-wrap inline strip layout for compact display (#90)', () => {
+    expect(code).toMatch(/flex flex-wrap/);
   });
 });

--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -46,10 +46,12 @@ import {
   Save,
   RotateCcw,
   Link,
+  Calendar,
   ChevronDown,
   Trash2,
   Plus,
   LayoutGrid,
+  Info,
 } from 'lucide-react';
 import { TrustBadge } from '../../ui';
 import {
@@ -307,6 +309,9 @@ export default function StickyFilterBar({
   setCompareYoy,
   // UI mode toggle (issue #51 — moved from standalone row)
   onToggleUiMode,
+  // Portfolio banner (issue #90 — moved from page into "Plus de filtres")
+  portfolioBannerDismissed = false,
+  onDismissPortfolioBanner,
 }) {
   const isClassic = uiMode === 'classic';
 
@@ -315,6 +320,8 @@ export default function StickyFilterBar({
   const [showPresets, setShowPresets] = useState(false);
   const [showCustomDates, setShowCustomDates] = useState(!!(startDate || endDate));
   const [showAddSite, setShowAddSite] = useState(false);
+  const [showOverflowSites, setShowOverflowSites] = useState(false);
+  const [showMore, setShowMore] = useState(false);
 
   const addRef = useRef(null);
   const presetsBtnRef = useRef(null);
@@ -414,16 +421,15 @@ export default function StickyFilterBar({
   const showModePills = setMode && (isClassic || effectiveSiteIds.length > 1 || isPortfolioMode);
 
   return (
-    <div className="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-gray-100 -mx-4 px-4 py-2.5 md:-mx-6 md:px-6 space-y-2">
-      {/* Row 1: Site chips + Portfolio toggle — "Who" (stable, independent of config) */}
-      <div className="flex items-center gap-3 flex-wrap">
-        {/* V19: Site section — ALWAYS visible when setSiteIds is provided */}
+    <div className="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-gray-100 -mx-4 px-4 py-1.5 md:-mx-6 md:px-6 space-y-1.5">
+      {/* Row A: Sites + | + Energy + Period + Granularity (#90 compact) */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {/* Site chips */}
         {setSiteIds && !isPortfolioMode && (
           <div className="flex items-center gap-1.5">
             {effectiveSiteIds.length > 0 ? (
-              /* Selected site chips */
               <div className="flex gap-1.5 flex-wrap min-w-0">
-                {effectiveSiteIds.map((id, idx) => {
+                {effectiveSiteIds.slice(0, 3).map((id, idx) => {
                   const site = sites.find((s) => s.id === id);
                   const color = colorForSite(id, idx);
                   return (
@@ -446,21 +452,52 @@ export default function StickyFilterBar({
                     </button>
                   );
                 })}
+                {effectiveSiteIds.length > 3 && !showOverflowSites && (
+                  <button
+                    onClick={() => setShowOverflowSites(true)}
+                    className="flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-200 text-gray-700 hover:bg-gray-300 shrink-0 transition"
+                    title={effectiveSiteIds
+                      .slice(3)
+                      .map((id) => sites.find((s) => s.id === id)?.nom || id)
+                      .join(', ')}
+                  >
+                    +{effectiveSiteIds.length - 3}
+                  </button>
+                )}
+                {showOverflowSites &&
+                  effectiveSiteIds.slice(3).map((id, idx) => {
+                    const site = sites.find((s) => s.id === id);
+                    const color = colorForSite(id, idx + 3);
+                    return (
+                      <button
+                        key={id}
+                        onClick={() => {
+                          toggleSite(id);
+                          if (effectiveSiteIds.length <= 4) setShowOverflowSites(false);
+                        }}
+                        className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border text-white border-transparent shrink-0 transition"
+                        style={{ backgroundColor: color, borderColor: color }}
+                        title={`Retirer ${site?.nom || id}`}
+                      >
+                        <span className="w-2 h-2 rounded-full bg-white/60 shrink-0" />
+                        <span className="max-w-[120px] truncate">{site?.nom || id}</span>
+                        <X size={10} className="opacity-70 shrink-0" />
+                      </button>
+                    );
+                  })}
               </div>
             ) : (
-              /* Placeholder: loading or no sites yet */
               <span className="text-xs text-gray-400 italic px-1 py-1">
                 {sitesLoading ? 'Chargement…' : 'Sélectionner des sites…'}
               </span>
             )}
 
-            {/* "+" add site button — only when more sites exist to add */}
             {effectiveSiteIds.length < MAX_SITES && sites.length > effectiveSiteIds.length && (
               <div ref={addRef}>
                 <button
                   data-testid="sticky-sitesearch-trigger"
                   onClick={() => setShowAddSite((v) => !v)}
-                  className="flex items-center justify-center w-6 h-6 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 transition"
+                  className="flex items-center justify-center w-5 h-5 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 transition"
                   title="Ajouter un site"
                 >
                   <Plus size={12} />
@@ -481,7 +518,7 @@ export default function StickyFilterBar({
           </div>
         )}
 
-        {/* Portfolio mode: show label instead of chips */}
+        {/* Portfolio mode label */}
         {isMultiMode && isPortfolioMode && (
           <div className="flex items-center gap-2 px-3 py-1 bg-indigo-50 border border-indigo-200 rounded-full">
             <LayoutGrid size={12} className="text-indigo-600" />
@@ -491,30 +528,7 @@ export default function StickyFilterBar({
           </div>
         )}
 
-        {/* Portfolio toggle button (shown when multi-site available) */}
-        {isMultiMode && onTogglePortfolio && (
-          <div className="flex items-center gap-1">
-            <button
-              onClick={onTogglePortfolio}
-              className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border transition ${
-                isPortfolioMode
-                  ? 'bg-indigo-600 text-white border-indigo-600'
-                  : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300 hover:text-indigo-600'
-              }`}
-              title={
-                isPortfolioMode
-                  ? 'Quitter le mode Portfolio'
-                  : 'Passer en mode Portfolio (tous les sites)'
-              }
-            >
-              <LayoutGrid size={11} />
-              Portfolio
-            </button>
-            <InfoTip content="Portfolio : vue agrégée de tous les sites. Mode Agrégé uniquement." />
-          </div>
-        )}
-
-        {/* Legacy single-site select (when setSiteIds not provided) */}
+        {/* Legacy single-site select */}
         {!setSiteIds && sites.length > 1 && (
           <select
             value={siteId || effectiveSiteIds[0] || ''}
@@ -531,35 +545,10 @@ export default function StickyFilterBar({
           </select>
         )}
 
-        {/* UI mode toggle — pushed to right side of Row 1 (issue #51) */}
-        {onToggleUiMode && (
-          <div className="ml-auto flex items-center gap-2">
-            <button
-              onClick={onToggleUiMode}
-              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border transition ${
-                isClassic
-                  ? 'text-gray-600 border-gray-200 bg-white hover:bg-gray-50'
-                  : 'text-blue-700 border-blue-200 bg-blue-50 hover:bg-blue-100'
-              }`}
-              title={
-                isClassic
-                  ? 'Passer en mode Expert (contrôles avancés)'
-                  : 'Passer en mode Classique (vue standard)'
-              }
-            >
-              {isClassic ? 'Mode Expert →' : '← Mode Classique'}
-            </button>
-            <span className="text-[10px] text-gray-400 max-w-[180px] leading-tight">
-              {isClassic ? 'Signature, météo, tunnel, objectifs' : 'Analyses avancées activées'}
-            </span>
-          </div>
-        )}
-      </div>
+        <span className="w-px h-5 bg-gray-200 shrink-0" aria-hidden="true" />
 
-      {/* Row 2: Energy · Period · Granularité · TrustBadge — "What & When" (never reflows when sites change) */}
-      <div className="flex items-center gap-3 flex-wrap">
         {/* Energy toggle */}
-        <div className="flex gap-1 bg-gray-100 rounded-lg p-0.5">
+        <div className="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
           {ENERGY_OPTIONS.map((opt) => {
             const Icon = opt.icon;
             const disabled = availableTypes && !availableTypes.includes(opt.value);
@@ -568,7 +557,7 @@ export default function StickyFilterBar({
                 key={opt.value}
                 onClick={() => !disabled && setEnergyType(opt.value)}
                 disabled={disabled}
-                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition ${
+                className={`flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium transition ${
                   energyType === opt.value
                     ? 'bg-white text-blue-700 shadow-sm'
                     : disabled
@@ -583,13 +572,13 @@ export default function StickyFilterBar({
           })}
         </div>
 
-        {/* Period pills — 7j / 30j / 90j / 12m / YTD */}
-        <div className="flex gap-1 bg-gray-100 rounded-lg p-0.5">
+        {/* Period pills */}
+        <div className="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
           {PERIOD_PILLS.map((pill) => (
             <button
               key={pill.value}
               onClick={() => handlePillClick(pill.value)}
-              className={`px-2.5 py-1 rounded-md text-xs font-medium transition ${
+              className={`px-2 py-1 rounded-md text-xs font-medium transition ${
                 activePill === pill.value
                   ? 'bg-white text-blue-700 shadow-sm'
                   : 'text-gray-600 hover:text-gray-900'
@@ -598,23 +587,25 @@ export default function StickyFilterBar({
               {pill.label}
             </button>
           ))}
-          {/* Custom date range pill */}
           <button
-            onClick={() => setShowCustomDates((v) => !v)}
-            className={`px-2.5 py-1 rounded-md text-xs font-medium transition ${
+            onClick={() => {
+              setShowCustomDates((v) => !v);
+              if (!showMore && !showCustomDates) setShowMore(true);
+            }}
+            className={`px-2 py-1 rounded-md text-xs font-medium transition flex items-center gap-0.5 ${
               isCustomRange || showCustomDates
                 ? 'bg-white text-blue-700 shadow-sm'
                 : 'text-gray-600 hover:text-gray-900'
             }`}
           >
-            Personnaliser
+            <Calendar size={10} />
           </button>
         </div>
 
-        {/* Granularity selector (V21-C) — pills when setGranularity provided, badge otherwise */}
+        {/* Granularity */}
         {setGranularity ? (
           <div className="flex items-center gap-1">
-            <span className="text-xs text-gray-500 shrink-0">Granularité :</span>
+            <span className="text-xs text-gray-400 shrink-0">Gran:</span>
             <div className="flex rounded-lg overflow-hidden border border-gray-200 bg-gray-50">
               {granularityPills(availableGranularities, days).map((g) => {
                 const isActive = granularity === g.key;
@@ -640,15 +631,28 @@ export default function StickyFilterBar({
           </div>
         ) : (
           <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-gray-100 rounded-lg text-xs font-medium text-gray-600">
-            Granularité&nbsp;: {GRAN_LABELS[gran] || gran}
+            Gran&nbsp;: {GRAN_LABELS[gran] || gran}
           </span>
         )}
+      </div>
 
-        {/* YoY comparison toggle (Step 10 — F1) — not portfolio */}
+      {/* Row B: Mode + Unit + YoY + TrustBadge + icon actions (#90 compact) */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {showModePills && (
+          <ModePills
+            mode={mode}
+            setMode={setMode}
+            isPortfolioMode={isPortfolioMode}
+            availableModes={availableModes}
+          />
+        )}
+        {setUnit && <UnitPills unit={unit} setUnit={setUnit} />}
+
+        {/* YoY toggle — compact */}
         {setCompareYoy && !isPortfolioMode && (
           <button
             onClick={() => setCompareYoy(!compareYoy)}
-            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium border transition-colors duration-100 ${
+            className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border transition-colors duration-100 ${
               compareYoy
                 ? 'bg-blue-50 text-blue-700 border-blue-200'
                 : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
@@ -656,200 +660,264 @@ export default function StickyFilterBar({
             title="Comparer avec la même période l'année précédente (N-1)"
             data-testid="compare-yoy-toggle"
           >
-            Comparer N-1
+            N-1
           </button>
         )}
 
-        {/* Data quality badge (right-aligned) */}
-        {confidence && (
-          <div className="ml-auto">
+        {/* Right-aligned: TrustBadge + icon actions */}
+        <div className="ml-auto flex items-center gap-2">
+          {confidence && (
             <TrustBadge
               source={`${(availability.readings_count || 0).toLocaleString('fr-FR')} relevés`}
               confidence={confidence}
             />
+          )}
+
+          {/* Compact icon-only actions */}
+          <div className="flex items-center gap-0.5">
+            {onSave &&
+              (showSaveInput ? (
+                <div className="flex items-center gap-1.5">
+                  <input
+                    type="text"
+                    value={presetName}
+                    onChange={(e) => setPresetName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleSave();
+                      if (e.key === 'Escape') setShowSaveInput(false);
+                    }}
+                    placeholder="Nom du preset..."
+                    autoFocus
+                    className="text-xs border border-blue-300 rounded-md px-2 py-1 bg-white w-36 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  />
+                  <button
+                    onClick={handleSave}
+                    disabled={!presetName.trim()}
+                    className="px-2.5 py-1 text-xs font-medium bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-40"
+                  >
+                    OK
+                  </button>
+                  <button
+                    onClick={() => setShowSaveInput(false)}
+                    className="px-2 py-1 text-xs text-gray-500 hover:text-gray-700"
+                  >
+                    <X size={12} />
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setShowSaveInput(true)}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition"
+                  title="Enregistrer un preset"
+                >
+                  <Save size={14} />
+                </button>
+              ))}
+            {onReset && (
+              <button
+                onClick={onReset}
+                className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition"
+                title="Réinitialiser les filtres"
+              >
+                <RotateCcw size={14} />
+              </button>
+            )}
+            <button
+              onClick={handleCopyLink}
+              className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition"
+              title="Copier le lien de partage"
+            >
+              <Link size={14} />
+            </button>
           </div>
-        )}
+        </div>
       </div>
 
-      {/* Custom date range row (collapsible) */}
-      {showCustomDates && (
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-xs text-gray-500 font-medium">Du</span>
-          <input
-            type="date"
-            value={startDate || ''}
-            onChange={(e) => setStartDate && setStartDate(e.target.value || null)}
-            className="text-xs border border-gray-200 rounded-md px-2 py-1 bg-white"
-          />
-          <span className="text-xs text-gray-500 font-medium">au</span>
-          <input
-            type="date"
-            value={endDate || ''}
-            onChange={(e) => setEndDate && setEndDate(e.target.value || null)}
-            className="text-xs border border-gray-200 rounded-md px-2 py-1 bg-white"
-          />
-          {(startDate || endDate) && (
-            <button
-              onClick={() => {
-                if (setStartDate) setStartDate(null);
-                if (setEndDate) setEndDate(null);
-                setShowCustomDates(false);
-                if (setDays) setDays(90);
-              }}
-              className="text-xs text-gray-400 hover:text-gray-600 underline"
-            >
-              Effacer
-            </button>
-          )}
-        </div>
-      )}
+      {/* Option A: Breadcrumb strip — lists hidden filter names, click to expand (#90) */}
+      <button
+        onClick={() => setShowMore((v) => !v)}
+        className="w-full flex items-center gap-1 py-0.5 text-[11px] text-gray-400 border-t border-gray-100 hover:text-gray-600 transition cursor-pointer group"
+      >
+        <ChevronDown
+          size={12}
+          className={`text-gray-300 group-hover:text-gray-500 transition-transform ${showMore ? 'rotate-180' : ''}`}
+        />
+        <span
+          className={isPortfolioMode ? 'text-blue-600 font-medium' : 'text-gray-500 font-medium'}
+        >
+          Portfolio
+        </span>
+        <span className="text-gray-300">&middot;</span>
+        <span className={!isClassic ? 'text-blue-600 font-medium' : 'text-gray-500 font-medium'}>
+          {isClassic ? 'Expert' : 'Classique'}
+        </span>
+        <span className="text-gray-300">&middot;</span>
+        <span className={isCustomRange ? 'text-blue-600 font-medium' : 'text-gray-400'}>Dates</span>
+        <span className="text-gray-300">&middot;</span>
+        <span className={savedPresets.length > 0 ? 'text-gray-500 font-medium' : 'text-gray-400'}>
+          Presets{savedPresets.length > 0 ? ` (${savedPresets.length})` : ''}
+        </span>
+      </button>
 
-      {/* Row 2: Mode pills + Unit toggle (Classic: always shown; Expert: multi-site/portfolio only) */}
-      {(showModePills || setUnit) && (
-        <div className="flex items-center gap-3 flex-wrap">
-          {showModePills && (
-            <ModePills
-              mode={mode}
-              setMode={setMode}
-              isPortfolioMode={isPortfolioMode}
-              availableModes={availableModes}
-              showTooltips={isClassic}
-            />
-          )}
-          {setUnit && <UnitPills unit={unit} setUnit={setUnit} showTooltips={isClassic} />}
-        </div>
-      )}
-
-      {/* Row 3: Actions (Enregistrer / Effacer / Copier le lien / Presets) */}
-      {(onSave || onReset || onCopyLink) && (
-        <div className="flex items-center gap-2 flex-wrap">
-          {/* Save preset */}
-          {onSave &&
-            (showSaveInput ? (
-              <div className="flex items-center gap-1.5">
-                <input
-                  type="text"
-                  value={presetName}
-                  onChange={(e) => setPresetName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSave();
-                    if (e.key === 'Escape') setShowSaveInput(false);
-                  }}
-                  placeholder="Nom du preset..."
-                  autoFocus
-                  className="text-xs border border-blue-300 rounded-md px-2 py-1 bg-white w-36 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                />
-                <button
-                  onClick={handleSave}
-                  disabled={!presetName.trim()}
-                  className="px-2.5 py-1 text-xs font-medium bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-40"
-                >
-                  OK
-                </button>
-                <button
-                  onClick={() => setShowSaveInput(false)}
-                  className="px-2 py-1 text-xs text-gray-500 hover:text-gray-700"
-                >
-                  <X size={12} />
-                </button>
-              </div>
-            ) : (
+      {/* Collapsible "Plus de filtres" section */}
+      {showMore && (
+        <div className="pb-1 space-y-2">
+          {/* Portfolio + UI mode + Presets */}
+          <div className="flex items-center gap-3 flex-wrap">
+            {isMultiMode && onTogglePortfolio && (
               <button
-                onClick={() => setShowSaveInput(true)}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition"
+                onClick={onTogglePortfolio}
+                className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border transition ${
+                  isPortfolioMode
+                    ? 'bg-indigo-600 text-white border-indigo-600'
+                    : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300 hover:text-indigo-600'
+                }`}
+                title={
+                  isPortfolioMode
+                    ? 'Quitter le mode Portfolio'
+                    : 'Passer en mode Portfolio (tous les sites)'
+                }
               >
-                <Save size={12} />
-                Enregistrer
+                <LayoutGrid size={11} />
+                Portfolio
               </button>
-            ))}
+            )}
 
-          {/* Presets dropdown */}
-          {savedPresets.length > 0 && onLoadPreset && (
-            <div>
+            {onToggleUiMode && (
               <button
-                ref={presetsBtnRef}
-                data-testid="sticky-presets-trigger"
-                onClick={() => setShowPresets((v) => !v)}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition"
+                onClick={onToggleUiMode}
+                className={`flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded-lg border transition ${
+                  isClassic
+                    ? 'text-gray-600 border-gray-200 bg-white hover:bg-gray-50'
+                    : 'text-blue-700 border-blue-200 bg-blue-50 hover:bg-blue-100'
+                }`}
+                title={
+                  isClassic
+                    ? 'Passer en mode Expert (contrôles avancés)'
+                    : 'Passer en mode Classique (vue standard)'
+                }
               >
-                Presets ({savedPresets.length})
-                <ChevronDown size={11} />
+                {isClassic ? 'Mode Expert →' : '← Mode Classique'}
               </button>
-              {showPresets &&
-                createPortal(
-                  <div
-                    ref={presetsDropRef}
-                    data-testid="sticky-presets-panel"
-                    className="fixed w-52 bg-white rounded-lg shadow-lg border border-gray-200 z-[120] py-1"
-                    style={presetsStyle}
-                  >
-                    {savedPresets.map((p) => (
-                      <div
-                        key={p.name}
-                        className="flex items-center gap-1 px-2 py-1.5 hover:bg-gray-50 group"
-                      >
-                        <button
-                          onClick={() => {
-                            onLoadPreset(p.name);
-                            setShowPresets(false);
-                          }}
-                          className="flex-1 text-left text-xs font-medium text-gray-700 truncate"
-                          title={p.name}
+            )}
+
+            {savedPresets.length > 0 && onLoadPreset && (
+              <div>
+                <button
+                  ref={presetsBtnRef}
+                  data-testid="sticky-presets-trigger"
+                  onClick={() => setShowPresets((v) => !v)}
+                  className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition"
+                >
+                  Presets ({savedPresets.length})
+                  <ChevronDown size={11} />
+                </button>
+                {showPresets &&
+                  createPortal(
+                    <div
+                      ref={presetsDropRef}
+                      data-testid="sticky-presets-panel"
+                      className="fixed w-52 bg-white rounded-lg shadow-lg border border-gray-200 z-[120] py-1"
+                      style={presetsStyle}
+                    >
+                      {savedPresets.map((p) => (
+                        <div
+                          key={p.name}
+                          className="flex items-center gap-1 px-2 py-1.5 hover:bg-gray-50 group"
                         >
-                          {p.name}
-                        </button>
-                        {onDeletePreset && (
                           <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onDeletePreset(p.name);
+                            onClick={() => {
+                              onLoadPreset(p.name);
+                              setShowPresets(false);
                             }}
-                            className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition"
-                            title="Supprimer"
+                            className="flex-1 text-left text-xs font-medium text-gray-700 truncate"
+                            title={p.name}
                           >
-                            <Trash2 size={11} />
+                            {p.name}
                           </button>
-                        )}
-                      </div>
-                    ))}
-                  </div>,
-                  document.body
-                )}
+                          {onDeletePreset && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onDeletePreset(p.name);
+                              }}
+                              className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition"
+                              title="Supprimer"
+                            >
+                              <Trash2 size={11} />
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                    </div>,
+                    document.body
+                  )}
+              </div>
+            )}
+          </div>
+
+          {/* Custom date range */}
+          {showCustomDates && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-xs text-gray-500 font-medium">Du</span>
+              <input
+                type="date"
+                value={startDate || ''}
+                onChange={(e) => setStartDate && setStartDate(e.target.value || null)}
+                className="text-xs border border-gray-200 rounded-md px-2 py-1 bg-white"
+              />
+              <span className="text-xs text-gray-500 font-medium">au</span>
+              <input
+                type="date"
+                value={endDate || ''}
+                onChange={(e) => setEndDate && setEndDate(e.target.value || null)}
+                className="text-xs border border-gray-200 rounded-md px-2 py-1 bg-white"
+              />
+              {(startDate || endDate) && (
+                <button
+                  onClick={() => {
+                    if (setStartDate) setStartDate(null);
+                    if (setEndDate) setEndDate(null);
+                    setShowCustomDates(false);
+                    if (setDays) setDays(90);
+                  }}
+                  className="text-xs text-gray-400 hover:text-gray-600 underline"
+                >
+                  Effacer
+                </button>
+              )}
             </div>
           )}
 
-          {/* Reset */}
-          {onReset && (
-            <button
-              onClick={onReset}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition"
-              title="Réinitialiser les filtres"
-            >
-              <RotateCcw size={12} />
-              Effacer
-            </button>
+          {/* Portfolio info banner (moved from page) */}
+          {isPortfolioMode && !portfolioBannerDismissed && onDismissPortfolioBanner && (
+            <div className="flex items-start gap-2 px-3 py-2 bg-indigo-50 border border-indigo-200 rounded-lg text-xs text-indigo-700">
+              <Info size={14} className="shrink-0 mt-0.5 text-indigo-500" />
+              <span className="flex-1">
+                <strong>Mode Portfolio</strong> — vue agrégée multi-sites (mode Agrégé uniquement).
+                Chaque site contribue à l&apos;enveloppe globale. Pour comparer des sites
+                individuellement, quittez le Portfolio.
+              </span>
+              <button
+                onClick={onDismissPortfolioBanner}
+                className="shrink-0 text-indigo-400 hover:text-indigo-600"
+                aria-label="Fermer la bannière Portfolio"
+              >
+                <X size={13} />
+              </button>
+            </div>
           )}
 
-          {/* Copy link */}
-          <button
-            onClick={handleCopyLink}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition"
-            title="Copier le lien de partage"
-          >
-            <Link size={12} />
-            Copier le lien
-          </button>
+          {/* Résumé contexte */}
+          {isClassic && (
+            <ResumeContexte
+              days={days}
+              gran={gran}
+              nSites={effectiveSiteIds.length || sites.length}
+              availability={availability}
+            />
+          )}
         </div>
-      )}
-
-      {/* Row 4: Résumé contexte (Classic mode only) */}
-      {isClassic && (
-        <ResumeContexte
-          days={days}
-          gran={gran}
-          nSites={effectiveSiteIds.length || sites.length}
-          availability={availability}
-        />
       )}
     </div>
   );

--- a/frontend/src/pages/consumption/StickyFilterBar.jsx
+++ b/frontend/src/pages/consumption/StickyFilterBar.jsx
@@ -381,8 +381,10 @@ export default function StickyFilterBar({
   };
 
   // Determine which period pill is active
-  const isCustomRange = !!(startDate || endDate);
-  const activePill = isCustomRange ? 'custom' : days === 'ytd' ? 'ytd' : days;
+  // YTD sets startDate/endDate internally but should NOT activate the custom calendar
+  const isYtd = days === 'ytd' || (days === 365 && startDate === ytdStart());
+  const isCustomRange = !!(startDate || endDate) && !isYtd;
+  const activePill = isCustomRange ? 'custom' : isYtd ? 'ytd' : days;
 
   const handlePillClick = (value) => {
     if (value === 'ytd') {

--- a/frontend/src/pages/consumption/TimeseriesPanel.jsx
+++ b/frontend/src/pages/consumption/TimeseriesPanel.jsx
@@ -42,8 +42,21 @@ const GRAN_LABELS = {
 
 // ── DataCoverageBadge ──────────────────────────────────────────────────────────
 
-function DataCoverageBadge({ meta, siteCount, qualityPct }) {
+/** Format ISO date string (YYYY-MM-DD) to DD/MM/YYYY */
+function formatDateFR(iso) {
+  if (!iso) return null;
+  const [y, m, d] = iso.split('T')[0].split('-');
+  return `${d}/${m}/${y}`;
+}
+
+function DataCoverageBadge({ meta, siteCount, qualityPct, startDate, endDate }) {
+  const dateRange =
+    startDate || endDate
+      ? `${formatDateFR(startDate) || '…'} → ${formatDateFR(endDate) || '…'}`
+      : null;
+
   const parts = [
+    dateRange,
     siteCount > 1 ? `${siteCount} sites` : null,
     meta?.n_meters ? `${meta.n_meters}\u00a0compteur${meta.n_meters > 1 ? 's' : ''}` : null,
     meta?.n_points ? `${meta.n_points.toLocaleString('fr-FR')}\u00a0mesures` : null,
@@ -428,7 +441,15 @@ export default function TimeseriesPanel({
         {debugPanel}
 
         {/* DataCoverageBadge — compact coverage line above chart */}
-        <DataCoverageBadge meta={meta} siteCount={siteIds.length} qualityPct={qualityPct} />
+        <DataCoverageBadge
+          meta={meta}
+          siteCount={siteIds.length}
+          qualityPct={qualityPct}
+          startDate={
+            startDate || new Date(Date.now() - days * 86400000).toISOString().split('T')[0]
+          }
+          endDate={endDate || new Date().toISOString().split('T')[0]}
+        />
 
         {/* Chart */}
         <ExplorerChart

--- a/frontend/src/pages/consumption/explorer-option-A.html
+++ b/frontend/src/pages/consumption/explorer-option-A.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Option A — Active Filters Breadcrumb Strip</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<style>
+  body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
+  .collapse-section { max-height: 0; overflow: hidden; transition: max-height 0.25s ease-out, opacity 0.2s ease-out; opacity: 0; }
+  .collapse-section.open { max-height: 300px; opacity: 1; }
+</style>
+</head>
+<body class="bg-gray-50 min-h-screen">
+
+<!-- Option label -->
+<div class="bg-indigo-600 text-white text-center py-2 text-sm font-semibold sticky top-0 z-50">
+  OPTION A — Active Filters Breadcrumb Strip
+  <span class="text-indigo-200 ml-2 font-normal">Clickable strip listing hidden filter names. Active ones light up.</span>
+</div>
+
+<!-- Parent shell -->
+<div class="bg-white border-b border-gray-200">
+  <div class="max-w-7xl mx-auto px-6 py-2">
+    <nav class="text-xs text-gray-400">PROMEOS &rsaquo; Energie &rsaquo; Consommations &rsaquo; <span class="text-gray-700 font-medium">Explorer</span></nav>
+  </div>
+  <div class="max-w-7xl mx-auto px-6 pb-3">
+    <div class="flex items-center gap-2">
+      <span class="text-lg font-bold text-gray-900">Consommations</span>
+      <div class="flex gap-1 ml-4">
+        <span class="px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 rounded-lg">Portefeuille</span>
+        <span class="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg">Explorer</span>
+        <span class="px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 rounded-lg">Import</span>
+        <span class="px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 rounded-lg">Memobox</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="max-w-7xl mx-auto px-6">
+  <div class="space-y-3 relative">
+
+    <!-- Compact header -->
+    <div class="flex items-center gap-3 pt-3 flex-wrap">
+      <h1 class="text-base font-semibold text-gray-900 flex items-center gap-2">
+        <svg class="w-[18px] h-[18px] text-blue-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+        Explorateur de consommation
+      </h1>
+      <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium whitespace-nowrap bg-blue-50 text-blue-700 border border-blue-200">
+        Siege HELIOS Paris — multi-selection disponible
+      </span>
+      <div class="flex items-center gap-2 ml-auto shrink-0">
+        <a href="#" class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition">
+          <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+          Diagnostic
+        </a>
+        <a href="#" class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition">
+          <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          Performance
+        </a>
+      </div>
+    </div>
+
+    <!-- StickyFilterBar -->
+    <div class="sticky top-8 z-20 bg-white/95 backdrop-blur border-b border-gray-100 -mx-6 px-6 py-1.5 space-y-1.5">
+
+      <!-- Row A: Sites + Energy + Period + Granularity -->
+      <div class="flex items-center gap-2 flex-wrap">
+        <div class="flex items-center gap-1.5">
+          <button class="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium text-white shrink-0 transition hover:opacity-90" style="background-color: #3b82f6">
+            <span class="w-2 h-2 rounded-full bg-white/60 shrink-0"></span>
+            <span class="max-w-[120px] truncate">Siege HELIOS Paris</span>
+          </button>
+          <button class="flex items-center justify-center w-5 h-5 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 transition" title="Ajouter un site">
+            <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          </button>
+        </div>
+        <span class="w-px h-5 bg-gray-200 shrink-0" aria-hidden="true"></span>
+        <div class="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
+          <button class="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-white text-blue-700 shadow-sm">
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+            Elec
+          </button>
+          <button class="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/></svg>
+            Gaz
+          </button>
+        </div>
+        <div class="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
+          <button class="px-2 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">7j</button>
+          <button class="px-2 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">30j</button>
+          <button class="px-2 py-1 rounded-md text-xs font-medium bg-white text-blue-700 shadow-sm">90j</button>
+          <button class="px-2 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">12m</button>
+          <button class="px-2 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">YTD</button>
+          <button class="px-2 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900 flex items-center gap-0.5">
+            <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+          </button>
+        </div>
+        <div class="flex items-center gap-1">
+          <span class="text-xs text-gray-400 shrink-0">Gran:</span>
+          <div class="flex rounded-lg overflow-hidden border border-gray-200 bg-gray-50">
+            <button class="px-2 py-1 text-xs font-medium bg-white text-blue-700 shadow-sm">Auto</button>
+            <button class="px-2 py-1 text-xs font-medium bg-blue-50 text-blue-600 ring-1 ring-inset ring-blue-200">1h</button>
+            <button class="px-2 py-1 text-xs font-medium text-gray-600 hover:text-gray-900">1j</button>
+            <button class="px-2 py-1 text-xs font-medium text-gray-600 hover:text-gray-900">Mois</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Row B: Mode + Unit + YoY + TrustBadge + icon actions -->
+      <div class="flex items-center gap-2 flex-wrap">
+        <div class="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
+          <button class="px-2.5 py-1 rounded-md text-xs font-medium bg-white text-blue-700 shadow-sm">Agrege</button>
+          <button class="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">Superpose</button>
+          <button class="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">Empile</button>
+          <button class="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">Separe</button>
+        </div>
+        <div class="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
+          <button class="px-2.5 py-1 rounded-md text-xs font-medium bg-white text-blue-700 shadow-sm">kWh</button>
+          <button class="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">kW</button>
+          <button class="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 hover:text-gray-900">&euro;</button>
+        </div>
+        <button class="flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border border-gray-200 bg-white text-gray-600 hover:bg-gray-50">N-1</button>
+        <div class="ml-auto flex items-center gap-2">
+          <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-green-50 text-green-700 border border-green-200">
+            <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+            210 369 releves
+          </span>
+          <div class="flex items-center gap-0.5">
+            <button class="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition" title="Enregistrer un preset">
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+            </button>
+            <button class="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition" title="Reinitialiser">
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+            </button>
+            <button class="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition" title="Copier le lien">
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ════════════════════════════════════════════════════════
+           OPTION A: Breadcrumb strip listing hidden filter names.
+           Clicking the strip toggles the collapsed section.
+           Active filters appear in blue. Inactive in gray.
+           ════════════════════════════════════════════════════════ -->
+      <button
+        onclick="document.getElementById('moreA').classList.toggle('open'); this.querySelector('.chevron-a').classList.toggle('rotate-180')"
+        class="w-full flex items-center gap-1 py-1 text-[11px] text-gray-400 border-t border-gray-100 hover:text-gray-600 transition cursor-pointer group"
+      >
+        <svg class="w-3 h-3 chevron-a transition-transform text-gray-300 group-hover:text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+        <span class="text-gray-600 font-medium">Portfolio</span>
+        <span class="text-gray-300">&middot;</span>
+        <span class="text-gray-600 font-medium">Expert</span>
+        <span class="text-gray-300">&middot;</span>
+        <span class="text-gray-400">Dates</span>
+        <span class="text-gray-300">&middot;</span>
+        <span class="text-gray-400">Presets</span>
+      </button>
+
+      <!-- Collapsible section -->
+      <div id="moreA" class="collapse-section">
+        <div class="pb-1 space-y-2">
+          <div class="flex items-center gap-3 flex-wrap">
+            <button class="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border border-gray-200 bg-white text-gray-600 hover:border-indigo-300 hover:text-indigo-600 transition">
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+              Portfolio
+            </button>
+            <button class="flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded-lg border border-gray-200 bg-white text-gray-600 hover:bg-gray-50 transition">Mode Expert &rarr;</button>
+            <button class="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition">
+              Presets (2)
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-gray-500 font-medium">Du</span>
+            <input type="date" class="text-xs border border-gray-200 rounded-md px-2 py-1 bg-white">
+            <span class="text-xs text-gray-500 font-medium">au</span>
+            <input type="date" class="text-xs border border-gray-200 rounded-md px-2 py-1 bg-white">
+          </div>
+          <div class="text-[10px] text-gray-400 flex flex-wrap gap-x-3 gap-y-0.5">
+            <span>90 j</span><span>Jour</span><span>1 site</span><span>1 compteur</span><span>Qualite : 100 %</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- KPI strip -->
+    <div class="flex flex-wrap items-baseline gap-x-5 gap-y-1 px-3 py-2 rounded-lg bg-gray-50 border border-gray-100 text-xs">
+      <div class="flex flex-col"><span class="text-gray-400">Conso. totale</span><span class="font-semibold text-gray-700 whitespace-nowrap">983,9 MWh</span></div>
+      <div class="flex flex-col"><span class="text-gray-400">Cout total</span><span class="font-semibold text-gray-700 whitespace-nowrap">158 338 &euro;</span></div>
+      <div class="flex flex-col"><span class="text-gray-400">Prix moyen</span><span class="font-semibold text-gray-700 whitespace-nowrap">160,92 &euro;/MWh</span></div>
+      <div class="flex flex-col"><span class="text-gray-400">Emissions CO&#8322;e</span><span class="font-semibold text-gray-700 whitespace-nowrap">51 t CO&#8322;e</span></div>
+      <div class="flex flex-col"><span class="text-gray-400">Pic P95</span><span class="font-semibold text-gray-700 whitespace-nowrap">66 kW</span></div>
+      <div class="flex flex-col"><span class="text-gray-400">Nuit (22h-6h)</span><span class="font-semibold text-green-600 whitespace-nowrap">19 %</span></div>
+      <div class="flex flex-col ml-auto"><span class="text-gray-400">Confiance</span><span class="font-semibold text-green-600 whitespace-nowrap">Haute</span></div>
+    </div>
+
+    <!-- Chart -->
+    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <div class="flex items-center gap-4 px-4 py-2 text-[11px] text-gray-400 border-b border-gray-50">
+        <span>1 compteur</span><span>2 160 mesures</span><span>Granularite : Horaire</span><span>Qualite : 100 %</span><span>Source : Compteurs</span>
+      </div>
+      <div class="h-[380px] bg-white relative">
+        <div class="absolute inset-0 px-4 py-4">
+          <div class="absolute left-2 top-4 bottom-12 flex flex-col justify-between text-[10px] text-gray-400">
+            <span>276 kWh</span><span>216 kWh</span><span>146 kWh</span><span>76 kWh</span><span>6 kWh</span>
+          </div>
+          <div class="ml-12 mr-4 h-full">
+            <svg id="chartA" class="w-full h-full" preserveAspectRatio="none"></svg>
+          </div>
+        </div>
+        <div class="absolute bottom-1 left-12 right-4 flex justify-between text-[9px] text-gray-400">
+          <span>20 dec.</span><span>05 janv.</span><span>22 janv.</span><span>08 fevr.</span><span>24 fevr.</span><span>16 mars</span>
+        </div>
+      </div>
+      <div class="flex items-center justify-center gap-2 py-2 border-t border-gray-50">
+        <span class="w-3 h-0.5 rounded-full bg-blue-500"></span>
+        <span class="text-xs text-gray-500">Siege HELIOS Paris</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Design rationale -->
+<div class="max-w-7xl mx-auto px-6 mt-10 mb-8">
+  <div class="bg-white rounded-xl border border-gray-200 p-5">
+    <h2 class="text-sm font-bold text-gray-900 mb-2">Option A — Rationale</h2>
+    <ul class="text-xs text-gray-600 space-y-1">
+      <li><strong>Full-width clickable strip</strong> lists all hidden filter names: Portfolio, Expert, Dates, Presets.</li>
+      <li><strong>Active filters appear in blue/dark</strong>, inactive in gray. User sees at a glance what's available and what's active without expanding.</li>
+      <li><strong>Large click target</strong> — the entire strip row is the toggle, not a tiny button.</li>
+      <li><strong>Cost:</strong> +16px for the strip row (vs 0px if hidden), but provides persistent wayfinding.</li>
+      <li><strong>Best for:</strong> Returning B2B users who need to learn the filter vocabulary once, then scan by name daily.</li>
+    </ul>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const svg = document.getElementById('chartA');
+  if (!svg) return;
+  const W = 960, H = 340;
+  svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+  const points = [];
+  const N = 400;
+  for (let i = 0; i < N; i++) {
+    const t = i / N;
+    const daily = Math.sin(t * Math.PI * 2 * 45) * 60;
+    const weekly = Math.sin(t * Math.PI * 2 * 6.5) * 20;
+    const spike = Math.random() > 0.92 ? (Math.random() * 80 + 20) : 0;
+    const noise = (Math.random() - 0.5) * 30;
+    const seasonal = Math.sin(t * Math.PI * 0.8) * 25;
+    const val = 160 + daily + weekly + spike + noise + seasonal;
+    const x = (i / (N - 1)) * W;
+    const y = H - ((Math.max(6, Math.min(276, val)) - 6) / 270) * H;
+    points.push({ x, y });
+  }
+  const pathD = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+  defs.innerHTML = '<linearGradient id="ag" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#3b82f6" stop-opacity="0.15"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0.02"/></linearGradient>';
+  svg.appendChild(defs);
+  for (let i = 0; i <= 4; i++) { const gy = (i/4)*H; const l = document.createElementNS('http://www.w3.org/2000/svg','line'); l.setAttribute('x1','0'); l.setAttribute('y1',gy); l.setAttribute('x2',W); l.setAttribute('y2',gy); l.setAttribute('stroke','#f3f4f6'); l.setAttribute('stroke-width','1'); svg.appendChild(l); }
+  const area = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  area.setAttribute('d', `${pathD} L${W},${H} L0,${H} Z`);
+  area.setAttribute('fill', 'url(#ag)');
+  svg.appendChild(area);
+  const line = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  line.setAttribute('d', pathD);
+  line.setAttribute('fill', 'none');
+  line.setAttribute('stroke', '#3b82f6');
+  line.setAttribute('stroke-width', '1.5');
+  line.setAttribute('stroke-linejoin', 'round');
+  svg.appendChild(line);
+});
+</script>
+</body>
+</html>

--- a/frontend/src/ui/PageShell.jsx
+++ b/frontend/src/ui/PageShell.jsx
@@ -10,6 +10,7 @@ export default function PageShell({
   title,
   subtitle,
   actions,
+  inlineActions,
   children,
   className = '',
   tintColor = 'text-blue-600',
@@ -25,10 +26,11 @@ export default function PageShell({
               className={`${moduleKey ? tint.module(moduleKey).icon() : tintColor} shrink-0`}
             />
           )}
-          <div className="min-w-0 flex-1">
+          <div className={`min-w-0 ${inlineActions ? '' : 'flex-1'}`}>
             <h1 className="text-2xl font-bold text-gray-900 truncate">{title}</h1>
             {subtitle && <p className="text-sm text-gray-500 mt-0.5 line-clamp-2">{subtitle}</p>}
           </div>
+          {inlineActions}
         </div>
         {actions && <div className="flex items-center gap-2 flex-wrap shrink-0">{actions}</div>}
       </div>

--- a/frontend/src/ui/__tests__/EvidenceDrawer.test.js
+++ b/frontend/src/ui/__tests__/EvidenceDrawer.test.js
@@ -173,9 +173,10 @@ describe('ConsumptionExplorer EvidenceDrawer integration', () => {
     expect(headerSrc).toContain('onEvidence');
   });
 
-  it('ConsoKpiHeader passes evidenceId for kWh and CO2e tiles', () => {
-    expect(headerSrc).toContain('evidenceId="conso-kwh-total"');
-    expect(headerSrc).toContain('evidenceId="conso-co2e"');
+  it('ConsoKpiHeader has evidence data-testid for kWh and CO2e', () => {
+    // #90: inline strip uses data-testid directly instead of evidenceId prop
+    expect(headerSrc).toContain('evidence-open-conso-kwh-total');
+    expect(headerSrc).toContain('evidence-open-conso-co2e');
   });
 
   it('ConsoKpiHeader has Pourquoi ce chiffre aria-label', () => {


### PR DESCRIPTION
## Summary
- **Compact filter bar**: merged site chips + energy + period + granularity into 2 dense rows (~55px vs ~180px before)
- **Progressive disclosure**: mode/unit/presets/portfolio collapsed behind a breadcrumb strip + expandable section
- **Inline KPI strip**: single-row scoreboard replaces the 110px 6-tile grid
- **Site chips overflow**: max 3 visible + clickable `+N` badge to expand and remove hidden sites
- **Calendar icon**: custom date toggle uses calendar icon (matches approved mockup)
- **Consommations title + tabs**: single row via PageShell `actions` prop, subtitle removed
- **Approved mockup**: `explorer-option-A.html` included as reference

## Test plan
- [x] Verify filter bar takes ~55px (2 rows) on desktop
- [x] Click breadcrumb strip to expand Portfolio / Expert / Dates / Presets controls
- [x] Select 4+ sites → confirm first 3 shown + `+N` badge appears
- [x] Click `+N` → overflow chips expand with X to remove individual sites
- [x] Calendar icon visible at end of period pills
- [x] "Consommations" title + 4 tab buttons on same row
- [x] Chart visible within ~150px from top of explorer section
- [x] `npx vitest run` — no new test failures

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)