### PR TITLE
fix(consumption): exclude sub-meters from site aggregations (#120)

### DIFF
--- a/backend/routes/consumption_diagnostic.py
+++ b/backend/routes/consumption_diagnostic.py
@@ -846,6 +846,7 @@ def gas_summary(
     from models import Meter, MeterReading
     from models.energy_models import EnergyVector
     from collections import defaultdict
+    from services.ems.timeseries_service import get_site_meter_ids as _get_gas_ids
 
     if start_date_param and end_date_param:
         start_date = datetime.combine(start_date_param, datetime.min.time(), tzinfo=timezone.utc)
@@ -854,17 +855,9 @@ def gas_summary(
         end_date = datetime.now(timezone.utc)
         start_date = end_date - timedelta(days=days)
 
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-            Meter.energy_vector == EnergyVector.GAS,
-        )
-        .all()
-    )
+    meter_ids = _get_gas_ids(db, site_id, EnergyVector.GAS)
 
-    if not meters:
+    if not meter_ids:
         return {
             "site_id": site_id,
             "energy_type": "gas",
@@ -876,8 +869,6 @@ def gas_summary(
             "summer_base_kwh": 0,
             "confidence": "low",
         }
-
-    meter_ids = [m.id for m in meters]
 
     from services.ems.timeseries_service import resolve_best_freq
 

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -18,7 +18,7 @@ from models.consumption_insight import ConsumptionInsight
 from models.action_item import ActionItem
 from models.enums import ActionStatus
 from services.billing_service import get_reference_price, DEFAULT_PRICE_ELEC
-from services.ems.timeseries_service import resolve_best_freq
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 from config.emission_factors import get_emission_factor
 
 router = APIRouter(prefix="/api/portfolio/consumption", tags=["Portfolio Consumption"])
@@ -41,39 +41,36 @@ def _parse_date_or_default(val: Optional[str], default_days_ago: int = 90) -> da
     return date_cls.today() - timedelta(days=default_days_ago)
 
 
-def _site_consumption(db: Session, site_id: int, dt_from: datetime, dt_to: datetime, best_freq=None):
-    """Get aggregated consumption for a single site in the period."""
-    q = (
-        db.query(
-            func.sum(MeterReading.value_kwh).label("kwh"),
-            func.count(MeterReading.id).label("n_readings"),
-            func.max(MeterReading.timestamp).label("last_reading"),
-        )
-        .join(Meter, MeterReading.meter_id == Meter.id)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-            MeterReading.timestamp >= dt_from,
-            MeterReading.timestamp < dt_to,
-        )
+def _site_consumption(db: Session, meter_ids: list, dt_from: datetime, dt_to: datetime, best_freq=None):
+    """Get aggregated consumption for filtered meter IDs in the period."""
+    if not meter_ids:
+        from collections import namedtuple
+
+        Row = namedtuple("Row", ["kwh", "n_readings", "last_reading"])
+        return Row(kwh=None, n_readings=0, last_reading=None)
+    q = db.query(
+        func.sum(MeterReading.value_kwh).label("kwh"),
+        func.count(MeterReading.id).label("n_readings"),
+        func.max(MeterReading.timestamp).label("last_reading"),
+    ).filter(
+        MeterReading.meter_id.in_(meter_ids),
+        MeterReading.timestamp >= dt_from,
+        MeterReading.timestamp < dt_to,
     )
     if best_freq:
         q = q.filter(MeterReading.frequency.in_(best_freq))
     return q.first()
 
 
-def _site_peak_kw(db: Session, site_id: int, dt_from: datetime, dt_to: datetime, best_freq=None):
+def _site_peak_kw(db: Session, meter_ids: list, dt_from: datetime, dt_to: datetime, best_freq=None):
     """P95 peak: 95th percentile of kWh readings (proxy for kW peak)."""
-    q = (
-        db.query(MeterReading.value_kwh)
-        .join(Meter, MeterReading.meter_id == Meter.id)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-            MeterReading.timestamp >= dt_from,
-            MeterReading.timestamp < dt_to,
-            MeterReading.value_kwh.isnot(None),
-        )
+    if not meter_ids:
+        return None
+    q = db.query(MeterReading.value_kwh).filter(
+        MeterReading.meter_id.in_(meter_ids),
+        MeterReading.timestamp >= dt_from,
+        MeterReading.timestamp < dt_to,
+        MeterReading.value_kwh.isnot(None),
     )
     if best_freq:
         q = q.filter(MeterReading.frequency.in_(best_freq))
@@ -84,37 +81,29 @@ def _site_peak_kw(db: Session, site_id: int, dt_from: datetime, dt_to: datetime,
     return readings[idx].value_kwh
 
 
-def _base_night_pct(db: Session, site_id: int, dt_from: datetime, dt_to: datetime, best_freq=None):
+def _base_night_pct(db: Session, meter_ids: list, dt_from: datetime, dt_to: datetime, best_freq=None):
     """Base nocturne %: part de la conso nuit (22h-6h) dans la conso totale.
     Fenêtre 22h-06h = standard tertiaire France (bureaux fermés).
     Résultat en % (0-100). Théorique si plat = 33% (8h/24h).
     """
+    if not meter_ids:
+        return None
     from sqlalchemy import extract
 
-    q_night = (
-        db.query(func.sum(MeterReading.value_kwh))
-        .join(Meter, MeterReading.meter_id == Meter.id)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-            MeterReading.timestamp >= dt_from,
-            MeterReading.timestamp < dt_to,
-            ((extract("hour", MeterReading.timestamp) < 6) | (extract("hour", MeterReading.timestamp) >= 22)),
-        )
+    q_night = db.query(func.sum(MeterReading.value_kwh)).filter(
+        MeterReading.meter_id.in_(meter_ids),
+        MeterReading.timestamp >= dt_from,
+        MeterReading.timestamp < dt_to,
+        ((extract("hour", MeterReading.timestamp) < 6) | (extract("hour", MeterReading.timestamp) >= 22)),
     )
     if best_freq:
         q_night = q_night.filter(MeterReading.frequency.in_(best_freq))
     night_kwh = q_night.scalar()
 
-    q_total = (
-        db.query(func.sum(MeterReading.value_kwh))
-        .join(Meter, MeterReading.meter_id == Meter.id)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-            MeterReading.timestamp >= dt_from,
-            MeterReading.timestamp < dt_to,
-        )
+    q_total = db.query(func.sum(MeterReading.value_kwh)).filter(
+        MeterReading.meter_id.in_(meter_ids),
+        MeterReading.timestamp >= dt_from,
+        MeterReading.timestamp < dt_to,
     )
     if best_freq:
         q_total = q_total.filter(MeterReading.frequency.in_(best_freq))
@@ -168,18 +157,11 @@ def _site_open_actions(db: Session, site_id: int) -> int:
 def _build_site_row(db, site, dt_from, dt_to, days):
     """Build a single site row dict with all metrics (patrimoine-first)."""
     # Resolve best frequency ONCE per site — used for filtering + display
-    meter_ids = [
-        r[0]
-        for r in db.query(Meter.id)
-        .filter(
-            Meter.site_id == site.id,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-        )
-        .all()
-    ]
+    # Use helper to exclude sub-meters whose parent is already counted (avoid double-counting)
+    meter_ids = get_site_meter_ids(db, site.id, EnergyVector.ELECTRICITY)
     best = resolve_best_freq(db, meter_ids, dt_from, dt_to) if meter_ids else None
 
-    conso = _site_consumption(db, site.id, dt_from, dt_to, best_freq=best)
+    conso = _site_consumption(db, meter_ids, dt_from, dt_to, best_freq=best)
     kwh = conso.kwh or 0
     n = conso.n_readings or 0
     last_reading = conso.last_reading
@@ -216,8 +198,8 @@ def _build_site_row(db, site, dt_from, dt_to, days):
         or 0
     )
 
-    peak_kw = _site_peak_kw(db, site.id, dt_from, dt_to, best_freq=best) if has_data else None
-    base_night = _base_night_pct(db, site.id, dt_from, dt_to, best_freq=best) if has_data else None
+    peak_kw = _site_peak_kw(db, meter_ids, dt_from, dt_to, best_freq=best) if has_data else None
+    base_night = _base_night_pct(db, meter_ids, dt_from, dt_to, best_freq=best) if has_data else None
     impact_eur = _site_impact_eur(db, site.id, dt_from)
     open_actions = _site_open_actions(db, site.id)
 

--- a/backend/services/consumption_context_service.py
+++ b/backend/services/consumption_context_service.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 
 from models import Site, Meter, MeterReading, ConsumptionInsight, Portefeuille, EntiteJuridique
 from models.energy_models import FrequencyType, EnergyVector
-from services.ems.timeseries_service import resolve_best_freq
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 logger = logging.getLogger(__name__)
 
@@ -139,21 +139,12 @@ def get_consumption_profile(db: Session, site_id: int, days: int = 30) -> dict:
     heatmap = hphc.get("heatmap", [])
 
     # Get raw readings for daily profile + baseload
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-        )
-        .all()
-    )
+    meter_ids = get_site_meter_ids(db, site_id, EnergyVector.ELECTRICITY)
 
     readings = []
