### PR TITLE
fix(enedis): rename enedis_flux_mesure → enedis_flux_mesure_r4x (#155)

### DIFF
--- a/backend/data_ingestion/enedis/models.py
+++ b/backend/data_ingestion/enedis/models.py
@@ -4,7 +4,7 @@ Raw archive layer: store every byte Enedis sends, without transformation.
 
 Tables:
   enedis_flux_file   — one row per ingested file (registry + raw header)
-  enedis_flux_mesure — one row per Donnees_Point_Mesure (fully denormalized)
+  enedis_flux_mesure_r4x — one row per Donnees_Point_Mesure (fully denormalized)
 
 Design decisions:
   - Uses the shared Base (models.base.Base) so tables are created in promeos.db
@@ -55,7 +55,7 @@ class EnedisFluxFile(Base, TimestampMixin):
     # Full raw header as JSON for complete fidelity
     header_raw = Column(Text, nullable=True, comment="Entete XML complet en JSON")
 
-    mesures = relationship("EnedisFluxMesure", back_populates="flux_file", cascade="all, delete-orphan")
+    mesures = relationship("EnedisFluxMesureR4x", back_populates="flux_file", cascade="all, delete-orphan")
 
     def set_header_raw(self, header_dict: dict) -> None:
         self.header_raw = json.dumps(header_dict, ensure_ascii=False)
@@ -69,7 +69,7 @@ class EnedisFluxFile(Base, TimestampMixin):
         return f"<EnedisFluxFile {self.filename} [{self.flux_type}] {self.status}>"
 
 
-class EnedisFluxMesure(Base, TimestampMixin):
+class EnedisFluxMesureR4x(Base, TimestampMixin):
     """Raw measurement point from an Enedis R4x CDC flux.
 
     Fully denormalized: each row carries its Donnees_Courbe context
@@ -80,12 +80,12 @@ class EnedisFluxMesure(Base, TimestampMixin):
     deferred to a future staging layer.
     """
 
-    __tablename__ = "enedis_flux_mesure"
+    __tablename__ = "enedis_flux_mesure_r4x"
     __table_args__ = (
         # Performance indexes (not unique — raw archive)
-        Index("ix_enedis_mesure_point_horodatage", "point_id", "horodatage"),
-        Index("ix_enedis_mesure_flux_file", "flux_file_id"),
-        Index("ix_enedis_mesure_flux_type", "flux_type"),
+        Index("ix_enedis_mesure_r4x_point_horodatage", "point_id", "horodatage"),
+        Index("ix_enedis_mesure_r4x_flux_file", "flux_file_id"),
+        Index("ix_enedis_mesure_r4x_flux_type", "flux_type"),
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -116,4 +116,4 @@ class EnedisFluxMesure(Base, TimestampMixin):
     flux_file = relationship("EnedisFluxFile", back_populates="mesures")
 
     def __repr__(self) -> str:
-        return f"<EnedisFluxMesure {self.point_id} {self.horodatage} {self.valeur_point}>"
+        return f"<EnedisFluxMesureR4x {self.point_id} {self.horodatage} {self.valeur_point}>"

--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -31,7 +31,7 @@ from data_ingestion.enedis.decrypt import (
     decrypt_file,
 )
 from data_ingestion.enedis.enums import FluxStatus, FluxType
-from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesure
+from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesureR4x
 from data_ingestion.enedis.parsers.r4 import R4xParseError, parse_r4x
 
 logger = logging.getLogger("promeos.enedis.pipeline")
@@ -142,7 +142,7 @@ def ingest_file(
         for courbe in parsed.courbes:
             for point in courbe.points:
                 batch.append(
-                    EnedisFluxMesure(
+                    EnedisFluxMesureR4x(
                         flux_file_id=flux_file.id,
                         flux_type=flux_type.value,
                         point_id=parsed.point_id,

--- a/backend/data_ingestion/enedis/tests/test_models.py
+++ b/backend/data_ingestion/enedis/tests/test_models.py
@@ -3,7 +3,7 @@
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesure
+from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesureR4x
 
 
 # ---------------------------------------------------------------------------
@@ -84,11 +84,11 @@ class TestEnedisFluxFile:
 
 
 # ---------------------------------------------------------------------------
-# EnedisFluxMesure
+# EnedisFluxMesureR4x
 # ---------------------------------------------------------------------------
 
 
-class TestEnedisFluxMesure:
+class TestEnedisFluxMesureR4x:
     def _make_file(self, db, file_hash="h1"):
         f = EnedisFluxFile(filename="a.zip", file_hash=file_hash, flux_type="R4H", status="parsed")
         db.add(f)
@@ -97,7 +97,7 @@ class TestEnedisFluxMesure:
 
     def test_create_mesure(self, db):
         f = self._make_file(db)
-        m = EnedisFluxMesure(
+        m = EnedisFluxMesureR4x(
             flux_file_id=f.id,
             flux_type="R4H",
             point_id="30000210411333",
@@ -114,7 +114,7 @@ class TestEnedisFluxMesure:
         db.add(m)
         db.commit()
 
-        result = db.query(EnedisFluxMesure).first()
+        result = db.query(EnedisFluxMesureR4x).first()
         assert result.point_id == "30000210411333"
         assert result.valeur_point == "398"
         assert result.statut_point == "R"
@@ -124,7 +124,7 @@ class TestEnedisFluxMesure:
     def test_duplicate_mesures_allowed(self, db):
         """No unique constraint on mesures — raw archive allows duplicates."""
         f = self._make_file(db)
-        m1 = EnedisFluxMesure(
+        m1 = EnedisFluxMesureR4x(
             flux_file_id=f.id,
             flux_type="R4H",
             point_id="30000210411333",
@@ -132,7 +132,7 @@ class TestEnedisFluxMesure:
             valeur_point="398",
             statut_point="R",
         )
-        m2 = EnedisFluxMesure(
+        m2 = EnedisFluxMesureR4x(
             flux_file_id=f.id,
             flux_type="R4H",
             point_id="30000210411333",
@@ -142,13 +142,13 @@ class TestEnedisFluxMesure:
         )
         db.add_all([m1, m2])
         db.commit()
-        assert db.query(EnedisFluxMesure).count() == 2
+        assert db.query(EnedisFluxMesureR4x).count() == 2
 
     def test_mesure_from_different_files_coexist(self, db):
         """Same PRM/timestamp from different files are both stored."""
         f1 = self._make_file(db, file_hash="h1")
         f2 = self._make_file(db, file_hash="h2")
-        m1 = EnedisFluxMesure(
+        m1 = EnedisFluxMesureR4x(
             flux_file_id=f1.id,
             flux_type="R4H",
             point_id="30000210411333",
@@ -156,7 +156,7 @@ class TestEnedisFluxMesure:
             valeur_point="398",
             statut_point="R",
         )
-        m2 = EnedisFluxMesure(
+        m2 = EnedisFluxMesureR4x(
             flux_file_id=f2.id,
             flux_type="R4H",
             point_id="30000210411333",
@@ -166,11 +166,11 @@ class TestEnedisFluxMesure:
         )
         db.add_all([m1, m2])
         db.commit()
-        assert db.query(EnedisFluxMesure).count() == 2
+        assert db.query(EnedisFluxMesureR4x).count() == 2
 
     def test_null_valeur_point_allowed(self, db):
         f = self._make_file(db)
-        m = EnedisFluxMesure(
+        m = EnedisFluxMesureR4x(
             flux_file_id=f.id,
             flux_type="R4H",
             point_id="30000210411333",
@@ -180,13 +180,13 @@ class TestEnedisFluxMesure:
         )
         db.add(m)
         db.commit()
-        result = db.query(EnedisFluxMesure).first()
+        result = db.query(EnedisFluxMesureR4x).first()
         assert result.valeur_point is None
         assert result.statut_point is None
 
     def test_cascade_delete_with_file(self, db):
         f = self._make_file(db)
-        m = EnedisFluxMesure(
+        m = EnedisFluxMesureR4x(
             flux_file_id=f.id,
             flux_type="R4H",
             point_id="30000210411333",
@@ -195,17 +195,17 @@ class TestEnedisFluxMesure:
         )
         db.add(m)
         db.commit()
-        assert db.query(EnedisFluxMesure).count() == 1
+        assert db.query(EnedisFluxMesureR4x).count() == 1
 
         db.delete(f)
         db.commit()
-        assert db.query(EnedisFluxMesure).count() == 0
+        assert db.query(EnedisFluxMesureR4x).count() == 0
 
     def test_relationship_file_to_mesures(self, db):
         f = self._make_file(db)
         db.add_all(
             [
-                EnedisFluxMesure(
+                EnedisFluxMesureR4x(
                     flux_file_id=f.id,
                     flux_type="R4H",
                     point_id="PRM1",

--- a/backend/data_ingestion/enedis/tests/test_pipeline.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 from data_ingestion.enedis.enums import FluxStatus
-from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesure
+from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesureR4x
 from data_ingestion.enedis.pipeline import ingest_file
 
 from .conftest import TEST_IV, TEST_KEY, make_encrypted_zip
@@ -146,7 +146,7 @@ class TestIngestFilePipeline:
         assert f.get_header_raw()["Reference_Demande"] == "189465931"
 
         # Mesures
-        mesures = db.query(EnedisFluxMesure).all()
+        mesures = db.query(EnedisFluxMesureR4x).all()
         assert len(mesures) == 3
         m0 = mesures[0]
         assert m0.point_id == "30000210411333"
@@ -166,7 +166,7 @@ class TestIngestFilePipeline:
         f = db.query(EnedisFluxFile).first()
         assert f.measures_count == 4  # 2 EA + 2 ERI
 
-        mesures = db.query(EnedisFluxMesure).all()
+        mesures = db.query(EnedisFluxMesureR4x).all()
         assert len(mesures) == 4
         gp_values = {m.grandeur_physique for m in mesures}
         assert gp_values == {"EA", "ERI"}
@@ -185,7 +185,7 @@ class TestIngestIdempotence:
         assert status1 == FluxStatus.PARSED
         assert status2 == FluxStatus.PARSED  # returns PARSED (already done)
         assert db.query(EnedisFluxFile).count() == 1
-        assert db.query(EnedisFluxMesure).count() == 3  # not duplicated
+        assert db.query(EnedisFluxMesureR4x).count() == 3  # not duplicated
 
     def test_skipped_file_twice_is_noop(self, db, r172_file, test_keys):
         """Re-submitting a SKIPPED file should not raise IntegrityError."""
@@ -209,7 +209,7 @@ class TestIngestIdempotence:
         ingest_file(f2, db, test_keys)
 
         assert db.query(EnedisFluxFile).count() == 2
-        assert db.query(EnedisFluxMesure).count() == 6  # 3 + 3, both stored
+        assert db.query(EnedisFluxMesureR4x).count() == 6  # 3 + 3, both stored
 
     def test_retry_after_error(self, db, tmp_path, test_keys):
         """A file that previously failed can be retried."""
@@ -279,7 +279,7 @@ class TestIngestErrors:
         assert f.status == FluxStatus.ERROR
         assert "disk full" in f.error_message
         assert f.measures_count == 0
-        assert db.query(EnedisFluxMesure).count() == 0
+        assert db.query(EnedisFluxMesureR4x).count() == 0
 
     def test_zero_mesures_is_parsed_not_error(self, db, tmp_path, test_keys):
         """Valid XML with 0 points → status=parsed, measures_count=0."""

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -83,6 +83,7 @@ def run_migrations(engine):
     # Export manifest — chaine de preuve export
     _migrate_operat_export_manifest(engine)
     # Enedis SGE — CDC staging tables
+    _rename_enedis_mesure_table(engine)
     _create_enedis_tables(engine)
     _add_enedis_columns(engine)
 
@@ -1624,10 +1625,49 @@ def _migrate_bacs_remediation(engine):
         logger.info("migration: created bacs_remediation_actions")
 
 
-def _create_enedis_tables(engine):
-    """Create Enedis SGE staging tables (enedis_flux_file, enedis_flux_mesure) if missing."""
+def _rename_enedis_mesure_table(engine):
+    """Rename enedis_flux_mesure → enedis_flux_mesure_r4x for existing DBs.
+
+    Also drops old indexes and recreates them with r4x-qualified names.
+    Idempotent: skips if old table does not exist or new table already exists.
+    """
     insp = inspect(engine)
-    if insp.has_table("enedis_flux_file") and insp.has_table("enedis_flux_mesure"):
+    if not insp.has_table("enedis_flux_mesure"):
+        return
+    if insp.has_table("enedis_flux_mesure_r4x"):
+        return
+
+    with engine.begin() as conn:
+        conn.execute(text('ALTER TABLE "enedis_flux_mesure" RENAME TO "enedis_flux_mesure_r4x"'))
+        # Drop old indexes (SQLite doesn't support RENAME INDEX)
+        conn.execute(text('DROP INDEX IF EXISTS "ix_enedis_mesure_point_horodatage"'))
+        conn.execute(text('DROP INDEX IF EXISTS "ix_enedis_mesure_flux_file"'))
+        conn.execute(text('DROP INDEX IF EXISTS "ix_enedis_mesure_flux_type"'))
+        # Recreate with r4x-qualified names
+        conn.execute(
+            text(
+                'CREATE INDEX IF NOT EXISTS "ix_enedis_mesure_r4x_point_horodatage"'
+                ' ON "enedis_flux_mesure_r4x" ("point_id", "horodatage")'
+            )
+        )
+        conn.execute(
+            text(
+                'CREATE INDEX IF NOT EXISTS "ix_enedis_mesure_r4x_flux_file"'
+                ' ON "enedis_flux_mesure_r4x" ("flux_file_id")'
+            )
+        )
+        conn.execute(
+            text(
+                'CREATE INDEX IF NOT EXISTS "ix_enedis_mesure_r4x_flux_type" ON "enedis_flux_mesure_r4x" ("flux_type")'
+            )
+        )
+    logger.info("migration: renamed enedis_flux_mesure → enedis_flux_mesure_r4x")
+
+
+def _create_enedis_tables(engine):
+    """Create Enedis SGE staging tables (enedis_flux_file, enedis_flux_mesure_r4x) if missing."""
+    insp = inspect(engine)
+    if insp.has_table("enedis_flux_file") and insp.has_table("enedis_flux_mesure_r4x"):
         return
 
     # Import models to register them with Base.metadata
@@ -1637,7 +1677,7 @@ def _create_enedis_tables(engine):
     Base.metadata.create_all(
         bind=engine,
         tables=[
-            Base.metadata.tables[t] for t in ("enedis_flux_file", "enedis_flux_mesure") if t in Base.metadata.tables
+            Base.metadata.tables[t] for t in ("enedis_flux_file", "enedis_flux_mesure_r4x") if t in Base.metadata.tables
         ],
     )
     logger.info("migration: created Enedis SGE staging tables")
@@ -1647,7 +1687,7 @@ def _add_enedis_columns(engine):
     """Add columns to existing Enedis tables that may have been created before schema evolution.
 
     Follows the same pattern as _add_soft_delete_columns, _add_site_geocoding_columns, etc.
-    When new columns are added to EnedisFluxFile or EnedisFluxMesure models,
+    When new columns are added to EnedisFluxFile or EnedisFluxMesureR4x models,
     add them to the relevant list below so existing DBs receive them via ALTER TABLE.
     """
     insp = inspect(engine)
@@ -1659,15 +1699,15 @@ def _add_enedis_columns(engine):
         # ("new_column_name", "VARCHAR(100)"),
     ]
 
-    # --- enedis_flux_mesure columns ---
-    enedis_flux_mesure_columns = [
+    # --- enedis_flux_mesure_r4x columns ---
+    enedis_flux_mesure_r4x_columns = [
         # Example for future SF3+:
         # ("new_column_name", "VARCHAR(50)"),
     ]
 
     table_column_map = {
         "enedis_flux_file": enedis_flux_file_columns,
-        "enedis_flux_mesure": enedis_flux_mesure_columns,
+        "enedis_flux_mesure_r4x": enedis_flux_mesure_r4x_columns,
     }
 
     added = 0


### PR DESCRIPTION
## Summary
- Rename `EnedisFluxMesure` class → `EnedisFluxMesureR4x` and table `enedis_flux_mesure` → `enedis_flux_mesure_r4x` to explicitly identify R4x-specific measurements
- Rename 3 indexes with `r4x`-qualified names (`ix_enedis_mesure_r4x_*`)
- Add `_rename_enedis_mesure_table()` migration for existing DBs (ALTER TABLE RENAME + drop/recreate indexes)
- Update all references in pipeline, tests, and migrations

Closes #155

## Test plan
- [x] 76/76 Enedis tests pass
- [x] Fresh DB creates `enedis_flux_mesure_r4x` (no old table)
- [x] Rename migration correctly upgrades existing DBs (table + indexes)
- [x] Full backend test suite (`pytest backend/tests/ -x -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)