### PR TITLE
fix(explorer): round Y-axis labels and format with French locale (#132)

### DIFF
--- a/frontend/src/pages/consumption/ExplorerChart.jsx
+++ b/frontend/src/pages/consumption/ExplorerChart.jsx
@@ -131,6 +131,7 @@ function SepareGrid({
                 <XAxis dataKey={xKey} tick={{ fontSize: 9 }} />
                 <YAxis
                   tick={{ fontSize: 9 }}
+                  tickFormatter={(v) => Math.round(v).toLocaleString('fr-FR')}
                   label={{
                     value: UNIT_AXIS_LABELS[unit],
                     angle: -90,
@@ -216,7 +217,7 @@ export default function ExplorerChart({
   const isNearFlat = range < avg * 0.05;
   const topPad = yMax > 0 ? yMax * 0.08 : 1;
   const pad = isNearFlat ? Math.max(1, avg * 0.1) : topPad;
-  const yDomain = [Math.max(0, yMin - (isNearFlat ? pad : 0)), yMax + pad];
+  const yDomain = [Math.max(0, Math.floor(yMin - (isNearFlat ? pad : 0))), Math.ceil(yMax + pad)];
 
   if (mode === 'separe' && siteIds.length > 1) {
     return (
@@ -249,6 +250,7 @@ export default function ExplorerChart({
           <XAxis dataKey={xKey} tick={{ fontSize: 11 }} />
           <YAxis
             tick={{ fontSize: 11 }}
+            tickFormatter={(v) => Math.round(v).toLocaleString('fr-FR')}
             label={{ value: yLabel, angle: -90, position: 'insideLeft', style: { fontSize: 11 } }}
             domain={yDomain}
           />


### PR DESCRIPTION
## Summary

- **Root cause**: Missing `tickFormatter` on both `<YAxis>` components + non-rounded `yDomain` bounds producing decimal ticks and potential aberrant values
- **Fix**: Added `tickFormatter={(v) => Math.round(v).toLocaleString('fr-FR')}` on both YAxis (main chart + SepareGrid), and rounded yDomain bounds with `Math.floor`/`Math.ceil`

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/consumption/ExplorerChart.jsx` | Added `tickFormatter` on both `<YAxis>` components; rounded `yDomain` bounds |

## Test plan

**Automated tests**
```bash
cd frontend && npx vitest run src/pages/__tests__/ExplorerChartBrush.test.js --reporter=verbose
```

**Steps to reproduce the bug**
1. Go to Consommations → Explorer
2. Select any site/period combination
3. Observe Y-axis labels showing decimals (e.g. 215.83, 145.83)

**Steps to verify the fix**
1. Go to Consommations → Explorer
2. Select any site/period — Y-axis labels should be rounded integers with French locale (space as thousands separator)
3. Switch to mode "Séparé" — same formatting on sub-charts
4. Verify no aberrant large value at the top of the axis

Closes #132