### PR TITLE
fix(enedis): add try/except around DB storage in pipeline (#149)

### DIFF
--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -118,52 +118,59 @@ def ingest_file(
         session.commit()
         return FluxStatus.ERROR
 
-    # Store file record
-    flux_file = EnedisFluxFile(
-        filename=filename,
-        file_hash=file_hash,
-        flux_type=flux_type.value,
-        status=FluxStatus.PARSED,
-        frequence_publication=parsed.header.frequence_publication,
-        nature_courbe_demandee=parsed.header.nature_courbe_demandee,
-        identifiant_destinataire=parsed.header.identifiant_destinataire,
-    )
-    flux_file.set_header_raw(parsed.header.raw)
-    session.add(flux_file)
-    session.flush()  # Get flux_file.id
+    # Store file record + mesures
+    try:
+        flux_file = EnedisFluxFile(
+            filename=filename,
+            file_hash=file_hash,
+            flux_type=flux_type.value,
+            status=FluxStatus.PARSED,
+            frequence_publication=parsed.header.frequence_publication,
+            nature_courbe_demandee=parsed.header.nature_courbe_demandee,
+            identifiant_destinataire=parsed.header.identifiant_destinataire,
+        )
+        flux_file.set_header_raw(parsed.header.raw)
+        session.add(flux_file)
+        session.flush()  # Get flux_file.id
 
-    # Store mesures in batches
-    total_inserted = 0
-    batch = []
-    for courbe in parsed.courbes:
-        for point in courbe.points:
-            batch.append(
-                EnedisFluxMesure(
-                    flux_file_id=flux_file.id,
-                    flux_type=flux_type.value,
-                    point_id=parsed.point_id,
-                    grandeur_physique=courbe.grandeur_physique,
-                    grandeur_metier=courbe.grandeur_metier,
-                    unite_mesure=courbe.unite_mesure,
-                    granularite=courbe.granularite,
-                    horodatage_debut=courbe.horodatage_debut,
-                    horodatage_fin=courbe.horodatage_fin,
-                    horodatage=point.horodatage,
-                    valeur_point=point.valeur_point,
-                    statut_point=point.statut_point,
+        # Store mesures in batches
+        total_inserted = 0
+        batch = []
+        for courbe in parsed.courbes:
+            for point in courbe.points:
+                batch.append(
+                    EnedisFluxMesure(
+                        flux_file_id=flux_file.id,
+                        flux_type=flux_type.value,
+                        point_id=parsed.point_id,
+                        grandeur_physique=courbe.grandeur_physique,
+                        grandeur_metier=courbe.grandeur_metier,
+                        unite_mesure=courbe.unite_mesure,
+                        granularite=courbe.granularite,
+                        horodatage_debut=courbe.horodatage_debut,
+                        horodatage_fin=courbe.horodatage_fin,
+                        horodatage=point.horodatage,
+                        valeur_point=point.valeur_point,
+                        statut_point=point.statut_point,
+                    )
                 )
-            )
-            if len(batch) >= chunk_size:
-                session.bulk_save_objects(batch)
-                total_inserted += len(batch)
-                batch = []
+                if len(batch) >= chunk_size:
+                    session.bulk_save_objects(batch)
+                    total_inserted += len(batch)
+                    batch = []
 
-    if batch:
-        session.bulk_save_objects(batch)
-        total_inserted += len(batch)
+        if batch:
+            session.bulk_save_objects(batch)
+            total_inserted += len(batch)
 
-    flux_file.measures_count = total_inserted
-    session.commit()
+        flux_file.measures_count = total_inserted
+        session.commit()
+    except Exception as exc:
+        session.rollback()
+        logger.error("DB storage failed for %s: %s", filename, exc)
+        _record_file(session, filename, file_hash, flux_type.value, FluxStatus.ERROR, str(exc))
+        session.commit()
+        return FluxStatus.ERROR
 
     logger.info(
         "Ingested %s: %d mesures from PRM %s [%s]",

--- a/backend/data_ingestion/enedis/tests/test_pipeline.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline.py
@@ -265,6 +265,22 @@ class TestIngestErrors:
         with pytest.raises(FileNotFoundError):
             ingest_file(Path("/nonexistent/file.zip"), db, test_keys)
 
+    def test_db_storage_error_records_error_and_returns(self, db, r4h_encrypted_file, test_keys):
+        """DB error during storage → rollback, record error, return ERROR."""
+        from unittest.mock import patch
+
+        with patch.object(db, "bulk_save_objects", side_effect=Exception("disk full")):
+            status = ingest_file(r4h_encrypted_file, db, test_keys)
+
+        assert status == FluxStatus.ERROR
+
+        f = db.query(EnedisFluxFile).first()
+        assert f is not None
+        assert f.status == FluxStatus.ERROR
+        assert "disk full" in f.error_message
+        assert f.measures_count == 0
+        assert db.query(EnedisFluxMesure).count() == 0
+
     def test_zero_mesures_is_parsed_not_error(self, db, tmp_path, test_keys):
         """Valid XML with 0 points → status=parsed, measures_count=0."""
         xml = b"""\

--- a/docs/specs/feature-enedis-implementation-review.md
+++ b/docs/specs/feature-enedis-implementation-review.md
@@ -26,7 +26,8 @@ Si `session.flush()` (ligne 133) ou `session.bulk_save_objects()` (ligne 157) le
 La session est laissee dans un etat dirty. Le caller doit gerer lui-meme, ce qui contredit le contrat documente ("rolls back on unhandled error").
 
 **Fix propose** : wrapper le bloc store dans un try/except qui fait rollback + enregistre le fichier en erreur.
-**Décision Utilisateur** : Fix convenable qui apporte de la sécurité. A implémenter. 
+**Décision Utilisateur** : Fix convenable qui apporte de la sécurité. A implémenter.
+**Statut** : Resolu — PR fix/issue-149-db-storage-try-except (#149).
 
 ---
 
@@ -166,7 +167,7 @@ Si SF3 ajoute de nouvelles colonnes aux tables existantes, `_create_enedis_table
 
 | # | Type | Sujet | Severite | Action |
 |---|------|-------|----------|--------|
-| 1 | Bug | Pas de try/except autour du stockage DB | **Haute** | Fix necessaire — **#149** |
+| 1 | Bug | Pas de try/except autour du stockage DB | **Haute** | ~~Fix necessaire~~ Resolu — **#149** |
 | 2 | Bug | Index duplique sur `flux_file_id` | Basse | Fix simple — **#150** |
 | 3 | Edge case | Concurrence sur idempotence | Basse (POC) | A traiter si parallelisme — **#152** |
 | 4 | Edge case | `_hash_file` lit tout en memoire | Basse (POC) | Note pour production — **#153** |


### PR DESCRIPTION
## Summary

- **Root cause**: the DB storage phase (flush, bulk_save_objects, commit) in `ingest_file()` had no error handling — any DB exception would crash the pipeline without rollback or error recording, violating the documented contract ("rolls back on unhandled error")
- **Fix**: wrapped the storage block in try/except that rolls back, records the file as error via `_record_file()`, commits, and returns `FluxStatus.ERROR` — matching the existing pattern used for decrypt/parse errors

## Files changed

| File | Change |
|------|--------|
| `backend/data_ingestion/enedis/pipeline.py` | Wrapped DB storage block (lines 121-166) in try/except with rollback + error recording |
| `backend/data_ingestion/enedis/tests/test_pipeline.py` | Added `test_db_storage_error_records_error_and_returns` — mocks `bulk_save_objects` to verify rollback + error status |
| `docs/specs/feature-enedis-implementation-review.md` | Marked point #1 as resolved |

## Test plan

**Automated tests**
```bash
cd promeos-poc && ./backend/venv/bin/pytest backend/data_ingestion/enedis/tests/test_pipeline.py backend/tests/test_integration_pipeline.py -v
```

**Steps to reproduce the bug**
1. Call `ingest_file()` with a valid encrypted file
2. Simulate a DB error during `session.flush()` or `session.bulk_save_objects()` (e.g., disk full, constraint violation)
3. Observe: pipeline crashes, no rollback, no error record, session left dirty

**Steps to verify the fix**
1. Run the new test `test_db_storage_error_records_error_and_returns` — passes
2. Verify the file is recorded with `status=error` and the exception message in `error_message`
3. Verify no partial mesures are committed (rollback cleans up)
4. All 23 pre-existing tests still pass (11 unit + 12 integration)

Part of #149