-    if meters:
+    if meter_ids:
         now_dt = datetime.now(timezone.utc).replace(tzinfo=None)
         cutoff = now_dt - timedelta(days=days)
-        meter_ids = [m.id for m in meters]
         best = resolve_best_freq(db, meter_ids, cutoff, now_dt)
         readings = (
             db.query(MeterReading)
@@ -382,23 +373,14 @@ def get_anomalies_and_score(db: Session, site_id: int, days: int = 30) -> dict:
 
     # Weekend active detection
     schedule = get_site_schedule_params(db, site_id)
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-        )
-        .all()
-    )
+    meter_ids = get_site_meter_ids(db, site_id, EnergyVector.ELECTRICITY)
 
     weekend_result = {"detected": False, "reason": "no_meters"}
     weekend_ratio = 0.0
 
-    if meters:
+    if meter_ids:
         now_dt = datetime.now(timezone.utc).replace(tzinfo=None)
         cutoff = now_dt - timedelta(days=days)
-        meter_ids = [m.id for m in meters]
         best = resolve_best_freq(db, meter_ids, cutoff, now_dt)
         readings = (
             db.query(MeterReading)

--- a/backend/services/consumption_diagnostic.py
+++ b/backend/services/consumption_diagnostic.py
@@ -37,7 +37,7 @@ from models import (
 from models.energy_models import FrequencyType
 
 from config.default_prices import DEFAULT_PRICE_ELEC_EUR_KWH
-from services.ems.timeseries_service import resolve_best_freq
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 # Fallback price — used when no SiteTariffProfile exists
 DEFAULT_PRICE_REF_KWH = DEFAULT_PRICE_ELEC_EUR_KWH
@@ -750,9 +750,11 @@ def run_diagnostic(
 
     Returns list of created ConsumptionInsight objects.
     """
-    meters = db.query(Meter).filter(Meter.site_id == site_id, Meter.is_active == True).all()
-    if not meters:
+    meter_ids = get_site_meter_ids(db, site_id)
+    if not meter_ids:
         return []
+
+    meters = db.query(Meter).filter(Meter.id.in_(meter_ids)).all()
 
     # Load schedule + tariff
     schedule = _get_schedule_params(db, site_id)

--- a/backend/services/consumption_unified_service.py
+++ b/backend/services/consumption_unified_service.py
@@ -25,7 +25,7 @@ from models import (
     EntiteJuridique,
 )
 from models.energy_models import EnergyVector
-from services.ems.timeseries_service import resolve_best_freq
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 logger = logging.getLogger(__name__)
 
@@ -44,17 +44,8 @@ RECONCILIATION_ALERT_THRESHOLD = 0.10
 
 
 def _get_meter_ids(db: Session, site_id: int, energy_vector: EnergyVector = EnergyVector.ELECTRICITY):
-    """Return active meter IDs for a site."""
-    rows = (
-        db.query(Meter.id)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-            Meter.energy_vector == energy_vector,
-        )
-        .all()
-    )
-    return [r[0] for r in rows]
+    """Return active meter IDs for a site, excluding sub-meters whose parent is in the list."""
+    return get_site_meter_ids(db, site_id, energy_vector)
 
 
 def _metered_kwh(db: Session, meter_ids: list, start: date, end: date):

--- a/backend/services/copilot_engine.py
+++ b/backend/services/copilot_engine.py
@@ -32,7 +32,7 @@ from models.copilot_models import CopilotAction, CopilotActionStatus
 logger = logging.getLogger("promeos.copilot")
 
 from config.default_prices import DEFAULT_PRICE_ELEC_EUR_KWH
-from services.ems.timeseries_service import resolve_best_freq
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 EUR_PER_KWH = DEFAULT_PRICE_ELEC_EUR_KWH  # Source: config.default_prices
 
@@ -286,15 +286,7 @@ def run_copilot_for_site(
     if today is None:
         today = date.today()
 
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-        )
-        .all()
-    )
-    meter_ids = [m.id for m in meters]
+    meter_ids = get_site_meter_ids(db, site_id)
 
     findings = []
 

--- a/backend/services/ems/timeseries_service.py
+++ b/backend/services/ems/timeseries_service.py
@@ -55,6 +55,26 @@ _COMPATIBLE_FREQS = {
 # -------------------------------------------------------------------
 # Public API
 # -------------------------------------------------------------------
+
+
+def get_site_meter_ids(
+    db: Session,
+    site_id: int,
+    energy_vector: Optional[EnergyVector] = None,
+) -> List[int]:
+    """Return active meter IDs for a site, excluding sub-meters whose parent is already in the list.
+
+    This prevents double-counting when a parent meter's readings already include
+    sub-meter consumption.  Pass *energy_vector=None* to return meters of all types.
+    """
+    q = db.query(Meter).filter(Meter.site_id == site_id, Meter.is_active == True)
+    if energy_vector is not None:
+        q = q.filter(Meter.energy_vector == energy_vector)
+    meters = q.all()
+    all_ids = {m.id for m in meters}
+    return [m.id for m in meters if m.parent_meter_id is None or m.parent_meter_id not in all_ids]
+
+
 def suggest_granularity(date_from: datetime, date_to: datetime) -> str:
     """Auto-suggest granularity based on date range span.
 
@@ -670,7 +690,9 @@ def compare_summary(
     if not meters:
         return {"current_kwh": None, "previous_kwh": None, "delta_pct": None}
 
-    meter_ids = [m.id for m in meters]
+    # Exclude sub-meters whose parent is already in the list (avoid double-counting)
+    all_ids = {m.id for m in meters}
+    meter_ids = [m.id for m in meters if m.parent_meter_id is None or m.parent_meter_id not in all_ids]
 
     def _sum_kwh(mids, dt_from, dt_to):
         best = _resolve_best_freq(db, mids, dt_from, dt_to, "daily")

--- a/backend/services/gas_weather_service.py
+++ b/backend/services/gas_weather_service.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 
 from models import Meter, MeterReading, Site
 from models.energy_models import EnergyVector
-from services.ems.timeseries_service import resolve_best_freq
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 
 def _mock_dju(doy: int) -> float:
@@ -80,20 +80,11 @@ def compute_weather_normalized(
         end_date = datetime.now(timezone.utc).replace(tzinfo=None)
         start_date = end_date - timedelta(days=days)
 
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-            Meter.energy_vector == EnergyVector.GAS,
-        )
-        .all()
-    )
+    meter_ids = get_site_meter_ids(db, site_id, EnergyVector.GAS)
 
-    if not meters:
+    if not meter_ids:
         return _empty_gas_weather(site_id, days, reason="no_gas_meters")
 
-    meter_ids = [m.id for m in meters]
     best = resolve_best_freq(db, meter_ids, start_date, end_date)
 
     readings = (

--- a/backend/services/schedule_detection_service.py
+++ b/backend/services/schedule_detection_service.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 from models import Site, Meter, MeterReading
 from models.energy_models import FrequencyType, EnergyVector
 from models.site_operating_schedule import SiteOperatingSchedule
+from services.ems.timeseries_service import get_site_meter_ids
 
 logger = logging.getLogger(__name__)
 
@@ -76,20 +77,11 @@ def _minutes_to_hhmm(m: int) -> str:
 
 def _fetch_readings(db: Session, site_id: int, days: int):
     """Fetch sub-daily readings for a site."""
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-        )
-        .all()
-    )
-    if not meters:
+    meter_ids = get_site_meter_ids(db, site_id, EnergyVector.ELECTRICITY)
+    if not meter_ids:
         return [], 60  # no meters
 
     cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
-    meter_ids = [m.id for m in meters]
     readings = (
         db.query(MeterReading)
         .filter(

--- a/backend/services/targets_service.py
+++ b/backend/services/targets_service.py
@@ -11,7 +11,7 @@ from sqlalchemy import func
 from models.consumption_target import ConsumptionTarget
 from models import Meter, MeterReading, Site
 from models.energy_models import EnergyVector
-from services.ems.timeseries_service import resolve_best_freq
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 
 def get_targets(
@@ -287,20 +287,11 @@ def get_progression_v2(
         ev_map = {"electricity": EnergyVector.ELECTRICITY, "gas": EnergyVector.GAS}
         target_ev = ev_map.get(energy_type, EnergyVector.ELECTRICITY)
 
-        meters = (
-            db.query(Meter)
-            .filter(
-                Meter.site_id == site_id,
-                Meter.is_active == True,
-                Meter.energy_vector == target_ev,
-            )
-            .all()
-        )
+        meter_ids = get_site_meter_ids(db, site_id, target_ev)
 
-        if meters:
+        if meter_ids:
             from datetime import timedelta
 
-            meter_ids = [m.id for m in meters]
             start_date = datetime(year, 1, 1)
             end_date = datetime(year, current_month, 28)
 

--- a/backend/services/tou_service.py
+++ b/backend/services/tou_service.py
@@ -13,7 +13,7 @@ from models.tou_schedule import TOUSchedule
 from models import Meter, MeterReading, Site
 from models.energy_models import EnergyVector
 from config.default_prices import DEFAULT_PRICE_ELEC_EUR_KWH, DEFAULT_PRICE_HC_EUR_KWH
-from services.ems.timeseries_service import resolve_best_freq
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 
 # Default TURPE-like schedule (HP 6h-22h weekday, HC rest)
@@ -221,15 +221,10 @@ def compute_hp_hc_ratio(
     end_date = datetime.now(timezone.utc).replace(tzinfo=None)
     start_date = end_date - timedelta(days=days)
 
-    meters_query = db.query(Meter).filter(
-        Meter.site_id == site_id,
-        Meter.is_active == True,
-        Meter.energy_vector == EnergyVector.ELECTRICITY,
-    )
     if meter_id:
-        meters_query = meters_query.filter(Meter.id == meter_id)
-
-    meter_ids = [m.id for m in meters_query.all()]
+        meter_ids = [meter_id]
+    else:
+        meter_ids = get_site_meter_ids(db, site_id, EnergyVector.ELECTRICITY)
     if not meter_ids:
         return _empty_hp_hc(site_id)
 
@@ -374,20 +369,11 @@ def compute_hphc_breakdown_v2(
         end_date = datetime.now(timezone.utc).replace(tzinfo=None)
         start_date = end_date - timedelta(days=days)
 
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-            Meter.energy_vector == EnergyVector.ELECTRICITY,
-        )
-        .all()
-    )
+    meter_ids = get_site_meter_ids(db, site_id, EnergyVector.ELECTRICITY)
 
-    if not meters:
+    if not meter_ids:
         return _empty_hphc_v2(site_id, cal_name)
 
-    meter_ids = [m.id for m in meters]
     best = resolve_best_freq(db, meter_ids, start_date, end_date)
 
     readings = (

--- a/backend/services/tunnel_service.py
+++ b/backend/services/tunnel_service.py
@@ -11,8 +11,8 @@ from collections import defaultdict
 from sqlalchemy.orm import Session
 
 from models import Meter, MeterReading, Site
-from models.energy_models import FrequencyType
-from services.ems.timeseries_service import resolve_best_freq
+from models.energy_models import EnergyVector, FrequencyType
+from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 
 def _percentile(data: List[float], pct: float) -> float:
@@ -68,29 +68,14 @@ def compute_tunnel(
     end_date = datetime.now(timezone.utc).replace(tzinfo=None)
     start_date = end_date - timedelta(days=days)
 
-    # Find meters for this site and energy type
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-        )
-        .all()
-    )
+    # Find meters for this site and energy type (excluding sub-meters)
+    _ev_map = {"electricity": EnergyVector.ELECTRICITY, "gas": EnergyVector.GAS}
+    target_ev = _ev_map.get(energy_type)
+    meter_ids = get_site_meter_ids(db, site_id, target_ev)
 
-    if energy_type == "electricity":
-        from models.energy_models import EnergyVector
-
-        meters = [m for m in meters if m.energy_vector == EnergyVector.ELECTRICITY]
-    elif energy_type == "gas":
-        from models.energy_models import EnergyVector
-
-        meters = [m for m in meters if m.energy_vector == EnergyVector.GAS]
-
-    if not meters:
+    if not meter_ids:
         return _empty_tunnel(site_id, energy_type, days)
 
-    meter_ids = [m.id for m in meters]
     best = resolve_best_freq(db, meter_ids, start_date, end_date)
 
     # Fetch readings
@@ -219,29 +204,14 @@ def compute_tunnel_v2(
         end_date = datetime.now(timezone.utc).replace(tzinfo=None)
         start_date = end_date - timedelta(days=days)
 
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-        )
-        .all()
-    )
-
-    if energy_type == "electricity":
-        from models.energy_models import EnergyVector
-
-        meters = [m for m in meters if m.energy_vector == EnergyVector.ELECTRICITY]
-    elif energy_type == "gas":
-        from models.energy_models import EnergyVector
-
-        meters = [m for m in meters if m.energy_vector == EnergyVector.GAS]
+    _ev_map2 = {"electricity": EnergyVector.ELECTRICITY, "gas": EnergyVector.GAS}
+    target_ev2 = _ev_map2.get(energy_type)
+    meter_ids = get_site_meter_ids(db, site_id, target_ev2)
 
     unit = "kW" if mode == "power" else "kWh"
-    if not meters:
+    if not meter_ids:
         return _empty_tunnel_v2(site_id, energy_type, days, mode, unit)
 
-    meter_ids = [m.id for m in meters]
     best = resolve_best_freq(db, meter_ids, start_date, end_date)
 
     readings = (


### PR DESCRIPTION
## Summary

- **Root cause**: 12 service/route files queried all active meters for a site without filtering out sub-meters whose parent was already included, causing double-counted kWh in KPIs (e.g. Siege HELIOS Paris showing 321 MWh instead of 189 MWh — ~70% inflation)
- **Fix**: Centralized sub-meter exclusion in a new `get_site_meter_ids()` helper in `timeseries_service.py` and replaced direct `Meter` queries across all affected files

## Files changed

| File | Change |
|------|--------|
| `services/ems/timeseries_service.py` | New `get_site_meter_ids()` helper + fix in `compare_summary()` |
| `services/consumption_unified_service.py` | `_get_meter_ids()` now delegates to helper |
| `routes/portfolio.py` | `_build_site_row`, `_site_consumption`, `_site_peak_kw`, `_base_night_pct` use helper |
| `services/tou_service.py` | `compute_hp_hc_ratio`, `compute_hphc_breakdown_v2` use helper |
| `services/tunnel_service.py` | `compute_tunnel`, `compute_tunnel_v2` use helper + fixed `_EV` NameError |
| `services/gas_weather_service.py` | `compute_weather_normalized` uses helper |
| `services/consumption_context_service.py` | `get_consumption_profile`, `get_anomalies_and_score` use helper |
| `services/targets_service.py` | `get_progression_v2` uses helper |
| `services/copilot_engine.py` | `run_copilot_for_site` uses helper |
| `services/schedule_detection_service.py` | `_fetch_readings` uses helper |
| `routes/consumption_diagnostic.py` | `gas_summary` uses helper |
| `services/consumption_diagnostic.py` | `run_diagnostic` uses helper |

## Blast-radius review

- Reviewed all backend callers of Meter queries and MeterReading aggregations
- Found 7 additional instances in `data_quality_service.py`, `monitoring_orchestrator.py`, `patrimoine_service.py`, and `check_diagnostic_data()` — these are cosmetic/metadata (not kWh sums) and tracked in follow-up #128
- No CRITICAL findings requiring immediate fix

## Test plan

**Automated tests**
```bash
cd promeos-poc && ./backend/venv/bin/pytest backend/tests/ -v -k "consumption or portfolio or tunnel or target or tou or diagnostic or copilot or gas_weather or schedule_detect or timeseries or unified"
```
465 passed, 0 failures from our changes (4 pre-existing failures excluded).

**Steps to reproduce the bug**
1. Open portfolio page for a site with sub-meters (e.g. Siege HELIOS Paris)
2. Observe inflated total kWh (~321 MWh instead of ~189 MWh)

**Steps to verify the fix**
1. Open portfolio page for Siege HELIOS Paris
2. Verify total kWh is ~189 MWh (parent meter only, sub-meters excluded)
3. Check consumption explorer, tunnel, TOU breakdown — all should show lower, correct values

Closes #120