### PR TITLE
fix(meters): apply sub-meter exclusion to data_quality, diagnostic, monitoring (#128)

### DIFF
--- a/backend/routes/consumption_diagnostic.py
+++ b/backend/routes/consumption_diagnostic.py
@@ -303,6 +303,7 @@ def consumption_availability(
     from models import Meter, MeterReading
     from models.energy_models import EnergyVector
     from sqlalchemy import func
+    from services.ems.timeseries_service import get_site_meter_ids
 
     check_site_access(auth, site_id)
     energy_type = _normalize_energy_type(energy_type)
@@ -312,8 +313,9 @@ def consumption_availability(
     if not site:
         return {"has_data": False, "reasons": ["no_site"], "energy_types": [], "meters_count": 0}
 
-    # All active meters for this site
-    all_meters = db.query(Meter).filter(Meter.site_id == site_id, Meter.is_active == True).all()
+    # All active meters for this site, excluding sub-meters whose parent is in the list
+    top_meter_ids = get_site_meter_ids(db, site_id)
+    all_meters = db.query(Meter).filter(Meter.id.in_(top_meter_ids)).all() if top_meter_ids else []
     if not all_meters:
         return {"has_data": False, "reasons": ["no_meter"], "energy_types": [], "meters_count": 0, "site_nom": site.nom}
 

--- a/backend/services/data_quality_service.py
+++ b/backend/services/data_quality_service.py
@@ -21,6 +21,7 @@ from models import (
     EntiteJuridique,
 )
 from models.energy_models import EnergyVector, Anomaly
+from services.ems.timeseries_service import get_site_meter_ids
 
 
 def _to_date(val, fallback=None):
@@ -135,15 +136,9 @@ def compute_site_completeness(
     window_start = today - timedelta(days=365)
     results = []
 
-    # ── Meter readings ──
-    meters = (
-        db.query(Meter)
-        .filter(
-            Meter.site_id == site_id,
-            Meter.is_active == True,
-        )
-        .all()
-    )
+    # ── Meter readings (exclude sub-meters whose parent is already in the list) ──
+    top_meter_ids = get_site_meter_ids(db, site_id)
+    meters = db.query(Meter).filter(Meter.id.in_(top_meter_ids)).all() if top_meter_ids else []
 
     meters_by_energy = defaultdict(list)
     for m in meters:
@@ -428,7 +423,7 @@ def _grade(score: float) -> str:
 
 def _dim_completeness(db: Session, site_id: int, window_start: date, today: date) -> dict:
     """COMPLETENESS (35%) — months with readings / 12."""
-    meter_ids = [r[0] for r in db.query(Meter.id).filter(Meter.site_id == site_id, Meter.is_active == True).all()]
+    meter_ids = get_site_meter_ids(db, site_id)
 
     if meter_ids:
         month_rows = (
@@ -464,7 +459,7 @@ def _dim_completeness(db: Session, site_id: int, window_start: date, today: date
 
 def _dim_freshness(db: Session, site_id: int, today: date) -> dict:
     """FRESHNESS (25%) — recency of last reading."""
-    meter_ids = [r[0] for r in db.query(Meter.id).filter(Meter.site_id == site_id, Meter.is_active == True).all()]
+    meter_ids = get_site_meter_ids(db, site_id)
 
     last_ts = None
     if meter_ids:
@@ -486,7 +481,7 @@ def _dim_freshness(db: Session, site_id: int, today: date) -> dict:
 
 def _dim_accuracy(db: Session, site_id: int, window_start: date) -> dict:
     """ACCURACY (25%) — anomaly ratio over readings."""
-    meter_ids = [r[0] for r in db.query(Meter.id).filter(Meter.site_id == site_id, Meter.is_active == True).all()]
+    meter_ids = get_site_meter_ids(db, site_id)
 
     if not meter_ids:
         return {
@@ -626,7 +621,7 @@ def compute_site_freshness(
         today = date.today()
 
     # Last meter reading
-    meter_ids = [r[0] for r in db.query(Meter.id).filter(Meter.site_id == site_id, Meter.is_active == True).all()]
+    meter_ids = get_site_meter_ids(db, site_id)
 
     last_reading_date = None
     if meter_ids:

--- a/backend/services/electric_monitoring/monitoring_orchestrator.py
+++ b/backend/services/electric_monitoring/monitoring_orchestrator.py
@@ -54,15 +54,17 @@ class MonitoringOrchestrator:
             dict with kpis, power_risk, data_quality, alerts, snapshot_id
         """
         from models import Meter, MeterReading, MonitoringSnapshot, MonitoringAlert, AlertStatus, AlertSeverity, Site
+        from services.ems.timeseries_service import get_site_meter_ids
 
         if not self.db:
             raise RuntimeError("DB session required for orchestrator.run()")
 
-        # Determine meters
+        # Determine meters (exclude sub-meters whose parent is already included)
         if meter_id:
             meters = self.db.query(Meter).filter_by(id=meter_id, site_id=site_id).all()
         else:
-            meters = self.db.query(Meter).filter_by(site_id=site_id).all()
+            top_ids = get_site_meter_ids(self.db, site_id)
+            meters = self.db.query(Meter).filter(Meter.id.in_(top_ids)).all() if top_ids else []
 
         if not meters:
             return {"error": f"No meters found for site {site_id}", "kpis": {}, "alerts": []}


### PR DESCRIPTION
## Summary

- **Root cause**: Raw `Meter.site_id` queries in data quality, diagnostic, and monitoring code included sub-meters whose parent was already in the list, inflating scores and counts
- **Fix**: Replaced 6 raw meter queries with `get_site_meter_ids()` (from `timeseries_service.py`) which excludes sub-meters whose parent is already present

## Analysis

### Root Cause Investigation

**Issue hypothesis**: Pre-existing code queries meters without sub-meter exclusion, leading to double-counting in data quality scores, diagnostic checks, and monitoring.
**Actual root cause**: Confirmed — 6 locations used `db.query(Meter.id).filter(Meter.site_id == site_id, Meter.is_active == True)` without the sub-meter exclusion already implemented in `get_site_meter_ids()`.
**Evidence**: `data_quality_service.py:431,467,489,629,140`, `consumption_diagnostic.py:316`, `monitoring_orchestrator.py:65`
**Match**: YES

### Approach Selection

No meaningful alternatives — single clear fix. `get_site_meter_ids()` already exists with the correct filtering logic. All affected locations should use it.

**Auto-selected**: Use `get_site_meter_ids()` (RECOMMENDED) — canonical function, already used by timeseries module since #120

### Complexity Assessment

**Score**: 1/5
**Model**: Opus (current session model)

| Criterion | Points |
|-----------|--------|
| Fix touches > 3 files | +1 (3 files) |
| Non-trivial state / async / race logic | 0 |
| Meaningful regression risk | 0 |
| Overriding library internals | 0 |
| Hypothesis wrong | 0 |

### Pre-Mortem Analysis

No significant risks identified. The change is the intended behavioral correction — data quality scores/counts will change for sites with sub-meters (this is the desired outcome).

### Blast-Radius Review

| # | Component | Risk | Impact |
|---|-----------|------|--------|
| 1 | Data Quality Score (D.1) | HIGH (intended) | Scores correct for sites with sub-meters; grades may change |
| 2 | Data Freshness (D.2) | HIGH (intended) | Staleness based on parent meters only |
| 3 | Consumption Availability | MEDIUM (intended) | `meters_count` excludes sub-meters |
| 4 | Monitoring Orchestrator | MEDIUM (intended) | `meters_analyzed` count correct |
| 5 | Usage Service | SAFE | Already filters principals/subs explicitly |
| 6 | EMS Timeseries | SAFE | Already excludes subs |
| 7 | Patrimoine matching (#7) | SAFE — skipped | Identity matching by PRM, not aggregation |

**Note**: `compute_site_completeness` (finding #7 in issue was MEDIUM, but code review found it was a 6th missing location) was also migrated during code review.

### Code Review

| Finding | Severity | Description | Action |
|---------|----------|-------------|--------|
| `data_quality_service.py:140` | HIGH | `compute_site_completeness` also had raw meter query — missed in initial scope | Fixed — added `get_site_meter_ids()` call |
| `consumption_diagnostic.py:306` local import | FALSE POSITIVE | Reviewer claimed duplicate import — verified line 40 is `get_targets`, not `get_site_meter_ids` | No action needed |

Fixed 1 issue in 1 iteration.

## Files Changed

| File | Change |
|------|--------|
| `backend/services/data_quality_service.py` | Replace 5 raw meter queries with `get_site_meter_ids()` in `_dim_completeness`, `_dim_freshness`, `_dim_accuracy`, `compute_site_freshness`, `compute_site_completeness` |
| `backend/routes/consumption_diagnostic.py` | Replace meter query in `consumption_availability` with `get_site_meter_ids()` + Meter object load |
| `backend/services/electric_monitoring/monitoring_orchestrator.py` | Replace meter query in `run()` else branch with `get_site_meter_ids()` |

## Test Plan

**Automated tests**
```
pytest backend/tests/test_data_quality.py test_data_quality_d1.py test_v113_data_quality_causes.py test_consumption_diag.py test_monitoring_integration.py test_monitoring_v45.py -v
→ 112 passed
```

**Steps to reproduce the bug**
1. Create a site with a parent meter and a sub-meter (parent_meter_id set)
2. Call `/api/data-quality/site/{id}` — completeness/freshness/accuracy scores include sub-meter readings
3. Call `/api/consumption/availability?site_id={id}` — `meters_count` includes sub-meters
4. Call `/api/monitoring/run?site_id={id}` — `meters_analyzed` includes sub-meters

**Steps to verify the fix**
1. Same setup — parent meter + sub-meter
2. Call `/api/data-quality/site/{id}` — scores now based only on top-level meters
3. Call `/api/consumption/availability?site_id={id}` — `meters_count` excludes sub-meters whose parent is present
4. Call `/api/monitoring/run?site_id={id}` — `meters_analyzed` excludes sub-meters

Closes #128

---
_Auto-generated by `/fix-issue-auto` — all analysis embedded for PR review._