### PR TITLE
feat(enedis): SF3-A step 7 — multi-flux pipeline dispatch

### DIFF
--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -23,7 +23,7 @@ Usage:
 import hashlib
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from sqlalchemy.orm import Session
 
@@ -278,9 +278,11 @@ def _prm_summary(parsed: Any) -> str:
     if hasattr(parsed, "series"):
         # R171 — PRM per serie
         prm_ids = {s.point_id for s in parsed.series}
-    else:
+    elif hasattr(parsed, "prms"):
         # R50 / R151 — PRM per prm block
         prm_ids = {p.point_id for p in parsed.prms}
+    else:
+        return "unknown PRMs"
 
     count = len(prm_ids)
     if count == 1:
@@ -430,7 +432,10 @@ def _store_r151(parsed: Any, flux_file: EnedisFluxFile, session: Session, chunk_
 # Dispatch table — FluxType → (parser_fn, parse_error_cls, store_fn)
 # ---------------------------------------------------------------------------
 
-_DISPATCH: dict[FluxType, tuple] = {
+_StoreFn = Callable[[Any, EnedisFluxFile, Session, int], int]
+_DispatchEntry = tuple[Callable[[bytes], Any], type[Exception], _StoreFn]
+
+_DISPATCH: dict[FluxType, _DispatchEntry] = {
     FluxType.R4H: (parse_r4x, R4xParseError, _store_r4x),
     FluxType.R4M: (parse_r4x, R4xParseError, _store_r4x),
     FluxType.R4Q: (parse_r4x, R4xParseError, _store_r4x),

--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -1,6 +1,7 @@
-"""PROMEOS — Enedis R4x CDC ingestion pipeline.
+"""PROMEOS — Enedis multi-flux ingestion pipeline.
 
 Orchestrates: classify → hash check → decrypt → parse → store.
+Supports R4x (CDC C1-C4), R171 (index C2-C4), R50 (CDC C5), R151 (index C5).
 
 Idempotence:
   - File-level: SHA256 of the raw ciphertext. Same .zip = skip.
@@ -22,6 +23,7 @@ Usage:
 import hashlib
 import logging
 from pathlib import Path
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -32,12 +34,21 @@ from data_ingestion.enedis.decrypt import (
     decrypt_file,
 )
 from data_ingestion.enedis.enums import FluxStatus, FluxType
-from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesureR4x
+from data_ingestion.enedis.models import (
+    EnedisFluxFile,
+    EnedisFluxMesureR4x,
+    EnedisFluxMesureR50,
+    EnedisFluxMesureR151,
+    EnedisFluxMesureR171,
+)
 from data_ingestion.enedis.parsers.r4 import R4xParseError, parse_r4x
+from data_ingestion.enedis.parsers.r50 import R50ParseError, parse_r50
+from data_ingestion.enedis.parsers.r151 import R151ParseError, parse_r151
+from data_ingestion.enedis.parsers.r171 import R171ParseError, parse_r171
 
 logger = logging.getLogger("promeos.enedis.pipeline")
 
-R4X_FLUX_TYPES = frozenset({FluxType.R4H, FluxType.R4M, FluxType.R4Q})
+_R4X_FLUX_TYPES = frozenset({FluxType.R4H, FluxType.R4M, FluxType.R4Q})
 
 DEFAULT_CHUNK_SIZE = 1000
 
@@ -97,12 +108,15 @@ def ingest_file(
         session.commit()
         return FluxStatus.SKIPPED
 
-    # Only R4x is supported in SF2
-    if flux_type not in R4X_FLUX_TYPES:
-        logger.info("Skipping %s (flux type %s not in R4x scope)", filename, flux_type.value)
+    # Dispatch lookup — skip flux types without a handler
+    handler = _DISPATCH.get(flux_type)
+    if handler is None:
+        logger.info("Skipping %s (flux type %s not yet supported)", filename, flux_type.value)
         _record_file(session, filename, file_hash, flux_type.value, FluxStatus.SKIPPED)
         session.commit()
         return FluxStatus.SKIPPED
+
+    parser_fn, parse_error_cls, store_fn = handler
 
     # Republication detection — same filename, different hash, already ingested
     previous_file = (
@@ -127,8 +141,8 @@ def ingest_file(
 
     # Parse
     try:
-        parsed = parse_r4x(xml_bytes)
-    except R4xParseError as exc:
+        parsed = parser_fn(xml_bytes)
+    except parse_error_cls as exc:
         logger.error("Parse failed for %s: %s", filename, exc)
         _record_file(session, filename, file_hash, flux_type.value, FluxStatus.ERROR, str(exc))
         session.commit()
@@ -152,51 +166,13 @@ def ingest_file(
             file_version = 1
             supersedes_id = None
 
-        flux_file = EnedisFluxFile(
-            filename=filename,
-            file_hash=file_hash,
-            flux_type=flux_type.value,
-            status=file_status,
-            version=file_version,
-            supersedes_file_id=supersedes_id,
-            frequence_publication=parsed.header.frequence_publication,
-            nature_courbe_demandee=parsed.header.nature_courbe_demandee,
-            identifiant_destinataire=parsed.header.identifiant_destinataire,
+        flux_file = _create_flux_file(
+            filename, file_hash, flux_type, file_status, file_version, supersedes_id, parsed,
         )
-        flux_file.set_header_raw(parsed.header.raw)
         session.add(flux_file)
         session.flush()  # Get flux_file.id
 
-        # Store mesures in batches
-        total_inserted = 0
-        batch = []
-        for courbe in parsed.courbes:
-            for point in courbe.points:
-                batch.append(
-                    EnedisFluxMesureR4x(
-                        flux_file_id=flux_file.id,
-                        flux_type=flux_type.value,
-                        point_id=parsed.point_id,
-                        grandeur_physique=courbe.grandeur_physique,
-                        grandeur_metier=courbe.grandeur_metier,
-                        unite_mesure=courbe.unite_mesure,
-                        granularite=courbe.granularite,
-                        horodatage_debut=courbe.horodatage_debut,
-                        horodatage_fin=courbe.horodatage_fin,
-                        horodatage=point.horodatage,
-                        valeur_point=point.valeur_point,
-                        statut_point=point.statut_point,
-                    )
-                )
-                if len(batch) >= chunk_size:
-                    session.bulk_save_objects(batch)
-                    total_inserted += len(batch)
-                    batch = []
-
-        if batch:
-            session.bulk_save_objects(batch)
-            total_inserted += len(batch)
-
+        total_inserted = store_fn(parsed, flux_file, session, chunk_size)
         flux_file.measures_count = total_inserted
         session.commit()
     except Exception as exc:
@@ -207,15 +183,20 @@ def ingest_file(
         return FluxStatus.ERROR
 
     logger.info(
-        "Ingested %s: %d mesures from PRM %s [%s] (v%d%s)",
+        "Ingested %s: %d mesures from %s [%s] (v%d%s)",
         filename,
         total_inserted,
-        parsed.point_id,
+        _prm_summary(parsed),
         flux_type.value,
         file_version,
         ", needs_review" if is_republication else "",
     )
     return file_status
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
 
 
 def _hash_file(file_path: Path) -> str:
@@ -242,3 +223,218 @@ def _record_file(
     )
     session.add(flux_file)
     return flux_file
+
+
+def _create_flux_file(
+    filename: str,
+    file_hash: str,
+    flux_type: FluxType,
+    status: FluxStatus,
+    version: int,
+    supersedes_id: int | None,
+    parsed: Any,
+) -> EnedisFluxFile:
+    """Create an EnedisFluxFile ORM object with header fields.
+
+    R4x-specific columns (frequence_publication, nature_courbe_demandee,
+    identifiant_destinataire) are populated only for R4x flux types.
+    header_raw is always set from parsed.header.raw.
+    """
+    # R4x headers expose promoted queryable fields; others do not
+    if flux_type in _R4X_FLUX_TYPES:
+        freq = parsed.header.frequence_publication
+        nature = parsed.header.nature_courbe_demandee
+        dest = parsed.header.identifiant_destinataire
+    else:
+        freq = None
+        nature = None
+        dest = None
+
+    flux_file = EnedisFluxFile(
+        filename=filename,
+        file_hash=file_hash,
+        flux_type=flux_type.value,
+        status=status,
+        version=version,
+        supersedes_file_id=supersedes_id,
+        frequence_publication=freq,
+        nature_courbe_demandee=nature,
+        identifiant_destinataire=dest,
+    )
+    flux_file.set_header_raw(parsed.header.raw)
+    return flux_file
+
+
+def _prm_summary(parsed: Any) -> str:
+    """Return a concise PRM summary for log output.
+
+    R4x (single PRM): "PRM 30000210411333"
+    Multi-PRM (R171/R50/R151): "2 PRMs" or single PRM if only one.
+    """
+    if hasattr(parsed, "point_id"):
+        # R4x — single PRM at file level
+        return f"PRM {parsed.point_id}"
+
+    if hasattr(parsed, "series"):
+        # R171 — PRM per serie
+        prm_ids = {s.point_id for s in parsed.series}
+    else:
+        # R50 / R151 — PRM per prm block
+        prm_ids = {p.point_id for p in parsed.prms}
+
+    count = len(prm_ids)
+    if count == 1:
+        return f"PRM {next(iter(prm_ids))}"
+    return f"{count} PRMs"
+
+
+# ---------------------------------------------------------------------------
+# Store functions — one per flux family
+# ---------------------------------------------------------------------------
+
+
+def _store_r4x(parsed: Any, flux_file: EnedisFluxFile, session: Session, chunk_size: int) -> int:
+    """Store R4x CDC measures. Returns total rows inserted."""
+    total_inserted = 0
+    batch: list[EnedisFluxMesureR4x] = []
+    for courbe in parsed.courbes:
+        for point in courbe.points:
+            batch.append(
+                EnedisFluxMesureR4x(
+                    flux_file_id=flux_file.id,
+                    flux_type=flux_file.flux_type,
+                    point_id=parsed.point_id,
+                    grandeur_physique=courbe.grandeur_physique,
+                    grandeur_metier=courbe.grandeur_metier,
+                    unite_mesure=courbe.unite_mesure,
+                    granularite=courbe.granularite,
+                    horodatage_debut=courbe.horodatage_debut,
+                    horodatage_fin=courbe.horodatage_fin,
+                    horodatage=point.horodatage,
+                    valeur_point=point.valeur_point,
+                    statut_point=point.statut_point,
+                )
+            )
+            if len(batch) >= chunk_size:
+                session.bulk_save_objects(batch)
+                total_inserted += len(batch)
+                batch = []
+
+    if batch:
+        session.bulk_save_objects(batch)
+        total_inserted += len(batch)
+    return total_inserted
+
+
+def _store_r171(parsed: Any, flux_file: EnedisFluxFile, session: Session, chunk_size: int) -> int:
+    """Store R171 index measures. Returns total rows inserted."""
+    total_inserted = 0
+    batch: list[EnedisFluxMesureR171] = []
+    for serie in parsed.series:
+        for mesure in serie.mesures:
+            batch.append(
+                EnedisFluxMesureR171(
+                    flux_file_id=flux_file.id,
+                    flux_type=flux_file.flux_type,
+                    point_id=serie.point_id,
+                    type_mesure=serie.type_mesure,
+                    grandeur_metier=serie.grandeur_metier,
+                    grandeur_physique=serie.grandeur_physique,
+                    type_calendrier=serie.type_calendrier,
+                    code_classe_temporelle=serie.code_classe_temporelle,
+                    libelle_classe_temporelle=serie.libelle_classe_temporelle,
+                    unite=serie.unite,
+                    date_fin=mesure.date_fin,
+                    valeur=mesure.valeur,
+                )
+            )
+            if len(batch) >= chunk_size:
+                session.bulk_save_objects(batch)
+                total_inserted += len(batch)
+                batch = []
+
+    if batch:
+        session.bulk_save_objects(batch)
+        total_inserted += len(batch)
+    return total_inserted
+
+
+def _store_r50(parsed: Any, flux_file: EnedisFluxFile, session: Session, chunk_size: int) -> int:
+    """Store R50 CDC C5 measures. Returns total rows inserted."""
+    total_inserted = 0
+    batch: list[EnedisFluxMesureR50] = []
+    for prm in parsed.prms:
+        for releve in prm.releves:
+            for point in releve.points:
+                batch.append(
+                    EnedisFluxMesureR50(
+                        flux_file_id=flux_file.id,
+                        flux_type=flux_file.flux_type,
+                        point_id=prm.point_id,
+                        date_releve=releve.date_releve,
+                        id_affaire=releve.id_affaire,
+                        horodatage=point.horodatage,
+                        valeur=point.valeur,
+                        indice_vraisemblance=point.indice_vraisemblance,
+                    )
+                )
+                if len(batch) >= chunk_size:
+                    session.bulk_save_objects(batch)
+                    total_inserted += len(batch)
+                    batch = []
+
+    if batch:
+        session.bulk_save_objects(batch)
+        total_inserted += len(batch)
+    return total_inserted
+
+
+def _store_r151(parsed: Any, flux_file: EnedisFluxFile, session: Session, chunk_size: int) -> int:
+    """Store R151 index + puissance max C5 measures. Returns total rows inserted."""
+    total_inserted = 0
+    batch: list[EnedisFluxMesureR151] = []
+    for prm in parsed.prms:
+        for releve in prm.releves:
+            for donnee in releve.donnees:
+                batch.append(
+                    EnedisFluxMesureR151(
+                        flux_file_id=flux_file.id,
+                        flux_type=flux_file.flux_type,
+                        point_id=prm.point_id,
+                        date_releve=releve.date_releve,
+                        id_calendrier_fournisseur=releve.id_calendrier_fournisseur,
+                        libelle_calendrier_fournisseur=releve.libelle_calendrier_fournisseur,
+                        id_calendrier_distributeur=releve.id_calendrier_distributeur,
+                        libelle_calendrier_distributeur=releve.libelle_calendrier_distributeur,
+                        id_affaire=releve.id_affaire,
+                        type_donnee=donnee.type_donnee,
+                        id_classe_temporelle=donnee.id_classe_temporelle,
+                        libelle_classe_temporelle=donnee.libelle_classe_temporelle,
+                        rang_cadran=donnee.rang_cadran,
+                        valeur=donnee.valeur,
+                        indice_vraisemblance=donnee.indice_vraisemblance,
+                    )
+                )
+                if len(batch) >= chunk_size:
+                    session.bulk_save_objects(batch)
+                    total_inserted += len(batch)
+                    batch = []
+
+    if batch:
+        session.bulk_save_objects(batch)
+        total_inserted += len(batch)
+    return total_inserted
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table — FluxType → (parser_fn, parse_error_cls, store_fn)
+# ---------------------------------------------------------------------------
+
+_DISPATCH: dict[FluxType, tuple] = {
+    FluxType.R4H: (parse_r4x, R4xParseError, _store_r4x),
+    FluxType.R4M: (parse_r4x, R4xParseError, _store_r4x),
+    FluxType.R4Q: (parse_r4x, R4xParseError, _store_r4x),
+    FluxType.R171: (parse_r171, R171ParseError, _store_r171),
+    FluxType.R50: (parse_r50, R50ParseError, _store_r50),
+    FluxType.R151: (parse_r151, R151ParseError, _store_r151),
+}

--- a/backend/data_ingestion/enedis/tests/test_pipeline.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline.py
@@ -1,11 +1,17 @@
-"""Tests for the Enedis R4x CDC ingestion pipeline."""
+"""Tests for the Enedis multi-flux ingestion pipeline."""
 
 import os
 
 import pytest
 
 from data_ingestion.enedis.enums import FluxStatus
-from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesureR4x
+from data_ingestion.enedis.models import (
+    EnedisFluxFile,
+    EnedisFluxMesureR4x,
+    EnedisFluxMesureR50,
+    EnedisFluxMesureR151,
+    EnedisFluxMesureR171,
+)
 from data_ingestion.enedis.pipeline import ingest_file
 
 from .conftest import TEST_IV, TEST_KEY, make_encrypted_zip
@@ -437,3 +443,609 @@ class TestRepublicationDetection:
         assert f.version == 1
         assert f.supersedes_file_id is None
         assert f.status == FluxStatus.PARSED
+
+
+# ===========================================================================
+# R171 pipeline tests
+# ===========================================================================
+
+R171_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<ns2:R171 xmlns:ns2="http://www.enedis.fr/stm/R171">
+  <entete>
+    <emetteur>Enedis</emetteur>
+    <destinataire>GRD-F121</destinataire>
+    <dateHeureCreation>2026-03-01T01:13:01</dateHeureCreation>
+    <flux>R171</flux>
+    <version>1.0</version>
+  </entete>
+  <serieMesuresDateesListe>
+    <serieMesuresDatees>
+      <prmId>30000550506121</prmId>
+      <type>INDEX</type>
+      <grandeurMetier>CONS</grandeurMetier>
+      <grandeurPhysique>EA</grandeurPhysique>
+      <typeCalendrier>D</typeCalendrier>
+      <codeClasseTemporelle>HPH</codeClasseTemporelle>
+      <libelleClasseTemporelle>Heures Pleines Hiver</libelleClasseTemporelle>
+      <unite>Wh</unite>
+      <mesuresDateesListe>
+        <mesureDatee>
+          <dateFin>2026-03-01T00:51:11</dateFin>
+          <valeur>1320</valeur>
+        </mesureDatee>
+        <mesureDatee>
+          <dateFin>2026-03-02T00:51:11</dateFin>
+          <valeur>1450</valeur>
+        </mesureDatee>
+      </mesuresDateesListe>
+    </serieMesuresDatees>
+  </serieMesuresDateesListe>
+</ns2:R171>"""
+
+R171_MULTI_PRM_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R171>
+  <entete>
+    <emetteur>Enedis</emetteur>
+    <flux>R171</flux>
+  </entete>
+  <serieMesuresDateesListe>
+    <serieMesuresDatees>
+      <prmId>30000550506121</prmId>
+      <type>INDEX</type>
+      <grandeurPhysique>EA</grandeurPhysique>
+      <unite>Wh</unite>
+      <mesuresDateesListe>
+        <mesureDatee>
+          <dateFin>2026-03-01T00:00:00</dateFin>
+          <valeur>1000</valeur>
+        </mesureDatee>
+      </mesuresDateesListe>
+    </serieMesuresDatees>
+    <serieMesuresDatees>
+      <prmId>30000550506999</prmId>
+      <type>INDEX</type>
+      <grandeurPhysique>ERI</grandeurPhysique>
+      <unite>VArh</unite>
+      <mesuresDateesListe>
+        <mesureDatee>
+          <dateFin>2026-03-01T00:00:00</dateFin>
+          <valeur>2000</valeur>
+        </mesureDatee>
+        <mesureDatee>
+          <dateFin>2026-03-02T00:00:00</dateFin>
+          <valeur>2100</valeur>
+        </mesureDatee>
+      </mesuresDateesListe>
+    </serieMesuresDatees>
+  </serieMesuresDateesListe>
+</R171>"""
+
+R171_XML_V2 = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R171>
+  <entete>
+    <emetteur>Enedis</emetteur>
+    <flux>R171</flux>
+  </entete>
+  <serieMesuresDateesListe>
+    <serieMesuresDatees>
+      <prmId>30000550506121</prmId>
+      <type>INDEX</type>
+      <grandeurPhysique>EA</grandeurPhysique>
+      <unite>Wh</unite>
+      <mesuresDateesListe>
+        <mesureDatee>
+          <dateFin>2026-03-01T00:51:11</dateFin>
+          <valeur>1325</valeur>
+        </mesureDatee>
+      </mesuresDateesListe>
+    </serieMesuresDatees>
+  </serieMesuresDateesListe>
+</R171>"""
+
+
+@pytest.fixture
+def r171_encrypted_file(tmp_path):
+    """Encrypted R171 file with 1 PRM, 2 mesures."""
+    ct = make_encrypted_zip(R171_XML, "r171.xml", TEST_KEY, TEST_IV)
+    path = tmp_path / "ENEDIS_23X--TEST_R171_20260302.zip"
+    path.write_bytes(ct)
+    return path
+
+
+class TestIngestR171Pipeline:
+    def test_ingest_r171_success(self, db, r171_encrypted_file, test_keys):
+        status = ingest_file(r171_encrypted_file, db, test_keys)
+        assert status == FluxStatus.PARSED
+
+        f = db.query(EnedisFluxFile).first()
+        assert f.flux_type == "R171"
+        assert f.status == FluxStatus.PARSED
+        assert f.measures_count == 2
+        # R4x-specific columns should be NULL
+        assert f.frequence_publication is None
+        assert f.nature_courbe_demandee is None
+        assert f.identifiant_destinataire is None
+        # header_raw always populated
+        assert f.get_header_raw() is not None
+        assert f.get_header_raw()["flux"] == "R171"
+
+        mesures = db.query(EnedisFluxMesureR171).all()
+        assert len(mesures) == 2
+        m0 = mesures[0]
+        assert m0.point_id == "30000550506121"
+        assert m0.flux_type == "R171"
+        assert m0.type_mesure == "INDEX"
+        assert m0.grandeur_physique == "EA"
+        assert m0.grandeur_metier == "CONS"
+        assert m0.unite == "Wh"
+        assert m0.code_classe_temporelle == "HPH"
+        assert m0.date_fin == "2026-03-01T00:51:11"
+        assert m0.valeur == "1320"
+
+    def test_r171_multi_prm(self, db, tmp_path, test_keys):
+        """R171 with 2 distinct PRMs → all mesures stored, correct point_ids."""
+        ct = make_encrypted_zip(R171_MULTI_PRM_XML, "r171_multi.xml", TEST_KEY, TEST_IV)
+        path = tmp_path / "ENEDIS_23X--TEST_R171_MULTI.zip"
+        path.write_bytes(ct)
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.PARSED
+
+        f = db.query(EnedisFluxFile).first()
+        assert f.measures_count == 3  # 1 + 2
+
+        mesures = db.query(EnedisFluxMesureR171).all()
+        assert len(mesures) == 3
+        prm_ids = {m.point_id for m in mesures}
+        assert prm_ids == {"30000550506121", "30000550506999"}
+
+    def test_r171_idempotence(self, db, r171_encrypted_file, test_keys):
+        ingest_file(r171_encrypted_file, db, test_keys)
+        status2 = ingest_file(r171_encrypted_file, db, test_keys)
+
+        assert status2 == FluxStatus.PARSED
+        assert db.query(EnedisFluxFile).count() == 1
+        assert db.query(EnedisFluxMesureR171).count() == 2
+
+    def test_r171_republication(self, db, tmp_path, test_keys):
+        shared_name = "ENEDIS_23X--TEST_R171_20260302.zip"
+        path = tmp_path / shared_name
+
+        ct1 = make_encrypted_zip(R171_XML, "a.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct1)
+        status1 = ingest_file(path, db, test_keys)
+        assert status1 == FluxStatus.PARSED
+
+        ct2 = make_encrypted_zip(R171_XML_V2, "b.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct2)
+        status2 = ingest_file(path, db, test_keys)
+        assert status2 == FluxStatus.NEEDS_REVIEW
+
+        files = db.query(EnedisFluxFile).order_by(EnedisFluxFile.version).all()
+        assert len(files) == 2
+        assert files[0].version == 1
+        assert files[1].version == 2
+        assert files[1].supersedes_file_id == files[0].id
+        # Both data sets preserved
+        assert db.query(EnedisFluxMesureR171).count() == 3  # 2 + 1
+
+    def test_r171_zero_mesures(self, db, tmp_path, test_keys):
+        """R171 with empty mesuresDateesListe → PARSED, measures_count=0."""
+        xml = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R171>
+  <entete><emetteur>Enedis</emetteur><flux>R171</flux></entete>
+  <serieMesuresDateesListe/>
+</R171>"""
+        ct = make_encrypted_zip(xml, "empty.xml", TEST_KEY, TEST_IV)
+        path = tmp_path / "ENEDIS_23X--TEST_R171_EMPTY.zip"
+        path.write_bytes(ct)
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.PARSED
+        assert db.query(EnedisFluxFile).first().measures_count == 0
+
+    def test_r171_corrupt_returns_error(self, db, tmp_path, test_keys):
+        """Corrupt R171 file → ERROR with error_message."""
+        path = tmp_path / "ENEDIS_23X--TEST_R171_CORRUPT.zip"
+        path.write_bytes(os.urandom(256))
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.ERROR
+        f = db.query(EnedisFluxFile).first()
+        assert f.status == FluxStatus.ERROR
+        assert f.error_message is not None
+
+
+# ===========================================================================
+# R50 pipeline tests
+# ===========================================================================
+
+R50_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R50>
+  <En_Tete_Flux>
+    <Identifiant_Flux>R50</Identifiant_Flux>
+    <Libelle_Flux>Courbes de charge C5</Libelle_Flux>
+    <Version_XSD>1.1.0</Version_XSD>
+    <Identifiant_Emetteur>ERDF</Identifiant_Emetteur>
+    <Identifiant_Destinataire>GRD-F121</Identifiant_Destinataire>
+    <Date_Creation>2026-03-01</Date_Creation>
+    <Pas_Publication>30</Pas_Publication>
+  </En_Tete_Flux>
+  <PRM>
+    <Id_PRM>30001234567890</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <Id_Affaire>M041AWXF</Id_Affaire>
+      <PDC>
+        <H>2026-03-01T00:00:00+01:00</H>
+        <V>20710</V>
+        <IV>0</IV>
+      </PDC>
+      <PDC>
+        <H>2026-03-01T00:30:00+01:00</H>
+        <V>20750</V>
+        <IV>0</IV>
+      </PDC>
+    </Donnees_Releve>
+  </PRM>
+</R50>"""
+
+R50_MULTI_PRM_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R50>
+  <En_Tete_Flux>
+    <Identifiant_Flux>R50</Identifiant_Flux>
+  </En_Tete_Flux>
+  <PRM>
+    <Id_PRM>30001234567890</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <PDC><H>2026-03-01T00:00:00+01:00</H><V>100</V></PDC>
+    </Donnees_Releve>
+  </PRM>
+  <PRM>
+    <Id_PRM>30009876543210</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <PDC><H>2026-03-01T00:00:00+01:00</H><V>200</V></PDC>
+      <PDC><H>2026-03-01T00:30:00+01:00</H><V>210</V></PDC>
+    </Donnees_Releve>
+  </PRM>
+</R50>"""
+
+R50_XML_V2 = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R50>
+  <En_Tete_Flux>
+    <Identifiant_Flux>R50</Identifiant_Flux>
+  </En_Tete_Flux>
+  <PRM>
+    <Id_PRM>30001234567890</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <PDC><H>2026-03-01T00:00:00+01:00</H><V>20715</V><IV>1</IV></PDC>
+    </Donnees_Releve>
+  </PRM>
+</R50>"""
+
+
+@pytest.fixture
+def r50_encrypted_file(tmp_path):
+    """Encrypted R50 file with 1 PRM, 2 PDC points."""
+    ct = make_encrypted_zip(R50_XML, "r50.xml", TEST_KEY, TEST_IV)
+    path = tmp_path / "ERDF_R50_23X--TEST_20260302.zip"
+    path.write_bytes(ct)
+    return path
+
+
+class TestIngestR50Pipeline:
+    def test_ingest_r50_success(self, db, r50_encrypted_file, test_keys):
+        status = ingest_file(r50_encrypted_file, db, test_keys)
+        assert status == FluxStatus.PARSED
+
+        f = db.query(EnedisFluxFile).first()
+        assert f.flux_type == "R50"
+        assert f.status == FluxStatus.PARSED
+        assert f.measures_count == 2
+        assert f.frequence_publication is None
+        assert f.nature_courbe_demandee is None
+        assert f.identifiant_destinataire is None
+        assert f.get_header_raw() is not None
+        assert f.get_header_raw()["Identifiant_Flux"] == "R50"
+
+        mesures = db.query(EnedisFluxMesureR50).all()
+        assert len(mesures) == 2
+        m0 = mesures[0]
+        assert m0.point_id == "30001234567890"
+        assert m0.flux_type == "R50"
+        assert m0.date_releve == "2026-03-01"
+        assert m0.id_affaire == "M041AWXF"
+        assert m0.horodatage == "2026-03-01T00:00:00+01:00"
+        assert m0.valeur == "20710"
+        assert m0.indice_vraisemblance == "0"
+
+    def test_r50_multi_prm(self, db, tmp_path, test_keys):
+        ct = make_encrypted_zip(R50_MULTI_PRM_XML, "r50_multi.xml", TEST_KEY, TEST_IV)
+        path = tmp_path / "ERDF_R50_23X--TEST_MULTI.zip"
+        path.write_bytes(ct)
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.PARSED
+
+        f = db.query(EnedisFluxFile).first()
+        assert f.measures_count == 3  # 1 + 2
+
+        mesures = db.query(EnedisFluxMesureR50).all()
+        assert len(mesures) == 3
+        prm_ids = {m.point_id for m in mesures}
+        assert prm_ids == {"30001234567890", "30009876543210"}
+
+    def test_r50_idempotence(self, db, r50_encrypted_file, test_keys):
+        ingest_file(r50_encrypted_file, db, test_keys)
+        status2 = ingest_file(r50_encrypted_file, db, test_keys)
+
+        assert status2 == FluxStatus.PARSED
+        assert db.query(EnedisFluxFile).count() == 1
+        assert db.query(EnedisFluxMesureR50).count() == 2
+
+    def test_r50_republication(self, db, tmp_path, test_keys):
+        shared_name = "ERDF_R50_23X--TEST_20260302.zip"
+        path = tmp_path / shared_name
+
+        ct1 = make_encrypted_zip(R50_XML, "a.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct1)
+        assert ingest_file(path, db, test_keys) == FluxStatus.PARSED
+
+        ct2 = make_encrypted_zip(R50_XML_V2, "b.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct2)
+        assert ingest_file(path, db, test_keys) == FluxStatus.NEEDS_REVIEW
+
+        files = db.query(EnedisFluxFile).order_by(EnedisFluxFile.version).all()
+        assert len(files) == 2
+        assert files[1].supersedes_file_id == files[0].id
+        assert db.query(EnedisFluxMesureR50).count() == 3  # 2 + 1
+
+    def test_r50_zero_mesures(self, db, tmp_path, test_keys):
+        xml = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R50>
+  <En_Tete_Flux><Identifiant_Flux>R50</Identifiant_Flux></En_Tete_Flux>
+</R50>"""
+        ct = make_encrypted_zip(xml, "empty.xml", TEST_KEY, TEST_IV)
+        path = tmp_path / "ERDF_R50_23X--TEST_EMPTY.zip"
+        path.write_bytes(ct)
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.PARSED
+        assert db.query(EnedisFluxFile).first().measures_count == 0
+
+    def test_r50_corrupt_returns_error(self, db, tmp_path, test_keys):
+        path = tmp_path / "ERDF_R50_23X--TEST_CORRUPT.zip"
+        path.write_bytes(os.urandom(256))
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.ERROR
+        assert db.query(EnedisFluxFile).first().error_message is not None
+
+
+# ===========================================================================
+# R151 pipeline tests
+# ===========================================================================
+
+R151_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R151>
+  <En_Tete_Flux>
+    <Identifiant_Flux>R151</Identifiant_Flux>
+    <Libelle_Flux>Index et puissances max C5</Libelle_Flux>
+    <Version_XSD>V1</Version_XSD>
+    <Identifiant_Emetteur>ERDF</Identifiant_Emetteur>
+    <Identifiant_Destinataire>GRD-F121</Identifiant_Destinataire>
+    <Date_Creation>2026-03-01</Date_Creation>
+    <Unite_Mesure_Index>Wh</Unite_Mesure_Index>
+    <Unite_Mesure_Puissance>VA</Unite_Mesure_Puissance>
+  </En_Tete_Flux>
+  <PRM>
+    <Id_PRM>30001234567890</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <Id_Calendrier_Fournisseur>CF01</Id_Calendrier_Fournisseur>
+      <Libelle_Calendrier_Fournisseur>Base</Libelle_Calendrier_Fournisseur>
+      <Id_Calendrier_Distributeur>CD01</Id_Calendrier_Distributeur>
+      <Libelle_Calendrier_Distributeur>Distributeur Base</Libelle_Calendrier_Distributeur>
+      <Id_Affaire>AFF001</Id_Affaire>
+      <Classe_Temporelle_Distributeur>
+        <Id_Classe_Temporelle>HCB</Id_Classe_Temporelle>
+        <Libelle_Classe_Temporelle>Heures Creuses Basses</Libelle_Classe_Temporelle>
+        <Rang_Cadran>1</Rang_Cadran>
+        <Valeur>83044953</Valeur>
+        <Indice_Vraisemblance>0</Indice_Vraisemblance>
+      </Classe_Temporelle_Distributeur>
+      <Classe_Temporelle>
+        <Id_Classe_Temporelle>HC</Id_Classe_Temporelle>
+        <Libelle_Classe_Temporelle>Heures Creuses</Libelle_Classe_Temporelle>
+        <Rang_Cadran>1</Rang_Cadran>
+        <Valeur>18047813</Valeur>
+        <Indice_Vraisemblance>0</Indice_Vraisemblance>
+      </Classe_Temporelle>
+      <Puissance_Maximale>
+        <Valeur>7452</Valeur>
+      </Puissance_Maximale>
+    </Donnees_Releve>
+  </PRM>
+</R151>"""
+
+R151_MULTI_PRM_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R151>
+  <En_Tete_Flux>
+    <Identifiant_Flux>R151</Identifiant_Flux>
+  </En_Tete_Flux>
+  <PRM>
+    <Id_PRM>30001234567890</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <Classe_Temporelle_Distributeur>
+        <Id_Classe_Temporelle>HCB</Id_Classe_Temporelle>
+        <Valeur>1000</Valeur>
+      </Classe_Temporelle_Distributeur>
+    </Donnees_Releve>
+  </PRM>
+  <PRM>
+    <Id_PRM>30009876543210</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <Classe_Temporelle>
+        <Id_Classe_Temporelle>HC</Id_Classe_Temporelle>
+        <Valeur>2000</Valeur>
+      </Classe_Temporelle>
+      <Puissance_Maximale>
+        <Valeur>5000</Valeur>
+      </Puissance_Maximale>
+    </Donnees_Releve>
+  </PRM>
+</R151>"""
+
+R151_XML_V2 = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R151>
+  <En_Tete_Flux>
+    <Identifiant_Flux>R151</Identifiant_Flux>
+  </En_Tete_Flux>
+  <PRM>
+    <Id_PRM>30001234567890</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <Classe_Temporelle_Distributeur>
+        <Id_Classe_Temporelle>HCB</Id_Classe_Temporelle>
+        <Valeur>83044960</Valeur>
+        <Indice_Vraisemblance>1</Indice_Vraisemblance>
+      </Classe_Temporelle_Distributeur>
+    </Donnees_Releve>
+  </PRM>
+</R151>"""
+
+
+@pytest.fixture
+def r151_encrypted_file(tmp_path):
+    """Encrypted R151 file with 1 PRM, 3 donnees (CT_DIST + CT + PMAX)."""
+    ct = make_encrypted_zip(R151_XML, "r151.xml", TEST_KEY, TEST_IV)
+    path = tmp_path / "ERDF_R151_23X--TEST_20260302.zip"
+    path.write_bytes(ct)
+    return path
+
+
+class TestIngestR151Pipeline:
+    def test_ingest_r151_success(self, db, r151_encrypted_file, test_keys):
+        status = ingest_file(r151_encrypted_file, db, test_keys)
+        assert status == FluxStatus.PARSED
+
+        f = db.query(EnedisFluxFile).first()
+        assert f.flux_type == "R151"
+        assert f.status == FluxStatus.PARSED
+        assert f.measures_count == 3  # CT_DIST + CT + PMAX
+        assert f.frequence_publication is None
+        assert f.nature_courbe_demandee is None
+        assert f.identifiant_destinataire is None
+        assert f.get_header_raw() is not None
+        assert f.get_header_raw()["Identifiant_Flux"] == "R151"
+
+        mesures = db.query(EnedisFluxMesureR151).order_by(EnedisFluxMesureR151.id).all()
+        assert len(mesures) == 3
+
+        # CT_DIST
+        m_ct_dist = [m for m in mesures if m.type_donnee == "CT_DIST"]
+        assert len(m_ct_dist) == 1
+        m = m_ct_dist[0]
+        assert m.point_id == "30001234567890"
+        assert m.flux_type == "R151"
+        assert m.date_releve == "2026-03-01"
+        assert m.id_calendrier_fournisseur == "CF01"
+        assert m.id_calendrier_distributeur == "CD01"
+        assert m.id_affaire == "AFF001"
+        assert m.id_classe_temporelle == "HCB"
+        assert m.libelle_classe_temporelle == "Heures Creuses Basses"
+        assert m.rang_cadran == "1"
+        assert m.valeur == "83044953"
+        assert m.indice_vraisemblance == "0"
+
+        # CT
+        m_ct = [m for m in mesures if m.type_donnee == "CT"]
+        assert len(m_ct) == 1
+        assert m_ct[0].id_classe_temporelle == "HC"
+        assert m_ct[0].valeur == "18047813"
+
+        # PMAX
+        m_pmax = [m for m in mesures if m.type_donnee == "PMAX"]
+        assert len(m_pmax) == 1
+        assert m_pmax[0].valeur == "7452"
+        assert m_pmax[0].id_classe_temporelle is None
+        assert m_pmax[0].indice_vraisemblance is None
+
+    def test_r151_multi_prm(self, db, tmp_path, test_keys):
+        ct = make_encrypted_zip(R151_MULTI_PRM_XML, "r151_multi.xml", TEST_KEY, TEST_IV)
+        path = tmp_path / "ERDF_R151_23X--TEST_MULTI.zip"
+        path.write_bytes(ct)
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.PARSED
+
+        f = db.query(EnedisFluxFile).first()
+        assert f.measures_count == 3  # 1 + 2
+
+        mesures = db.query(EnedisFluxMesureR151).all()
+        assert len(mesures) == 3
+        prm_ids = {m.point_id for m in mesures}
+        assert prm_ids == {"30001234567890", "30009876543210"}
+
+    def test_r151_idempotence(self, db, r151_encrypted_file, test_keys):
+        ingest_file(r151_encrypted_file, db, test_keys)
+        status2 = ingest_file(r151_encrypted_file, db, test_keys)
+
+        assert status2 == FluxStatus.PARSED
+        assert db.query(EnedisFluxFile).count() == 1
+        assert db.query(EnedisFluxMesureR151).count() == 3
+
+    def test_r151_republication(self, db, tmp_path, test_keys):
+        shared_name = "ERDF_R151_23X--TEST_20260302.zip"
+        path = tmp_path / shared_name
+
+        ct1 = make_encrypted_zip(R151_XML, "a.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct1)
+        assert ingest_file(path, db, test_keys) == FluxStatus.PARSED
+
+        ct2 = make_encrypted_zip(R151_XML_V2, "b.xml", TEST_KEY, TEST_IV)
+        path.write_bytes(ct2)
+        assert ingest_file(path, db, test_keys) == FluxStatus.NEEDS_REVIEW
+
+        files = db.query(EnedisFluxFile).order_by(EnedisFluxFile.version).all()
+        assert len(files) == 2
+        assert files[1].supersedes_file_id == files[0].id
+        assert db.query(EnedisFluxMesureR151).count() == 4  # 3 + 1
+
+    def test_r151_zero_mesures(self, db, tmp_path, test_keys):
+        xml = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R151>
+  <En_Tete_Flux><Identifiant_Flux>R151</Identifiant_Flux></En_Tete_Flux>
+</R151>"""
+        ct = make_encrypted_zip(xml, "empty.xml", TEST_KEY, TEST_IV)
+        path = tmp_path / "ERDF_R151_23X--TEST_EMPTY.zip"
+        path.write_bytes(ct)
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.PARSED
+        assert db.query(EnedisFluxFile).first().measures_count == 0
+
+    def test_r151_corrupt_returns_error(self, db, tmp_path, test_keys):
+        path = tmp_path / "ERDF_R151_23X--TEST_CORRUPT.zip"
+        path.write_bytes(os.urandom(256))
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.ERROR
+        assert db.query(EnedisFluxFile).first().error_message is not None


### PR DESCRIPTION
## Summary

- Replace the R4x-only guard in `ingest_file()` with a `_DISPATCH` table mapping `FluxType → (parser_fn, parse_error_cls, store_fn)` for R4H/R4M/R4Q/R171/R50/R151
- Extract inline R4x storage into `_store_r4x()`, add `_store_r171()`, `_store_r50()`, `_store_r151()` with identical batch-insert pattern
- Add `_create_flux_file()` helper — R4x-specific columns (`frequence_publication`, `nature_courbe_demandee`, `identifiant_destinataire`) populated only for R4x, `header_raw` always set
- Add `_prm_summary()` for multi-PRM log output (R171/R50/R151 can contain multiple PRMs per file)

## Files modified

| File | Change |
|------|--------|
| `pipeline.py` | Dispatch table, 4 `_store_*` functions, `_create_flux_file`, `_prm_summary` |
| `tests/test_pipeline.py` | 18 new tests for R171/R50/R151 pipeline integration |

## Acceptance criteria (plan step 7)

| Criteria | Test(s) |
|----------|---------|
| Pipeline R171 end-to-end | `test_ingest_r171_success` |
| Pipeline R50 end-to-end | `test_ingest_r50_success` |
| Pipeline R151 end-to-end | `test_ingest_r151_success` |
| Idempotence R171/R50/R151 | `test_r1{71,50,51}_idempotence` |
| Fichier corrompu non-R4x | `test_r1{71,50,51}_corrupt_returns_error` |
| 0 mesures valide | `test_r1{71,50,51}_zero_mesures` |
| Non-regression R4x | 15 existing tests pass unchanged |

## Test plan

- [x] `pytest backend/data_ingestion/enedis/ -x -v` — 195/195 passed
- [x] Review dispatch table correctness
- [x] Verify field mapping in each `_store_*` matches the corresponding model columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)