### PR TITLE
fix(r4): rename total_points → total_measures

### DIFF
--- a/backend/data_ingestion/enedis/parsers/r4.py
+++ b/backend/data_ingestion/enedis/parsers/r4.py
@@ -86,7 +86,7 @@ class ParsedR4xFile:
     courbes: list[ParsedCourbe] = field(default_factory=list)
 
     @property
-    def total_points(self) -> int:
+    def total_measures(self) -> int:
         return sum(len(c.points) for c in self.courbes)
 
 

--- a/backend/data_ingestion/enedis/tests/test_parsers_r4.py
+++ b/backend/data_ingestion/enedis/tests/test_parsers_r4.py
@@ -194,9 +194,9 @@ class TestParseR4xCourbe:
         result = parse_r4x(xml)
 
         assert len(result.courbes) == 0
-        assert result.total_points == 0
+        assert result.total_measures == 0
 
-    def test_total_points_across_courbes(self):
+    def test_total_measures_across_courbes(self):
         courbe1 = _make_courbe_xml(
             grandeur_physique="EA",
             points_xml="\n".join(
@@ -213,7 +213,7 @@ class TestParseR4xCourbe:
         xml = _make_r4x_xml(courbes_xml=courbe1 + courbe2)
         result = parse_r4x(xml)
 
-        assert result.total_points == 3
+        assert result.total_measures == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Rename `total_points` → `total_measures` in R4 parser and tests
- Aligns R4 with R171, R50, R151 so pipeline dispatch (Étape 7) can call `result.total_measures` uniformly on all 4 parsers

## Test plan
- [x] 19/19 R4 parser tests pass
- [x] No remaining `total_points` references in `backend/data_ingestion/enedis/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)