### PR TITLE
fix(perf): optimize tunnel/hphc computation and cache TTL (#126)

### DIFF
--- a/backend/services/tou_service.py
+++ b/backend/services/tou_service.py
@@ -244,11 +244,18 @@ def compute_hp_hc_ratio(
     if not readings:
         return _empty_hp_hc(site_id)
 
+    # Pre-compute 7x24 period lookup table
+    period_lookup = {}
+    for dow in range(7):
+        for hour in range(24):
+            ref = datetime(2024, 1, 1 + dow, hour, 0)  # 2024-01-01 is Monday (weekday=0)
+            period_lookup[(dow, hour)] = _classify_period(ref, windows)
+
     hp_kwh = 0.0
     hc_kwh = 0.0
 
     for r in readings:
-        period = _classify_period(r.timestamp, windows)
+        period = period_lookup[(r.timestamp.weekday(), r.timestamp.hour)]
         if period == "HP":
             hp_kwh += r.value_kwh
         else:
@@ -390,21 +397,27 @@ def compute_hphc_breakdown_v2(
     if not readings:
         return _empty_hphc_v2(site_id, cal_name)
 
-    # Classify + build heatmap
+    # Pre-compute 7x24 period lookup table (avoids per-reading window iteration)
+    period_lookup = {}
+    for dow in range(7):
+        for hour in range(24):
+            ref = datetime(2024, 1, 1 + dow, hour, 0)  # 2024-01-01 is Monday (weekday=0)
+            period_lookup[(dow, hour)] = _classify_period(ref, windows)
+
+    # Classify + build heatmap using lookup table
     hp_kwh = 0.0
     hc_kwh = 0.0
     heatmap_data = defaultdict(lambda: {"sum_kwh": 0.0, "count": 0, "period": "HC"})
 
     for r in readings:
-        period = _classify_period(r.timestamp, windows)
+        dow = r.timestamp.weekday()
+        hour = r.timestamp.hour
+        period = period_lookup[(dow, hour)]
         if period == "HP":
             hp_kwh += r.value_kwh
         else:
             hc_kwh += r.value_kwh
 
-        # Heatmap: day_of_week (0=Mon) x hour
-        dow = r.timestamp.weekday()
-        hour = r.timestamp.hour
         key = (dow, hour)
         heatmap_data[key]["sum_kwh"] += r.value_kwh
         heatmap_data[key]["count"] += 1

--- a/backend/services/tunnel_service.py
+++ b/backend/services/tunnel_service.py
@@ -15,11 +15,10 @@ from models.energy_models import EnergyVector, FrequencyType
 from services.ems.timeseries_service import resolve_best_freq, get_site_meter_ids
 
 
-def _percentile(data: List[float], pct: float) -> float:
-    """Compute percentile without numpy."""
-    if not data:
+def _percentile(sorted_data: List[float], pct: float) -> float:
+    """Compute percentile from pre-sorted data (caller must sort)."""
+    if not sorted_data:
         return 0.0
-    sorted_data = sorted(data)
     k = (len(sorted_data) - 1) * pct / 100.0
     f = int(k)
     c = f + 1
@@ -107,21 +106,22 @@ def compute_tunnel(
         power_kw = r.value_kwh / hours_per_interval if hours_per_interval > 0 else r.value_kwh
         buckets[day_type][hour].append(power_kw)
 
-    # Compute envelope per (day_type, hour)
+    # Compute envelope per (day_type, hour) — sort each bucket once
     envelope = {}
     for day_type in ("weekday", "weekend"):
         slots = []
         for h in range(24):
             vals = buckets[day_type].get(h, [])
             if vals:
+                sorted_vals = sorted(vals)
                 slots.append(
                     {
                         "hour": h,
-                        "p10": round(_percentile(vals, 10), 2),
-                        "p25": round(_percentile(vals, 25), 2),
-                        "p50": round(_percentile(vals, 50), 2),
-                        "p75": round(_percentile(vals, 75), 2),
-                        "p90": round(_percentile(vals, 90), 2),
+                        "p10": round(_percentile(sorted_vals, 10), 2),
+                        "p25": round(_percentile(sorted_vals, 25), 2),
+                        "p50": round(_percentile(sorted_vals, 50), 2),
+                        "p75": round(_percentile(sorted_vals, 75), 2),
+                        "p90": round(_percentile(sorted_vals, 90), 2),
                         "count": len(vals),
                     }
                 )
@@ -250,14 +250,15 @@ def compute_tunnel_v2(
         for h in range(24):
             vals = buckets[day_type].get(h, [])
             if vals:
+                sorted_vals = sorted(vals)
                 slots.append(
                     {
                         "hour": h,
-                        "p10": round(_percentile(vals, 10), 2),
-                        "p25": round(_percentile(vals, 25), 2),
-                        "p50": round(_percentile(vals, 50), 2),
-                        "p75": round(_percentile(vals, 75), 2),
-                        "p90": round(_percentile(vals, 90), 2),
+                        "p10": round(_percentile(sorted_vals, 10), 2),
+                        "p25": round(_percentile(sorted_vals, 25), 2),
+                        "p50": round(_percentile(sorted_vals, 50), 2),
+                        "p75": round(_percentile(sorted_vals, 75), 2),
+                        "p90": round(_percentile(sorted_vals, 90), 2),
                         "count": len(vals),
                     }
                 )

--- a/frontend/src/pages/consumption/TargetsPanel.jsx
+++ b/frontend/src/pages/consumption/TargetsPanel.jsx
@@ -15,6 +15,7 @@ import {
   deleteConsumptionTarget,
   getTargetsProgressionV2,
 } from '../../services/api';
+import { clearApiCache } from '../../services/api/core';
 import ExplorerChart from './ExplorerChart';
 import LayerToggle from './LayerToggle';
 import ObjectivesLayer from './layers/ObjectivesLayer';
@@ -86,6 +87,7 @@ export default function TargetsPanel({
       });
       setShowAdd(false);
       setNewTarget({ month: 1, target_kwh: '', target_eur: '' });
+      clearApiCache();
       load();
       onRefreshMotor?.();
     } catch (e) {
@@ -96,6 +98,7 @@ export default function TargetsPanel({
   const handleDelete = async (id) => {
     try {
       await deleteConsumptionTarget(id);
+      clearApiCache();
       load();
       onRefreshMotor?.();
     } catch (e) {

--- a/frontend/src/services/api/core.js
+++ b/frontend/src/services/api/core.js
@@ -18,7 +18,7 @@ const api = axios.create({
 // Eliminates duplicate concurrent GET requests (React StrictMode double-mount)
 // and caches responses for a short TTL (tab switching in Expert mode).
 const _getCache = new Map();
-const GET_CACHE_TTL_MS = 5000; // 5 seconds
+const GET_CACHE_TTL_MS = 60_000; // 60 seconds — historical consumption data changes rarely
 
 function _cacheKey(url, params) {
   if (!params || Object.keys(params).length === 0) return url;


### PR DESCRIPTION
## Summary

- **Root cause**: `_percentile()` re-sorted bucket data 5× per slot (240 redundant sorts for 90-day tunnel), `_classify_period()` iterated all TOU windows per reading instead of using a lookup table, and frontend cache TTL of 5s forced constant API re-fetches on filter changes.
- **Fix**: Pre-sort buckets once before computing all 5 percentiles; pre-compute a 7×24 HP/HC period lookup table for O(1) classification per reading; increase frontend cache TTL to 60s for historical data; add `clearApiCache()` in TargetsPanel after create/delete mutations.

## Files changed

| File | Change |
|------|--------|
| `backend/services/tunnel_service.py` | Pre-sort bucket data once, pass sorted list to `_percentile()` instead of re-sorting 5× per bucket |
| `backend/services/tou_service.py` | Pre-compute 7×24 period lookup table in `compute_hphc_breakdown_v2()` and `compute_hp_hc_ratio()` |
| `frontend/src/services/api/core.js` | Increase `GET_CACHE_TTL_MS` from 5s to 60s |
| `frontend/src/pages/consumption/TargetsPanel.jsx` | Add `clearApiCache()` before `load()` after create/delete mutations |

## Blast-radius review

- Reviewed all callers of `_percentile()`, `_classify_period()`, `compute_hp_hc_ratio()`, `compute_hphc_breakdown_v2()`, and `cachedGet()`
- Fixed 1 HIGH finding: `TargetsPanel.jsx` mutations didn't clear cache (stale data with 60s TTL)
- 2 MEDIUM pre-existing findings out of scope: `cachedGet()` ignores custom TTL 3rd param in `actions.js`, test mock uses hardcoded 5s TTL

## Test plan

**Automated tests**
```bash
cd promeos-poc && ./backend/venv/bin/pytest backend/tests/ -x -v -k "tunnel or tou"
cd promeos-poc/frontend && npx vitest run src/services/__tests__/api.test.js
```

**Steps to reproduce the bug**
1. Open Consommations / Explorer for a site with 90-day data
2. Observe KPI load time (2-5s)
3. Toggle energy/period filters rapidly — observe repeated slow loads

**Steps to verify the fix**
1. Open Consommations / Explorer — KPIs should load noticeably faster
2. Toggle filters — second load within 60s should be near-instant (cached)
3. In TargetsPanel, create then delete a target — data should refresh immediately (no stale cache)

Closes #126