### PR TITLE
fix(benchmark): display actual consumption curve in BenchmarkPanel chart (#89)

### DIFF
--- a/backend/routes/ems.py
+++ b/backend/routes/ems.py
@@ -1105,8 +1105,9 @@ def get_reference_profile(
             daily[day] = daily.get(day, 0) + pt["v"]
         ref_series = [{"t": d, "v": round(v, 1)} for d, v in sorted(daily.items())]
 
-    # Get actual consumption for KPI delta
+    # Get actual consumption for KPI delta + actual series for chart
     kpi = None
+    actual_series = []
     try:
         ts_data = query_timeseries(
             db,
@@ -1119,12 +1120,15 @@ def get_reference_profile(
             "kwh",
         )
         if ts_data["series"] and ts_data["series"][0]["data"]:
-            actual_total = sum(p["v"] for p in ts_data["series"][0]["data"] if p.get("v"))
+            actual_series = [
+                {"t": p["t"], "v": round(p["v"], 1)} for p in ts_data["series"][0]["data"] if p.get("v") is not None
+            ]
+            actual_total = sum(p["v"] for p in actual_series)
             ref_total = sum(p["v"] for p in ref_series)
             delta_kwh = actual_total - ref_total
             delta_pct = round(delta_kwh / ref_total * 100, 1) if ref_total > 0 else 0
             # Confidence based on actual data coverage
-            n_actual = len([p for p in ts_data["series"][0]["data"] if p.get("v")])
+            n_actual = len(actual_series)
             n_expected = len(ref_series)
             coverage = min(100, round(n_actual / max(n_expected, 1) * 100))
             confidence = "high" if coverage >= 80 else "medium" if coverage >= 50 else "low"
@@ -1144,6 +1148,7 @@ def get_reference_profile(
         "puissance": puissance,
         "granularity": granularity,
         "series": ref_series,
+        "actual_series": actual_series,
         "kpi": kpi,
     }
 

--- a/backend/tests/test_ems_p1.py
+++ b/backend/tests/test_ems_p1.py
@@ -139,6 +139,25 @@ class TestReferenceProfile:
         # 2 days * 24h = 48 hourly points
         assert len(data["series"]) == 48
 
+    def test_returns_actual_series(self, env):
+        client, _, site = env
+        r = client.get(
+            "/api/ems/reference_profile",
+            params={
+                "site_id": site.id,
+                "date_from": "2025-03-01",
+                "date_to": "2025-03-15",
+                "famille": "entreprise",
+                "puissance": "9-12",
+                "granularity": "daily",
+            },
+        )
+        data = r.json()
+        assert "actual_series" in data
+        assert len(data["actual_series"]) > 0
+        assert "t" in data["actual_series"][0]
+        assert "v" in data["actual_series"][0]
+
     def test_weekend_factor_applied(self, env):
         client, _, site = env
         # 2025-03-01 is Saturday, 2025-03-03 is Monday

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -767,7 +767,6 @@ export default function ConsumptionExplorerPage() {
                   days={days}
                   startDate={startDate}
                   endDate={endDate}
-                  seriesData={null}
                   toast={toast}
                 />
               )}
@@ -880,7 +879,6 @@ export default function ConsumptionExplorerPage() {
                     days={days}
                     startDate={startDate}
                     endDate={endDate}
-                    seriesData={null}
                     toast={toast}
                   />
                 )}

--- a/frontend/src/pages/__tests__/consoV2.audit.test.js
+++ b/frontend/src/pages/__tests__/consoV2.audit.test.js
@@ -380,7 +380,7 @@ describe('AR · P1-1 benchmark reference curve', () => {
 
   it('BenchmarkPanel has toggle checkbox', () => {
     const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
-    expect(code).toMatch(/Comparer a la courbe moyenne/);
+    expect(code).toMatch(/Comparer au profil de reference/);
     expect(code).toMatch(/type="checkbox"/);
   });
 
@@ -399,7 +399,7 @@ describe('AR · P1-1 benchmark reference curve', () => {
   it('BenchmarkPanel has 4 KPI cards (actual, reference, ecart, couverture)', () => {
     const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
     expect(code).toMatch(/Votre consommation/);
-    expect(code).toMatch(/Moyenne sites similaires/);
+    expect(code).toMatch(/Profil de reference/);
     expect(code).toMatch(/Écart/);
     expect(code).toMatch(/Couverture/);
   });
@@ -558,15 +558,15 @@ describe('AT · P1-3 overlay meteo UTC', () => {
 // AU. P1.1 — Polish UX labels + tooltips + confidence
 // ============================================================
 describe('AU · P1.1 polish labels & tooltips', () => {
-  it('BenchmarkPanel uses "courbe moyenne de sites similaires" label', () => {
+  it('BenchmarkPanel uses "profil de reference" label', () => {
     const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
-    expect(code).toMatch(/courbe moyenne de sites similaires/);
+    expect(code).toMatch(/profil de reference/);
   });
 
-  it('BenchmarkPanel KPI shows "Votre consommation" and "Moyenne sites similaires"', () => {
+  it('BenchmarkPanel KPI shows "Votre consommation" and "Profil de reference"', () => {
     const code = readSrc('pages', 'consumption', 'BenchmarkPanel.jsx');
     expect(code).toMatch(/Votre consommation/);
-    expect(code).toMatch(/Moyenne sites similaires/);
+    expect(code).toMatch(/Profil de reference/);
   });
 
   it('BenchmarkPanel has confidence tooltip with HelpCircle', () => {

--- a/frontend/src/pages/consumption/BenchmarkPanel.jsx
+++ b/frontend/src/pages/consumption/BenchmarkPanel.jsx
@@ -48,7 +48,7 @@ function formatDate(t) {
   return d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' });
 }
 
-export default function BenchmarkPanel({ siteId, days, startDate, endDate, seriesData, toast }) {
+export default function BenchmarkPanel({ siteId, days, startDate, endDate, toast }) {
   const [enabled, setEnabled] = useState(false);
   const [famille, setFamille] = useState('entreprise');
   const [puissance, setPuissance] = useState('9-12');
@@ -99,10 +99,10 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
       refMap[key] = pt.v;
     }
 
-    // Actual data from seriesData (parent TimeseriesPanel)
+    // Actual data from backend response (actual_series)
     const actualMap = {};
-    if (seriesData?.[0]?.data) {
-      for (const pt of seriesData[0].data) {
+    if (refData?.actual_series) {
+      for (const pt of refData.actual_series) {
         const key = (pt.t || '').slice(0, 10);
         if (pt.v != null) actualMap[key] = (actualMap[key] || 0) + pt.v;
       }
@@ -115,7 +115,7 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
       actual: actualMap[d] != null ? Math.round(actualMap[d] * 10) / 10 : null,
       reference: refMap[d] != null ? Math.round(refMap[d] * 10) / 10 : null,
     }));
-  }, [refData, seriesData]);
+  }, [refData]);
 
   const kpi = refData?.kpi;
   const conf = kpi?.confidence ? CONFIDENCE_MAP[kpi.confidence] : null;
@@ -131,9 +131,7 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
             onChange={(e) => setEnabled(e.target.checked)}
             className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
           />
-          <span className="text-sm font-medium text-gray-700">
-            Comparer a la courbe moyenne de sites similaires
-          </span>
+          <span className="text-sm font-medium text-gray-700">Comparer au profil de reference</span>
         </label>
       </div>
 
@@ -201,11 +199,16 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
               </Card>
               <Card>
                 <CardBody className="py-3 px-4 text-center">
-                  <p className="text-xs text-gray-500">Moyenne sites similaires</p>
+                  <p className="text-xs text-gray-500">Profil de reference</p>
                   <p className="text-lg font-bold text-blue-600">
                     {fmtKwh(Math.round(kpi.reference_kwh))}
                   </p>
-                  <p className="text-[10px] text-gray-400">Profil statistique</p>
+                  <p
+                    className="text-[10px] text-gray-400"
+                    title="Profil statistique estime par famille et puissance souscrite — non base sur les donnees reelles de sites pairs"
+                  >
+                    Profil statistique estime
+                  </p>
                 </CardBody>
               </Card>
               <Card>
@@ -243,7 +246,7 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
             <Card>
               <CardBody>
                 <h4 className="text-sm font-semibold text-gray-700 mb-3">
-                  Votre consommation vs moyenne de sites similaires
+                  Votre consommation vs profil de reference
                 </h4>
                 <ResponsiveContainer width="100%" height={280}>
                   <AreaChart data={chartData}>
@@ -272,7 +275,7 @@ export default function BenchmarkPanel({ siteId, days, startDate, endDate, serie
                       stroke="#93c5fd"
                       fill="#dbeafe"
                       fillOpacity={0.5}
-                      name="Moyenne sites similaires"
+                      name="Profil de reference"
                       strokeDasharray="5 5"
                     />
                     <Area


### PR DESCRIPTION
## Summary

- **Root cause**: `seriesData={null}` hardcoded in ConsumptionExplorerPage + backend `/reference_profile` endpoint computed actual data for KPIs but did not return it in the response
- **Fix**: Backend now returns `actual_series` in the API response; BenchmarkPanel reads it directly from the API instead of a (null) prop; labels clarified from "Moyenne sites similaires" to "Profil de reference" to avoid misleading users about the nature of the reference data

## Analysis

### Root Cause Investigation

**Issue hypothesis**: `seriesData={null}` hardcoded + backend doesn't return actual series
**Actual root cause**: Confirmed — both problems match the hypothesis exactly
**Evidence**: `ConsumptionExplorerPage.jsx:770,883` (null props), `ems.py:1142-1148` (missing actual_series in response)
**Match**: YES

### Approach Selection

| Approach | Description | Pros | Cons | Risk | Verdict |
|----------|-------------|------|------|------|---------|
| A | Backend: include `actual_series` in response | Self-contained component, data already computed | Slightly larger API response | Low | **RECOMMENDED** |
| B | Frontend: pass timeseries data from parent via prop | No backend change | Requires parent state threading, coupling | Medium | - |

**Auto-selected**: Approach A (RECOMMENDED) — data already computed server-side, keeps BenchmarkPanel self-contained

### Complexity Assessment

**Score**: 1/5
**Model**: Opus (current)

### Pre-Mortem Analysis

No significant risks identified — adding a field to an existing API response is backward compatible.

### Blast-Radius Review

| Area | Finding | Status |
|------|---------|--------|
| `getEmsReferenceProfile` callers | Only BenchmarkPanel | SAFE |
| BenchmarkPanel importers | Only ConsumptionExplorerPage (2 usages) | SAFE |
| Old label references in tests | All updated | SAFE |
| `seriesData` prop references | No external references | SAFE |

### Code Review

| File | Severity | Description | Status |
|------|----------|-------------|--------|
| `test_ems_p1.py` | HIGH | Missing assertion for `actual_series` in response | Fixed — added `test_returns_actual_series` |

Fixed 1 issue in 1 iteration.

## Files Changed

| File | Change |
|------|--------|
| `backend/routes/ems.py` | Include `actual_series` (actual consumption data) in `/reference_profile` response |
| `frontend/src/pages/consumption/BenchmarkPanel.jsx` | Read actual data from `refData.actual_series` instead of null prop; clarify labels to "Profil de reference" |
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Remove unused `seriesData={null}` props |
| `frontend/src/pages/__tests__/consoV2.audit.test.js` | Update test assertions for new labels |
| `backend/tests/test_ems_p1.py` | Add test for `actual_series` presence in API response |

## Test Plan

**Automated tests**
```
pytest backend/tests/test_ems_p1.py -v  → 11 passed
pytest backend/tests/test_benchmark.py -v → 12 passed
vitest run consoV2.audit.test.js → all BenchmarkPanel tests pass
```

**Steps to reproduce the bug**
1. Go to Consommations > Explorer, select a site with data
2. Toggle "Comparer au profil de reference"
3. Observe: only reference curve shown, no actual consumption curve

**Steps to verify the fix**
1. Go to Consommations > Explorer, select a site with consumption data
2. Toggle "Comparer au profil de reference"
3. Verify: both curves visible (blue solid = your consumption, dashed = reference profile)
4. Verify: KPI card shows "Profil de reference" instead of "Moyenne sites similaires"
5. Verify: tooltip on reference KPI explains "Profil statistique estime"

Closes #89

---
_Auto-generated by `/fix-issue-auto` — all analysis embedded for PR review._