### PR TITLE
fix(enedis): remove duplicate index on flux_file_id (#150)

### DIFF
--- a/backend/data_ingestion/enedis/models.py
+++ b/backend/data_ingestion/enedis/models.py
@@ -93,7 +93,6 @@ class EnedisFluxMesure(Base, TimestampMixin):
         Integer,
         ForeignKey("enedis_flux_file.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
         comment="FK vers enedis_flux_file",
     )
     flux_type = Column(String(10), nullable=False, comment="R4H/R4M/R4Q — dénormalisé pour les requêtes")


### PR DESCRIPTION
## Summary

- **Root cause**: `flux_file_id` in `EnedisFluxMesure` had both `index=True` on the column definition and a named `Index("ix_enedis_mesure_flux_file", "flux_file_id")` in `__table_args__`, creating two identical B-tree indexes.
- **Fix**: Removed `index=True` from the column, keeping the named index for consistency with other indexes in the model.

## Files changed

| File | Change |
|------|--------|
| `backend/data_ingestion/enedis/models.py` | Removed redundant `index=True` from `flux_file_id` column (line 96) |

## Test plan

**Automated tests**
```bash
cd backend && ./venv/bin/python -c "from data_ingestion.enedis.models import EnedisFluxMesure; t = EnedisFluxMesure.__table__; assert sum(1 for i in t.indexes if 'flux_file_id' in [c.name for c in i.columns]) == 1; print('OK')"
```

**Steps to verify the fix**
1. Import `EnedisFluxMesure` and inspect `__table__.indexes`
2. Confirm only one index covers `flux_file_id` (`ix_enedis_mesure_flux_file`)
3. Confirm no implicit auto-generated index on `flux_file_id`

Part of #150