### PR TITLE
fix(tunnel): pass granularity=hourly to resolve_best_freq (#140)

### DIFF
--- a/backend/services/tunnel_service.py
+++ b/backend/services/tunnel_service.py
@@ -75,7 +75,7 @@ def compute_tunnel(
     if not meter_ids:
         return _empty_tunnel(site_id, energy_type, days)
 
-    best = resolve_best_freq(db, meter_ids, start_date, end_date)
+    best = resolve_best_freq(db, meter_ids, start_date, end_date, granularity="hourly")
 
     # Fetch readings
     readings = (
@@ -212,7 +212,7 @@ def compute_tunnel_v2(
     if not meter_ids:
         return _empty_tunnel_v2(site_id, energy_type, days, mode, unit)
 
-    best = resolve_best_freq(db, meter_ids, start_date, end_date)
+    best = resolve_best_freq(db, meter_ids, start_date, end_date, granularity="hourly")
 
     readings = (
         db.query(MeterReading)


### PR DESCRIPTION
## Summary

- **Root cause**: `compute_tunnel()` and `compute_tunnel_v2()` called `resolve_best_freq()` without specifying `granularity`, defaulting to `"daily"`. This allowed DAILY frequency readings to be selected, collapsing all data into hour 0 and breaking the hourly envelope grouping.
- **Fix**: Pass `granularity="hourly"` explicitly in both calls, restricting frequency selection to MIN_15, MIN_30, and HOURLY.

## Affected KPIs

| KPI | Before fix | After fix |
|-----|-----------|-----------|
| Ratio Conso. Nuit | "—" (null — dayAvg=0 → division error) | Correct night/day percentage |
| Pic kW (P95/P90) | Wrong value (~24x inflated) | Correct hourly peak |
| Confidence | Artificially low | Reflects actual hourly data density |

## Files changed

| File | Change |
|------|--------|
| `backend/services/tunnel_service.py` | Added `granularity="hourly"` to both `resolve_best_freq` calls (lines 78, 215) |

## Blast-radius review

- Reviewed 13 other `resolve_best_freq` callers across the codebase — all SAFE (use default `"daily"` or explicit granularity)
- No follow-up issues needed

## Test plan

**Automated tests**
```bash
cd backend && pytest tests/ -k tunnel -x -v
```

**Steps to reproduce the bug**
1. Open Consommation > Explorer for any site
2. Observe "Ratio Conso. Nuit" KPI shows "—"
3. Observe "Pic kW" shows an inflated value

**Steps to verify the fix**
1. Open Consommation > Explorer for any site with hourly meter data
2. "Ratio Conso. Nuit" displays a percentage with color coding (green/amber/red)
3. "Pic kW" shows a realistic hourly peak value

Closes #140