### PR TITLE
fix(pipeline): add early file existence check with clear error message (#151)

### DIFF
--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -67,6 +67,9 @@ def ingest_file(
         FileNotFoundError: file_path does not exist.
         MissingKeyError: no decryption keys available (from decrypt module).
     """
+    if not file_path.exists():
+        raise FileNotFoundError(f"Flux file not found: {file_path}")
+
     filename = file_path.name
     flux_type = classify_flux(filename)
 

--- a/backend/data_ingestion/enedis/tests/test_pipeline.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline.py
@@ -262,7 +262,7 @@ class TestIngestErrors:
     def test_file_not_found_raises(self, db, tmp_path, test_keys):
         from pathlib import Path
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Flux file not found"):
             ingest_file(Path("/nonexistent/file.zip"), db, test_keys)
 
     def test_db_storage_error_records_error_and_returns(self, db, r4h_encrypted_file, test_keys):

--- a/docs/specs/feature-enedis-implementation-review.md
+++ b/docs/specs/feature-enedis-implementation-review.md
@@ -74,6 +74,7 @@ La contrainte `unique=True` protege contre les doublons, mais l'exception n'est 
 `_hash_file(file_path)` est appele **avant** `decrypt_file()`. Si le fichier n'existe pas, l'erreur vient de `Path.read_bytes()` (message generique) plutot que du message custom de `decrypt_file` ("File not found: ..."). Mineur.
 
 **Décision Utilisateur** : La clarté dans le traitement et les causes d'erreurs est essentielle. Ouvrir une issue github et faire le fix.
+**Statut** : Résolu — PR fix/issue-151-filenotfounderror-message (#151).
 
 
 ---
@@ -172,7 +173,7 @@ Si SF3 ajoute de nouvelles colonnes aux tables existantes, `_create_enedis_table
 | 2 | Bug | Index duplique sur `flux_file_id` | Basse | ~~Fix simple~~ Résolu — **#150** |
 | 3 | Edge case | Concurrence sur idempotence | Basse (POC) | A traiter si parallelisme — **#152** |
 | 4 | Edge case | `_hash_file` lit tout en memoire | Basse (POC) | Note pour production — **#153** |
-| 5 | Edge case | `FileNotFoundError` message peu clair | Basse | Amelioration mineure — **#151** |
+| 5 | Edge case | `FileNotFoundError` message peu clair | Basse | ~~Amelioration mineure~~ Résolu — **#151** |
 | 6 | Cleanup | Enum `RECEIVED` inutilise | Basse | Conserver, implémenter en SF3 — **#154** |
 | 7 | Cleanup | Docstring `EnedisFluxMesure` restrictive | Basse | Résolu par tables dédiées — **#155** |
 | 8 | Decision | Pas de contrainte unique mesures | -- | Versioning republications avant SF3 — **#156** |


### PR DESCRIPTION
## Summary

- **Root cause**: `_hash_file()` is called before `decrypt_file()` in `ingest_file()`, so a missing file raises a generic `read_bytes()` FileNotFoundError instead of a clear pipeline-context message.
- **Fix**: Added a guard clause at the top of `ingest_file()` that checks `file_path.exists()` and raises `FileNotFoundError("Flux file not found: {file_path}")` before any processing begins.

## Files changed

| File | Change |
|------|--------|
| `backend/data_ingestion/enedis/pipeline.py` | Added early existence check with explicit error message |
| `docs/specs/feature-enedis-implementation-review.md` | Marked item #5 as resolved |

## Test plan

**Automated tests**
```bash
cd backend && pytest tests/test_integration_pipeline.py -v
```
12/12 tests pass.

**Steps to verify the fix**
1. Call `ingest_file(Path("/nonexistent/file.zip"), session, keys)`
2. Verify the error message is `"Flux file not found: /nonexistent/file.zip"` (not a generic `read_bytes()` traceback)

Part of #151