### PR TITLE
fix(migration): add _add_enedis_columns for future schema evolution (#158)

### DIFF
--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -84,6 +84,7 @@ def run_migrations(engine):
     _migrate_operat_export_manifest(engine)
     # Enedis SGE — CDC staging tables
     _create_enedis_tables(engine)
+    _add_enedis_columns(engine)
 
 
 def _add_soft_delete_columns(engine):
@@ -1640,3 +1641,54 @@ def _create_enedis_tables(engine):
         ],
     )
     logger.info("migration: created Enedis SGE staging tables")
+
+
+def _add_enedis_columns(engine):
+    """Add columns to existing Enedis tables that may have been created before schema evolution.
+
+    Follows the same pattern as _add_soft_delete_columns, _add_site_geocoding_columns, etc.
+    When new columns are added to EnedisFluxFile or EnedisFluxMesure models,
+    add them to the relevant list below so existing DBs receive them via ALTER TABLE.
+    """
+    insp = inspect(engine)
+
+    # --- enedis_flux_file columns ---
+    # Add new columns here as (col_name, col_type) when evolving the model.
+    enedis_flux_file_columns = [
+        # Example for future SF3+:
+        # ("new_column_name", "VARCHAR(100)"),
+    ]
+
+    # --- enedis_flux_mesure columns ---
+    enedis_flux_mesure_columns = [
+        # Example for future SF3+:
+        # ("new_column_name", "VARCHAR(50)"),
+    ]
+
+    table_column_map = {
+        "enedis_flux_file": enedis_flux_file_columns,
+        "enedis_flux_mesure": enedis_flux_mesure_columns,
+    }
+
+    added = 0
+    with engine.begin() as conn:
+        for table_name, columns in table_column_map.items():
+            if not insp.has_table(table_name) or not columns:
+                continue
+
+            existing_cols = {c["name"] for c in insp.get_columns(table_name)}
+
+            for col_name, col_type in columns:
+                if col_name in existing_cols:
+                    continue
+                try:
+                    conn.execute(text(f'ALTER TABLE "{table_name}" ADD COLUMN "{col_name}" {col_type}'))
+                    added += 1
+                    logger.info("migration: added %s.%s (%s)", table_name, col_name, col_type)
+                except Exception as e:
+                    logger.warning("migration: could not add %s.%s: %s", table_name, col_name, e)
+
+    if added > 0:
+        logger.info("migration: added %d Enedis column(s)", added)
+    else:
+        logger.debug("migration: Enedis columns already present — no changes")

--- a/docs/specs/feature-enedis-implementation-review.md
+++ b/docs/specs/feature-enedis-implementation-review.md
@@ -151,6 +151,7 @@ Les PRM francais font toujours 14 chiffres. Mais est-ce que R50/R151 utilisent b
 
 Si SF3 ajoute de nouvelles colonnes aux tables existantes, `_create_enedis_tables` fait `has_table()` -> `return` (skip). Il faudra une logique de migration complementaire (comme les `_add_*_columns` patterns existants dans `migrations.py`).
 **Décision Utilisateur** : Ceci doit être régle en code ou en processus lors de l'implémentation de nouvelles colonnes?
+**Statut** : Résolu — PR fix/issue-158-enedis-alter-table-columns (#162). Ajout de `_add_enedis_columns()` suivant le pattern existant, appelée dans `run_migrations()` après `_create_enedis_tables()`. Listes de colonnes vides aujourd'hui — scaffold prêt pour SF3+.
 
 ---
 
@@ -181,4 +182,4 @@ Si SF3 ajoute de nouvelles colonnes aux tables existantes, `_create_enedis_table
 | 10 | Decision | Colonnes R4x-specifiques sur mesures | -- | Tables dédiées par flux — **#155** |
 | 11 | Decision | `point_id` String(14) suffisant ? | -- | Point d'attention — **#157** |
 | 12 | Decision | Colonnes header R4x-specifiques | -- | Résolu par tables dédiées — **#155** |
-| 13 | Decision | Migration ne gere pas ALTER TABLE | -- | A traiter dans SF3 — **#158** |
+| 13 | Decision | Migration ne gere pas ALTER TABLE | -- | ~~A traiter dans SF3~~ Résolu — **#158** |


### PR DESCRIPTION
## Summary

- **Root cause**: `_create_enedis_tables()` returned early if tables existed, with no column-level inspection — future schema additions would never reach existing databases.
- **Fix**: Added `_add_enedis_columns()` following the established `_add_*_columns` pattern (inspect existing columns, ALTER TABLE ADD COLUMN for missing ones). Called after `_create_enedis_tables()` in `run_migrations()`. Column lists are empty today — they serve as the scaffold for SF3+ schema evolution.

## Files changed

| File | Change |
|------|--------|
| `backend/database/migrations.py` | Added `_add_enedis_columns()` function + registered in `run_migrations()` |

## Test plan

**Automated tests**
```bash
cd promeos-poc && ./backend/venv/bin/pytest backend/tests/ -v -k "enedis or migrat or delivery_point"
```

**Steps to verify the fix**
1. Confirm `_add_enedis_columns` is called in `run_migrations()` after `_create_enedis_tables()`
2. Confirm the function follows the same pattern as `_add_site_geocoding_columns` (line 1128)
3. When SF3 adds new columns to `EnedisFluxFile` or `EnedisFluxMesure`, add them to the column lists — existing DBs will receive them via ALTER TABLE

Part of #158