### PR TITLE
feat(enedis): detect and version republished flux files (#156)

### DIFF
--- a/backend/data_ingestion/enedis/enums.py
+++ b/backend/data_ingestion/enedis/enums.py
@@ -28,3 +28,4 @@ class FluxStatus(str, Enum):
     PARSED = "parsed"
     ERROR = "error"
     SKIPPED = "skipped"
+    NEEDS_REVIEW = "needs_review"

--- a/backend/data_ingestion/enedis/models.py
+++ b/backend/data_ingestion/enedis/models.py
@@ -13,8 +13,12 @@ Design decisions:
   - No unique constraint on mesure rows: Enedis may republish corrections for the
     same PRM/timestamp. Both versions are archived; deduplication is deferred to a
     future staging/normalization layer.
-  - File-level idempotence only: file_hash (SHA256 of ciphertext) prevents
+  - File-level idempotence: file_hash (SHA256 of ciphertext) prevents
     re-processing the exact same physical file.
+  - Republication detection: if a new file shares the filename of an already-parsed
+    file (but has a different hash), it is ingested as a versioned republication
+    (version 2+, supersedes_file_id → previous file) with status needs_review.
+    Both original and republication data are preserved for data manager analysis.
   - All values stored as raw strings from the XML (no float conversion, no UTC
     normalization) to guarantee zero data loss or transformation.
 """
@@ -46,6 +50,15 @@ class EnedisFluxFile(Base, TimestampMixin):
     status = Column(String(20), nullable=False, default="received", comment="received/parsed/error/skipped")
     error_message = Column(Text, nullable=True, comment="Message d'erreur si status=error")
     measures_count = Column(Integer, nullable=True, default=0, comment="Nombre de mesures extraites")
+
+    # Republication versioning
+    version = Column(Integer, nullable=False, default=1, comment="Version du fichier (1=original, 2+=republication)")
+    supersedes_file_id = Column(
+        Integer,
+        ForeignKey("enedis_flux_file.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="FK vers le fichier précédent que cette version remplace",
+    )
 
     # Header fields — dedicated columns for queryable fields
     frequence_publication = Column(String(5), nullable=True, comment="H/M/Q — Frequence_Publication")

--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -3,10 +3,11 @@
 Orchestrates: classify → hash check → decrypt → parse → store.
 
 Idempotence:
-  - File-level only: SHA256 of the raw ciphertext. Same .zip = skip.
-  - No measure-level deduplication: corrections/republications by Enedis
-    are archived alongside originals. Deduplication is deferred to a
-    future staging/normalization layer.
+  - File-level: SHA256 of the raw ciphertext. Same .zip = skip.
+  - Republication detection: same filename + different hash = versioned
+    republication (status needs_review, version 2+, supersedes_file_id chain).
+    Both original and republication data are preserved.
+  - No measure-level deduplication: deferred to a future staging layer.
 
 Usage:
     from data_ingestion.enedis.pipeline import ingest_file
@@ -79,7 +80,7 @@ def ingest_file(
     # Idempotence check — applies to all flux types
     existing = session.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
     if existing is not None:
-        if existing.status in (FluxStatus.PARSED, FluxStatus.SKIPPED):
+        if existing.status in (FluxStatus.PARSED, FluxStatus.SKIPPED, FluxStatus.NEEDS_REVIEW):
             logger.info(
                 "Already processed %s (hash=%s…, status=%s), skipping", filename, file_hash[:12], existing.status
             )
@@ -103,6 +104,18 @@ def ingest_file(
         session.commit()
         return FluxStatus.SKIPPED
 
+    # Republication detection — same filename, different hash, already ingested
+    previous_file = (
+        session.query(EnedisFluxFile)
+        .filter(
+            EnedisFluxFile.filename == filename,
+            EnedisFluxFile.status.in_([FluxStatus.PARSED, FluxStatus.NEEDS_REVIEW]),
+        )
+        .order_by(EnedisFluxFile.version.desc())
+        .first()
+    )
+    is_republication = previous_file is not None
+
     # Decrypt
     try:
         xml_bytes = decrypt_file(file_path, keys, archive_dir)
@@ -123,11 +136,29 @@ def ingest_file(
 
     # Store file record + mesures
     try:
+        if is_republication:
+            file_status = FluxStatus.NEEDS_REVIEW
+            file_version = previous_file.version + 1
+            supersedes_id = previous_file.id
+            logger.warning(
+                "Republication detected for %s: v%d supersedes file id=%d (v%d). Status set to needs_review.",
+                filename,
+                file_version,
+                previous_file.id,
+                previous_file.version,
+            )
+        else:
+            file_status = FluxStatus.PARSED
+            file_version = 1
+            supersedes_id = None
+
         flux_file = EnedisFluxFile(
             filename=filename,
             file_hash=file_hash,
             flux_type=flux_type.value,
-            status=FluxStatus.PARSED,
+            status=file_status,
+            version=file_version,
+            supersedes_file_id=supersedes_id,
             frequence_publication=parsed.header.frequence_publication,
             nature_courbe_demandee=parsed.header.nature_courbe_demandee,
             identifiant_destinataire=parsed.header.identifiant_destinataire,
@@ -176,13 +207,15 @@ def ingest_file(
         return FluxStatus.ERROR
 
     logger.info(
-        "Ingested %s: %d mesures from PRM %s [%s]",
+        "Ingested %s: %d mesures from PRM %s [%s] (v%d%s)",
         filename,
         total_inserted,
         parsed.point_id,
         flux_type.value,
+        file_version,
+        ", needs_review" if is_republication else "",
     )
-    return FluxStatus.PARSED
+    return file_status
 
 
 def _hash_file(file_path: Path) -> str:

--- a/backend/data_ingestion/enedis/tests/test_models.py
+++ b/backend/data_ingestion/enedis/tests/test_models.py
@@ -47,6 +47,35 @@ class TestEnedisFluxFile:
         db.commit()
         assert db.query(EnedisFluxFile).count() == 2
 
+    def test_version_defaults_to_1(self, db):
+        f = EnedisFluxFile(filename="a.zip", file_hash="h_ver", flux_type="R4H", status="parsed")
+        db.add(f)
+        db.commit()
+
+        result = db.query(EnedisFluxFile).first()
+        assert result.version == 1
+        assert result.supersedes_file_id is None
+
+    def test_version_chain_fk(self, db):
+        f1 = EnedisFluxFile(filename="a.zip", file_hash="h1_chain", flux_type="R4H", status="parsed", version=1)
+        db.add(f1)
+        db.flush()
+
+        f2 = EnedisFluxFile(
+            filename="a.zip",
+            file_hash="h2_chain",
+            flux_type="R4H",
+            status="needs_review",
+            version=2,
+            supersedes_file_id=f1.id,
+        )
+        db.add(f2)
+        db.commit()
+
+        result = db.query(EnedisFluxFile).filter_by(version=2).first()
+        assert result.supersedes_file_id == f1.id
+        assert result.status == "needs_review"
+
     def test_header_raw_json_roundtrip(self, db):
         f = EnedisFluxFile(filename="a.zip", file_hash="h1", flux_type="R4H", status="parsed")
         header = {"Identifiant_Flux": "R4x", "Frequence_Publication": "H"}

--- a/backend/data_ingestion/enedis/tests/test_pipeline.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline.py
@@ -196,8 +196,8 @@ class TestIngestIdempotence:
         assert status2 == FluxStatus.SKIPPED
         assert db.query(EnedisFluxFile).count() == 1
 
-    def test_different_files_same_data_both_stored(self, db, tmp_path, test_keys):
-        """Two different files (different hash) with same measures → both archived."""
+    def test_different_filenames_same_data_both_parsed(self, db, tmp_path, test_keys):
+        """Two different filenames (different hash) with same measures → both v1 parsed."""
         ct1 = make_encrypted_zip(R4H_XML, "inner1.xml", TEST_KEY, TEST_IV)
         ct2 = make_encrypted_zip(R4H_XML, "inner2.xml", TEST_KEY, TEST_IV)
         f1 = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_20260302a.zip"
@@ -210,6 +210,11 @@ class TestIngestIdempotence:
 
         assert db.query(EnedisFluxFile).count() == 2
         assert db.query(EnedisFluxMesureR4x).count() == 6  # 3 + 3, both stored
+        # Both are v1 parsed — different filenames, not republications
+        files = db.query(EnedisFluxFile).order_by(EnedisFluxFile.id).all()
+        assert all(f.version == 1 for f in files)
+        assert all(f.status == FluxStatus.PARSED for f in files)
+        assert all(f.supersedes_file_id is None for f in files)
 
     def test_retry_after_error(self, db, tmp_path, test_keys):
         """A file that previously failed can be retried."""
@@ -304,3 +309,131 @@ class TestIngestErrors:
         f = db.query(EnedisFluxFile).first()
         assert f.status == FluxStatus.PARSED
         assert f.measures_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — Republication detection
+# ---------------------------------------------------------------------------
+
+
+R4H_XML_V2 = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<Courbe>
+  <Entete>
+    <Identifiant_Flux>R4x</Identifiant_Flux>
+    <Libelle_Flux>Flux de courbes de charge R4x</Libelle_Flux>
+    <Identifiant_Emetteur>ENEDIS</Identifiant_Emetteur>
+    <Identifiant_Destinataire>23X--130624--EE1</Identifiant_Destinataire>
+    <Date_Creation>2026-03-17T10:00:00+01:00</Date_Creation>
+    <Frequence_Publication>H</Frequence_Publication>
+    <Reference_Demande>189465931</Reference_Demande>
+    <Nature_De_Courbe_Demandee>Corrigee</Nature_De_Courbe_Demandee>
+  </Entete>
+  <Corps>
+    <Identifiant_PRM>30000210411333</Identifiant_PRM>
+    <Donnees_Courbe>
+      <Horodatage_Debut>2026-03-07T00:00:00+01:00</Horodatage_Debut>
+      <Horodatage_Fin>2026-03-07T23:59:59+01:00</Horodatage_Fin>
+      <Granularite>5</Granularite>
+      <Unite_Mesure>kW</Unite_Mesure>
+      <Grandeur_Metier>CONS</Grandeur_Metier>
+      <Grandeur_Physique>EA</Grandeur_Physique>
+      <Donnees_Point_Mesure Horodatage="2026-03-07T00:00:00+01:00" Valeur_Point="402" Statut_Point="C"/>
+      <Donnees_Point_Mesure Horodatage="2026-03-07T00:05:00+01:00" Valeur_Point="390" Statut_Point="C"/>
+      <Donnees_Point_Mesure Horodatage="2026-03-07T00:10:00+01:00" Valeur_Point="388" Statut_Point="C"/>
+    </Donnees_Courbe>
+  </Corps>
+</Courbe>"""
+
+
+class TestRepublicationDetection:
+    def test_same_filename_different_hash_is_republication(self, db, tmp_path, test_keys):
+        """Same filename, different content → v2 needs_review, both data sets preserved."""
+        shared_name = "ENEDIS_23X--TEST_R4H_CDC_20260302.zip"
+
+        ct1 = make_encrypted_zip(R4H_XML, "inner.xml", TEST_KEY, TEST_IV)
+        f1 = tmp_path / shared_name
+        f1.write_bytes(ct1)
+        status1 = ingest_file(f1, db, test_keys)
+        assert status1 == FluxStatus.PARSED
+
+        # Republication: same filename, different XML content
+        ct2 = make_encrypted_zip(R4H_XML_V2, "inner.xml", TEST_KEY, TEST_IV)
+        f1.write_bytes(ct2)
+        status2 = ingest_file(f1, db, test_keys)
+        assert status2 == FluxStatus.NEEDS_REVIEW
+
+        files = db.query(EnedisFluxFile).order_by(EnedisFluxFile.version).all()
+        assert len(files) == 2
+
+        # Original: v1 parsed
+        assert files[0].version == 1
+        assert files[0].status == FluxStatus.PARSED
+        assert files[0].supersedes_file_id is None
+
+        # Republication: v2 needs_review, chained to v1
+        assert files[1].version == 2
+        assert files[1].status == FluxStatus.NEEDS_REVIEW
+        assert files[1].supersedes_file_id == files[0].id
+
+        # Both data sets preserved
+        assert db.query(EnedisFluxMesureR4x).count() == 6  # 3 + 3
+
+    def test_triple_republication_chains_versions(self, db, tmp_path, test_keys):
+        """Three files with same filename → v1 parsed, v2 needs_review, v3 needs_review."""
+        shared_name = "ENEDIS_23X--TEST_R4H_CDC_20260302.zip"
+        path = tmp_path / shared_name
+
+        # v1
+        ct1 = make_encrypted_zip(R4H_XML, "a.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct1)
+        ingest_file(path, db, test_keys)
+
+        # v2
+        ct2 = make_encrypted_zip(R4H_XML_V2, "b.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct2)
+        ingest_file(path, db, test_keys)
+
+        # v3 — yet another content variant
+        ct3 = make_encrypted_zip(R4H_XML, "c.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct3)
+        ingest_file(path, db, test_keys)
+
+        files = db.query(EnedisFluxFile).order_by(EnedisFluxFile.version).all()
+        assert len(files) == 3
+        assert [f.version for f in files] == [1, 2, 3]
+        assert files[0].supersedes_file_id is None
+        assert files[1].supersedes_file_id == files[0].id
+        # v3 supersedes v2 (the latest versioned file)
+        assert files[2].supersedes_file_id == files[1].id
+        assert db.query(EnedisFluxMesureR4x).count() == 9  # 3 * 3
+
+    def test_republication_idempotence(self, db, tmp_path, test_keys):
+        """Re-running the same republication file (same hash) is a no-op."""
+        shared_name = "ENEDIS_23X--TEST_R4H_CDC_20260302.zip"
+        path = tmp_path / shared_name
+
+        # v1
+        ct1 = make_encrypted_zip(R4H_XML, "a.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct1)
+        ingest_file(path, db, test_keys)
+
+        # v2
+        ct2 = make_encrypted_zip(R4H_XML_V2, "b.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct2)
+        ingest_file(path, db, test_keys)
+
+        # Re-run v2 (same bytes) → should be skipped
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.NEEDS_REVIEW  # returns existing status
+        assert db.query(EnedisFluxFile).count() == 2  # not duplicated
+        assert db.query(EnedisFluxMesureR4x).count() == 6
+
+    def test_original_file_has_version_1(self, db, r4h_encrypted_file, test_keys):
+        """First ingestion of a file sets version=1, no supersedes."""
+        ingest_file(r4h_encrypted_file, db, test_keys)
+
+        f = db.query(EnedisFluxFile).first()
+        assert f.version == 1
+        assert f.supersedes_file_id is None
+        assert f.status == FluxStatus.PARSED

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -1695,8 +1695,8 @@ def _add_enedis_columns(engine):
     # --- enedis_flux_file columns ---
     # Add new columns here as (col_name, col_type) when evolving the model.
     enedis_flux_file_columns = [
-        # Example for future SF3+:
-        # ("new_column_name", "VARCHAR(100)"),
+        ("version", "INTEGER DEFAULT 1"),
+        ("supersedes_file_id", "INTEGER REFERENCES enedis_flux_file(id) ON DELETE SET NULL"),
     ]
 
     # --- enedis_flux_mesure_r4x columns ---


### PR DESCRIPTION
## Summary

- **Root cause**: No protection against semantic duplicates when Enedis republishes a file with the same filename but different content (different SHA256 hash). The pipeline silently ingests both, creating duplicate measures.
- **Fix**: Filename-based republication detection with version chaining. When a file with an already-known filename arrives with a new hash, it is ingested as a versioned republication (`version=2+`, `supersedes_file_id` → previous file, `status=needs_review`). Both original and republication data are preserved for data manager analysis.

## Files changed

| File | Change |
|------|--------|
| `backend/data_ingestion/enedis/enums.py` | Added `NEEDS_REVIEW` status to `FluxStatus` enum |
| `backend/data_ingestion/enedis/models.py` | Added `version` (default 1) and `supersedes_file_id` (FK to self) columns on `EnedisFluxFile` |
| `backend/data_ingestion/enedis/pipeline.py` | Republication detection after hash check: same filename + different hash → version chain + `needs_review` status |
| `backend/database/migrations.py` | Added migration entries for `version` and `supersedes_file_id` columns |
| `backend/data_ingestion/enedis/tests/test_models.py` | Tests for version default and FK chain |
| `backend/data_ingestion/enedis/tests/test_pipeline.py` | Tests for republication detection, triple version chain, idempotence of needs_review files |

## Blast-radius review

- Reviewed all consumers of `FluxStatus`, `EnedisFluxFile`, and `ingest_file()` across the codebase
- Module is fully isolated — no downstream code depends on these
- Migration entries added for pre-existing DBs (MEDIUM finding, addressed in this PR)

## Test plan

**Automated tests**
```bash
cd backend && pytest data_ingestion/enedis/tests/ -x -v
```

**Steps to reproduce the problem**
1. Ingest an R4H file (e.g. `ENEDIS_23X--TEST_R4H_CDC_20260302.zip`)
2. Re-ingest a file with the same filename but different content (Enedis correction)
3. Observe both files are stored as `status=parsed` with no version link — silent duplication

**Steps to verify the fix**
1. Ingest an R4H file → `status=parsed`, `version=1`
2. Re-ingest same filename with different content → `status=needs_review`, `version=2`, `supersedes_file_id` points to v1
3. Both data sets are preserved (6 measures total for 2x3-point files)
4. Re-ingest the v2 file again (same hash) → skipped, no duplication

Part of #156