### PR TITLE
feat(enedis): SF3-B — ingest_directory() + statut RECEIVED (#154)

### DIFF
--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -11,13 +11,17 @@ Idempotence:
   - No measure-level deduplication: deferred to a future staging layer.
 
 Usage:
-    from data_ingestion.enedis.pipeline import ingest_file
+    from data_ingestion.enedis.pipeline import ingest_file, ingest_directory
     from data_ingestion.enedis.decrypt import load_keys_from_env
 
     keys = load_keys_from_env()
     session = SessionLocal()
+
+    # Single file
     status = ingest_file(Path("flux.zip"), session, keys)
-    # ingest_file commits on success, rolls back on unhandled error
+
+    # Whole directory (scan → register RECEIVED → process)
+    counters = ingest_directory(Path("flux_enedis/C1-C4"), session, keys)
 """
 
 import hashlib
@@ -89,6 +93,9 @@ def ingest_file(
     file_hash = _hash_file(file_path)
 
     # Idempotence check — applies to all flux types
+    # pre_registered tracks a RECEIVED record to update in-place
+    pre_registered: EnedisFluxFile | None = None
+
     existing = session.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
     if existing is not None:
         if existing.status in (FluxStatus.PARSED, FluxStatus.SKIPPED, FluxStatus.NEEDS_REVIEW):
@@ -100,11 +107,14 @@ def ingest_file(
             logger.info("Retrying previously failed %s (hash=%s…)", filename, file_hash[:12])
             session.delete(existing)
             session.flush()
+        elif existing.status == FluxStatus.RECEIVED:
+            logger.info("Processing pre-registered %s (hash=%s…)", filename, file_hash[:12])
+            pre_registered = existing
 
     # Skip non-decryptable flux types
     if flux_type in SKIP_FLUX_TYPES:
         logger.info("Skipping %s (flux type %s)", filename, flux_type.value)
-        _record_file(session, filename, file_hash, flux_type.value, FluxStatus.SKIPPED)
+        _record_file(session, filename, file_hash, flux_type.value, FluxStatus.SKIPPED, existing=pre_registered)
         session.commit()
         return FluxStatus.SKIPPED
 
@@ -112,7 +122,7 @@ def ingest_file(
     handler = _DISPATCH.get(flux_type)
     if handler is None:
         logger.info("Skipping %s (flux type %s not yet supported)", filename, flux_type.value)
-        _record_file(session, filename, file_hash, flux_type.value, FluxStatus.SKIPPED)
+        _record_file(session, filename, file_hash, flux_type.value, FluxStatus.SKIPPED, existing=pre_registered)
         session.commit()
         return FluxStatus.SKIPPED
 
@@ -135,7 +145,9 @@ def ingest_file(
         xml_bytes = decrypt_file(file_path, keys, archive_dir)
     except DecryptError as exc:
         logger.error("Decrypt failed for %s: %s", filename, exc)
-        _record_file(session, filename, file_hash, flux_type.value, FluxStatus.ERROR, str(exc))
+        _record_file(
+            session, filename, file_hash, flux_type.value, FluxStatus.ERROR, str(exc), existing=pre_registered,
+        )
         session.commit()
         return FluxStatus.ERROR
 
@@ -144,7 +156,9 @@ def ingest_file(
         parsed = parser_fn(xml_bytes)
     except parse_error_cls as exc:
         logger.error("Parse failed for %s: %s", filename, exc)
-        _record_file(session, filename, file_hash, flux_type.value, FluxStatus.ERROR, str(exc))
+        _record_file(
+            session, filename, file_hash, flux_type.value, FluxStatus.ERROR, str(exc), existing=pre_registered,
+        )
         session.commit()
         return FluxStatus.ERROR
 
@@ -168,8 +182,10 @@ def ingest_file(
 
         flux_file = _create_flux_file(
             filename, file_hash, flux_type, file_status, file_version, supersedes_id, parsed,
+            existing=pre_registered,
         )
-        session.add(flux_file)
+        if pre_registered is None:
+            session.add(flux_file)
         session.flush()  # Get flux_file.id
 
         total_inserted = store_fn(parsed, flux_file, session, chunk_size)
@@ -178,7 +194,17 @@ def ingest_file(
     except Exception as exc:
         session.rollback()
         logger.error("DB storage failed for %s: %s", filename, exc)
-        _record_file(session, filename, file_hash, flux_type.value, FluxStatus.ERROR, str(exc))
+        # After rollback, objects are detached — re-fetch the pre-registered
+        # record if it exists so the update actually persists.
+        refetched = (
+            session.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
+            if pre_registered is not None
+            else None
+        )
+        _record_file(
+            session, filename, file_hash, flux_type.value, FluxStatus.ERROR, str(exc),
+            existing=refetched,
+        )
         session.commit()
         return FluxStatus.ERROR
 
@@ -192,6 +218,113 @@ def ingest_file(
         ", needs_review" if is_republication else "",
     )
     return file_status
+
+
+def ingest_directory(
+    directory: Path,
+    session: Session,
+    keys: list[tuple[bytes, bytes]],
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    archive_dir: Path | None = None,
+    recursive: bool = False,
+    pattern: str = "*.zip",
+) -> dict[str, int]:
+    """Ingest all flux files in a directory: scan → register → process.
+
+    Two-phase design for crash recovery:
+      Phase 1: scan directory, register each new file as RECEIVED (single commit).
+      Phase 2: process each RECEIVED file via ingest_file() → PARSED/ERROR/SKIPPED.
+    Files left in RECEIVED after a crash are re-processed on the next run.
+
+    Args:
+        directory: Path to the directory containing encrypted .zip files.
+        session: SQLAlchemy session.
+        keys: Decryption key/IV pairs from load_keys_from_env().
+        chunk_size: Number of mesure rows per batch insert.
+        archive_dir: Optional directory to write decrypted XML for audit.
+        recursive: If True, scan subdirectories recursively.
+        pattern: Glob pattern for file matching (default ``*.zip``).
+
+    Returns:
+        Dict of counters: received, parsed, needs_review, skipped, error,
+        already_processed.
+        ``received == parsed + needs_review + skipped + error``.
+    """
+    counters: dict[str, int] = {
+        "received": 0,
+        "parsed": 0,
+        "needs_review": 0,
+        "skipped": 0,
+        "error": 0,
+        "already_processed": 0,
+    }
+
+    if not directory.is_dir():
+        logger.warning("ingest_directory: %s is not a directory", directory)
+        return counters
+
+    # Phase 1 — Scan & register as RECEIVED
+    glob_fn = directory.rglob if recursive else directory.glob
+    zip_files = sorted(p for p in glob_fn(pattern) if p.is_file())
+
+    # (file_path, file_hash, flux_file) — hash is kept to avoid re-reading
+    # the file in the Phase 2 exception handler.
+    to_process: list[tuple[Path, str, EnedisFluxFile]] = []
+
+    for file_path in zip_files:
+        file_hash = _hash_file(file_path)
+        existing = session.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
+
+        if existing is not None:
+            if existing.status == FluxStatus.RECEIVED:
+                # Stale from a previous interrupted run — re-process
+                logger.info("Found stale RECEIVED %s, will re-process", file_path.name)
+                to_process.append((file_path, file_hash, existing))
+            else:
+                # Already processed (PARSED/ERROR/SKIPPED/NEEDS_REVIEW)
+                counters["already_processed"] += 1
+            continue
+
+        # New file — register as RECEIVED
+        flux_file = EnedisFluxFile(
+            filename=file_path.name,
+            file_hash=file_hash,
+            flux_type=classify_flux(file_path.name).value,
+            status=FluxStatus.RECEIVED,
+            measures_count=0,
+        )
+        session.add(flux_file)
+        to_process.append((file_path, file_hash, flux_file))
+
+    if to_process:
+        session.commit()  # Single commit for all RECEIVED registrations
+    counters["received"] = len(to_process)
+
+    logger.info(
+        "ingest_directory: %d files to process, %d already processed",
+        len(to_process),
+        counters["already_processed"],
+    )
+
+    # Phase 2 — Process each RECEIVED file
+    for file_path, phase1_hash, flux_file in to_process:
+        try:
+            status = ingest_file(file_path, session, keys, chunk_size, archive_dir)
+        except Exception as exc:
+            # ingest_file raises FileNotFoundError/MissingKeyError without recording;
+            # update the RECEIVED record to ERROR so it doesn't stay stale.
+            logger.error("Unhandled error processing %s: %s", file_path.name, exc)
+            # Use Phase 1 hash — the file may no longer exist on disk.
+            record = session.query(EnedisFluxFile).filter_by(file_hash=phase1_hash).first()
+            if record is not None and record.status == FluxStatus.RECEIVED:
+                record.status = FluxStatus.ERROR
+                record.error_message = str(exc)
+                session.commit()
+            status = FluxStatus.ERROR
+
+        counters[status.value] += 1
+
+    return counters
 
 
 # ---------------------------------------------------------------------------
@@ -211,8 +344,18 @@ def _record_file(
     flux_type: str,
     status: FluxStatus,
     error_message: str | None = None,
+    existing: EnedisFluxFile | None = None,
 ) -> EnedisFluxFile:
-    """Create a minimal EnedisFluxFile record for skipped/error files."""
+    """Create or update a minimal EnedisFluxFile record for skipped/error files.
+
+    If *existing* is provided (pre-registered RECEIVED record), updates it
+    in-place instead of creating a new row.
+    """
+    if existing is not None:
+        existing.status = status
+        existing.error_message = error_message
+        existing.measures_count = 0
+        return existing
     flux_file = EnedisFluxFile(
         filename=filename,
         file_hash=file_hash,
@@ -233,8 +376,12 @@ def _create_flux_file(
     version: int,
     supersedes_id: int | None,
     parsed: Any,
+    existing: EnedisFluxFile | None = None,
 ) -> EnedisFluxFile:
-    """Create an EnedisFluxFile ORM object with header fields.
+    """Create or update an EnedisFluxFile ORM object with header fields.
+
+    If *existing* is provided (pre-registered RECEIVED record), updates it
+    in-place instead of creating a new row — preserving id and created_at.
 
     R4x-specific columns (frequence_publication, nature_courbe_demandee,
     identifiant_destinataire) are populated only for R4x flux types.
@@ -249,6 +396,16 @@ def _create_flux_file(
         freq = None
         nature = None
         dest = None
+
+    if existing is not None:
+        existing.status = status
+        existing.version = version
+        existing.supersedes_file_id = supersedes_id
+        existing.frequence_publication = freq
+        existing.nature_courbe_demandee = nature
+        existing.identifiant_destinataire = dest
+        existing.set_header_raw(parsed.header.raw)
+        return existing
 
     flux_file = EnedisFluxFile(
         filename=filename,

--- a/backend/data_ingestion/enedis/tests/test_pipeline_full.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline_full.py
@@ -3,6 +3,7 @@
 import hashlib
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -14,7 +15,7 @@ from data_ingestion.enedis.models import (
     EnedisFluxMesureR151,
     EnedisFluxMesureR171,
 )
-from data_ingestion.enedis.pipeline import ingest_directory
+from data_ingestion.enedis.pipeline import ingest_directory, ingest_file
 
 from .conftest import TEST_IV, TEST_KEY, make_encrypted_zip
 
@@ -222,19 +223,33 @@ class TestAllSkipped:
 class TestLifecycleReceived:
     """RECEIVED status lifecycle — files are registered before processing."""
 
-    def test_files_registered_as_received_then_transition(self, db, tmp_path, test_keys):
+    def test_intermediate_received_state_visible_between_phases(self, db, tmp_path, test_keys):
+        """After Phase 1 scan, files must be RECEIVED. After Phase 2, they transition."""
         _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
         _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260301.zip", R171_XML)
 
-        counters = ingest_directory(tmp_path, db, test_keys)
+        # Capture the intermediate DB state between Phase 1 (register) and Phase 2 (process)
+        # by wrapping ingest_file to snapshot statuses before it runs.
+        intermediate_statuses: list[str] = []
+        original_ingest_file = ingest_file.__wrapped__ if hasattr(ingest_file, "__wrapped__") else ingest_file
 
-        # After full processing, no file should remain in RECEIVED
-        received_files = db.query(EnedisFluxFile).filter_by(status=FluxStatus.RECEIVED).count()
-        assert received_files == 0
+        def capturing_ingest_file(file_path, session, keys, chunk_size=1000, archive_dir=None):
+            # On first call, capture the state of ALL files (both should be RECEIVED)
+            if not intermediate_statuses:
+                for f in session.query(EnedisFluxFile).all():
+                    intermediate_statuses.append(f.status)
+            return original_ingest_file(file_path, session, keys, chunk_size, archive_dir)
 
-        # All transitioned to final statuses
-        parsed_files = db.query(EnedisFluxFile).filter_by(status=FluxStatus.PARSED).count()
-        assert parsed_files == 2
+        with patch("data_ingestion.enedis.pipeline.ingest_file", side_effect=capturing_ingest_file):
+            counters = ingest_directory(tmp_path, db, test_keys)
+
+        # Between phases: both files were RECEIVED
+        assert len(intermediate_statuses) == 2
+        assert all(s == FluxStatus.RECEIVED for s in intermediate_statuses)
+
+        # After processing: no file remains RECEIVED
+        assert db.query(EnedisFluxFile).filter_by(status=FluxStatus.RECEIVED).count() == 0
+        assert db.query(EnedisFluxFile).filter_by(status=FluxStatus.PARSED).count() == 2
         assert counters["received"] == 2
         assert counters["parsed"] == 2
 
@@ -342,3 +357,140 @@ class TestSortOrder:
             "ENEDIS_23X--TEST_R4H_CDC_20260302.zip",
             "ENEDIS_23X--TEST_R4H_CDC_20260303.zip",
         ]
+
+
+# ===========================================================================
+# Edge case tests
+# ===========================================================================
+
+
+class TestFileDisappears:
+    """File deleted between Phase 1 (scan) and Phase 2 (process)."""
+
+    def test_file_removed_after_scan_records_error(self, db, tmp_path, test_keys):
+        """If a file is deleted between scan and processing, it should not abort the batch."""
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260302.zip", R171_XML)
+
+        # Wrap ingest_file: delete the R4H file just before its first call
+        call_count = 0
+        original_ingest = ingest_file.__wrapped__ if hasattr(ingest_file, "__wrapped__") else ingest_file
+
+        def delete_first_then_ingest(file_path, session, keys, chunk_size=1000, archive_dir=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Delete the file before ingest_file reads it
+                file_path.unlink()
+            return original_ingest(file_path, session, keys, chunk_size, archive_dir)
+
+        with patch("data_ingestion.enedis.pipeline.ingest_file", side_effect=delete_first_then_ingest):
+            counters = ingest_directory(tmp_path, db, test_keys)
+
+        # First file → error (deleted), second file → parsed (still exists)
+        assert counters["error"] == 1
+        assert counters["parsed"] == 1
+        assert counters["received"] == 2
+
+        # The deleted file's RECEIVED record transitioned to ERROR
+        error_files = db.query(EnedisFluxFile).filter_by(status=FluxStatus.ERROR).all()
+        assert len(error_files) == 1
+        assert "not found" in error_files[0].error_message.lower()
+
+        # No file stuck in RECEIVED
+        assert db.query(EnedisFluxFile).filter_by(status=FluxStatus.RECEIVED).count() == 0
+
+
+class TestDbStorageErrorInBatch:
+    """DB storage error on one file does not block the rest of the batch."""
+
+    def test_storage_error_transitions_received_to_error(self, db, tmp_path, test_keys):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260302.zip", R171_XML)
+
+        call_count = 0
+        original_bulk_save = db.bulk_save_objects
+
+        def fail_first_bulk_save(objects):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("simulated disk full")
+            return original_bulk_save(objects)
+
+        with patch.object(db, "bulk_save_objects", side_effect=fail_first_bulk_save):
+            counters = ingest_directory(tmp_path, db, test_keys)
+
+        # First file fails at storage, second succeeds
+        assert counters["error"] == 1
+        assert counters["parsed"] == 1
+
+        # The failed file's record transitioned from RECEIVED → ERROR (not stuck)
+        error_file = db.query(EnedisFluxFile).filter_by(status=FluxStatus.ERROR).first()
+        assert error_file is not None
+        assert "simulated disk full" in error_file.error_message
+
+        # No file stuck in RECEIVED
+        assert db.query(EnedisFluxFile).filter_by(status=FluxStatus.RECEIVED).count() == 0
+
+
+class TestRecursiveDirectory:
+    """Recursive scanning of subdirectories."""
+
+    def test_recursive_finds_nested_files(self, db, tmp_path, test_keys):
+        # Mimic real Enedis directory structure
+        c1c4 = tmp_path / "C1-C4"
+        c5 = tmp_path / "C5"
+        c1c4.mkdir()
+        c5.mkdir()
+
+        _write_encrypted(c1c4, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(c1c4, "ENEDIS_23X--TEST_R171_20260301.zip", R171_XML)
+        _write_encrypted(c5, "ERDF_R50_23X--TEST_20260301.zip", R50_XML)
+        _write_encrypted(c5, "ERDF_R151_23X--TEST_20260301.zip", R151_XML)
+
+        # Non-recursive: should find nothing (files are in subdirs)
+        counters_flat = ingest_directory(tmp_path, db, test_keys)
+        assert counters_flat["received"] == 0
+
+        # Recursive: should find all 4
+        counters_recursive = ingest_directory(tmp_path, db, test_keys, recursive=True)
+        assert counters_recursive["received"] == 4
+        assert counters_recursive["parsed"] == 4
+
+
+class TestRepublicationInBatch:
+    """Republication (same filename, different hash) within a single batch directory."""
+
+    def test_republication_detected_in_batch(self, db, tmp_path, test_keys):
+        """Two files with the same Enedis filename but different content in the same batch.
+
+        This can't happen in a single flat directory (filenames must be unique),
+        but can happen across two runs. Here we verify that a pre-existing PARSED
+        file is detected as already_processed, and a new republication variant
+        (different hash via different inner XML) is ingested with needs_review.
+        """
+        # First run: ingest v1
+        ct1 = make_encrypted_zip(R4H_XML, "a.xml", TEST_KEY, TEST_IV)
+        path1 = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_20260301.zip"
+        path1.write_bytes(ct1)
+
+        counters1 = ingest_directory(tmp_path, db, test_keys)
+        assert counters1["parsed"] == 1
+
+        # Second run: same filename, different content (republication)
+        ct2 = make_encrypted_zip(R4H_XML, "b.xml", TEST_KEY, TEST_IV)
+        path1.write_bytes(ct2)
+
+        counters2 = ingest_directory(tmp_path, db, test_keys)
+        assert counters2["received"] == 1
+        assert counters2["needs_review"] == 1
+        assert counters2["already_processed"] == 0  # old hash no longer on disk
+
+        # Both versions in DB
+        files = db.query(EnedisFluxFile).order_by(EnedisFluxFile.version).all()
+        assert len(files) == 2
+        assert files[0].version == 1
+        assert files[0].status == FluxStatus.PARSED
+        assert files[1].version == 2
+        assert files[1].status == FluxStatus.NEEDS_REVIEW

--- a/backend/data_ingestion/enedis/tests/test_pipeline_full.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline_full.py
@@ -1,0 +1,344 @@
+"""Tests for ingest_directory() — SF3-B full pipeline batch ingestion."""
+
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from data_ingestion.enedis.enums import FluxStatus
+from data_ingestion.enedis.models import (
+    EnedisFluxFile,
+    EnedisFluxMesureR4x,
+    EnedisFluxMesureR50,
+    EnedisFluxMesureR151,
+    EnedisFluxMesureR171,
+)
+from data_ingestion.enedis.pipeline import ingest_directory
+
+from .conftest import TEST_IV, TEST_KEY, make_encrypted_zip
+
+
+# ---------------------------------------------------------------------------
+# Shared XML fixtures (minimal valid XML per flux type)
+# ---------------------------------------------------------------------------
+
+R4H_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<Courbe>
+  <Entete>
+    <Identifiant_Flux>R4x</Identifiant_Flux>
+    <Frequence_Publication>H</Frequence_Publication>
+  </Entete>
+  <Corps>
+    <Identifiant_PRM>30000210411333</Identifiant_PRM>
+    <Donnees_Courbe>
+      <Horodatage_Debut>2026-03-07T00:00:00+01:00</Horodatage_Debut>
+      <Horodatage_Fin>2026-03-07T23:59:59+01:00</Horodatage_Fin>
+      <Granularite>5</Granularite>
+      <Unite_Mesure>kW</Unite_Mesure>
+      <Grandeur_Metier>CONS</Grandeur_Metier>
+      <Grandeur_Physique>EA</Grandeur_Physique>
+      <Donnees_Point_Mesure Horodatage="2026-03-07T00:00:00+01:00" Valeur_Point="398" Statut_Point="R"/>
+    </Donnees_Courbe>
+  </Corps>
+</Courbe>"""
+
+R171_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R171>
+  <entete><emetteur>Enedis</emetteur><flux>R171</flux></entete>
+  <serieMesuresDateesListe>
+    <serieMesuresDatees>
+      <prmId>30000550506121</prmId>
+      <type>INDEX</type>
+      <grandeurPhysique>EA</grandeurPhysique>
+      <unite>Wh</unite>
+      <mesuresDateesListe>
+        <mesureDatee>
+          <dateFin>2026-03-01T00:00:00</dateFin>
+          <valeur>1320</valeur>
+        </mesureDatee>
+      </mesuresDateesListe>
+    </serieMesuresDatees>
+  </serieMesuresDateesListe>
+</R171>"""
+
+R50_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R50>
+  <En_Tete_Flux><Identifiant_Flux>R50</Identifiant_Flux></En_Tete_Flux>
+  <PRM>
+    <Id_PRM>30001234567890</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <PDC><H>2026-03-01T00:00:00+01:00</H><V>20710</V></PDC>
+    </Donnees_Releve>
+  </PRM>
+</R50>"""
+
+R151_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<R151>
+  <En_Tete_Flux><Identifiant_Flux>R151</Identifiant_Flux></En_Tete_Flux>
+  <PRM>
+    <Id_PRM>30001234567890</Id_PRM>
+    <Donnees_Releve>
+      <Date_Releve>2026-03-01</Date_Releve>
+      <Classe_Temporelle_Distributeur>
+        <Id_Classe_Temporelle>HCB</Id_Classe_Temporelle>
+        <Valeur>83044953</Valeur>
+      </Classe_Temporelle_Distributeur>
+    </Donnees_Releve>
+  </PRM>
+</R151>"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_encrypted(directory: Path, filename: str, xml: bytes) -> Path:
+    """Write an encrypted zip file to *directory* with the given filename."""
+    ct = make_encrypted_zip(xml, "inner.xml", TEST_KEY, TEST_IV)
+    path = directory / filename
+    path.write_bytes(ct)
+    return path
+
+
+def _write_corrupt(directory: Path, filename: str) -> Path:
+    """Write a corrupt (random bytes) file to *directory*."""
+    path = directory / filename
+    path.write_bytes(os.urandom(256))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchMixed:
+    """Directory with multiple flux types — all processed correctly."""
+
+    def test_mixed_flux_types(self, db, tmp_path, test_keys):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260301.zip", R171_XML)
+        _write_encrypted(tmp_path, "ERDF_R50_23X--TEST_20260301.zip", R50_XML)
+        _write_encrypted(tmp_path, "ERDF_R151_23X--TEST_20260301.zip", R151_XML)
+
+        # R172 — should be skipped
+        (tmp_path / "ENEDIS_23X--TEST_R172_20260301.zip").write_bytes(os.urandom(64))
+
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["received"] == 5
+        assert counters["parsed"] == 4
+        assert counters["skipped"] == 1
+        assert counters["error"] == 0
+        assert counters["already_processed"] == 0
+
+        # Verify all flux types present in DB
+        flux_types = {f.flux_type for f in db.query(EnedisFluxFile).all()}
+        assert flux_types == {"R4H", "R171", "R50", "R151", "R172"}
+
+        # Verify measures stored in correct tables
+        assert db.query(EnedisFluxMesureR4x).count() == 1
+        assert db.query(EnedisFluxMesureR171).count() == 1
+        assert db.query(EnedisFluxMesureR50).count() == 1
+        assert db.query(EnedisFluxMesureR151).count() == 1
+
+
+class TestIdempotenceBatch:
+    """Running ingest_directory twice is a no-op."""
+
+    def test_second_run_all_already_processed(self, db, tmp_path, test_keys):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260301.zip", R171_XML)
+
+        counters1 = ingest_directory(tmp_path, db, test_keys)
+        counters2 = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters1["received"] == 2
+        assert counters1["parsed"] == 2
+
+        assert counters2["received"] == 0
+        assert counters2["already_processed"] == 2
+        assert counters2["parsed"] == 0
+
+        # No duplicate data
+        assert db.query(EnedisFluxFile).count() == 2
+        assert db.query(EnedisFluxMesureR4x).count() == 1
+        assert db.query(EnedisFluxMesureR171).count() == 1
+
+
+class TestResilience:
+    """Mix of valid, corrupt, and out-of-scope files."""
+
+    def test_corrupt_does_not_block_batch(self, db, tmp_path, test_keys):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_corrupt(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_CORRUPT.zip")
+        (tmp_path / "ENEDIS_23X--TEST_R172_20260301.zip").write_bytes(os.urandom(64))
+
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["received"] == 3
+        assert counters["parsed"] == 1
+        assert counters["error"] == 1
+        assert counters["skipped"] == 1
+
+        # All 3 files recorded — no crash
+        assert db.query(EnedisFluxFile).count() == 3
+
+
+class TestEmptyDirectory:
+    """Empty directory returns zero counters."""
+
+    def test_empty_dir(self, db, tmp_path, test_keys):
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters == {
+            "received": 0, "parsed": 0, "needs_review": 0,
+            "skipped": 0, "error": 0, "already_processed": 0,
+        }
+        assert db.query(EnedisFluxFile).count() == 0
+
+
+class TestAllSkipped:
+    """Directory with only out-of-scope files."""
+
+    def test_only_r172(self, db, tmp_path, test_keys):
+        (tmp_path / "ENEDIS_23X--TEST_R172_A.zip").write_bytes(os.urandom(64))
+        (tmp_path / "ENEDIS_23X--TEST_R172_B.zip").write_bytes(os.urandom(64))
+
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["received"] == 2
+        assert counters["skipped"] == 2
+        assert counters["parsed"] == 0
+
+
+class TestLifecycleReceived:
+    """RECEIVED status lifecycle — files are registered before processing."""
+
+    def test_files_registered_as_received_then_transition(self, db, tmp_path, test_keys):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260301.zip", R171_XML)
+
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        # After full processing, no file should remain in RECEIVED
+        received_files = db.query(EnedisFluxFile).filter_by(status=FluxStatus.RECEIVED).count()
+        assert received_files == 0
+
+        # All transitioned to final statuses
+        parsed_files = db.query(EnedisFluxFile).filter_by(status=FluxStatus.PARSED).count()
+        assert parsed_files == 2
+        assert counters["received"] == 2
+        assert counters["parsed"] == 2
+
+
+class TestReceivedStale:
+    """Crash recovery: stale RECEIVED records are re-processed."""
+
+    def test_stale_received_reprocessed(self, db, tmp_path, test_keys):
+        """Simulate a crash: manually create a RECEIVED record, then run ingest_directory."""
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        file_path = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_20260301.zip"
+        file_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+
+        # Simulate crash: file registered as RECEIVED but never processed
+        stale_record = EnedisFluxFile(
+            filename="ENEDIS_23X--TEST_R4H_CDC_20260301.zip",
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.RECEIVED,
+            measures_count=0,
+        )
+        db.add(stale_record)
+        db.commit()
+        stale_id = stale_record.id
+
+        # Run ingest_directory — should re-process the stale file
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["received"] == 1  # stale RECEIVED counted
+        assert counters["parsed"] == 1
+        assert counters["already_processed"] == 0
+
+        # The original record was updated in-place (same id)
+        f = db.query(EnedisFluxFile).first()
+        assert f.id == stale_id
+        assert f.status == FluxStatus.PARSED
+        assert f.measures_count == 1
+        # Header fields populated by the update-in-place path
+        assert f.get_header_raw() is not None
+        assert f.frequence_publication == "H"
+
+        # Measures stored
+        assert db.query(EnedisFluxMesureR4x).count() == 1
+
+
+class TestCrossFluxQuery:
+    """After ingesting all flux types, verify querying by PRM across tables."""
+
+    def test_query_by_prm_across_tables(self, db, tmp_path, test_keys):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260301.zip", R171_XML)
+        _write_encrypted(tmp_path, "ERDF_R50_23X--TEST_20260301.zip", R50_XML)
+        _write_encrypted(tmp_path, "ERDF_R151_23X--TEST_20260301.zip", R151_XML)
+
+        ingest_directory(tmp_path, db, test_keys)
+
+        # Query R4x PRM
+        r4x = db.query(EnedisFluxMesureR4x).filter_by(point_id="30000210411333").all()
+        assert len(r4x) == 1
+
+        # Query R171 PRM
+        r171 = db.query(EnedisFluxMesureR171).filter_by(point_id="30000550506121").all()
+        assert len(r171) == 1
+
+        # Query R50/R151 shared PRM
+        r50 = db.query(EnedisFluxMesureR50).filter_by(point_id="30001234567890").all()
+        assert len(r50) == 1
+        r151 = db.query(EnedisFluxMesureR151).filter_by(point_id="30001234567890").all()
+        assert len(r151) == 1
+
+
+class TestNonZipIgnored:
+    """Non-.zip files in the directory are completely ignored."""
+
+    def test_non_zip_files_ignored(self, db, tmp_path, test_keys):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        # Non-zip files — should be invisible
+        (tmp_path / "readme.txt").write_text("ignore me")
+        (tmp_path / "data.csv").write_text("a,b,c")
+        (tmp_path / "ENEDIS_R4H.xml").write_text("<xml/>")
+
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["received"] == 1
+        assert counters["parsed"] == 1
+        assert db.query(EnedisFluxFile).count() == 1
+
+
+class TestSortOrder:
+    """Files are processed in filename order (chronological for Enedis naming)."""
+
+    def test_files_sorted_by_name(self, db, tmp_path, test_keys):
+        # Write in reverse order — each with a unique inner filename to produce
+        # distinct hashes (otherwise idempotency would skip duplicates).
+        for day, inner in [("20260303", "c.xml"), ("20260301", "a.xml"), ("20260302", "b.xml")]:
+            ct = make_encrypted_zip(R4H_XML, inner, TEST_KEY, TEST_IV)
+            (tmp_path / f"ENEDIS_23X--TEST_R4H_CDC_{day}.zip").write_bytes(ct)
+
+        ingest_directory(tmp_path, db, test_keys)
+
+        files = db.query(EnedisFluxFile).order_by(EnedisFluxFile.id).all()
+        filenames = [f.filename for f in files]
+        assert filenames == [
+            "ENEDIS_23X--TEST_R4H_CDC_20260301.zip",
+            "ENEDIS_23X--TEST_R4H_CDC_20260302.zip",
+            "ENEDIS_23X--TEST_R4H_CDC_20260303.zip",
+        ]


### PR DESCRIPTION
## Summary

- **`ingest_directory()`** : ingestion batch en 2 phases (scan → register RECEIVED → process via `ingest_file()`). Tri par nom de fichier, résilience (un fichier en erreur ne bloque pas le batch), support récursif optionnel.
- **Statut RECEIVED** (#154) : chaque fichier est enregistré en base avec `status=RECEIVED` avant tout traitement. Crash recovery : les fichiers restés en RECEIVED après un crash sont re-traités au prochain cycle.
- **Update-in-place** : `ingest_file()` détecte un enregistrement RECEIVED pré-existant et le met à jour (préserve `id`/`created_at`) au lieu de supprimer/recréer — compatible avec un futur historique d'audit.
- **14 tests** dans `test_pipeline_full.py` : 8 cas spec + 6 edge cases (fichier supprimé entre phases, erreur DB en batch, scan récursif, republication en batch, etc.)

## Fichiers modifiés

| Fichier | Changement |
|---------|-----------|
| `pipeline.py` | Branche RECEIVED dans le check d'idempotence, param `existing` sur `_record_file()` et `_create_flux_file()`, re-fetch après rollback, nouvelle fonction `ingest_directory()` |
| `tests/test_pipeline_full.py` | Nouveau — 14 tests couvrant batch mixte, idempotence, résilience, répertoire vide, all-skipped, lifecycle RECEIVED (état intermédiaire), crash recovery, cross-flux query, fichiers non-zip ignorés, tri, fichier disparu, erreur DB, récursif, republication |

## Non-régression

- 209/209 tests `data_ingestion/` passent
- 1 échec pré-existant dans `backend/tests/` (non lié — `test_action_close_rules_v49.py`)

## Test plan

- [ ] `pytest backend/data_ingestion/enedis/tests/ -x -v` — 209 pass
- [ ] `pytest backend/data_ingestion/enedis/tests/test_pipeline_full.py -v` — 14 tests SF3-B
- [ ] Vérifier que `ingest_directory()` sur un répertoire vide retourne des compteurs à 0
- [ ] Vérifier le crash recovery : créer un RECEIVED stale manuellement, relancer → re-traité
- [ ] Review : aucun fichier ne reste bloqué en RECEIVED après un cycle complet

🤖 Generated with [Claude Code](https://claude.com/claude-code)