### PR TITLE
fix(explorer): add weekday + year to chart tooltip label (#122)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -34,6 +34,24 @@ import {
 } from 'recharts';
 import { colorForSite } from './helpers';
 
+/** Format tooltip date label with weekday + year (fr-FR), preserving hour when present */
+function tooltipLabelFormatter(label, payload) {
+  const raw = payload?.[0]?.payload?.rawDate;
+  if (!raw) return label;
+  const normalized = typeof raw === 'string' ? raw.replace(' ', 'T') : raw;
+  const d = new Date(normalized);
+  if (isNaN(d.getTime())) return label;
+  const hasTime = typeof label === 'string' && /\d:\d/.test(label);
+  const opts = {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    ...(hasTime && { hour: '2-digit', minute: '2-digit' }),
+  };
+  return d.toLocaleString('fr-FR', opts);
+}
+
 const UNIT_AXIS_LABELS = {
   kwh: 'kWh',
   kw: 'kW',
@@ -121,6 +139,7 @@ function SepareGrid({
                   }}
                 />
                 <Tooltip
+                  labelFormatter={tooltipLabelFormatter}
                   formatter={(v) => (v != null ? `${v} ${UNIT_AXIS_LABELS[unit]}` : 'N/A')}
                 />
                 <Area
@@ -234,6 +253,7 @@ export default function ExplorerChart({
             domain={yDomain}
           />
           <Tooltip
+            labelFormatter={tooltipLabelFormatter}
             formatter={(v, name) =>
               v != null && !isNaN(v)
                 ? [`${Number(v).toLocaleString('fr-FR')} ${yLabel}`, name]


### PR DESCRIPTION
## Summary
- Add `labelFormatter` to both `<Tooltip>` instances in `ExplorerChart.jsx` so the tooltip header shows enriched dates (e.g. "lun. 15 mars 2026" for daily, "lun. 15 mars 2026, 14:00" for hourly/sub-hourly)
- Falls back to the raw label for non-date xKeys (e.g. `name`, `hour`)
- X-axis labels remain unchanged

## Test plan
- [x] Open `/consommations/explorer`, hover chart → tooltip shows "lun. 15 mars 2026" style dates (daily)
- [x] Switch to hourly granularity → tooltip shows "lun. 15 mars 2026, 14:00" (including midnight 00:00)
- [x] Select multiple sites + "Séparé" mode → same enriched tooltip on each sub-chart
- [x] Verify x-axis labels are unchanged
- [x] `npx vitest run` — no new failures

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)