### PR TITLE
feat(enedis): SF4 — Operationalization pipeline (config, audit, CLI, API)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ METEOFRANCE_API_KEY=your_meteofrance_api_key_here
 ENEDIS_CLIENT_ID=your_enedis_client_id_here
 ENEDIS_CLIENT_SECRET=your_enedis_client_secret_here
 
+# Enedis SGE Flux Ingestion (required for SGE pipeline — SF4)
+# Absolute path to the directory containing encrypted .zip flux files
+ENEDIS_FLUX_DIR=/absolute/path/to/flux_enedis
+
 # ============================================================================
 # Public Connectors (No credentials needed - already functional)
 # ============================================================================

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,3 +16,7 @@ SEED_START_YEAR=2020
 SECRET_KEY=your-secret-key-change-in-production
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+
+# Enedis SGE Flux Ingestion (required for SGE pipeline — SF4)
+# Absolute path to the directory containing encrypted .zip flux files
+ENEDIS_FLUX_DIR=/absolute/path/to/flux_enedis

--- a/backend/data_ingestion/enedis/cli.py
+++ b/backend/data_ingestion/enedis/cli.py
@@ -117,6 +117,7 @@ def _print_report(
     print(f"  needs_review:  {counters['needs_review']}")
     print(f"Retried:         {counters['retried']}  (from previous errors)")
     print(f"Max retries:     {counters['max_retries_reached']}  (permanently failed — skipped)")
+    print(f"Perm. failed:    {counters['permanently_failed']}  (status set this run)")
     print(f"Already processed: {counters['already_processed']}")
 
     # Staging totals (all rows in each measure table)
@@ -165,6 +166,7 @@ def _dry_run_report(
     print(f"New files:       {counters['received']}")
     print(f"Retryable errors: {counters['retried']}  (eligible for retry, < MAX_RETRIES)")
     print(f"Max retries:     {counters['max_retries_reached']}  (permanently failed — will be skipped)")
+    print(f"Perm. failed:    {counters['permanently_failed']}  (status set this run)")
     print(f"Already processed: {counters['already_processed']}")
     print(f"No data modifications made.")
 

--- a/backend/data_ingestion/enedis/cli.py
+++ b/backend/data_ingestion/enedis/cli.py
@@ -1,0 +1,280 @@
+"""PROMEOS — Enedis SGE ingestion CLI.
+
+Usage:
+    cd promeos-poc/backend
+    python -m data_ingestion.enedis.cli ingest [OPTIONS]
+
+Options:
+    --dir PATH          Override ENEDIS_FLUX_DIR env var
+    --dry-run           Scan and classify without writing to DB
+    --no-recursive      Disable recursive directory scan (default: recursive)
+    --verbose           Enable DEBUG logging
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Ensure backend/ is on sys.path for project imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# database import triggers load_dotenv() via connection.py
+from database import SessionLocal, engine, run_migrations  # noqa: E402
+from models.base import Base  # noqa: E402
+
+from data_ingestion.enedis.config import get_flux_dir  # noqa: E402
+from data_ingestion.enedis.decrypt import MissingKeyError, load_keys_from_env  # noqa: E402
+from data_ingestion.enedis.enums import FluxStatus, IngestionRunStatus  # noqa: E402
+from data_ingestion.enedis.models import (  # noqa: E402
+    EnedisFluxFile,
+    EnedisFluxMesureR4x,
+    EnedisFluxMesureR50,
+    EnedisFluxMesureR151,
+    EnedisFluxMesureR171,
+    IngestionRun,
+)
+from data_ingestion.enedis.pipeline import ingest_directory  # noqa: E402
+
+logger = logging.getLogger("promeos.enedis.cli")
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _ensure_tables(eng):
+    """Create all tables if DB is missing or empty, then run migrations."""
+    import models  # noqa: F401 — register all models with SQLAlchemy
+    import data_ingestion.enedis.models  # noqa: F401 — register Enedis staging models
+
+    Base.metadata.create_all(bind=eng)
+    run_migrations(eng)
+
+
+# ---------------------------------------------------------------------------
+# argparse
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m data_ingestion.enedis.cli",
+        description="PROMEOS — Enedis SGE ingestion CLI",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    ingest_p = subparsers.add_parser("ingest", help="Run ingestion pipeline")
+    ingest_p.add_argument(
+        "--dir", type=str, default=None,
+        help="Override ENEDIS_FLUX_DIR env var (must be an existing directory)",
+    )
+    ingest_p.add_argument(
+        "--dry-run", action="store_true", default=False,
+        help="Scan and classify without writing to DB",
+    )
+    ingest_p.set_defaults(recursive=True)
+    ingest_p.add_argument(
+        "--no-recursive", dest="recursive", action="store_false",
+        help="Disable recursive directory scan (default: recursive)",
+    )
+    ingest_p.add_argument(
+        "--verbose", action="store_true", default=False,
+        help="Enable DEBUG logging",
+    )
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Reports
+# ---------------------------------------------------------------------------
+
+
+def _print_report(
+    counters: dict[str, int],
+    session,
+    run: IngestionRun,
+    duration: float,
+    flux_dir: Path,
+    recursive: bool,
+) -> None:
+    """Structured report for normal (non-dry-run) ingestion."""
+    mode = "recursive" if recursive else "non-recursive"
+
+    print(f"\n=== ENEDIS SGE INGESTION REPORT ===")
+    print(f"Run #{run.id}        triggered_by: {run.triggered_by}        status: {run.status}")
+    print(f"Source:          {flux_dir} ({mode})")
+    print(f"Duration:        {duration:.1f}s")
+    print(f"Files received:  {counters['received']}")
+    print(f"  parsed:        {counters['parsed']}")
+    print(f"  skipped:       {counters['skipped']}")
+    print(f"  error:         {counters['error']}")
+    print(f"  needs_review:  {counters['needs_review']}")
+    print(f"Retried:         {counters['retried']}  (from previous errors)")
+    print(f"Max retries:     {counters['max_retries_reached']}  (permanently failed — skipped)")
+    print(f"Already processed: {counters['already_processed']}")
+
+    # Staging totals (all rows in each measure table)
+    r4x_total = session.query(EnedisFluxMesureR4x).count()
+    r171_total = session.query(EnedisFluxMesureR171).count()
+    r50_total = session.query(EnedisFluxMesureR50).count()
+    r151_total = session.query(EnedisFluxMesureR151).count()
+    grand_total = r4x_total + r171_total + r50_total + r151_total
+
+    print(f"Measures stored (staging totals):")
+    print(f"  R4x:    {r4x_total:>8,}")
+    print(f"  R171:   {r171_total:>8,}")
+    print(f"  R50:    {r50_total:>8,}")
+    print(f"  R151:   {r151_total:>8,}")
+    print(f"  TOTAL:  {grand_total:>8,}")
+
+    # Error details from this run
+    # Normalize to naive UTC for SQLite comparison (TimestampMixin stores naive)
+    started_at_naive = run.started_at.replace(tzinfo=None) if run.started_at.tzinfo else run.started_at
+    error_files = (
+        session.query(EnedisFluxFile)
+        .filter(
+            EnedisFluxFile.status.in_([FluxStatus.ERROR, FluxStatus.PERMANENTLY_FAILED]),
+            EnedisFluxFile.updated_at >= started_at_naive,
+        )
+        .all()
+    )
+    if error_files:
+        print(f"ERRORS ({len(error_files)}):")
+        for ef in error_files:
+            print(f"  {ef.filename}: {ef.error_message}")
+
+
+def _dry_run_report(
+    counters: dict[str, int],
+    run: IngestionRun,
+    flux_dir: Path,
+    recursive: bool,
+) -> None:
+    """Structured report for dry-run mode."""
+    mode = "recursive" if recursive else "non-recursive"
+
+    print(f"\n=== ENEDIS SGE DRY-RUN REPORT ===")
+    print(f"Run #{run.id}        triggered_by: {run.triggered_by}  (dry-run)")
+    print(f"Source:          {flux_dir} ({mode})")
+    print(f"New files:       {counters['received']}")
+    print(f"Retryable errors: {counters['retried']}  (eligible for retry, < MAX_RETRIES)")
+    print(f"Max retries:     {counters['max_retries_reached']}  (permanently failed — will be skipped)")
+    print(f"Already processed: {counters['already_processed']}")
+    print(f"No data modifications made.")
+
+
+# ---------------------------------------------------------------------------
+# Command: ingest
+# ---------------------------------------------------------------------------
+
+
+def cmd_ingest(args: argparse.Namespace) -> int:
+    """Run the Enedis ingestion pipeline. Returns exit code (0=success, 1=error)."""
+    # Verbose logging — set level on the enedis logger hierarchy
+    enedis_logger = logging.getLogger("promeos.enedis")
+    if args.verbose:
+        enedis_logger.setLevel(logging.DEBUG)
+        if not enedis_logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter("%(name)s %(levelname)s %(message)s"))
+            enedis_logger.addHandler(handler)
+    else:
+        enedis_logger.setLevel(logging.INFO)
+
+    # --- Bootstrap ---
+    _ensure_tables(engine)
+
+    # --- Pre-flight validation ---
+    try:
+        flux_dir = get_flux_dir(override=args.dir)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        keys = load_keys_from_env()
+    except MissingKeyError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    # --- Open session ---
+    session = SessionLocal()
+    try:
+        # --- Concurrency guard ---
+        existing_run = session.query(IngestionRun).filter_by(status=IngestionRunStatus.RUNNING).first()
+        if existing_run is not None:
+            print(
+                f"ERROR: another ingestion run is already in progress "
+                f"(run #{existing_run.id}, started {existing_run.started_at}). "
+                f"If the previous run crashed, update its status manually.",
+                file=sys.stderr,
+            )
+            return 1
+
+        # --- Create IngestionRun (always, even dry-run — for audit) ---
+        run = IngestionRun(
+            started_at=datetime.now(timezone.utc),
+            directory=str(flux_dir),
+            recursive=args.recursive,
+            dry_run=args.dry_run,
+            status=IngestionRunStatus.RUNNING,
+            triggered_by="cli",
+        )
+        session.add(run)
+        session.commit()
+
+        # --- Execute pipeline ---
+        start_time = time.monotonic()
+        try:
+            counters = ingest_directory(
+                flux_dir,
+                session,
+                keys,
+                recursive=args.recursive,
+                dry_run=args.dry_run,
+                run=run,
+            )
+        except Exception as exc:
+            run.status = IngestionRunStatus.FAILED
+            run.error_message = str(exc)
+            run.finished_at = datetime.now(timezone.utc)
+            session.commit()
+            print(f"ERROR: Run #{run.id} interrupted — status: failed", file=sys.stderr)
+            traceback.print_exc()
+            return 1
+
+        duration = time.monotonic() - start_time
+
+        # --- Report ---
+        # run.status already set to COMPLETED by ingest_directory()
+        if args.dry_run:
+            _dry_run_report(counters, run, flux_dir, args.recursive)
+        else:
+            _print_report(counters, session, run, duration, flux_dir, args.recursive)
+
+        return 0
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.command == "ingest":
+        sys.exit(cmd_ingest(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/data_ingestion/enedis/config.py
+++ b/backend/data_ingestion/enedis/config.py
@@ -1,0 +1,42 @@
+"""PROMEOS — Enedis SGE pipeline configuration.
+
+Externalized settings for the ingestion pipeline (SF4).
+"""
+
+import os
+from pathlib import Path
+
+# Max retries on a file in ERROR status (4 total attempts: 1 initial + 3 retries).
+# Beyond this limit the file transitions to PERMANENTLY_FAILED.
+MAX_RETRIES: int = 3
+
+
+def get_flux_dir(override: str | None = None) -> Path:
+    """Resolve the Enedis flux directory.
+
+    Priority: override > env var ENEDIS_FLUX_DIR.
+    No fallback — ENEDIS_FLUX_DIR is required if no override is provided.
+
+    Args:
+        override: Explicit directory path (from CLI --dir or API body).
+
+    Returns:
+        Path to the flux directory.
+
+    Raises:
+        ValueError: If no directory is configured or the path is not a directory.
+    """
+    if override and override.strip():
+        path = Path(override)
+    else:
+        env_value = os.environ.get("ENEDIS_FLUX_DIR")
+        if not env_value:
+            raise ValueError(
+                "ENEDIS_FLUX_DIR environment variable is required — set it in .env"
+            )
+        path = Path(env_value)
+
+    if not path.is_dir():
+        raise ValueError(f"{path} is not a directory")
+
+    return path

--- a/backend/data_ingestion/enedis/enums.py
+++ b/backend/data_ingestion/enedis/enums.py
@@ -29,3 +29,12 @@ class FluxStatus(str, Enum):
     ERROR = "error"
     SKIPPED = "skipped"
     NEEDS_REVIEW = "needs_review"
+    PERMANENTLY_FAILED = "permanently_failed"
+
+
+class IngestionRunStatus(str, Enum):
+    """Statut d'execution d'un run d'ingestion."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"

--- a/backend/data_ingestion/enedis/models.py
+++ b/backend/data_ingestion/enedis/models.py
@@ -29,7 +29,9 @@ Design decisions:
 import json
 
 from sqlalchemy import (
+    Boolean,
     Column,
+    DateTime,
     ForeignKey,
     Index,
     Integer,
@@ -75,6 +77,12 @@ class EnedisFluxFile(Base, TimestampMixin):
     mesures_r171 = relationship("EnedisFluxMesureR171", back_populates="flux_file", cascade="all, delete-orphan")
     mesures_r50 = relationship("EnedisFluxMesureR50", back_populates="flux_file", cascade="all, delete-orphan")
     mesures_r151 = relationship("EnedisFluxMesureR151", back_populates="flux_file", cascade="all, delete-orphan")
+    errors = relationship(
+        "EnedisFluxFileError",
+        back_populates="flux_file",
+        order_by="EnedisFluxFileError.created_at",
+        cascade="all, delete-orphan",
+    )
 
     def set_header_raw(self, header_dict: dict) -> None:
         self.header_raw = json.dumps(header_dict, ensure_ascii=False)
@@ -265,3 +273,68 @@ class EnedisFluxMesureR151(Base, TimestampMixin):
 
     def __repr__(self) -> str:
         return f"<EnedisFluxMesureR151 {self.point_id} {self.date_releve} {self.valeur}>"
+
+
+class EnedisFluxFileError(Base, TimestampMixin):
+    """Archived error entry for an Enedis flux file.
+
+    Each row represents one failed processing attempt. The number of
+    errors for a file gives the retry count (no dedicated column needed).
+    """
+
+    __tablename__ = "enedis_flux_file_error"
+    __table_args__ = (
+        Index("ix_enedis_flux_file_error_flux_file", "flux_file_id"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    flux_file_id = Column(
+        Integer,
+        ForeignKey("enedis_flux_file.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="FK vers enedis_flux_file",
+    )
+    error_message = Column(Text, nullable=False, comment="Message d'erreur de la tentative")
+
+    flux_file = relationship("EnedisFluxFile", back_populates="errors")
+
+    def __repr__(self) -> str:
+        return f"<EnedisFluxFileError file={self.flux_file_id} msg={self.error_message[:50]}>"
+
+
+class IngestionRun(Base, TimestampMixin):
+    """Tracks a single execution of the ingestion pipeline.
+
+    Counters are updated incrementally (per-file) so that a crash
+    mid-run still reflects the work actually completed.
+    """
+
+    __tablename__ = "enedis_ingestion_run"
+
+    id = Column(Integer, primary_key=True, index=True)
+    started_at = Column(DateTime, nullable=False, comment="Debut du run")
+    finished_at = Column(DateTime, nullable=True, comment="Fin du run (null si en cours)")
+    directory = Column(String(500), nullable=False, comment="Repertoire source scanne")
+    recursive = Column(Boolean, nullable=False, default=True, comment="Scan recursif")
+    dry_run = Column(Boolean, nullable=False, default=False, comment="Mode dry-run (pas de mutation)")
+    status = Column(
+        String(20), nullable=False, default="running",
+        comment="running / completed / failed",
+    )
+    triggered_by = Column(String(10), nullable=False, comment="cli / api")
+
+    # Counters — incremental updates
+    files_received = Column(Integer, default=0, comment="Fichiers nouveaux a traiter")
+    files_parsed = Column(Integer, default=0, comment="Fichiers parses avec succes")
+    files_skipped = Column(Integer, default=0, comment="Fichiers flux hors scope (R172, X14, HDM)")
+    files_error = Column(Integer, default=0, comment="Fichiers en erreur")
+    files_needs_review = Column(Integer, default=0, comment="Fichiers en attente de review (republication)")
+    files_already_processed = Column(Integer, default=0, comment="Fichiers deja traites (PARSED/SKIPPED)")
+    files_retried = Column(Integer, default=0, comment="Fichiers ERROR retentes dans ce run")
+    files_max_retries = Column(Integer, default=0, comment="Fichiers PERMANENTLY_FAILED (nouveau + existant)")
+
+    # Run-level error
+    error_message = Column(Text, nullable=True, comment="Erreur ayant interrompu le run")
+
+    def __repr__(self) -> str:
+        return f"<IngestionRun #{self.id} {self.status} triggered_by={self.triggered_by}>"

--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -26,6 +26,7 @@ Usage:
 
 import hashlib
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -37,13 +38,16 @@ from data_ingestion.enedis.decrypt import (
     classify_flux,
     decrypt_file,
 )
-from data_ingestion.enedis.enums import FluxStatus, FluxType
+from data_ingestion.enedis.config import MAX_RETRIES
+from data_ingestion.enedis.enums import FluxStatus, FluxType, IngestionRunStatus
 from data_ingestion.enedis.models import (
     EnedisFluxFile,
+    EnedisFluxFileError,
     EnedisFluxMesureR4x,
     EnedisFluxMesureR50,
     EnedisFluxMesureR151,
     EnedisFluxMesureR171,
+    IngestionRun,
 )
 from data_ingestion.enedis.parsers.r4 import R4xParseError, parse_r4x
 from data_ingestion.enedis.parsers.r50 import R50ParseError, parse_r50
@@ -66,7 +70,8 @@ def ingest_file(
 ) -> FluxStatus:
     """Ingest one Enedis flux file: decrypt → parse → store in DB.
 
-    Commits the session on success or on recorded error/skip.
+    Commits the session on success, on recorded error/skip, and when
+    archiving error history before a retry or PERMANENTLY_FAILED transition.
     The caller should NOT commit separately.
 
     Args:
@@ -98,15 +103,24 @@ def ingest_file(
 
     existing = session.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
     if existing is not None:
-        if existing.status in (FluxStatus.PARSED, FluxStatus.SKIPPED, FluxStatus.NEEDS_REVIEW):
+        if existing.status in (FluxStatus.PARSED, FluxStatus.SKIPPED, FluxStatus.NEEDS_REVIEW, FluxStatus.PERMANENTLY_FAILED):
             logger.info(
                 "Already processed %s (hash=%s…, status=%s), skipping", filename, file_hash[:12], existing.status
             )
             return FluxStatus(existing.status)
         if existing.status == FluxStatus.ERROR:
+            if len(existing.errors) >= MAX_RETRIES:
+                _archive_error(session, existing)
+                existing.status = FluxStatus.PERMANENTLY_FAILED
+                existing.error_message = None
+                session.commit()
+                logger.info("File %s reached MAX_RETRIES — marked PERMANENTLY_FAILED", filename)
+                return FluxStatus.PERMANENTLY_FAILED
             logger.info("Retrying previously failed %s (hash=%s…)", filename, file_hash[:12])
-            session.delete(existing)
-            session.flush()
+            _archive_error(session, existing)
+            existing.error_message = None
+            session.commit()  # persist error history before retry attempt
+            pre_registered = existing  # reuse same record in-place
         elif existing.status == FluxStatus.RECEIVED:
             logger.info("Processing pre-registered %s (hash=%s…)", filename, file_hash[:12])
             pre_registered = existing
@@ -228,12 +242,16 @@ def ingest_directory(
     archive_dir: Path | None = None,
     recursive: bool = False,
     pattern: str = "*.zip",
+    *,
+    dry_run: bool = False,
+    run: IngestionRun | None = None,
 ) -> dict[str, int]:
     """Ingest all flux files in a directory: scan → register → process.
 
     Two-phase design for crash recovery:
-      Phase 1: scan directory, register each new file as RECEIVED (single commit).
-      Phase 2: process each RECEIVED file via ingest_file() → PARSED/ERROR/SKIPPED.
+      Phase 1: scan directory, register new files as RECEIVED, queue ERROR
+        files for retry, transition max-retried files to PERMANENTLY_FAILED.
+      Phase 2: process each RECEIVED/ERROR file via ingest_file().
     Files left in RECEIVED after a crash are re-processed on the next run.
 
     Args:
@@ -244,11 +262,15 @@ def ingest_directory(
         archive_dir: Optional directory to write decrypted XML for audit.
         recursive: If True, scan subdirectories recursively.
         pattern: Glob pattern for file matching (default ``*.zip``).
+        dry_run: If True, scan and classify without ingesting (no DB mutations).
+        run: Optional IngestionRun for incremental counter updates.
 
     Returns:
-        Dict of counters: received, parsed, needs_review, skipped, error,
-        already_processed.
-        ``received == parsed + needs_review + skipped + error``.
+        Dict of counters: received (new files only), parsed, needs_review,
+        skipped, error, permanently_failed, already_processed, retried,
+        max_retries_reached.
+        ``received + retried == parsed + needs_review + skipped + error + permanently_failed``
+        (in non-dry-run mode).
     """
     counters: dict[str, int] = {
         "received": 0,
@@ -256,7 +278,10 @@ def ingest_directory(
         "needs_review": 0,
         "skipped": 0,
         "error": 0,
+        "permanently_failed": 0,
         "already_processed": 0,
+        "retried": 0,
+        "max_retries_reached": 0,
     }
 
     if not directory.is_dir():
@@ -280,25 +305,58 @@ def ingest_directory(
                 # Stale from a previous interrupted run — re-process
                 logger.info("Found stale RECEIVED %s, will re-process", file_path.name)
                 to_process.append((file_path, file_hash, existing))
+            elif existing.status == FluxStatus.NEEDS_REVIEW:
+                # Data loaded, awaiting human review (republication) — no retry
+                counters["already_processed"] += 1
+            elif existing.status == FluxStatus.PERMANENTLY_FAILED:
+                # Max retries reached — skip, needs manual intervention
+                counters["max_retries_reached"] += 1
+            elif existing.status == FluxStatus.ERROR:
+                error_count = len(existing.errors)
+                if error_count < MAX_RETRIES:
+                    logger.info("Retrying ERROR file %s (attempt %d/%d)",
+                                file_path.name, error_count + 1, MAX_RETRIES)
+                    to_process.append((file_path, file_hash, existing))
+                    counters["retried"] += 1
+                else:
+                    # Transition to PERMANENTLY_FAILED (skip in dry-run)
+                    if not dry_run:
+                        existing.status = FluxStatus.PERMANENTLY_FAILED
+                        session.commit()
+                    logger.info("File %s reached MAX_RETRIES (%d) — %s",
+                                file_path.name, MAX_RETRIES,
+                                "marked PERMANENTLY_FAILED" if not dry_run else "would mark PERMANENTLY_FAILED (dry-run)")
+                    counters["max_retries_reached"] += 1
             else:
-                # Already processed (PARSED/ERROR/SKIPPED/NEEDS_REVIEW)
+                # PARSED, SKIPPED
                 counters["already_processed"] += 1
             continue
 
         # New file — register as RECEIVED
-        flux_file = EnedisFluxFile(
-            filename=file_path.name,
-            file_hash=file_hash,
-            flux_type=classify_flux(file_path.name).value,
-            status=FluxStatus.RECEIVED,
-            measures_count=0,
-        )
-        session.add(flux_file)
-        to_process.append((file_path, file_hash, flux_file))
+        if not dry_run:
+            flux_file = EnedisFluxFile(
+                filename=file_path.name,
+                file_hash=file_hash,
+                flux_type=classify_flux(file_path.name).value,
+                status=FluxStatus.RECEIVED,
+                measures_count=0,
+            )
+            session.add(flux_file)
+            to_process.append((file_path, file_hash, flux_file))
+        else:
+            to_process.append((file_path, file_hash, None))
+        counters["received"] += 1
 
-    if to_process:
+    if to_process and not dry_run:
         session.commit()  # Single commit for all RECEIVED registrations
-    counters["received"] = len(to_process)
+
+    # Update run scan counters after Phase 1
+    if run:
+        run.files_received = counters["received"]
+        run.files_already_processed = counters["already_processed"]
+        run.files_retried = counters["retried"]
+        run.files_max_retries = counters["max_retries_reached"]
+        session.commit()
 
     logger.info(
         "ingest_directory: %d files to process, %d already processed",
@@ -306,23 +364,43 @@ def ingest_directory(
         counters["already_processed"],
     )
 
-    # Phase 2 — Process each RECEIVED file
-    for file_path, phase1_hash, flux_file in to_process:
-        try:
-            status = ingest_file(file_path, session, keys, chunk_size, archive_dir)
-        except Exception as exc:
-            # ingest_file raises FileNotFoundError/MissingKeyError without recording;
-            # update the RECEIVED record to ERROR so it doesn't stay stale.
-            logger.error("Unhandled error processing %s: %s", file_path.name, exc)
-            # Use Phase 1 hash — the file may no longer exist on disk.
-            record = session.query(EnedisFluxFile).filter_by(file_hash=phase1_hash).first()
-            if record is not None and record.status == FluxStatus.RECEIVED:
-                record.status = FluxStatus.ERROR
-                record.error_message = str(exc)
-                session.commit()
-            status = FluxStatus.ERROR
+    # Phase 2 — Process each RECEIVED file (skipped entirely in dry-run)
+    if not dry_run:
+        for file_path, phase1_hash, flux_file in to_process:
+            try:
+                status = ingest_file(file_path, session, keys, chunk_size, archive_dir)
+            except Exception as exc:
+                # ingest_file raises FileNotFoundError/MissingKeyError without recording;
+                # update the RECEIVED record to ERROR so it doesn't stay stale.
+                logger.error("Unhandled error processing %s: %s", file_path.name, exc)
+                # Use Phase 1 hash — the file may no longer exist on disk.
+                record = session.query(EnedisFluxFile).filter_by(file_hash=phase1_hash).first()
+                if record is not None and record.status == FluxStatus.RECEIVED:
+                    record.status = FluxStatus.ERROR
+                    record.error_message = str(exc)
+                    session.commit()
+                status = FluxStatus.ERROR
 
-        counters[status.value] += 1
+            counters[status.value] += 1
+
+            # Incremental run counter update after each file
+            if run:
+                if status == FluxStatus.PARSED:
+                    run.files_parsed += 1
+                elif status == FluxStatus.ERROR:
+                    run.files_error += 1
+                elif status == FluxStatus.SKIPPED:
+                    run.files_skipped += 1
+                elif status == FluxStatus.NEEDS_REVIEW:
+                    run.files_needs_review += 1
+                elif status == FluxStatus.PERMANENTLY_FAILED:
+                    run.files_max_retries += 1
+                session.commit()
+
+    if run:
+        run.status = IngestionRunStatus.COMPLETED
+        run.finished_at = datetime.now(timezone.utc)
+        session.commit()
 
     return counters
 
@@ -337,6 +415,19 @@ def _hash_file(file_path: Path) -> str:
     return hashlib.sha256(file_path.read_bytes()).hexdigest()
 
 
+def _archive_error(session: Session, flux_file: EnedisFluxFile) -> None:
+    """Archive the current error_message into EnedisFluxFileError before retry.
+
+    No-op if error_message is empty or None.
+    """
+    if flux_file.error_message:
+        session.add(EnedisFluxFileError(
+            flux_file_id=flux_file.id,
+            error_message=flux_file.error_message,
+        ))
+        session.flush()
+
+
 def _record_file(
     session: Session,
     filename: str,
@@ -348,8 +439,8 @@ def _record_file(
 ) -> EnedisFluxFile:
     """Create or update a minimal EnedisFluxFile record for skipped/error files.
 
-    If *existing* is provided (pre-registered RECEIVED record), updates it
-    in-place instead of creating a new row.
+    If *existing* is provided (pre-registered RECEIVED or ERROR record being
+    retried), updates it in-place instead of creating a new row.
     """
     if existing is not None:
         existing.status = status

--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -266,7 +266,7 @@ def ingest_directory(
         run: Optional IngestionRun for incremental counter updates.
 
     Returns:
-        Dict of counters: received (new files only), parsed, needs_review,
+        Dict of counters: received (new + stale RECEIVED files), parsed, needs_review,
         skipped, error, permanently_failed, already_processed, retried,
         max_retries_reached.
         ``received + retried == parsed + needs_review + skipped + error``
@@ -306,6 +306,7 @@ def ingest_directory(
                 # Stale from a previous interrupted run — re-process
                 logger.info("Found stale RECEIVED %s, will re-process", file_path.name)
                 to_process.append((file_path, file_hash, existing))
+                counters["received"] += 1
             elif existing.status == FluxStatus.NEEDS_REVIEW:
                 # Data loaded, awaiting human review (republication) — no retry
                 counters["already_processed"] += 1

--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -269,8 +269,9 @@ def ingest_directory(
         Dict of counters: received (new files only), parsed, needs_review,
         skipped, error, permanently_failed, already_processed, retried,
         max_retries_reached.
-        ``received + retried == parsed + needs_review + skipped + error + permanently_failed``
-        (in non-dry-run mode).
+        ``received + retried == parsed + needs_review + skipped + error``
+        (in non-dry-run mode).  ``permanently_failed`` counts files
+        transitioned to PERMANENTLY_FAILED during this run (Phase 1).
     """
     counters: dict[str, int] = {
         "received": 0,
@@ -327,6 +328,7 @@ def ingest_directory(
                                 file_path.name, MAX_RETRIES,
                                 "marked PERMANENTLY_FAILED" if not dry_run else "would mark PERMANENTLY_FAILED (dry-run)")
                     counters["max_retries_reached"] += 1
+                    counters["permanently_failed"] += 1
             else:
                 # PARSED, SKIPPED
                 counters["already_processed"] += 1

--- a/backend/data_ingestion/enedis/pipeline.py
+++ b/backend/data_ingestion/enedis/pipeline.py
@@ -322,7 +322,9 @@ def ingest_directory(
                 else:
                     # Transition to PERMANENTLY_FAILED (skip in dry-run)
                     if not dry_run:
+                        _archive_error(session, existing)
                         existing.status = FluxStatus.PERMANENTLY_FAILED
+                        existing.error_message = None
                         session.commit()
                     logger.info("File %s reached MAX_RETRIES (%d) — %s",
                                 file_path.name, MAX_RETRIES,

--- a/backend/data_ingestion/enedis/scripts/decrypt_samples.py
+++ b/backend/data_ingestion/enedis/scripts/decrypt_samples.py
@@ -1,5 +1,10 @@
 """Decrypt Enedis SGE files and save XML to flux_enedis/decrypted_xml/.
 
+.. deprecated:: SF4
+    This script is deprecated. Use the CLI instead:
+        python -m data_ingestion.enedis.cli ingest [--dir PATH] [--dry-run]
+    Will be removed after SF4 validation is complete.
+
 Organizes output by flux type for easy manual inspection.
 
 Usage:

--- a/backend/data_ingestion/enedis/scripts/ingest_real_db.py
+++ b/backend/data_ingestion/enedis/scripts/ingest_real_db.py
@@ -1,5 +1,10 @@
 """Ingest real Enedis SGE files into promeos.db.
 
+.. deprecated:: SF4
+    This script is deprecated. Use the CLI instead:
+        python -m data_ingestion.enedis.cli ingest [--dir PATH] [--dry-run]
+    Will be removed after SF4 validation is complete.
+
 Runs the full pipeline (decrypt -> parse -> store) against the real database.
 Displays a summary report at the end.
 

--- a/backend/data_ingestion/enedis/tests/test_cli.py
+++ b/backend/data_ingestion/enedis/tests/test_cli.py
@@ -1,0 +1,396 @@
+"""Tests for the Enedis SGE CLI (SF4 Phase 4).
+
+Tests cmd_ingest() directly (no subprocess) with an in-memory SQLite DB,
+mocking SessionLocal/engine to route all DB operations through the test session.
+"""
+
+import argparse
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data_ingestion.enedis.enums import FluxStatus, IngestionRunStatus
+from data_ingestion.enedis.models import (
+    EnedisFluxFile,
+    EnedisFluxMesureR4x,
+    IngestionRun,
+)
+from data_ingestion.enedis.cli import cmd_ingest, _print_report, _dry_run_report
+
+from .conftest import TEST_IV, TEST_KEY, make_encrypted_zip
+
+
+# ---------------------------------------------------------------------------
+# Shared XML (minimal valid R4H for end-to-end tests)
+# ---------------------------------------------------------------------------
+
+R4H_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<Courbe>
+  <Entete>
+    <Identifiant_Flux>R4x</Identifiant_Flux>
+    <Frequence_Publication>H</Frequence_Publication>
+  </Entete>
+  <Corps>
+    <Identifiant_PRM>30000210411333</Identifiant_PRM>
+    <Donnees_Courbe>
+      <Horodatage_Debut>2026-03-07T00:00:00+01:00</Horodatage_Debut>
+      <Horodatage_Fin>2026-03-07T23:59:59+01:00</Horodatage_Fin>
+      <Granularite>5</Granularite>
+      <Unite_Mesure>kW</Unite_Mesure>
+      <Grandeur_Metier>CONS</Grandeur_Metier>
+      <Grandeur_Physique>EA</Grandeur_Physique>
+      <Donnees_Point_Mesure Horodatage="2026-03-07T00:00:00+01:00" Valeur_Point="398" Statut_Point="R"/>
+    </Donnees_Courbe>
+  </Corps>
+</Courbe>"""
+
+# Second R4H with different data (different hash)
+R4H_XML_2 = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<Courbe>
+  <Entete>
+    <Identifiant_Flux>R4x</Identifiant_Flux>
+    <Frequence_Publication>H</Frequence_Publication>
+  </Entete>
+  <Corps>
+    <Identifiant_PRM>30000210411333</Identifiant_PRM>
+    <Donnees_Courbe>
+      <Horodatage_Debut>2026-03-08T00:00:00+01:00</Horodatage_Debut>
+      <Horodatage_Fin>2026-03-08T23:59:59+01:00</Horodatage_Fin>
+      <Granularite>5</Granularite>
+      <Unite_Mesure>kW</Unite_Mesure>
+      <Grandeur_Metier>CONS</Grandeur_Metier>
+      <Grandeur_Physique>EA</Grandeur_Physique>
+      <Donnees_Point_Mesure Horodatage="2026-03-08T00:00:00+01:00" Valeur_Point="412" Statut_Point="R"/>
+    </Donnees_Courbe>
+  </Corps>
+</Courbe>"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_encrypted(directory: Path, filename: str, xml: bytes = R4H_XML) -> Path:
+    """Write an encrypted zip file to *directory* with the given filename."""
+    ct = make_encrypted_zip(xml, "inner.xml", TEST_KEY, TEST_IV)
+    path = directory / filename
+    path.write_bytes(ct)
+    return path
+
+
+def _write_corrupt(directory: Path, filename: str) -> Path:
+    """Write a corrupt (random bytes) file to *directory*."""
+    path = directory / filename
+    path.write_bytes(os.urandom(256))
+    return path
+
+
+def _make_args(dir_path: str | None = None, dry_run: bool = False,
+               recursive: bool = True, verbose: bool = False) -> argparse.Namespace:
+    """Build an argparse.Namespace matching the CLI parser output."""
+    return argparse.Namespace(
+        command="ingest",
+        dir=dir_path,
+        dry_run=dry_run,
+        recursive=recursive,
+        verbose=verbose,
+    )
+
+
+def _patch_cli_deps(db_session, tmp_path):
+    """Return a dict of patches that redirect CLI DB operations to the test session.
+
+    Patches:
+    - cli.SessionLocal -> returns the test db session
+    - cli.engine -> a mock (used only by _ensure_tables which we also patch)
+    - cli._ensure_tables -> no-op (tables already created by conftest db fixture)
+    - cli.get_flux_dir -> returns tmp_path (or can be overridden)
+    - cli.load_keys_from_env -> returns the test keys
+    """
+    return {
+        "data_ingestion.enedis.cli.SessionLocal": MagicMock(return_value=db_session),
+        "data_ingestion.enedis.cli.engine": MagicMock(),
+        "data_ingestion.enedis.cli._ensure_tables": MagicMock(),
+        "data_ingestion.enedis.cli.load_keys_from_env": MagicMock(
+            return_value=[(TEST_KEY, TEST_IV)]
+        ),
+        "data_ingestion.enedis.cli.get_flux_dir": MagicMock(return_value=tmp_path),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliIngest:
+    """Normal mode with synthetic files — counters correct, IngestionRun created."""
+
+    def test_normal_ingest_creates_run_and_processes_files(self, db, tmp_path):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip")
+        args = _make_args()
+
+        patches = _patch_cli_deps(db, tmp_path)
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 0
+
+        # IngestionRun created with status=completed
+        run = db.query(IngestionRun).first()
+        assert run is not None
+        assert run.status == IngestionRunStatus.COMPLETED
+        assert run.triggered_by == "cli"
+        assert run.dry_run is False
+        assert run.finished_at is not None
+
+        # File processed
+        files = db.query(EnedisFluxFile).all()
+        assert len(files) == 1
+        assert files[0].status == FluxStatus.PARSED
+
+        # Measures stored
+        assert db.query(EnedisFluxMesureR4x).count() == 1
+
+        # Run counters reflect processing
+        assert run.files_received == 1
+        assert run.files_parsed == 1
+
+    def test_multiple_files(self, db, tmp_path):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip")
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260302.zip", R4H_XML_2)
+        # R172 should be skipped
+        (tmp_path / "ENEDIS_23X--TEST_R172_20260301.zip").write_bytes(os.urandom(64))
+
+        args = _make_args()
+        patches = _patch_cli_deps(db, tmp_path)
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 0
+
+        run = db.query(IngestionRun).first()
+        assert run.files_received == 3
+        assert run.files_parsed == 2
+        assert run.files_skipped == 1
+
+
+class TestCliNonRecursive:
+    """--no-recursive flag propagates to pipeline and IngestionRun."""
+
+    def test_non_recursive_skips_subdirectories(self, db, tmp_path):
+        # File in subdirectory — should NOT be found with recursive=False
+        subdir = tmp_path / "C1-C4"
+        subdir.mkdir()
+        _write_encrypted(subdir, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip")
+
+        args = _make_args(recursive=False)
+        patches = _patch_cli_deps(db, tmp_path)
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 0
+
+        run = db.query(IngestionRun).first()
+        assert run is not None
+        assert run.recursive is False
+        # No files found (all in subdirectory)
+        assert run.files_received == 0
+        assert db.query(EnedisFluxFile).count() == 0
+
+
+class TestCliDryRun:
+    """Dry-run mode: no data modifications, IngestionRun with dry_run=True."""
+
+    def test_dry_run_no_data_mutations(self, db, tmp_path):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip")
+        args = _make_args(dry_run=True)
+
+        patches = _patch_cli_deps(db, tmp_path)
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 0
+
+        # IngestionRun created with dry_run=True
+        run = db.query(IngestionRun).first()
+        assert run is not None
+        assert run.dry_run is True
+        assert run.status == IngestionRunStatus.COMPLETED
+
+        # No flux files created (dry-run skips DB mutations)
+        assert db.query(EnedisFluxFile).count() == 0
+
+        # No measures stored
+        assert db.query(EnedisFluxMesureR4x).count() == 0
+
+        # Scan counters still populated on the run
+        assert run.files_received == 1
+
+
+class TestCliVerbose:
+    """Verbose flag enables DEBUG logging."""
+
+    def test_verbose_sets_debug_level(self, db, tmp_path):
+        args = _make_args(verbose=True)
+
+        _zero_counters = {
+            "received": 0, "parsed": 0, "skipped": 0, "error": 0,
+            "needs_review": 0, "already_processed": 0, "retried": 0,
+            "max_retries_reached": 0, "permanently_failed": 0,
+        }
+
+        def mock_ingest(directory, session, keys, **kwargs):
+            run = kwargs.get("run")
+            if run:
+                run.status = IngestionRunStatus.COMPLETED
+                run.finished_at = datetime.now(timezone.utc)
+                session.commit()
+            return _zero_counters
+
+        patches = _patch_cli_deps(db, tmp_path)
+        patches["data_ingestion.enedis.cli.ingest_directory"] = MagicMock(
+            side_effect=mock_ingest
+        )
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 0
+        # The enedis logger hierarchy should be set to DEBUG
+        enedis_logger = logging.getLogger("promeos.enedis")
+        assert enedis_logger.level == logging.DEBUG
+
+
+class TestCliMissingDir:
+    """ENEDIS_FLUX_DIR absent + no --dir -> error, no IngestionRun created."""
+
+    def test_missing_dir_exits_with_error(self, db, tmp_path):
+        args = _make_args()
+
+        patches = _patch_cli_deps(db, tmp_path)
+        # Override get_flux_dir to raise ValueError
+        patches["data_ingestion.enedis.cli.get_flux_dir"] = MagicMock(
+            side_effect=ValueError("ENEDIS_FLUX_DIR environment variable is required — set it in .env")
+        )
+
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 1
+
+        # No IngestionRun created (pre-flight failure)
+        assert db.query(IngestionRun).count() == 0
+
+
+class TestCliMissingKeys:
+    """Keys absent -> error, no IngestionRun created."""
+
+    def test_missing_keys_exits_with_error(self, db, tmp_path):
+        args = _make_args()
+
+        from data_ingestion.enedis.decrypt import MissingKeyError
+        patches = _patch_cli_deps(db, tmp_path)
+        # Override load_keys_from_env to raise MissingKeyError
+        patches["data_ingestion.enedis.cli.load_keys_from_env"] = MagicMock(
+            side_effect=MissingKeyError("No decryption keys found in environment variables (KEY_1/IV_1 not set)")
+        )
+
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 1
+
+        # No IngestionRun created (pre-flight failure)
+        assert db.query(IngestionRun).count() == 0
+
+
+class TestCliConcurrentRun:
+    """IngestionRun in status "running" exists -> error, no new run created."""
+
+    def test_concurrent_run_rejected(self, db, tmp_path):
+        # Pre-seed a running IngestionRun
+        existing_run = IngestionRun(
+            started_at=datetime.now(timezone.utc),
+            directory="/some/dir",
+            recursive=True,
+            dry_run=False,
+            status=IngestionRunStatus.RUNNING,
+            triggered_by="api",
+        )
+        db.add(existing_run)
+        db.commit()
+
+        args = _make_args()
+        patches = _patch_cli_deps(db, tmp_path)
+
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 1
+
+        # Only the pre-existing run — no new run created
+        runs = db.query(IngestionRun).all()
+        assert len(runs) == 1
+        assert runs[0].id == existing_run.id
+
+
+class TestCliCrashRun:
+    """Pipeline crash mid-ingestion -> run.status='failed', counters correct."""
+
+    def test_crash_sets_run_failed_with_error_message(self, db, tmp_path):
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip")
+        args = _make_args()
+
+        patches = _patch_cli_deps(db, tmp_path)
+
+        def crashing_ingest(directory, session, keys, **kwargs):
+            # Create a partial run state before crashing
+            run = kwargs.get("run")
+            if run:
+                run.files_received = 1
+                session.commit()
+            raise RuntimeError("simulated pipeline crash")
+
+        patches["data_ingestion.enedis.cli.ingest_directory"] = MagicMock(
+            side_effect=crashing_ingest
+        )
+
+        with patch.multiple("data_ingestion.enedis.cli", **{
+            k.split(".")[-1]: v for k, v in patches.items()
+        }):
+            exit_code = cmd_ingest(args)
+
+        assert exit_code == 1
+
+        # IngestionRun exists with status=failed
+        run = db.query(IngestionRun).first()
+        assert run is not None
+        assert run.status == IngestionRunStatus.FAILED
+        assert run.finished_at is not None
+        assert "simulated pipeline crash" in run.error_message
+
+        # Incremental counters were committed before the crash
+        assert run.files_received == 1

--- a/backend/data_ingestion/enedis/tests/test_config.py
+++ b/backend/data_ingestion/enedis/tests/test_config.py
@@ -1,16 +1,9 @@
 """Tests for Enedis SGE pipeline configuration (SF4 Phase 1)."""
 
 import os
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(
-    0,
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
-)
 
 from data_ingestion.enedis.config import MAX_RETRIES, get_flux_dir
 

--- a/backend/data_ingestion/enedis/tests/test_config.py
+++ b/backend/data_ingestion/enedis/tests/test_config.py
@@ -1,0 +1,94 @@
+"""Tests for Enedis SGE pipeline configuration (SF4 Phase 1)."""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+)
+
+from data_ingestion.enedis.config import MAX_RETRIES, get_flux_dir
+
+
+# ---------------------------------------------------------------------------
+# TestGetFluxDir
+# ---------------------------------------------------------------------------
+
+
+class TestGetFluxDir:
+    """Tests for get_flux_dir() resolution logic."""
+
+    def test_env_var_set(self, tmp_path):
+        """ENEDIS_FLUX_DIR set → returns correct path."""
+        with patch.dict(os.environ, {"ENEDIS_FLUX_DIR": str(tmp_path)}):
+            result = get_flux_dir()
+            assert result == tmp_path
+
+    def test_env_var_absent_no_override(self):
+        """ENEDIS_FLUX_DIR absent + no override → ValueError with explicit message."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Ensure ENEDIS_FLUX_DIR is not set
+            os.environ.pop("ENEDIS_FLUX_DIR", None)
+            with pytest.raises(ValueError, match="ENEDIS_FLUX_DIR environment variable is required"):
+                get_flux_dir()
+
+    def test_override_takes_priority(self, tmp_path):
+        """Explicit override → used even if env var is set."""
+        override_dir = tmp_path / "override"
+        override_dir.mkdir()
+        with patch.dict(os.environ, {"ENEDIS_FLUX_DIR": str(tmp_path)}):
+            result = get_flux_dir(override=str(override_dir))
+            assert result == override_dir
+
+    def test_nonexistent_directory(self, tmp_path):
+        """Path that does not exist → ValueError."""
+        fake = tmp_path / "does_not_exist"
+        with patch.dict(os.environ, {"ENEDIS_FLUX_DIR": str(fake)}):
+            with pytest.raises(ValueError, match="is not a directory"):
+                get_flux_dir()
+
+    def test_empty_override_falls_back_to_env(self, tmp_path):
+        """Empty string override → fallback to env var."""
+        with patch.dict(os.environ, {"ENEDIS_FLUX_DIR": str(tmp_path)}):
+            result = get_flux_dir(override="")
+            assert result == tmp_path
+
+    def test_whitespace_override_falls_back_to_env(self, tmp_path):
+        """Whitespace-only override → fallback to env var."""
+        with patch.dict(os.environ, {"ENEDIS_FLUX_DIR": str(tmp_path)}):
+            result = get_flux_dir(override="   ")
+            assert result == tmp_path
+
+    def test_override_nonexistent_directory(self, tmp_path):
+        """Override pointing to non-existent dir → ValueError."""
+        fake = tmp_path / "nope"
+        with pytest.raises(ValueError, match="is not a directory"):
+            get_flux_dir(override=str(fake))
+
+    def test_none_override_uses_env(self, tmp_path):
+        """None override (default) → uses env var."""
+        with patch.dict(os.environ, {"ENEDIS_FLUX_DIR": str(tmp_path)}):
+            result = get_flux_dir(override=None)
+            assert result == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# TestMaxRetries
+# ---------------------------------------------------------------------------
+
+
+class TestMaxRetries:
+    """Tests for MAX_RETRIES constant."""
+
+    def test_value(self):
+        """MAX_RETRIES is 3."""
+        assert MAX_RETRIES == 3
+
+    def test_type(self):
+        """MAX_RETRIES is an int."""
+        assert isinstance(MAX_RETRIES, int)

--- a/backend/data_ingestion/enedis/tests/test_models.py
+++ b/backend/data_ingestion/enedis/tests/test_models.py
@@ -3,12 +3,15 @@
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from data_ingestion.enedis.enums import FluxStatus, IngestionRunStatus
 from data_ingestion.enedis.models import (
     EnedisFluxFile,
+    EnedisFluxFileError,
     EnedisFluxMesureR4x,
     EnedisFluxMesureR171,
     EnedisFluxMesureR50,
     EnedisFluxMesureR151,
+    IngestionRun,
 )
 
 
@@ -589,3 +592,237 @@ class TestEnedisFluxMesureR151:
         db.commit()
         db.refresh(f)
         assert len(f.mesures_r151) == 3
+
+
+# ---------------------------------------------------------------------------
+# FluxStatus.PERMANENTLY_FAILED + IngestionRunStatus
+# ---------------------------------------------------------------------------
+
+
+class TestFluxStatusPermanentlyFailed:
+    def test_permanently_failed_value(self):
+        assert FluxStatus.PERMANENTLY_FAILED == "permanently_failed"
+        assert FluxStatus.PERMANENTLY_FAILED.value == "permanently_failed"
+
+    def test_permanently_failed_distinct_from_error(self):
+        assert FluxStatus.PERMANENTLY_FAILED != FluxStatus.ERROR
+
+
+class TestIngestionRunStatus:
+    def test_running_value(self):
+        assert IngestionRunStatus.RUNNING == "running"
+
+    def test_completed_value(self):
+        assert IngestionRunStatus.COMPLETED == "completed"
+
+    def test_failed_value(self):
+        assert IngestionRunStatus.FAILED == "failed"
+
+    def test_all_values(self):
+        values = {s.value for s in IngestionRunStatus}
+        assert values == {"running", "completed", "failed"}
+
+
+# ---------------------------------------------------------------------------
+# EnedisFluxFileError
+# ---------------------------------------------------------------------------
+
+
+class TestEnedisFluxFileError:
+    def _make_file(self, db, file_hash="h_err"):
+        f = EnedisFluxFile(filename="err.zip", file_hash=file_hash, flux_type="R4H", status="error")
+        db.add(f)
+        db.flush()
+        return f
+
+    def test_create_error(self, db):
+        f = self._make_file(db)
+        err = EnedisFluxFileError(flux_file_id=f.id, error_message="decrypt failed")
+        db.add(err)
+        db.commit()
+
+        result = db.query(EnedisFluxFileError).first()
+        assert result.flux_file_id == f.id
+        assert result.error_message == "decrypt failed"
+        assert result.created_at is not None
+
+    def test_cascade_delete(self, db):
+        f = self._make_file(db)
+        db.add(EnedisFluxFileError(flux_file_id=f.id, error_message="err1"))
+        db.add(EnedisFluxFileError(flux_file_id=f.id, error_message="err2"))
+        db.commit()
+        assert db.query(EnedisFluxFileError).count() == 2
+
+        db.delete(f)
+        db.commit()
+        assert db.query(EnedisFluxFileError).count() == 0
+
+    def test_ordering_by_created_at(self, db):
+        """Errors are ordered by created_at via the relationship."""
+        import time
+
+        f = self._make_file(db)
+        err1 = EnedisFluxFileError(flux_file_id=f.id, error_message="first error")
+        db.add(err1)
+        db.commit()
+
+        # Small delay to ensure different timestamps
+        time.sleep(0.05)
+
+        err2 = EnedisFluxFileError(flux_file_id=f.id, error_message="second error")
+        db.add(err2)
+        db.commit()
+
+        db.refresh(f)
+        assert len(f.errors) == 2
+        assert f.errors[0].error_message == "first error"
+        assert f.errors[1].error_message == "second error"
+
+    def test_relationship_via_flux_file(self, db):
+        f = self._make_file(db)
+        db.add(EnedisFluxFileError(flux_file_id=f.id, error_message="attempt 1"))
+        db.add(EnedisFluxFileError(flux_file_id=f.id, error_message="attempt 2"))
+        db.add(EnedisFluxFileError(flux_file_id=f.id, error_message="attempt 3"))
+        db.commit()
+
+        db.refresh(f)
+        assert len(f.errors) == 3
+        # Retry count derived from len(errors)
+        assert len(f.errors) == 3
+
+
+# ---------------------------------------------------------------------------
+# IngestionRun
+# ---------------------------------------------------------------------------
+
+
+class TestIngestionRun:
+    def test_create_run(self, db):
+        from datetime import datetime, timezone
+
+        run = IngestionRun(
+            started_at=datetime.now(timezone.utc),
+            directory="/tmp/flux",
+            triggered_by="cli",
+        )
+        db.add(run)
+        db.commit()
+
+        result = db.query(IngestionRun).first()
+        assert result.status == "running"
+        assert result.triggered_by == "cli"
+        assert result.directory == "/tmp/flux"
+        assert result.recursive is True
+        assert result.dry_run is False
+        assert result.finished_at is None
+        assert result.error_message is None
+        assert result.created_at is not None
+
+    def test_default_counters(self, db):
+        from datetime import datetime, timezone
+
+        run = IngestionRun(
+            started_at=datetime.now(timezone.utc),
+            directory="/tmp/flux",
+            triggered_by="api",
+        )
+        db.add(run)
+        db.commit()
+
+        result = db.query(IngestionRun).first()
+        assert result.files_received == 0
+        assert result.files_parsed == 0
+        assert result.files_skipped == 0
+        assert result.files_error == 0
+        assert result.files_needs_review == 0
+        assert result.files_already_processed == 0
+        assert result.files_retried == 0
+        assert result.files_max_retries == 0
+
+    def test_status_transition_running_to_completed(self, db):
+        from datetime import datetime, timezone
+
+        run = IngestionRun(
+            started_at=datetime.now(timezone.utc),
+            directory="/tmp/flux",
+            triggered_by="cli",
+        )
+        db.add(run)
+        db.commit()
+        assert run.status == "running"
+
+        run.status = IngestionRunStatus.COMPLETED
+        run.finished_at = datetime.now(timezone.utc)
+        run.files_parsed = 10
+        db.commit()
+
+        result = db.query(IngestionRun).first()
+        assert result.status == "completed"
+        assert result.finished_at is not None
+        assert result.files_parsed == 10
+
+    def test_status_transition_running_to_failed(self, db):
+        from datetime import datetime, timezone
+
+        run = IngestionRun(
+            started_at=datetime.now(timezone.utc),
+            directory="/tmp/flux",
+            triggered_by="api",
+        )
+        db.add(run)
+        db.commit()
+
+        run.status = IngestionRunStatus.FAILED
+        run.finished_at = datetime.now(timezone.utc)
+        run.error_message = "KeyError: missing decryption key"
+        run.files_parsed = 3  # partial progress before crash
+        db.commit()
+
+        result = db.query(IngestionRun).first()
+        assert result.status == "failed"
+        assert result.error_message == "KeyError: missing decryption key"
+        assert result.files_parsed == 3
+
+    def test_all_counter_columns(self, db):
+        from datetime import datetime, timezone
+
+        run = IngestionRun(
+            started_at=datetime.now(timezone.utc),
+            directory="/tmp/flux",
+            triggered_by="cli",
+            files_received=45,
+            files_parsed=38,
+            files_skipped=5,
+            files_error=1,
+            files_needs_review=1,
+            files_already_processed=46,
+            files_retried=2,
+            files_max_retries=0,
+        )
+        db.add(run)
+        db.commit()
+
+        result = db.query(IngestionRun).first()
+        assert result.files_received == 45
+        assert result.files_parsed == 38
+        assert result.files_skipped == 5
+        assert result.files_error == 1
+        assert result.files_needs_review == 1
+        assert result.files_already_processed == 46
+        assert result.files_retried == 2
+        assert result.files_max_retries == 0
+
+    def test_dry_run_flag(self, db):
+        from datetime import datetime, timezone
+
+        run = IngestionRun(
+            started_at=datetime.now(timezone.utc),
+            directory="/tmp/flux",
+            triggered_by="api",
+            dry_run=True,
+        )
+        db.add(run)
+        db.commit()
+
+        result = db.query(IngestionRun).first()
+        assert result.dry_run is True

--- a/backend/data_ingestion/enedis/tests/test_pipeline.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline.py
@@ -4,15 +4,17 @@ import os
 
 import pytest
 
+from data_ingestion.enedis.config import MAX_RETRIES
 from data_ingestion.enedis.enums import FluxStatus
 from data_ingestion.enedis.models import (
     EnedisFluxFile,
+    EnedisFluxFileError,
     EnedisFluxMesureR4x,
     EnedisFluxMesureR50,
     EnedisFluxMesureR151,
     EnedisFluxMesureR171,
 )
-from data_ingestion.enedis.pipeline import ingest_file
+from data_ingestion.enedis.pipeline import ingest_file, ingest_directory
 
 from .conftest import TEST_IV, TEST_KEY, make_encrypted_zip
 
@@ -1049,3 +1051,268 @@ class TestIngestR151Pipeline:
         status = ingest_file(path, db, test_keys)
         assert status == FluxStatus.ERROR
         assert db.query(EnedisFluxFile).first().error_message is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests — Error history preservation (SF4 Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHistoryPreserved:
+    """Error history is preserved across retries via EnedisFluxFileError."""
+
+    def test_two_failures_create_two_error_entries(self, db, tmp_path, test_keys):
+        """File fails 2x → 2 error history entries, len(errors)==2."""
+        from data_ingestion.enedis.pipeline import _hash_file
+
+        # Create a corrupt file → first failure
+        path = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_ERR.zip"
+        path.write_bytes(os.urandom(256))
+        file_hash = _hash_file(path)
+
+        status1 = ingest_file(path, db, test_keys)
+        assert status1 == FluxStatus.ERROR
+
+        f = db.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
+        assert f.error_message is not None
+        assert len(f.errors) == 0  # first failure: error_message on record, no history yet
+
+        # Second failure — write different corrupt bytes to same filename
+        # but same hash won't work, we need to retry the same file
+        status2 = ingest_file(path, db, test_keys)
+        assert status2 == FluxStatus.ERROR
+
+        db.refresh(f)
+        assert len(f.errors) == 1  # first error archived
+        assert f.error_message is not None  # new error on record
+
+    def test_failure_then_success_preserves_history(self, db, tmp_path, test_keys):
+        """File fails once, then succeeds → error history preserved, status=PARSED."""
+        from data_ingestion.enedis.pipeline import _hash_file
+
+        # First: create corrupt file with R4H filename
+        path = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_RETRY.zip"
+
+        # Create valid R4H content as bytes (for the eventual success)
+        valid_ct = make_encrypted_zip(R4H_XML, "test.xml", TEST_KEY, TEST_IV)
+        # But first write corrupt data
+        path.write_bytes(os.urandom(256))
+        file_hash = _hash_file(path)
+
+        status1 = ingest_file(path, db, test_keys)
+        assert status1 == FluxStatus.ERROR
+        f = db.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
+        first_error_msg = f.error_message
+
+        # Now replace with valid content — BUT same hash won't match.
+        # We need to keep the same file hash for retry. So we reprocess
+        # the same corrupt file, which will fail again. Then we need a
+        # different approach: pre-seed an ERROR record with the hash of
+        # the valid file.
+
+        # Actually, the retry path is: same file_hash triggers retry.
+        # So let's write the valid file, compute its hash, pre-seed ERROR.
+        path.write_bytes(valid_ct)
+        valid_hash = _hash_file(path)
+
+        # Pre-seed an ERROR record with the valid file's hash
+        error_record = EnedisFluxFile(
+            filename=path.name,
+            file_hash=valid_hash,
+            flux_type="R4H",
+            status=FluxStatus.ERROR,
+            error_message="previous decrypt error",
+        )
+        db.add(error_record)
+        db.commit()
+
+        # Now ingest the valid file — it should retry and succeed
+        status2 = ingest_file(path, db, test_keys)
+        assert status2 == FluxStatus.PARSED
+
+        f = db.query(EnedisFluxFile).filter_by(file_hash=valid_hash).first()
+        assert f.status == FluxStatus.PARSED
+        # Error history preserved
+        assert len(f.errors) == 1
+        assert f.errors[0].error_message == "previous decrypt error"
+        assert f.error_message is None  # cleared on retry
+
+    def test_error_history_survives_store_failure_on_retry(self, db, tmp_path, test_keys):
+        """Error history is preserved even when the retry itself fails at DB storage."""
+        from unittest.mock import patch
+        from data_ingestion.enedis.pipeline import _hash_file
+
+        # Create valid R4H file
+        ct = make_encrypted_zip(R4H_XML, "test.xml", TEST_KEY, TEST_IV)
+        path = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_STORE_FAIL.zip"
+        path.write_bytes(ct)
+        file_hash = _hash_file(path)
+
+        # Pre-seed ERROR record
+        error_record = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.ERROR,
+            error_message="previous decrypt error",
+        )
+        db.add(error_record)
+        db.commit()
+
+        # Retry with store failure → rollback path
+        with patch.object(db, "bulk_save_objects", side_effect=Exception("disk full")):
+            status = ingest_file(path, db, test_keys)
+
+        assert status == FluxStatus.ERROR
+
+        f = db.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
+        assert f.status == FluxStatus.ERROR
+        assert "disk full" in f.error_message
+        # Error history survived the rollback (committed before retry)
+        assert len(f.errors) == 1
+        assert f.errors[0].error_message == "previous decrypt error"
+
+    def test_decrypt_then_parse_error_distinct_messages(self, db, tmp_path, test_keys):
+        """Two different error types produce distinct error messages in history."""
+        from data_ingestion.enedis.pipeline import _hash_file
+
+        # Create corrupt file (decrypt error)
+        path = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_MULTI_ERR.zip"
+        path.write_bytes(os.urandom(256))
+        file_hash = _hash_file(path)
+
+        status1 = ingest_file(path, db, test_keys)
+        assert status1 == FluxStatus.ERROR
+        f = db.query(EnedisFluxFile).first()
+        decrypt_error_msg = f.error_message
+        assert decrypt_error_msg is not None
+
+        # Second attempt — same file, different error (still decrypt but same type)
+        status2 = ingest_file(path, db, test_keys)
+        assert status2 == FluxStatus.ERROR
+
+        db.refresh(f)
+        assert len(f.errors) == 1
+        assert f.errors[0].error_message == decrypt_error_msg  # archived first error
+
+    def test_permanently_failed_skipped_on_retry(self, db, tmp_path, test_keys):
+        """PERMANENTLY_FAILED files are skipped immediately on re-ingestion."""
+        from data_ingestion.enedis.pipeline import _hash_file
+
+        path = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_PERM.zip"
+        path.write_bytes(os.urandom(256))
+        file_hash = _hash_file(path)
+
+        # Pre-seed as PERMANENTLY_FAILED
+        pf = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.PERMANENTLY_FAILED,
+        )
+        db.add(pf)
+        db.commit()
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.PERMANENTLY_FAILED
+        # No change in DB
+        assert db.query(EnedisFluxFile).count() == 1
+        assert db.query(EnedisFluxFile).first().status == FluxStatus.PERMANENTLY_FAILED
+
+    def test_max_retries_triggers_permanently_failed(self, db, tmp_path, test_keys):
+        """After MAX_RETRIES errors in history, ingest_file marks PERMANENTLY_FAILED."""
+        from data_ingestion.enedis.pipeline import _hash_file
+
+        path = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_MAXR.zip"
+        path.write_bytes(os.urandom(256))
+        file_hash = _hash_file(path)
+
+        # Pre-seed an ERROR record with MAX_RETRIES error entries
+        error_record = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.ERROR,
+            error_message="latest error",
+        )
+        db.add(error_record)
+        db.flush()
+
+        for i in range(MAX_RETRIES):
+            db.add(EnedisFluxFileError(
+                flux_file_id=error_record.id,
+                error_message=f"error attempt {i+1}",
+            ))
+        db.commit()
+
+        status = ingest_file(path, db, test_keys)
+        assert status == FluxStatus.PERMANENTLY_FAILED
+
+        f = db.query(EnedisFluxFile).first()
+        assert f.status == FluxStatus.PERMANENTLY_FAILED
+        assert f.error_message is None  # cleared after archiving
+        # Original MAX_RETRIES errors + the archived "latest error"
+        assert len(f.errors) == MAX_RETRIES + 1
+        assert f.errors[-1].error_message == "latest error"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Dry-run mode (SF4 Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    """dry_run=True scans and classifies without mutating the DB."""
+
+    def test_dry_run_returns_counters_without_db_changes(self, db, tmp_path, test_keys):
+        """ingest_directory(dry_run=True) returns correct counters without DB writes."""
+        # Write valid files
+        ct1 = make_encrypted_zip(R4H_XML, "a.xml", TEST_KEY, TEST_IV)
+        (tmp_path / "ENEDIS_23X--TEST_R4H_CDC_20260301.zip").write_bytes(ct1)
+
+        # Write a skippable R172 file
+        (tmp_path / "ENEDIS_23X--TEST_R172_20260301.zip").write_bytes(os.urandom(64))
+
+        counters = ingest_directory(tmp_path, db, test_keys, dry_run=True)
+
+        # Counters reflect what would happen
+        assert counters["received"] == 2
+        # Processing counters should be 0 (Phase 2 skipped)
+        assert counters["parsed"] == 0
+        assert counters["skipped"] == 0
+        assert counters["error"] == 0
+
+        # No DB modifications
+        assert db.query(EnedisFluxFile).count() == 0
+
+    def test_dry_run_does_not_transition_error_to_permanently_failed(self, db, tmp_path, test_keys):
+        """In dry-run, ERROR files at MAX_RETRIES are counted but not transitioned."""
+        from data_ingestion.enedis.pipeline import _hash_file
+
+        path = tmp_path / "ENEDIS_23X--TEST_R4H_CDC_DRYERR.zip"
+        path.write_bytes(os.urandom(256))
+        file_hash = _hash_file(path)
+
+        # Pre-seed ERROR record at MAX_RETRIES
+        error_record = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.ERROR,
+            error_message="err",
+        )
+        db.add(error_record)
+        db.flush()
+        for i in range(MAX_RETRIES):
+            db.add(EnedisFluxFileError(
+                flux_file_id=error_record.id,
+                error_message=f"error {i}",
+            ))
+        db.commit()
+
+        counters = ingest_directory(tmp_path, db, test_keys, dry_run=True)
+
+        assert counters["max_retries_reached"] == 1
+        # Status NOT changed in dry-run
+        db.refresh(error_record)
+        assert error_record.status == FluxStatus.ERROR

--- a/backend/data_ingestion/enedis/tests/test_pipeline_full.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline_full.py
@@ -2,18 +2,22 @@
 
 import hashlib
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from data_ingestion.enedis.enums import FluxStatus
+from data_ingestion.enedis.config import MAX_RETRIES
+from data_ingestion.enedis.enums import FluxStatus, IngestionRunStatus
 from data_ingestion.enedis.models import (
     EnedisFluxFile,
+    EnedisFluxFileError,
     EnedisFluxMesureR4x,
     EnedisFluxMesureR50,
     EnedisFluxMesureR151,
     EnedisFluxMesureR171,
+    IngestionRun,
 )
 from data_ingestion.enedis.pipeline import ingest_directory, ingest_file
 
@@ -201,7 +205,9 @@ class TestEmptyDirectory:
 
         assert counters == {
             "received": 0, "parsed": 0, "needs_review": 0,
-            "skipped": 0, "error": 0, "already_processed": 0,
+            "skipped": 0, "error": 0, "permanently_failed": 0,
+            "already_processed": 0,
+            "retried": 0, "max_retries_reached": 0,
         }
         assert db.query(EnedisFluxFile).count() == 0
 
@@ -278,7 +284,7 @@ class TestReceivedStale:
         # Run ingest_directory — should re-process the stale file
         counters = ingest_directory(tmp_path, db, test_keys)
 
-        assert counters["received"] == 1  # stale RECEIVED counted
+        assert counters["received"] == 0  # stale RECEIVED is not a new file
         assert counters["parsed"] == 1
         assert counters["already_processed"] == 0
 
@@ -494,3 +500,276 @@ class TestRepublicationInBatch:
         assert files[0].status == FluxStatus.PARSED
         assert files[1].version == 2
         assert files[1].status == FluxStatus.NEEDS_REVIEW
+
+
+# ===========================================================================
+# SF4 Phase 3 — Error retry in batch
+# ===========================================================================
+
+
+class TestErrorRetryInBatch:
+    """ERROR files are retried in ingest_directory(), with error history preserved."""
+
+    def test_error_file_retried_and_history_preserved(self, db, tmp_path, test_keys):
+        """An ERROR file is retried in a subsequent ingest_directory() run.
+        Error history is preserved via EnedisFluxFileError."""
+        path = _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        file_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+
+        # Pre-seed an ERROR record for this file (simulating a prior failed run)
+        error_record = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.ERROR,
+            error_message="previous decrypt error",
+        )
+        db.add(error_record)
+        db.commit()
+        original_id = error_record.id
+
+        # Run ingest_directory — should retry the ERROR file
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["retried"] == 1
+        assert counters["parsed"] == 1
+        assert counters["already_processed"] == 0
+
+        # Record updated in-place
+        f = db.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
+        assert f.id == original_id
+        assert f.status == FluxStatus.PARSED
+        # Error history preserved
+        assert len(f.errors) == 1
+        assert f.errors[0].error_message == "previous decrypt error"
+
+    def test_max_retries_reached_transitions_to_permanently_failed(self, db, tmp_path, test_keys):
+        """File at MAX_RETRIES errors → PERMANENTLY_FAILED, counted in max_retries_reached."""
+        path = _write_corrupt(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_MAXR.zip")
+        file_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+
+        # Pre-seed ERROR record with MAX_RETRIES error entries
+        error_record = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.ERROR,
+            error_message="latest error",
+        )
+        db.add(error_record)
+        db.flush()
+        for i in range(MAX_RETRIES):
+            db.add(EnedisFluxFileError(
+                flux_file_id=error_record.id,
+                error_message=f"error attempt {i+1}",
+            ))
+        db.commit()
+
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["max_retries_reached"] == 1
+        assert counters["retried"] == 0
+
+        f = db.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
+        assert f.status == FluxStatus.PERMANENTLY_FAILED
+
+    def test_permanently_failed_skipped_in_next_run(self, db, tmp_path, test_keys):
+        """A PERMANENTLY_FAILED file is skipped (not retried) in subsequent runs."""
+        path = _write_corrupt(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_PF.zip")
+        file_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+
+        # Pre-seed as PERMANENTLY_FAILED
+        pf = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.PERMANENTLY_FAILED,
+            error_message="gave up",
+        )
+        db.add(pf)
+        db.commit()
+
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["max_retries_reached"] == 1
+        assert counters["retried"] == 0
+        assert counters["received"] == 0
+
+        # Status unchanged
+        f = db.query(EnedisFluxFile).first()
+        assert f.status == FluxStatus.PERMANENTLY_FAILED
+
+
+class TestPermanentlyFailedInPhase2:
+    """ingest_file() returning PERMANENTLY_FAILED in Phase 2 must not crash counters."""
+
+    def test_permanently_failed_from_ingest_file_no_keyerror(self, db, tmp_path, test_keys):
+        """If ingest_file() returns PERMANENTLY_FAILED during Phase 2,
+        counters['permanently_failed'] is incremented without KeyError."""
+        path = _write_corrupt(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_PF2.zip")
+        file_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+
+        # Pre-seed ERROR record eligible for retry (errors < MAX_RETRIES)
+        error_record = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.ERROR,
+            error_message="some error",
+        )
+        db.add(error_record)
+        db.flush()
+        db.add(EnedisFluxFileError(
+            flux_file_id=error_record.id,
+            error_message="past error",
+        ))
+        db.commit()
+
+        # Mock ingest_file to return PERMANENTLY_FAILED (simulates concurrency)
+        with patch(
+            "data_ingestion.enedis.pipeline.ingest_file",
+            return_value=FluxStatus.PERMANENTLY_FAILED,
+        ):
+            counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["permanently_failed"] == 1
+        assert counters["retried"] == 1
+
+
+class TestNeedsReviewNoRetry:
+    """NEEDS_REVIEW files are not retried — counted as already_processed."""
+
+    def test_needs_review_not_retried(self, db, tmp_path, test_keys):
+        path = _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_NR.zip", R4H_XML)
+        file_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+
+        # Pre-seed as NEEDS_REVIEW
+        nr = EnedisFluxFile(
+            filename=path.name,
+            file_hash=file_hash,
+            flux_type="R4H",
+            status=FluxStatus.NEEDS_REVIEW,
+            measures_count=1,
+        )
+        db.add(nr)
+        db.commit()
+
+        counters = ingest_directory(tmp_path, db, test_keys)
+
+        assert counters["already_processed"] == 1
+        assert counters["received"] == 0
+        assert counters["retried"] == 0
+
+        # Status unchanged
+        f = db.query(EnedisFluxFile).first()
+        assert f.status == FluxStatus.NEEDS_REVIEW
+
+
+# ===========================================================================
+# SF4 Phase 3 — Incremental counters (IngestionRun)
+# ===========================================================================
+
+
+class TestIncrementalCounters:
+    """IngestionRun counters are updated incrementally during ingest_directory()."""
+
+    def _make_run(self, db, tmp_path, *, dry_run=False):
+        """Create an IngestionRun for testing."""
+        run = IngestionRun(
+            triggered_by="cli",
+            directory=str(tmp_path),
+            recursive=False,
+            dry_run=dry_run,
+            started_at=datetime.now(timezone.utc),
+        )
+        db.add(run)
+        db.commit()
+        return run
+
+    def test_run_counters_updated_after_each_file(self, db, tmp_path, test_keys):
+        """Counters on the IngestionRun reflect per-file updates, not batch."""
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260301.zip", R171_XML)
+        # R172 → skipped
+        (tmp_path / "ENEDIS_23X--TEST_R172_20260301.zip").write_bytes(os.urandom(64))
+
+        run = self._make_run(db, tmp_path)
+
+        counters = ingest_directory(tmp_path, db, test_keys, run=run)
+
+        db.refresh(run)
+        assert run.status == IngestionRunStatus.COMPLETED
+        assert run.finished_at is not None
+        assert run.files_received == 3
+        assert run.files_parsed == 2
+        assert run.files_skipped == 1
+        assert run.files_error == 0
+        assert run.files_needs_review == 0
+
+    def test_run_counters_reflect_partial_work_on_crash(self, db, tmp_path, test_keys):
+        """If processing crashes mid-run, counters reflect the work completed so far."""
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R171_20260302.zip", R171_XML)
+
+        run = self._make_run(db, tmp_path)
+
+        call_count = 0
+        original_ingest = ingest_file.__wrapped__ if hasattr(ingest_file, "__wrapped__") else ingest_file
+
+        def crash_on_second(file_path, session, keys, chunk_size=1000, archive_dir=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("simulated crash")
+            return original_ingest(file_path, session, keys, chunk_size, archive_dir)
+
+        with patch("data_ingestion.enedis.pipeline.ingest_file", side_effect=crash_on_second):
+            counters = ingest_directory(tmp_path, db, test_keys, run=run)
+
+        db.refresh(run)
+        # First file parsed successfully, second crashed → error
+        assert run.files_parsed == 1
+        assert run.files_error == 1
+        assert run.files_received == 2
+        # Run completed (crash was caught by ingest_directory's except block)
+        assert run.status == IngestionRunStatus.COMPLETED
+
+    def test_run_scan_counters_include_retried_and_max_retries(self, db, tmp_path, test_keys):
+        """Scan phase counters include retried and max_retries_reached."""
+        # Valid file
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+
+        # ERROR file eligible for retry (0 previous errors)
+        retry_path = _write_corrupt(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_RETRY.zip")
+        retry_hash = hashlib.sha256(retry_path.read_bytes()).hexdigest()
+        retry_record = EnedisFluxFile(
+            filename=retry_path.name,
+            file_hash=retry_hash,
+            flux_type="R4H",
+            status=FluxStatus.ERROR,
+            error_message="previous error",
+        )
+        db.add(retry_record)
+        db.commit()
+
+        run = self._make_run(db, tmp_path)
+        counters = ingest_directory(tmp_path, db, test_keys, run=run)
+
+        db.refresh(run)
+        assert run.files_retried == 1
+        assert run.files_received == 1  # new files only, retried tracked separately
+
+    def test_dry_run_with_run_sets_completed(self, db, tmp_path, test_keys):
+        """Even in dry-run mode, the IngestionRun is marked completed."""
+        _write_encrypted(tmp_path, "ENEDIS_23X--TEST_R4H_CDC_20260301.zip", R4H_XML)
+
+        run = self._make_run(db, tmp_path, dry_run=True)
+
+        counters = ingest_directory(tmp_path, db, test_keys, dry_run=True, run=run)
+
+        db.refresh(run)
+        assert run.status == IngestionRunStatus.COMPLETED
+        assert run.finished_at is not None
+        assert run.files_received == 1
+        # Phase 2 skipped → processing counters stay 0
+        assert run.files_parsed == 0

--- a/backend/data_ingestion/enedis/tests/test_pipeline_full.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline_full.py
@@ -568,6 +568,7 @@ class TestErrorRetryInBatch:
         counters = ingest_directory(tmp_path, db, test_keys)
 
         assert counters["max_retries_reached"] == 1
+        assert counters["permanently_failed"] == 1
         assert counters["retried"] == 0
 
         f = db.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()

--- a/backend/data_ingestion/enedis/tests/test_pipeline_full.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline_full.py
@@ -573,6 +573,9 @@ class TestErrorRetryInBatch:
 
         f = db.query(EnedisFluxFile).filter_by(file_hash=file_hash).first()
         assert f.status == FluxStatus.PERMANENTLY_FAILED
+        assert f.error_message is None  # cleared after archive
+        # "latest error" archived alongside the pre-seeded errors
+        assert len(f.errors) == MAX_RETRIES + 1
 
     def test_permanently_failed_skipped_in_next_run(self, db, tmp_path, test_keys):
         """A PERMANENTLY_FAILED file is skipped (not retried) in subsequent runs."""

--- a/backend/data_ingestion/enedis/tests/test_pipeline_full.py
+++ b/backend/data_ingestion/enedis/tests/test_pipeline_full.py
@@ -284,7 +284,7 @@ class TestReceivedStale:
         # Run ingest_directory — should re-process the stale file
         counters = ingest_directory(tmp_path, db, test_keys)
 
-        assert counters["received"] == 0  # stale RECEIVED is not a new file
+        assert counters["received"] == 1  # stale RECEIVED counted to maintain invariant
         assert counters["parsed"] == 1
         assert counters["already_processed"] == 0
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -70,6 +70,7 @@ from routes import (
     geocoding_router,
     usages_router,
     action_center_router,
+    enedis_router,
 )
 
 # Import KB router
@@ -166,6 +167,7 @@ app.include_router(geocoding_router)  # Géocodage BAN (sites → lat/lng)
 app.include_router(aper_router)  # Step 29 APER Solarisation (parkings & toitures)
 app.include_router(usages_router)  # V1.1 Usage (readiness, metering plan, UES, cost breakdown)
 app.include_router(action_center_router)  # Action Center (unified actionable issues)
+app.include_router(enedis_router)  # Enedis SGE Flux (ingestion API)
 
 # Run safe schema migrations (idempotent, no drop)
 from database import engine as _engine, run_migrations as _run_migrations

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -54,6 +54,7 @@ from .aper import router as aper_router
 from .geocoding import router as geocoding_router
 from .usages import router as usages_router
 from .action_center import router as action_center_router
+from .enedis import router as enedis_router
 
 __all__ = [
     "sites_router",
@@ -108,4 +109,5 @@ __all__ = [
     "geocoding_router",
     "usages_router",
     "action_center_router",
+    "enedis_router",
 ]

--- a/backend/routes/enedis.py
+++ b/backend/routes/enedis.py
@@ -212,12 +212,6 @@ def trigger_ingest(body: IngestRequest, db: Session = Depends(get_db)):
 
     duration = time.monotonic() - t0
 
-    # --- Safety net: finalize run if pipeline didn't ---
-    if run.status == IngestionRunStatus.RUNNING:
-        run.status = IngestionRunStatus.COMPLETED
-        run.finished_at = datetime.now(timezone.utc)
-        db.commit()
-
     # --- Collect error files from this run ---
     # Refresh run from DB so started_at has the same type as updated_at
     # (naive on SQLite, tz-aware on PostgreSQL with timezone=True columns),

--- a/backend/routes/enedis.py
+++ b/backend/routes/enedis.py
@@ -42,7 +42,7 @@ router = APIRouter(prefix="/api/enedis", tags=["Enedis SGE Flux"])
 
 class IngestRequest(BaseModel):
     directory: Optional[str] = Field(None, description="Override ENEDIS_FLUX_DIR")
-    recursive: bool = Field(True)
+    recursive: bool = Field(False)
     dry_run: bool = Field(False)
 
 
@@ -212,15 +212,22 @@ def trigger_ingest(body: IngestRequest, db: Session = Depends(get_db)):
 
     duration = time.monotonic() - t0
 
-    # --- Collect error files from this run (same query as CLI _print_report) ---
-    started_at_naive = (
-        run.started_at.replace(tzinfo=None) if run.started_at.tzinfo else run.started_at
-    )
+    # --- Safety net: finalize run if pipeline didn't ---
+    if run.status == IngestionRunStatus.RUNNING:
+        run.status = IngestionRunStatus.COMPLETED
+        run.finished_at = datetime.now(timezone.utc)
+        db.commit()
+
+    # --- Collect error files from this run ---
+    # Refresh run from DB so started_at has the same type as updated_at
+    # (naive on SQLite, tz-aware on PostgreSQL with timezone=True columns),
+    # avoiding mixed-type comparison errors.
+    db.refresh(run)
     error_files = (
         db.query(EnedisFluxFile)
         .filter(
             EnedisFluxFile.status.in_([FluxStatus.ERROR, FluxStatus.PERMANENTLY_FAILED]),
-            EnedisFluxFile.updated_at >= started_at_naive,
+            EnedisFluxFile.updated_at >= run.started_at,
         )
         .all()
     )

--- a/backend/routes/enedis.py
+++ b/backend/routes/enedis.py
@@ -1,0 +1,383 @@
+"""
+PROMEOS — Enedis SGE Flux REST API (SF4 Phase 5)
+Trigger ingestion, list flux files, view stats.
+No auth for POC (ops/admin only).
+Prefix: /api/enedis
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy import func, text
+from sqlalchemy.orm import Session
+
+from database import get_db
+from data_ingestion.enedis.config import get_flux_dir
+from data_ingestion.enedis.decrypt import MissingKeyError, load_keys_from_env
+from data_ingestion.enedis.enums import FluxStatus, IngestionRunStatus
+from data_ingestion.enedis.models import (
+    EnedisFluxFile,
+    EnedisFluxFileError,
+    EnedisFluxMesureR4x,
+    EnedisFluxMesureR151,
+    EnedisFluxMesureR171,
+    EnedisFluxMesureR50,
+    IngestionRun,
+)
+from data_ingestion.enedis.pipeline import ingest_directory
+
+logger = logging.getLogger("promeos.enedis.api")
+
+router = APIRouter(prefix="/api/enedis", tags=["Enedis SGE Flux"])
+
+
+# ========================================
+# Pydantic schemas — Ingestion
+# ========================================
+
+
+class IngestRequest(BaseModel):
+    directory: Optional[str] = Field(None, description="Override ENEDIS_FLUX_DIR")
+    recursive: bool = Field(True)
+    dry_run: bool = Field(False)
+
+
+class IngestErrorDetail(BaseModel):
+    filename: str
+    error_message: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IngestResponse(BaseModel):
+    run_id: int
+    status: str
+    dry_run: bool
+    duration_seconds: float
+    counters: dict[str, int]
+    errors: list[IngestErrorDetail]
+
+
+# ========================================
+# Pydantic schemas — Flux files
+# ========================================
+
+
+class FluxFileResponse(BaseModel):
+    id: int
+    filename: str
+    file_hash: str
+    flux_type: str
+    status: str
+    error_message: Optional[str] = None
+    measures_count: int = 0
+    version: int
+    supersedes_file_id: Optional[int] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("measures_count", mode="before")
+    @classmethod
+    def _normalize_measures_count(cls, v):
+        return v if v is not None else 0
+
+
+class FluxFileListResponse(BaseModel):
+    total: int
+    items: list[FluxFileResponse]
+    limit: int
+    offset: int
+
+
+class ErrorHistoryItem(BaseModel):
+    error_message: str
+    created_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FluxFileDetailResponse(FluxFileResponse):
+    header_raw: Optional[dict[str, Any]] = None
+    frequence_publication: Optional[str] = None
+    nature_courbe_demandee: Optional[str] = None
+    identifiant_destinataire: Optional[str] = None
+    errors_history: list[ErrorHistoryItem] = []
+
+
+# ========================================
+# Pydantic schemas — Stats
+# ========================================
+
+
+class FileStats(BaseModel):
+    total: int
+    by_status: dict[str, int]
+    by_flux_type: dict[str, int]
+
+
+class MeasureStats(BaseModel):
+    total: int
+    r4x: int
+    r171: int
+    r50: int
+    r151: int
+
+
+class PrmStats(BaseModel):
+    count: int
+    identifiers: list[str]
+
+
+class LastIngestion(BaseModel):
+    run_id: int
+    timestamp: Optional[datetime] = None
+    files_count: int
+    triggered_by: str
+
+
+class StatsResponse(BaseModel):
+    files: FileStats
+    measures: MeasureStats
+    prms: PrmStats
+    last_ingestion: Optional[LastIngestion] = None
+
+
+# ========================================
+# POST /api/enedis/ingest
+# ========================================
+
+
+@router.post("/ingest", response_model=IngestResponse)
+def trigger_ingest(body: IngestRequest, db: Session = Depends(get_db)):
+    """Trigger the Enedis SGE ingestion pipeline (synchronous)."""
+    # --- Pre-flight validation ---
+    try:
+        flux_dir = get_flux_dir(override=body.directory)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    try:
+        keys = load_keys_from_env()
+    except MissingKeyError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    # --- Concurrency guard ---
+    existing_run = db.query(IngestionRun).filter_by(status=IngestionRunStatus.RUNNING).first()
+    if existing_run is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Run #{existing_run.id} is already in progress "
+                   f"(started {existing_run.started_at})",
+        )
+
+    # --- Create IngestionRun (only after all validations pass) ---
+    run = IngestionRun(
+        started_at=datetime.now(timezone.utc),
+        directory=str(flux_dir),
+        recursive=body.recursive,
+        dry_run=body.dry_run,
+        status=IngestionRunStatus.RUNNING,
+        triggered_by="api",
+    )
+    db.add(run)
+    db.commit()
+
+    # --- Execute pipeline ---
+    t0 = time.monotonic()
+    try:
+        counters = ingest_directory(
+            flux_dir,
+            db,
+            keys,
+            recursive=body.recursive,
+            dry_run=body.dry_run,
+            run=run,
+        )
+    except Exception as exc:
+        run.status = IngestionRunStatus.FAILED
+        run.error_message = str(exc)
+        run.finished_at = datetime.now(timezone.utc)
+        db.commit()
+        logger.error("Enedis ingestion run #%d failed: %s", run.id, exc, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Run #{run.id} interrupted (status: failed) — {exc}",
+        )
+
+    duration = time.monotonic() - t0
+
+    # --- Collect error files from this run (same query as CLI _print_report) ---
+    started_at_naive = (
+        run.started_at.replace(tzinfo=None) if run.started_at.tzinfo else run.started_at
+    )
+    error_files = (
+        db.query(EnedisFluxFile)
+        .filter(
+            EnedisFluxFile.status.in_([FluxStatus.ERROR, FluxStatus.PERMANENTLY_FAILED]),
+            EnedisFluxFile.updated_at >= started_at_naive,
+        )
+        .all()
+    )
+
+    return IngestResponse(
+        run_id=run.id,
+        status=run.status,
+        dry_run=run.dry_run,
+        duration_seconds=round(duration, 2),
+        counters=counters,
+        errors=[IngestErrorDetail.model_validate(f) for f in error_files],
+    )
+
+
+# ========================================
+# GET /api/enedis/flux-files
+# ========================================
+
+
+@router.get("/flux-files", response_model=FluxFileListResponse)
+def list_flux_files(
+    status: Optional[str] = Query(None, description="Filter by status"),
+    flux_type: Optional[str] = Query(None, description="Filter by flux type"),
+    limit: int = Query(24, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+):
+    """List Enedis flux files with optional filters and pagination."""
+    q = db.query(EnedisFluxFile)
+    if status:
+        q = q.filter(EnedisFluxFile.status == status)
+    if flux_type:
+        q = q.filter(EnedisFluxFile.flux_type == flux_type)
+
+    total = q.count()
+    items = q.order_by(EnedisFluxFile.id.desc()).offset(offset).limit(limit).all()
+
+    return FluxFileListResponse(
+        total=total,
+        items=[FluxFileResponse.model_validate(f) for f in items],
+        limit=limit,
+        offset=offset,
+    )
+
+
+# ========================================
+# GET /api/enedis/flux-files/{id}
+# ========================================
+
+
+@router.get("/flux-files/{file_id}", response_model=FluxFileDetailResponse)
+def get_flux_file_detail(file_id: int, db: Session = Depends(get_db)):
+    """Get detail of a single flux file including header_raw and error history."""
+    f = db.query(EnedisFluxFile).filter(EnedisFluxFile.id == file_id).first()
+    if f is None:
+        raise HTTPException(status_code=404, detail=f"Flux file id={file_id} not found")
+
+    return FluxFileDetailResponse(
+        id=f.id,
+        filename=f.filename,
+        file_hash=f.file_hash,
+        flux_type=f.flux_type,
+        status=f.status,
+        error_message=f.error_message,
+        measures_count=f.measures_count,
+        version=f.version,
+        supersedes_file_id=f.supersedes_file_id,
+        created_at=f.created_at,
+        updated_at=f.updated_at,
+        header_raw=f.get_header_raw(),
+        frequence_publication=f.frequence_publication,
+        nature_courbe_demandee=f.nature_courbe_demandee,
+        identifiant_destinataire=f.identifiant_destinataire,
+        errors_history=[ErrorHistoryItem.model_validate(e) for e in f.errors],
+    )
+
+
+# ========================================
+# GET /api/enedis/stats
+# ========================================
+
+
+@router.get("/stats", response_model=StatsResponse)
+def get_stats(db: Session = Depends(get_db)):
+    """Aggregated ingestion stats: files, measures, PRMs, last ingestion."""
+    # --- Files by status ---
+    status_rows = (
+        db.query(EnedisFluxFile.status, func.count())
+        .group_by(EnedisFluxFile.status)
+        .all()
+    )
+    by_status = {row[0]: row[1] for row in status_rows}
+    files_total = sum(by_status.values())
+
+    # --- Files by flux type ---
+    type_rows = (
+        db.query(EnedisFluxFile.flux_type, func.count())
+        .group_by(EnedisFluxFile.flux_type)
+        .all()
+    )
+    by_flux_type = {row[0]: row[1] for row in type_rows}
+
+    # --- Measures per staging table ---
+    r4x = db.query(func.count()).select_from(EnedisFluxMesureR4x).scalar() or 0
+    r171 = db.query(func.count()).select_from(EnedisFluxMesureR171).scalar() or 0
+    r50 = db.query(func.count()).select_from(EnedisFluxMesureR50).scalar() or 0
+    r151 = db.query(func.count()).select_from(EnedisFluxMesureR151).scalar() or 0
+
+    # --- PRMs: UNION DISTINCT across 4 measure tables ---
+    prm_rows = db.execute(text(
+        "SELECT point_id FROM enedis_flux_mesure_r4x"
+        " UNION SELECT point_id FROM enedis_flux_mesure_r171"
+        " UNION SELECT point_id FROM enedis_flux_mesure_r50"
+        " UNION SELECT point_id FROM enedis_flux_mesure_r151"
+    )).fetchall()
+    prm_identifiers = sorted(row[0] for row in prm_rows)
+
+    # --- Last completed ingestion (non-dry-run) ---
+    last_run = (
+        db.query(IngestionRun)
+        .filter(
+            IngestionRun.status == IngestionRunStatus.COMPLETED,
+            IngestionRun.dry_run == False,
+        )
+        .order_by(IngestionRun.finished_at.desc())
+        .first()
+    )
+    last_ingestion = None
+    if last_run:
+        last_ingestion = LastIngestion(
+            run_id=last_run.id,
+            timestamp=last_run.finished_at,
+            files_count=(
+                (last_run.files_parsed or 0)
+                + (last_run.files_skipped or 0)
+                + (last_run.files_error or 0)
+                + (last_run.files_needs_review or 0)
+            ),
+            triggered_by=last_run.triggered_by,
+        )
+
+    return StatsResponse(
+        files=FileStats(
+            total=files_total,
+            by_status=by_status,
+            by_flux_type=by_flux_type,
+        ),
+        measures=MeasureStats(
+            total=r4x + r171 + r50 + r151,
+            r4x=r4x,
+            r171=r171,
+            r50=r50,
+            r151=r151,
+        ),
+        prms=PrmStats(
+            count=len(prm_identifiers),
+            identifiers=prm_identifiers,
+        ),
+        last_ingestion=last_ingestion,
+    )

--- a/backend/tests/test_enedis_api.py
+++ b/backend/tests/test_enedis_api.py
@@ -1,0 +1,594 @@
+"""
+PROMEOS — Tests for Enedis SGE Flux API endpoints (SF4 Phase 5).
+
+Follows the test_bacs_api.py pattern: in-memory SQLite with TestClient,
+dependency override for get_db, mock pipeline functions at the import site.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from main import app
+from models.base import Base
+import data_ingestion.enedis.models  # noqa: F401 — register Enedis tables
+from database import get_db
+from data_ingestion.enedis.models import (
+    EnedisFluxFile,
+    EnedisFluxFileError,
+    EnedisFluxMesureR4x,
+    EnedisFluxMesureR151,
+    EnedisFluxMesureR171,
+    EnedisFluxMesureR50,
+    IngestionRun,
+)
+from data_ingestion.enedis.enums import FluxStatus, IngestionRunStatus
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    """TestClient + session tuple with isolated in-memory DB."""
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    def _override():
+        try:
+            yield session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app), session
+    app.dependency_overrides.clear()
+    session.close()
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_flux_file(session, filename="ENEDIS_R4H_TEST.zip", flux_type="R4H",
+                    status=FluxStatus.PARSED, measures_count=10,
+                    file_hash=None, header_raw=None, error_message=None):
+    """Seed an EnedisFluxFile and return it."""
+    if file_hash is None:
+        file_hash = f"hash_{filename}_{id(session)}"
+    f = EnedisFluxFile(
+        filename=filename,
+        file_hash=file_hash,
+        flux_type=flux_type,
+        status=status,
+        measures_count=measures_count,
+        version=1,
+        error_message=error_message,
+    )
+    if header_raw is not None:
+        f.header_raw = json.dumps(header_raw, ensure_ascii=False)
+    session.add(f)
+    session.flush()
+    return f
+
+
+def _seed_run(session, status=IngestionRunStatus.COMPLETED, triggered_by="cli",
+              dry_run=False, files_parsed=0, files_error=0, files_skipped=0,
+              files_needs_review=0):
+    """Seed an IngestionRun and return it."""
+    run = IngestionRun(
+        started_at=datetime(2026, 3, 1, 10, 0, 0),
+        finished_at=datetime(2026, 3, 1, 10, 0, 5) if status != IngestionRunStatus.RUNNING else None,
+        directory="/tmp/flux",
+        recursive=True,
+        dry_run=dry_run,
+        status=status,
+        triggered_by=triggered_by,
+        files_parsed=files_parsed,
+        files_error=files_error,
+        files_skipped=files_skipped,
+        files_needs_review=files_needs_review,
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
+def _seed_measure_r4x(session, flux_file, point_id="30001234567890"):
+    """Seed a single R4x measure row."""
+    m = EnedisFluxMesureR4x(
+        flux_file_id=flux_file.id,
+        flux_type="R4H",
+        point_id=point_id,
+        horodatage="2026-03-07T00:00:00+01:00",
+        valeur_point="398",
+    )
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _seed_measure_r171(session, flux_file, point_id="30009876543210"):
+    """Seed a single R171 measure row."""
+    m = EnedisFluxMesureR171(
+        flux_file_id=flux_file.id,
+        flux_type="R171",
+        point_id=point_id,
+        type_mesure="INDEX",
+        date_fin="2026-03-01",
+    )
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _seed_measure_r50(session, flux_file, point_id="30001111111111"):
+    """Seed a single R50 measure row."""
+    m = EnedisFluxMesureR50(
+        flux_file_id=flux_file.id,
+        flux_type="R50",
+        point_id=point_id,
+        date_releve="2026-03-01",
+        horodatage="2026-03-01T00:00:00+01:00",
+    )
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _seed_measure_r151(session, flux_file, point_id="30002222222222"):
+    """Seed a single R151 measure row."""
+    m = EnedisFluxMesureR151(
+        flux_file_id=flux_file.id,
+        flux_type="R151",
+        point_id=point_id,
+        date_releve="2026-03-01",
+        type_donnee="CT_DIST",
+    )
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _seed_error_history(session, flux_file, error_message="decrypt failed"):
+    """Seed an EnedisFluxFileError entry."""
+    e = EnedisFluxFileError(
+        flux_file_id=flux_file.id,
+        error_message=error_message,
+    )
+    session.add(e)
+    session.flush()
+    return e
+
+
+# ---------------------------------------------------------------------------
+# Mock constants
+# ---------------------------------------------------------------------------
+
+_FAKE_COUNTERS = {
+    "received": 2,
+    "parsed": 1,
+    "needs_review": 0,
+    "skipped": 1,
+    "error": 0,
+    "permanently_failed": 0,
+    "already_processed": 0,
+    "retried": 0,
+    "max_retries_reached": 0,
+}
+
+
+def _mock_ingest_directory_success(directory, session, keys, *, recursive=True,
+                                   dry_run=False, run=None, **kwargs):
+    """Mock ingest_directory that updates run and returns fake counters."""
+    if run:
+        run.files_received = _FAKE_COUNTERS["received"]
+        run.files_parsed = _FAKE_COUNTERS["parsed"]
+        run.files_skipped = _FAKE_COUNTERS["skipped"]
+        run.status = IngestionRunStatus.COMPLETED
+        run.finished_at = datetime.now(timezone.utc)
+        session.commit()
+    return dict(_FAKE_COUNTERS)
+
+
+# ---------------------------------------------------------------------------
+# Tests — POST /api/enedis/ingest
+# ---------------------------------------------------------------------------
+
+
+class TestIngestEndpoint:
+    """POST /api/enedis/ingest — trigger ingestion."""
+
+    def test_ingest_success(self, client, tmp_path):
+        c, session = client
+
+        with (
+            patch("routes.enedis.get_flux_dir", return_value=tmp_path),
+            patch("routes.enedis.load_keys_from_env", return_value=[(b"\x00" * 16, b"\x00" * 16)]),
+            patch("routes.enedis.ingest_directory", side_effect=_mock_ingest_directory_success),
+        ):
+            r = c.post("/api/enedis/ingest", json={"recursive": True})
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["run_id"] >= 1
+        assert data["status"] == IngestionRunStatus.COMPLETED
+        assert data["dry_run"] is False
+        assert data["counters"]["received"] == 2
+        assert data["counters"]["parsed"] == 1
+        assert isinstance(data["duration_seconds"], float)
+
+    def test_ingest_dry_run(self, client, tmp_path):
+        c, session = client
+
+        with (
+            patch("routes.enedis.get_flux_dir", return_value=tmp_path),
+            patch("routes.enedis.load_keys_from_env", return_value=[(b"\x00" * 16, b"\x00" * 16)]),
+            patch("routes.enedis.ingest_directory", side_effect=_mock_ingest_directory_success),
+        ):
+            r = c.post("/api/enedis/ingest", json={"dry_run": True})
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["dry_run"] is True
+
+        # IngestionRun in DB has dry_run=True
+        run = session.query(IngestionRun).filter_by(id=data["run_id"]).first()
+        assert run.dry_run is True
+
+    def test_ingest_with_errors_in_response(self, client, tmp_path):
+        c, session = client
+
+        def _mock_with_error(directory, session, keys, *, recursive=True,
+                             dry_run=False, run=None, **kwargs):
+            """Mock that creates an error file during pipeline run."""
+            # Simulate an error file created during this run
+            err_file = EnedisFluxFile(
+                filename="CORRUPT.zip",
+                file_hash="hash_corrupt_001",
+                flux_type="R4H",
+                status=FluxStatus.ERROR,
+                error_message="none of the 3 keys could decrypt",
+                measures_count=0,
+                version=1,
+            )
+            session.add(err_file)
+            session.flush()
+
+            if run:
+                run.files_received = 1
+                run.files_error = 1
+                run.status = IngestionRunStatus.COMPLETED
+                run.finished_at = datetime.now(timezone.utc)
+                session.commit()
+            return {
+                "received": 1, "parsed": 0, "needs_review": 0,
+                "skipped": 0, "error": 1, "permanently_failed": 0,
+                "already_processed": 0, "retried": 0, "max_retries_reached": 0,
+            }
+
+        with (
+            patch("routes.enedis.get_flux_dir", return_value=tmp_path),
+            patch("routes.enedis.load_keys_from_env", return_value=[(b"\x00" * 16, b"\x00" * 16)]),
+            patch("routes.enedis.ingest_directory", side_effect=_mock_with_error),
+        ):
+            r = c.post("/api/enedis/ingest", json={})
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["counters"]["error"] == 1
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["filename"] == "CORRUPT.zip"
+        assert "decrypt" in data["errors"][0]["error_message"]
+
+
+class TestIngestPreFlight:
+    """POST /api/enedis/ingest — pre-flight validation errors."""
+
+    def test_bad_directory_422(self, client):
+        c, _ = client
+        with patch("routes.enedis.get_flux_dir", side_effect=ValueError("not a directory")):
+            r = c.post("/api/enedis/ingest", json={})
+        assert r.status_code == 422
+        assert "not a directory" in r.json()["message"]
+
+    def test_missing_keys_422(self, client, tmp_path):
+        c, _ = client
+        from data_ingestion.enedis.decrypt import MissingKeyError
+
+        with (
+            patch("routes.enedis.get_flux_dir", return_value=tmp_path),
+            patch("routes.enedis.load_keys_from_env", side_effect=MissingKeyError("no keys")),
+        ):
+            r = c.post("/api/enedis/ingest", json={})
+        assert r.status_code == 422
+        assert "no keys" in r.json()["message"]
+
+    def test_concurrent_run_409(self, client, tmp_path):
+        c, session = client
+        # Seed a running IngestionRun
+        _seed_run(session, status=IngestionRunStatus.RUNNING)
+
+        with (
+            patch("routes.enedis.get_flux_dir", return_value=tmp_path),
+            patch("routes.enedis.load_keys_from_env", return_value=[(b"\x00" * 16, b"\x00" * 16)]),
+        ):
+            r = c.post("/api/enedis/ingest", json={})
+        assert r.status_code == 409
+        assert "already in progress" in r.json()["message"]
+
+
+class TestIngestCrash:
+    """POST /api/enedis/ingest — pipeline crash sets run to failed."""
+
+    def test_pipeline_error_500(self, client, tmp_path):
+        c, session = client
+
+        with (
+            patch("routes.enedis.get_flux_dir", return_value=tmp_path),
+            patch("routes.enedis.load_keys_from_env", return_value=[(b"\x00" * 16, b"\x00" * 16)]),
+            patch("routes.enedis.ingest_directory", side_effect=RuntimeError("boom")),
+        ):
+            r = c.post("/api/enedis/ingest", json={})
+
+        assert r.status_code == 500
+        assert "boom" in r.json()["message"]
+
+        # Run marked as failed in DB
+        run = session.query(IngestionRun).first()
+        assert run is not None
+        assert run.status == IngestionRunStatus.FAILED
+        assert run.error_message == "boom"
+        assert run.finished_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests — GET /api/enedis/flux-files
+# ---------------------------------------------------------------------------
+
+
+class TestFluxFilesEndpoint:
+    """GET /api/enedis/flux-files — paginated list with filters."""
+
+    def test_list_empty(self, client):
+        c, _ = client
+        r = c.get("/api/enedis/flux-files")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+        assert data["limit"] == 24
+        assert data["offset"] == 0
+
+    def test_list_with_data(self, client):
+        c, session = client
+        _seed_flux_file(session, "file1.zip", file_hash="h1")
+        _seed_flux_file(session, "file2.zip", file_hash="h2")
+        _seed_flux_file(session, "file3.zip", file_hash="h3")
+
+        r = c.get("/api/enedis/flux-files")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 3
+        assert len(data["items"]) == 3
+
+    def test_filter_by_status(self, client):
+        c, session = client
+        _seed_flux_file(session, "ok1.zip", file_hash="h1", status=FluxStatus.PARSED)
+        _seed_flux_file(session, "ok2.zip", file_hash="h2", status=FluxStatus.PARSED)
+        _seed_flux_file(session, "err.zip", file_hash="h3", status=FluxStatus.ERROR,
+                        measures_count=0, error_message="fail")
+
+        r = c.get("/api/enedis/flux-files?status=parsed")
+        data = r.json()
+        assert data["total"] == 2
+        assert all(item["status"] == "parsed" for item in data["items"])
+
+    def test_filter_by_flux_type(self, client):
+        c, session = client
+        _seed_flux_file(session, "r4h.zip", flux_type="R4H", file_hash="h1")
+        _seed_flux_file(session, "r171.zip", flux_type="R171", file_hash="h2")
+
+        r = c.get("/api/enedis/flux-files?flux_type=R4H")
+        data = r.json()
+        assert data["total"] == 1
+        assert data["items"][0]["flux_type"] == "R4H"
+
+    def test_pagination(self, client):
+        c, session = client
+        for i in range(5):
+            _seed_flux_file(session, f"file{i}.zip", file_hash=f"h{i}")
+
+        r = c.get("/api/enedis/flux-files?limit=2&offset=2")
+        data = r.json()
+        assert data["total"] == 5
+        assert len(data["items"]) == 2
+        assert data["limit"] == 2
+        assert data["offset"] == 2
+
+    def test_items_contain_file_hash(self, client):
+        c, session = client
+        _seed_flux_file(session, "test.zip", file_hash="abc123def")
+
+        r = c.get("/api/enedis/flux-files")
+        data = r.json()
+        assert data["items"][0]["file_hash"] == "abc123def"
+
+    def test_measures_count_null_becomes_zero(self, client):
+        c, session = client
+        f = EnedisFluxFile(
+            filename="null_mc.zip", file_hash="h_null",
+            flux_type="R4H", status=FluxStatus.RECEIVED,
+            measures_count=None, version=1,
+        )
+        session.add(f)
+        session.flush()
+
+        r = c.get("/api/enedis/flux-files")
+        data = r.json()
+        assert data["items"][0]["measures_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — GET /api/enedis/flux-files/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestFluxFileDetailEndpoint:
+    """GET /api/enedis/flux-files/{id} — detail with header + error history."""
+
+    def test_detail_found(self, client):
+        c, session = client
+        f = _seed_flux_file(
+            session, "detail.zip", file_hash="h_detail",
+            header_raw={"Version": "2.0", "Flux": "R4H"},
+        )
+        _seed_error_history(session, f, "first error")
+        _seed_error_history(session, f, "second error")
+
+        r = c.get(f"/api/enedis/flux-files/{f.id}")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["filename"] == "detail.zip"
+        assert data["header_raw"] == {"Version": "2.0", "Flux": "R4H"}
+        assert len(data["errors_history"]) == 2
+        assert data["errors_history"][0]["error_message"] == "first error"
+
+    def test_detail_not_found(self, client):
+        c, _ = client
+        r = c.get("/api/enedis/flux-files/99999")
+        assert r.status_code == 404
+
+    def test_detail_null_header(self, client):
+        c, session = client
+        f = _seed_flux_file(session, "no_header.zip", file_hash="h_no_header")
+
+        r = c.get(f"/api/enedis/flux-files/{f.id}")
+        assert r.status_code == 200
+        assert r.json()["header_raw"] is None
+
+    def test_detail_no_errors(self, client):
+        c, session = client
+        f = _seed_flux_file(session, "clean.zip", file_hash="h_clean")
+
+        r = c.get(f"/api/enedis/flux-files/{f.id}")
+        assert r.status_code == 200
+        assert r.json()["errors_history"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests — GET /api/enedis/stats
+# ---------------------------------------------------------------------------
+
+
+class TestStatsEndpoint:
+    """GET /api/enedis/stats — aggregated stats."""
+
+    def test_stats_empty(self, client):
+        c, _ = client
+        r = c.get("/api/enedis/stats")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["files"]["total"] == 0
+        assert data["measures"]["total"] == 0
+        assert data["prms"]["count"] == 0
+        assert data["prms"]["identifiers"] == []
+        assert data["last_ingestion"] is None
+
+    def test_stats_with_data(self, client):
+        c, session = client
+
+        # Seed 2 PARSED + 1 ERROR files
+        f1 = _seed_flux_file(session, "f1.zip", file_hash="h1", status=FluxStatus.PARSED)
+        f2 = _seed_flux_file(session, "f2.zip", file_hash="h2", status=FluxStatus.PARSED,
+                             flux_type="R171")
+        _seed_flux_file(session, "f3.zip", file_hash="h3", status=FluxStatus.ERROR,
+                        measures_count=0, error_message="fail")
+
+        # Seed measures
+        _seed_measure_r4x(session, f1, "30001234567890")
+        _seed_measure_r171(session, f2, "30009876543210")
+
+        # Seed a completed run
+        _seed_run(session, status=IngestionRunStatus.COMPLETED,
+                  triggered_by="api", files_parsed=2, files_error=1)
+
+        r = c.get("/api/enedis/stats")
+        assert r.status_code == 200
+        data = r.json()
+
+        assert data["files"]["total"] == 3
+        assert data["files"]["by_status"]["parsed"] == 2
+        assert data["files"]["by_status"]["error"] == 1
+        assert data["files"]["by_flux_type"]["R4H"] == 2
+        assert data["files"]["by_flux_type"]["R171"] == 1
+
+        assert data["measures"]["r4x"] == 1
+        assert data["measures"]["r171"] == 1
+        assert data["measures"]["total"] == 2
+
+        assert data["last_ingestion"] is not None
+        assert data["last_ingestion"]["triggered_by"] == "api"
+
+    def test_stats_prms_distinct(self, client):
+        c, session = client
+
+        f1 = _seed_flux_file(session, "f1.zip", file_hash="h1", flux_type="R4H")
+        f2 = _seed_flux_file(session, "f2.zip", file_hash="h2", flux_type="R171")
+
+        # PRM A in R4x
+        _seed_measure_r4x(session, f1, "30001234567890")
+        # PRM B in R171
+        _seed_measure_r171(session, f2, "30009876543210")
+        # PRM A also in R171 (overlap)
+        _seed_measure_r171(session, f2, "30001234567890")
+
+        r = c.get("/api/enedis/stats")
+        data = r.json()
+        assert data["prms"]["count"] == 2
+        assert sorted(data["prms"]["identifiers"]) == [
+            "30001234567890", "30009876543210",
+        ]
+
+    def test_stats_last_ingestion_excludes_dry_run(self, client):
+        c, session = client
+        # Seed a dry-run completed run
+        _seed_run(session, status=IngestionRunStatus.COMPLETED, dry_run=True)
+
+        r = c.get("/api/enedis/stats")
+        data = r.json()
+        # Dry-run should not appear as last_ingestion
+        assert data["last_ingestion"] is None
+
+    def test_stats_last_ingestion_fields(self, client):
+        c, session = client
+        _seed_run(session, status=IngestionRunStatus.COMPLETED, triggered_by="cli",
+                  files_parsed=5, files_skipped=2, files_error=1, files_needs_review=1)
+
+        r = c.get("/api/enedis/stats")
+        data = r.json()
+        last = data["last_ingestion"]
+        assert last is not None
+        assert last["run_id"] >= 1
+        assert last["triggered_by"] == "cli"
+        assert last["files_count"] == 9  # 5+2+1+1
+        assert last["timestamp"] is not None

--- a/backend/tests/test_enedis_api.py
+++ b/backend/tests/test_enedis_api.py
@@ -337,6 +337,36 @@ class TestIngestPreFlight:
         assert "already in progress" in r.json()["message"]
 
 
+class TestIngestSafetyNet:
+    """POST /api/enedis/ingest — safety net when pipeline doesn't finalize run."""
+
+    def test_run_finalized_if_pipeline_forgets(self, client, tmp_path):
+        """If ingest_directory returns without setting run.status to COMPLETED,
+        the route must finalize the run itself to avoid a permanent 409 lock."""
+        c, session = client
+
+        def _mock_no_finalize(directory, session, keys, *, recursive=False,
+                              dry_run=False, run=None, **kwargs):
+            # Intentionally does NOT set run.status or run.finished_at
+            return dict(_FAKE_COUNTERS)
+
+        with (
+            patch("routes.enedis.get_flux_dir", return_value=tmp_path),
+            patch("routes.enedis.load_keys_from_env", return_value=[(b"\x00" * 16, b"\x00" * 16)]),
+            patch("routes.enedis.ingest_directory", side_effect=_mock_no_finalize),
+        ):
+            r = c.post("/api/enedis/ingest", json={})
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == IngestionRunStatus.COMPLETED
+
+        # Verify in DB: run is COMPLETED, not stuck as RUNNING
+        run = session.query(IngestionRun).filter_by(id=data["run_id"]).first()
+        assert run.status == IngestionRunStatus.COMPLETED
+        assert run.finished_at is not None
+
+
 class TestIngestCrash:
     """POST /api/enedis/ingest — pipeline crash sets run to failed."""
 

--- a/backend/tests/test_enedis_api.py
+++ b/backend/tests/test_enedis_api.py
@@ -337,36 +337,6 @@ class TestIngestPreFlight:
         assert "already in progress" in r.json()["message"]
 
 
-class TestIngestSafetyNet:
-    """POST /api/enedis/ingest — safety net when pipeline doesn't finalize run."""
-
-    def test_run_finalized_if_pipeline_forgets(self, client, tmp_path):
-        """If ingest_directory returns without setting run.status to COMPLETED,
-        the route must finalize the run itself to avoid a permanent 409 lock."""
-        c, session = client
-
-        def _mock_no_finalize(directory, session, keys, *, recursive=False,
-                              dry_run=False, run=None, **kwargs):
-            # Intentionally does NOT set run.status or run.finished_at
-            return dict(_FAKE_COUNTERS)
-
-        with (
-            patch("routes.enedis.get_flux_dir", return_value=tmp_path),
-            patch("routes.enedis.load_keys_from_env", return_value=[(b"\x00" * 16, b"\x00" * 16)]),
-            patch("routes.enedis.ingest_directory", side_effect=_mock_no_finalize),
-        ):
-            r = c.post("/api/enedis/ingest", json={})
-
-        assert r.status_code == 200
-        data = r.json()
-        assert data["status"] == IngestionRunStatus.COMPLETED
-
-        # Verify in DB: run is COMPLETED, not stuck as RUNNING
-        run = session.query(IngestionRun).filter_by(id=data["run_id"]).first()
-        assert run.status == IngestionRunStatus.COMPLETED
-        assert run.finished_at is not None
-
-
 class TestIngestCrash:
     """POST /api/enedis/ingest — pipeline crash sets run to failed."""
 

--- a/docs/specs/feature-enedis-sge-4-operationalization.md
+++ b/docs/specs/feature-enedis-sge-4-operationalization.md
@@ -1,8 +1,22 @@
 # SF4 — Enedis SGE Operational Ingestion Pipeline
 
-> **Status**: Spec v3 — decisions taken, ready for implementation planning
+> **Status**: Spec v4 — decisions validated, implementation plan ready
+> **Plan d'implémentation** : `docs/specs/plan-enedis-sge-4-implementation.md`
 > **Depends on**: SF1 (decrypt), SF2 (CDC ingestion), SF3 (index ingestion) — all complete on `feat/enedis-sge-ingestion`
 > **Out of scope**: Promotion staging → production (SF5). Pas de matching PRM→Site, pas d'écriture dans les tables fonctionnelles (`Consommation`, `MeterReading`), pas de déduplication des republications.
+
+## Décisions d'architecture
+
+| Question | Décision | Justification |
+|----------|----------|---------------|
+| Historique d'erreurs | **Table séparée** `enedis_flux_file_error` (FK vers `enedis_flux_file`) | Propre, extensible, requêtable en SQL directement. Plus robuste qu'une colonne JSON |
+| CLI scope | **Minimaliste** — sous-commande `ingest` uniquement (+ `--dry-run`) | Les stats restent côté API, évite la duplication de logique |
+| Auth API | **Pas d'auth** pour le POC | Usage ops/admin, ajout facile ultérieurement via `get_optional_auth` |
+| Schémas Pydantic | **Dans le router** (`routes/enedis.py`) | Pattern dominant du codebase — les schémas spécifiques à un domaine sont co-localisés avec le router |
+| `.env.example` | **Les deux** fichiers (racine + `backend/`) mis à jour | Cohérence avec les conventions existantes |
+| Tests API | **`backend/tests/test_enedis_api.py`** | Cohérent avec les autres tests d'API (`test_bacs_api.py`, etc.) — les tests HTTP vivent dans le répertoire de tests principal |
+
+---
 
 ## Contexte
 

--- a/docs/specs/feature-enedis-sge-4-operationalization.md
+++ b/docs/specs/feature-enedis-sge-4-operationalization.md
@@ -1,9 +1,9 @@
 # SF4 — Enedis SGE Operational Ingestion Pipeline
 
-> **Status**: Spec v5 — fully aligned with implementation plan v2
+> **Status**: Spec v6 — integre les decisions Q&A finales (concurrence, validation pre-flight, PERMANENTLY_FAILED, compteurs incrementaux)
 > **Plan d'implementation** : `docs/specs/plan-enedis-sge-4-implementation.md`
 > **Depends on**: SF1 (decrypt), SF2 (CDC ingestion), SF3 (index ingestion) — all complete on `feat/enedis-sge-ingestion`
-> **Out of scope**: Promotion staging → production (SF5). Pas de matching PRM→Site, pas d'ecriture dans les tables fonctionnelles (`Consommation`, `MeterReading`), pas de deduplication des republications.
+> **Out of scope**: Promotion staging → production (SF5). Pas de matching PRM→Site, pas d'ecriture dans les tables fonctionnelles (`Consommation`, `MeterReading`), pas de deduplication des republications. Pas d'endpoint de force-retry pour PERMANENTLY_FAILED (futur).
 
 ## Decisions d'architecture
 
@@ -12,13 +12,21 @@
 | Historique d'erreurs | **Table separee** `enedis_flux_file_error` (FK vers `enedis_flux_file`) | Propre, extensible, requetable en SQL directement. Plus robuste qu'une colonne JSON |
 | Compteur de tentatives | **Derive** de `len(flux_file.errors)` — pas de colonne `retry_count` | Pas de desynchronisation possible, source unique de verite (l'historique) |
 | Retry automatique en batch | **Auto-retry avec garde `MAX_RETRIES`** (default 3) dans `ingest_directory()` | Un seul point d'entree fait tout. Les fichiers definitivement casses ne sont pas retentes indefiniment |
-| Suivi d'execution | **Table `IngestionRun`** (1 row par execution CLI/API) | Audit trail lisible pour un data manager, `LastIngestion` trivial a calculer |
+| Fichiers PERMANENTLY_FAILED | **Nouveau statut `FluxStatus.PERMANENTLY_FAILED`** quand `MAX_RETRIES` atteint | Un data manager identifie d'un coup d'oeil les fichiers bloques. Forcer un retry = futur endpoint dedie |
+| Fichiers NEEDS_REVIEW | **Pas de retry automatique** — donnees deja chargees, en attente de review humaine | Traitement initial reussi, republication detectee. Pas un cas d'erreur |
+| Suivi d'execution | **Table `IngestionRun`** avec **compteurs incrementaux** mis a jour fichier par fichier | Si le run crashe, les compteurs refletent le travail reel. Statut "partial" plutot que compteurs a 0 |
+| Statuts IngestionRun | **running / completed / partial / failed** | "partial" = crash en cours d'execution (compteurs fiables). "failed" = erreur apres creation du run mais avant tout traitement |
 | Session API | **`Depends(get_db)`** standard + `IngestionRun` pour tracabilite | Pipeline commits per-file (by design). Pas de session cachee, tout est tracable via `IngestionRun` |
+| Concurrence | **Verrou simple** : refuser un nouveau run si un run est en status "running" | Evite les compteurs incoherents si deux runs traitent le meme repertoire en parallele |
+| Validation pre-flight | **Verifier cles + repertoire AVANT de creer l'IngestionRun** | Fail fast : pas de run inutile dans l'historique si les conditions minimales ne sont pas remplies |
+| Variable ENEDIS_FLUX_DIR | **Obligatoire** dans `.env` — pas de fallback | La clarte prime. Les chemins relatifs et fallbacks sont source d'erreurs |
 | CLI scope | **Minimaliste** — sous-commande `ingest` uniquement (+ `--dry-run`) | Les stats restent cote API, evite la duplication de logique |
 | Auth API | **Pas d'auth** pour le POC | Usage ops/admin, ajout facile ulterieurement via `get_optional_auth` |
 | Schemas Pydantic | **Dans le router** (`routes/enedis.py`) | Pattern dominant du codebase — les schemas specifiques a un domaine sont co-localises avec le router |
 | `.env.example` | **Les deux** fichiers (racine + `backend/`) mis a jour | Coherence avec les conventions existantes |
-| Tests API | **`backend/tests/test_enedis_api.py`** | Coherent avec les autres tests d'API (`test_bacs_api.py`, etc.) — les tests HTTP vivent dans le repertoire de tests principal |
+| Tests API | **`backend/tests/test_enedis_api.py`** | Coherent avec les autres tests d'API (`test_bacs_api.py`, etc.) |
+| Mesures dans IngestResponse | **Non** — IngestResponse retourne les compteurs fichiers uniquement | Les volumes de mesures sont des totaux staging (pas des deltas du run). Disponibles via GET /stats. Separation des responsabilites |
+| Scripts ad-hoc | **Deprecation** en phase 1, suppression apres validation SF4 complete | Garder comme reference pendant la transition, supprimer en cleanup |
 
 ---
 
@@ -36,11 +44,11 @@ SF4 livre 5 choses :
 
 1. **CLI** — commande propre avec arguments, remplacant les scripts ad-hoc
 2. **API REST** — declencher l'ingestion + consulter l'etat et les stats (scaffolding pour future UX)
-3. **Configuration** — variable d'environnement pour le repertoire de flux, plus de chemins hardcodes
-4. **Correction de l'audit d'erreurs** — preserver l'historique des erreurs au retry au lieu de supprimer les enregistrements
+3. **Configuration** — variable d'environnement obligatoire pour le repertoire de flux, plus de chemins hardcodes
+4. **Correction de l'audit d'erreurs** — preserver l'historique des erreurs au retry, nouveau statut `PERMANENTLY_FAILED` pour les fichiers ayant atteint `MAX_RETRIES`
 5. **Wiring** — nouveau router enregistre dans l'application
 
-**Hors scope :** integration JobOutbox, frontend/UI, alerting/notifications, promotion vers tables de production (SF5).
+**Hors scope :** integration JobOutbox, frontend/UI, alerting/notifications, promotion vers tables de production (SF5), endpoint de force-retry pour PERMANENTLY_FAILED.
 
 ---
 
@@ -49,6 +57,13 @@ SF4 livre 5 choses :
 ### Objectif
 
 Remplacer les scripts ad-hoc par une commande CLI propre avec arguments. Suit le pattern existant des autres commandes CLI du projet (`services.demo_seed`, `jobs.run`).
+
+### Validation pre-flight
+
+Avant de creer un IngestionRun, le CLI verifie :
+1. Variable `ENEDIS_FLUX_DIR` configuree et repertoire existant — sinon erreur explicite et exit
+2. Cles de dechiffrement disponibles (`load_keys_from_env()`) — sinon erreur explicite et exit
+3. Pas de run concurrent en status "running" — sinon message d'avertissement et exit
 
 ### Commandes
 
@@ -60,7 +75,7 @@ python -m data_ingestion.enedis.cli ingest [OPTIONS]
 
 | Option | Defaut | Description |
 |--------|--------|-------------|
-| `--dir PATH` | Variable d'env ou defaut projet | Repertoire source des fichiers .zip chiffres |
+| `--dir PATH` | Variable d'env `ENEDIS_FLUX_DIR` (obligatoire) | Repertoire source des fichiers .zip chiffres |
 | `--recursive` | Active | Scanner les sous-repertoires |
 | `--dry-run` | Desactive | Scanner et classifier sans ingerer (rapport uniquement) |
 | `--verbose` | Desactive | Logging niveau DEBUG |
@@ -69,16 +84,18 @@ python -m data_ingestion.enedis.cli ingest [OPTIONS]
 
 **Mode normal** — rapport structure resumant :
 - Source, numero de run, nombre de fichiers scannes
-- Repartition par statut (parsed, skipped, error, needs_review)
+- Repartition par statut (parsed, skipped, error, needs_review, permanently_failed)
 - Fichiers retentes (erreurs precedentes retraitees) et fichiers ayant atteint `MAX_RETRIES`
 - Detail des skips par type de flux (R172, X14, HDM)
 - Volume de mesures par table staging (R4x, R171, R50, R151) — requetes DB post-ingestion, pattern identique a `ingest_real_db.py`
 - Liste des erreurs eventuelles (filename + message)
+- Statut final du run (completed / partial)
 
 **Mode dry-run** — rapport de ce qui *serait* fait :
 - Nombre de fichiers nouveaux par type de flux
 - Nombre de fichiers deja traites
 - Nombre de fichiers en erreur eligibles au retry (< `MAX_RETRIES`)
+- Nombre de fichiers PERMANENTLY_FAILED (ne seront pas retentes)
 - Aucune modification sur les donnees d'ingestion (flux files, mesures). Un enregistrement `IngestionRun` avec `dry_run=True` est cree pour l'audit
 
 Le dry-run utilise le parametre `dry_run=True` de `ingest_directory()` : meme logique de scan/classify/hash-check, mais sans commit ni processing.
@@ -100,16 +117,21 @@ Exposer le declenchement d'ingestion et la consultation d'etat via REST. Doit fo
 `POST /api/enedis/ingest`
 
 - Parametres optionnels : repertoire source (override), mode recursif, mode dry-run
+- **Validation pre-flight** avant toute creation d'IngestionRun :
+  - Cles de dechiffrement disponibles — sinon **422** avec message explicite
+  - Repertoire source valide — sinon **422** avec message explicite
+  - Pas de run concurrent en status "running" — sinon **409** avec `run_id` du run en cours
 - Execution synchrone (suffisant pour le volume POC ~100 fichiers, <10 secondes)
-- Cree un enregistrement `IngestionRun` (`triggered_by='api'`) avant l'execution, mis a jour avec les resultats apres
-- Reponse : `run_id`, compteurs par statut, liste des erreurs, duree d'execution
+- Cree un enregistrement `IngestionRun` (`triggered_by='api'`) **apres** validation pre-flight reussie
+- **Compteurs mis a jour incrementalement** pendant l'execution : si le run crashe, l'IngestionRun passe en status "partial" avec les compteurs refletant le travail effectue
+- Reponse : `run_id`, compteurs par statut, liste des erreurs, duree d'execution, statut du run
 - Le mode dry-run retourne les memes compteurs sans effectuer de modification sur les donnees
 
 ### 2.2 Lister les fichiers flux
 
 `GET /api/enedis/flux-files`
 
-- Filtrage par statut et par type de flux
+- Filtrage par statut (incluant PERMANENTLY_FAILED) et par type de flux
 - Pagination (offset-based, coherent avec les autres endpoints PROMEOS)
 - Chaque item expose : filename, hash, type, statut, nombre de mesures, version, lien de supersession, message d'erreur, timestamps
 - Extensible ulterieurement avec tri et recherche par nom sans casser le schema
@@ -119,10 +141,12 @@ Exposer le declenchement d'ingestion et la consultation d'etat via REST. Doit fo
 `GET /api/enedis/stats`
 
 Retourne en un seul appel :
-- **Fichiers** : total, repartition par statut, repartition par type de flux
+- **Fichiers** : total, repartition par statut (incluant PERMANENTLY_FAILED), repartition par type de flux
 - **Mesures** : total, repartition par table staging (r4x, r171, r50, r151)
 - **PRMs** : nombre distinct et liste des identifiants PRM presents dans le staging (scaffolding pour le matching PRM→DeliveryPoint en SF5)
 - **Derniere ingestion** : `IngestionRun` le plus recent avec `status=completed` et `dry_run=False` — timestamp de fin et nombre de fichiers traites
+
+> **Note PRM scope** : Dans le POC, la liste PRM est globale (tous les PRM du staging). En production, cette API sera filtree par contrat/portefeuille en cours de visualisation. Le volume par contrat ne justifie pas de pagination pour le moment. Point d'attention pour la version production.
 
 ### 2.4 Detail d'un fichier flux
 
@@ -139,14 +163,15 @@ Retourne en un seul appel :
 
 `ENEDIS_FLUX_DIR` — chemin absolu vers le repertoire contenant les fichiers flux chiffres.
 
-- Ajoute dans `.env` et `.env.example`
-- Valeur par defaut : `flux_enedis/` au niveau racine du projet Promeos
+- **Obligatoire** — pas de valeur par defaut ni de fallback. La clarte prime sur la commodite
+- Ajoute dans `.env` et `.env.example` avec commentaire explicatif
 - Utilise par le CLI et l'API comme repertoire par defaut
-- Le parametre API `directory` permet de l'overrider ponctuellement
+- Le parametre API `directory` et l'option CLI `--dir` permettent de l'overrider ponctuellement
+- Si absente : erreur explicite `"ENEDIS_FLUX_DIR environment variable is required — set it in .env"`
 
 ### Constante `MAX_RETRIES`
 
-Nombre maximum de tentatives sur un fichier en erreur (default 3). Stocke dans `config.py`. Au-dela de cette limite, le fichier est ignore lors des executions batch et comptabilise comme `max_retries_reached`.
+Nombre maximum de retries sur un fichier en erreur (default 3, soit 4 tentatives au total : 1 initiale + 3 retries). Stocke dans `config.py`. Au-dela de cette limite, le fichier passe en statut `PERMANENTLY_FAILED` et n'est plus retente automatiquement.
 
 ---
 
@@ -167,7 +192,30 @@ Ce comportement est non-auditable et empeche toute analyse statistique des erreu
 - Le fichier est re-traite **in-place** (meme enregistrement, meme ID) au lieu d'etre supprime/recree
 - L'historique complet des erreurs est consultable via l'API (endpoint detail 2.4)
 - Le nombre de tentatives est derive de `len(flux_file.errors)` — pas de colonne dediee
-- En mode batch (`ingest_directory()`), les fichiers ERROR sont **automatiquement retentes** si `len(errors) < MAX_RETRIES`. Au-dela, ils sont comptabilises comme `max_retries_reached` et ignores
+- En mode batch (`ingest_directory()`), les fichiers ERROR sont **automatiquement retentes** si `len(errors) < MAX_RETRIES`. Au-dela, leur statut passe a `PERMANENTLY_FAILED`
+- Les fichiers `NEEDS_REVIEW` ne sont **pas retentes** automatiquement : leurs donnees ont ete chargees avec succes, seule une analyse manuelle est requise (republication detectee)
+
+### Nouveau statut : PERMANENTLY_FAILED
+
+Un fichier atteint `PERMANENTLY_FAILED` quand le nombre d'erreurs archivees atteint `MAX_RETRIES`. Ce statut signifie :
+- Le fichier ne sera plus retente automatiquement par `ingest_directory()`
+- Le data manager doit investiguer la cause (visible dans l'historique d'erreurs via API)
+- Forcer un retry necessite un futur endpoint dedie (hors scope SF4)
+- Le statut est visible dans l'API (liste, stats, detail) et dans le rapport CLI
+
+### Suivi d'execution : IngestionRun avec compteurs incrementaux
+
+Chaque execution (CLI ou API) cree un enregistrement `IngestionRun`. Les compteurs sont mis a jour **fichier par fichier** pendant l'execution (pas uniquement a la fin). Ce design a trois consequences :
+
+1. **Si le run crashe** : les compteurs refletent le travail reel effectue. Le statut passe a `partial`. Les fichiers traites avant le crash sont bien en base (commits per-file).
+2. **Run suivant** : les fichiers deja traites sont vus comme `already_processed`. Seuls les fichiers restants sont traites. Pas de reprocessing inutile grace a l'idempotence SHA256.
+3. **Audit** : on peut analyser sur la duree les patterns d'execution partielle pour identifier des problemes recurrents (timeout, memoire, fichier corrompu specifique).
+
+Statuts possibles d'un `IngestionRun` :
+- `running` — en cours d'execution
+- `completed` — tous les fichiers traites avec succes (certains peuvent etre en erreur, mais le run lui-meme a termine)
+- `partial` — interruption en cours d'execution, compteurs fiables pour la partie traitee
+- `failed` — erreur apres creation du run mais avant tout traitement de fichier
 
 ---
 
@@ -185,8 +233,8 @@ Le nouveau router Enedis est integre dans l'application via le meme pattern que 
 | Models | `backend/data_ingestion/enedis/models.py` | SF3 done, a enrichir (EnedisFluxFileError, IngestionRun) |
 | Parsers | `backend/data_ingestion/enedis/parsers/` | SF3 done |
 | Decrypt | `backend/data_ingestion/enedis/decrypt.py` | SF1 done |
-| Enums | `backend/data_ingestion/enedis/enums.py` | SF3 done |
-| Scripts ad-hoc | `backend/data_ingestion/enedis/scripts/` | Supersedes par le CLI |
+| Enums | `backend/data_ingestion/enedis/enums.py` | SF3 done, a enrichir (PERMANENTLY_FAILED) |
+| Scripts ad-hoc | `backend/data_ingestion/enedis/scripts/` | **Depreces** — remplaces par le CLI. Suppression apres validation SF4 complete |
 | Tests (221) | `backend/data_ingestion/enedis/tests/` | SF3 done |
 | Fichiers flux reels | `flux_enedis/` (hors repo, 91 in-scope) | — |
 | **Nouveau : CLI** | `backend/data_ingestion/enedis/cli.py` | **SF4** |
@@ -197,3 +245,6 @@ Le nouveau router Enedis est integre dans l'application via le meme pattern que 
 
 - **SF5 — Promotion staging → production** : matching PRM→DeliveryPoint, normalisation des donnees (string→float/datetime), resolution des republications, ecriture dans les tables fonctionnelles.
 - **Feature UX** : page frontend de gestion des flux (liste de fichiers, tableau de bord stats, bouton de re-ingestion) — s'appuie sur le scaffolding API de SF4.
+- **Endpoint force-retry** : permettre au data manager de remettre un fichier PERMANENTLY_FAILED en ERROR pour forcer un nouveau cycle de retry.
+- **Filtrage PRM par contrat** : adapter GET /stats pour filtrer les PRMs par portefeuille/contrat en cours de visualisation.
+- **Suppression scripts ad-hoc** : cleanup de `backend/data_ingestion/enedis/scripts/` une fois SF4 valide.

--- a/docs/specs/feature-enedis-sge-4-operationalization.md
+++ b/docs/specs/feature-enedis-sge-4-operationalization.md
@@ -1,6 +1,6 @@
 # SF4 — Enedis SGE Operational Ingestion Pipeline
 
-> **Status**: Spec v6 — integre les decisions Q&A finales (concurrence, validation pre-flight, PERMANENTLY_FAILED, compteurs incrementaux)
+> **Status**: Spec v7 — integre les decisions revue finale (garde MAX_RETRIES dans ingest_file, dry-run sans mutation, statut failed unique, IngestionRunStatus enum)
 > **Plan d'implementation** : `docs/specs/plan-enedis-sge-4-implementation.md`
 > **Depends on**: SF1 (decrypt), SF2 (CDC ingestion), SF3 (index ingestion) — all complete on `feat/enedis-sge-ingestion`
 > **Out of scope**: Promotion staging → production (SF5). Pas de matching PRM→Site, pas d'ecriture dans les tables fonctionnelles (`Consommation`, `MeterReading`), pas de deduplication des republications. Pas d'endpoint de force-retry pour PERMANENTLY_FAILED (futur).
@@ -14,8 +14,8 @@
 | Retry automatique en batch | **Auto-retry avec garde `MAX_RETRIES`** (default 3) dans `ingest_directory()` | Un seul point d'entree fait tout. Les fichiers definitivement casses ne sont pas retentes indefiniment |
 | Fichiers PERMANENTLY_FAILED | **Nouveau statut `FluxStatus.PERMANENTLY_FAILED`** quand `MAX_RETRIES` atteint | Un data manager identifie d'un coup d'oeil les fichiers bloques. Forcer un retry = futur endpoint dedie |
 | Fichiers NEEDS_REVIEW | **Pas de retry automatique** — donnees deja chargees, en attente de review humaine | Traitement initial reussi, republication detectee. Pas un cas d'erreur |
-| Suivi d'execution | **Table `IngestionRun`** avec **compteurs incrementaux** mis a jour fichier par fichier | Si le run crashe, les compteurs refletent le travail reel. Statut "partial" plutot que compteurs a 0 |
-| Statuts IngestionRun | **running / completed / partial / failed** | "partial" = crash en cours d'execution (compteurs fiables). "failed" = erreur apres creation du run mais avant tout traitement |
+| Suivi d'execution | **Table `IngestionRun`** avec **compteurs incrementaux** mis a jour fichier par fichier | Si le run crashe, les compteurs refletent le travail reel. Statut "failed" avec compteurs fiables |
+| Statuts IngestionRun | **running / completed / failed** | "failed" = crash ou erreur apres creation du run. Les compteurs incrementaux refletent le travail effectue avant le crash |
 | Session API | **`Depends(get_db)`** standard + `IngestionRun` pour tracabilite | Pipeline commits per-file (by design). Pas de session cachee, tout est tracable via `IngestionRun` |
 | Concurrence | **Verrou simple** : refuser un nouveau run si un run est en status "running" | Evite les compteurs incoherents si deux runs traitent le meme repertoire en parallele |
 | Validation pre-flight | **Verifier cles + repertoire AVANT de creer l'IngestionRun** | Fail fast : pas de run inutile dans l'historique si les conditions minimales ne sont pas remplies |
@@ -89,7 +89,7 @@ python -m data_ingestion.enedis.cli ingest [OPTIONS]
 - Detail des skips par type de flux (R172, X14, HDM)
 - Volume de mesures par table staging (R4x, R171, R50, R151) — requetes DB post-ingestion, pattern identique a `ingest_real_db.py`
 - Liste des erreurs eventuelles (filename + message)
-- Statut final du run (completed / partial)
+- Statut final du run (completed / failed)
 
 **Mode dry-run** — rapport de ce qui *serait* fait :
 - Nombre de fichiers nouveaux par type de flux
@@ -123,7 +123,7 @@ Exposer le declenchement d'ingestion et la consultation d'etat via REST. Doit fo
   - Pas de run concurrent en status "running" — sinon **409** avec `run_id` du run en cours
 - Execution synchrone (suffisant pour le volume POC ~100 fichiers, <10 secondes)
 - Cree un enregistrement `IngestionRun` (`triggered_by='api'`) **apres** validation pre-flight reussie
-- **Compteurs mis a jour incrementalement** pendant l'execution : si le run crashe, l'IngestionRun passe en status "partial" avec les compteurs refletant le travail effectue
+- **Compteurs mis a jour incrementalement** pendant l'execution : si le run crashe, l'IngestionRun passe en status "failed" avec les compteurs refletant le travail effectue
 - Reponse : `run_id`, compteurs par statut, liste des erreurs, duree d'execution, statut du run
 - Le mode dry-run retourne les memes compteurs sans effectuer de modification sur les donnees
 
@@ -194,6 +194,9 @@ Ce comportement est non-auditable et empeche toute analyse statistique des erreu
 - Le nombre de tentatives est derive de `len(flux_file.errors)` — pas de colonne dediee
 - En mode batch (`ingest_directory()`), les fichiers ERROR sont **automatiquement retentes** si `len(errors) < MAX_RETRIES`. Au-dela, leur statut passe a `PERMANENTLY_FAILED`
 - Les fichiers `NEEDS_REVIEW` ne sont **pas retentes** automatiquement : leurs donnees ont ete chargees avec succes, seule une analyse manuelle est requise (republication detectee)
+- `ingest_file()` refuse de traiter un fichier `PERMANENTLY_FAILED` (skip silencieux, meme comportement que PARSED/SKIPPED)
+- `ingest_file()` verifie `len(errors) >= MAX_RETRIES` avant de retenter un fichier ERROR — si la limite est atteinte, le fichier passe en `PERMANENTLY_FAILED` sans retry. Cette garde est necessaire pour les appels directs (futur endpoint UX de re-ingestion fichier par fichier)
+- En mode `dry_run`, la transition ERROR → `PERMANENTLY_FAILED` n'est pas commitee : le dry-run compte les fichiers concernes sans les modifier
 
 ### Nouveau statut : PERMANENTLY_FAILED
 
@@ -207,15 +210,14 @@ Un fichier atteint `PERMANENTLY_FAILED` quand le nombre d'erreurs archivees atte
 
 Chaque execution (CLI ou API) cree un enregistrement `IngestionRun`. Les compteurs sont mis a jour **fichier par fichier** pendant l'execution (pas uniquement a la fin). Ce design a trois consequences :
 
-1. **Si le run crashe** : les compteurs refletent le travail reel effectue. Le statut passe a `partial`. Les fichiers traites avant le crash sont bien en base (commits per-file).
+1. **Si le run crashe** : les compteurs refletent le travail reel effectue. Le statut passe a `failed`. Les fichiers traites avant le crash sont bien en base (commits per-file).
 2. **Run suivant** : les fichiers deja traites sont vus comme `already_processed`. Seuls les fichiers restants sont traites. Pas de reprocessing inutile grace a l'idempotence SHA256.
 3. **Audit** : on peut analyser sur la duree les patterns d'execution partielle pour identifier des problemes recurrents (timeout, memoire, fichier corrompu specifique).
 
 Statuts possibles d'un `IngestionRun` :
 - `running` — en cours d'execution
 - `completed` — tous les fichiers traites avec succes (certains peuvent etre en erreur, mais le run lui-meme a termine)
-- `partial` — interruption en cours d'execution, compteurs fiables pour la partie traitee
-- `failed` — erreur apres creation du run mais avant tout traitement de fichier
+- `failed` — interruption ou erreur apres creation du run. Les compteurs incrementaux refletent le travail effectue avant le crash
 
 ---
 
@@ -248,3 +250,4 @@ Le nouveau router Enedis est integre dans l'application via le meme pattern que 
 - **Endpoint force-retry** : permettre au data manager de remettre un fichier PERMANENTLY_FAILED en ERROR pour forcer un nouveau cycle de retry.
 - **Filtrage PRM par contrat** : adapter GET /stats pour filtrer les PRMs par portefeuille/contrat en cours de visualisation.
 - **Suppression scripts ad-hoc** : cleanup de `backend/data_ingestion/enedis/scripts/` une fois SF4 valide.
+- **Cleanup conftest.py** : remplacer `_FLUX_DIR` hardcode dans `conftest.py` par `get_flux_dir()` de `config.py`.

--- a/docs/specs/feature-enedis-sge-4-operationalization.md
+++ b/docs/specs/feature-enedis-sge-4-operationalization.md
@@ -1,42 +1,46 @@
 # SF4 — Enedis SGE Operational Ingestion Pipeline
 
-> **Status**: Spec v4 — decisions validated, implementation plan ready
-> **Plan d'implémentation** : `docs/specs/plan-enedis-sge-4-implementation.md`
+> **Status**: Spec v5 — fully aligned with implementation plan v2
+> **Plan d'implementation** : `docs/specs/plan-enedis-sge-4-implementation.md`
 > **Depends on**: SF1 (decrypt), SF2 (CDC ingestion), SF3 (index ingestion) — all complete on `feat/enedis-sge-ingestion`
-> **Out of scope**: Promotion staging → production (SF5). Pas de matching PRM→Site, pas d'écriture dans les tables fonctionnelles (`Consommation`, `MeterReading`), pas de déduplication des republications.
+> **Out of scope**: Promotion staging → production (SF5). Pas de matching PRM→Site, pas d'ecriture dans les tables fonctionnelles (`Consommation`, `MeterReading`), pas de deduplication des republications.
 
-## Décisions d'architecture
+## Decisions d'architecture
 
-| Question | Décision | Justification |
+| Question | Decision | Justification |
 |----------|----------|---------------|
-| Historique d'erreurs | **Table séparée** `enedis_flux_file_error` (FK vers `enedis_flux_file`) | Propre, extensible, requêtable en SQL directement. Plus robuste qu'une colonne JSON |
-| CLI scope | **Minimaliste** — sous-commande `ingest` uniquement (+ `--dry-run`) | Les stats restent côté API, évite la duplication de logique |
-| Auth API | **Pas d'auth** pour le POC | Usage ops/admin, ajout facile ultérieurement via `get_optional_auth` |
-| Schémas Pydantic | **Dans le router** (`routes/enedis.py`) | Pattern dominant du codebase — les schémas spécifiques à un domaine sont co-localisés avec le router |
-| `.env.example` | **Les deux** fichiers (racine + `backend/`) mis à jour | Cohérence avec les conventions existantes |
-| Tests API | **`backend/tests/test_enedis_api.py`** | Cohérent avec les autres tests d'API (`test_bacs_api.py`, etc.) — les tests HTTP vivent dans le répertoire de tests principal |
+| Historique d'erreurs | **Table separee** `enedis_flux_file_error` (FK vers `enedis_flux_file`) | Propre, extensible, requetable en SQL directement. Plus robuste qu'une colonne JSON |
+| Compteur de tentatives | **Derive** de `len(flux_file.errors)` — pas de colonne `retry_count` | Pas de desynchronisation possible, source unique de verite (l'historique) |
+| Retry automatique en batch | **Auto-retry avec garde `MAX_RETRIES`** (default 3) dans `ingest_directory()` | Un seul point d'entree fait tout. Les fichiers definitivement casses ne sont pas retentes indefiniment |
+| Suivi d'execution | **Table `IngestionRun`** (1 row par execution CLI/API) | Audit trail lisible pour un data manager, `LastIngestion` trivial a calculer |
+| Session API | **`Depends(get_db)`** standard + `IngestionRun` pour tracabilite | Pipeline commits per-file (by design). Pas de session cachee, tout est tracable via `IngestionRun` |
+| CLI scope | **Minimaliste** — sous-commande `ingest` uniquement (+ `--dry-run`) | Les stats restent cote API, evite la duplication de logique |
+| Auth API | **Pas d'auth** pour le POC | Usage ops/admin, ajout facile ulterieurement via `get_optional_auth` |
+| Schemas Pydantic | **Dans le router** (`routes/enedis.py`) | Pattern dominant du codebase — les schemas specifiques a un domaine sont co-localises avec le router |
+| `.env.example` | **Les deux** fichiers (racine + `backend/`) mis a jour | Coherence avec les conventions existantes |
+| Tests API | **`backend/tests/test_enedis_api.py`** | Coherent avec les autres tests d'API (`test_bacs_api.py`, etc.) — les tests HTTP vivent dans le repertoire de tests principal |
 
 ---
 
 ## Contexte
 
-SF1-SF3 ont livré un pipeline d'ingestion complet : déchiffrement, parsing et stockage de fichiers flux Enedis réels (R4H, R4M, R4Q, R171, R50, R151) dans 5 tables staging. 221 tests passent, 91 fichiers réels ingérés avec 0 erreur, 123 846 mesures au total.
+SF1-SF3 ont livre un pipeline d'ingestion complet : dechiffrement, parsing et stockage de fichiers flux Enedis reels (R4H, R4M, R4Q, R171, R50, R151) dans 5 tables staging. 221 tests passent, 91 fichiers reels ingeres avec 0 erreur, 123 846 mesures au total.
 
 Deux scripts ad-hoc existent dans `backend/data_ingestion/enedis/scripts/` pour lancer l'ingestion manuellement.
 
-**Problème :** Le pipeline n'a pas de point d'entrée opérationnel, pas de surface d'observabilité, et un bug qui détruit l'historique d'erreurs au retry. SF4 rend le pipeline staging brut **fiable, complet et auditable**.
+**Probleme :** Le pipeline n'a pas de point d'entree operationnel, pas de surface d'observabilite, et un bug qui detruit l'historique d'erreurs au retry. SF4 rend le pipeline staging brut **fiable, complet et auditable**.
 
 ## Scope SF4
 
 SF4 livre 5 choses :
 
-1. **CLI** — commande propre avec arguments, remplaçant les scripts ad-hoc
-2. **API REST** — déclencher l'ingestion + consulter l'état et les stats (scaffolding pour future UX)
-3. **Configuration** — variable d'environnement pour le répertoire de flux, plus de chemins hardcodés
-4. **Correction de l'audit d'erreurs** — préserver l'historique des erreurs au retry au lieu de supprimer les enregistrements
-5. **Wiring** — nouveau router enregistré dans l'application
+1. **CLI** — commande propre avec arguments, remplacant les scripts ad-hoc
+2. **API REST** — declencher l'ingestion + consulter l'etat et les stats (scaffolding pour future UX)
+3. **Configuration** — variable d'environnement pour le repertoire de flux, plus de chemins hardcodes
+4. **Correction de l'audit d'erreurs** — preserver l'historique des erreurs au retry au lieu de supprimer les enregistrements
+5. **Wiring** — nouveau router enregistre dans l'application
 
-**Hors scope :** intégration JobOutbox, frontend/UI, alerting/notifications, promotion vers tables de production (SF5).
+**Hors scope :** integration JobOutbox, frontend/UI, alerting/notifications, promotion vers tables de production (SF5).
 
 ---
 
@@ -54,26 +58,30 @@ Remplacer les scripts ad-hoc par une commande CLI propre avec arguments. Suit le
 python -m data_ingestion.enedis.cli ingest [OPTIONS]
 ```
 
-| Option | Défaut | Description |
+| Option | Defaut | Description |
 |--------|--------|-------------|
-| `--dir PATH` | Variable d'env ou défaut projet | Répertoire source des fichiers .zip chiffrés |
-| `--recursive` | Activé | Scanner les sous-répertoires |
-| `--dry-run` | Désactivé | Scanner et classifier sans ingérer (rapport uniquement) |
-| `--verbose` | Désactivé | Logging niveau DEBUG |
+| `--dir PATH` | Variable d'env ou defaut projet | Repertoire source des fichiers .zip chiffres |
+| `--recursive` | Active | Scanner les sous-repertoires |
+| `--dry-run` | Desactive | Scanner et classifier sans ingerer (rapport uniquement) |
+| `--verbose` | Desactive | Logging niveau DEBUG |
 
 ### Sorties attendues
 
-**Mode normal** — rapport structuré résumant :
-- Source, nombre de fichiers scannés
-- Répartition par statut (parsed, skipped, error, needs_review)
-- Détail des skips par type de flux (R172, X14, HDM)
-- Volume de mesures par table staging (R4x, R171, R50, R151)
-- Liste des erreurs éventuelles (filename + message)
+**Mode normal** — rapport structure resumant :
+- Source, numero de run, nombre de fichiers scannes
+- Repartition par statut (parsed, skipped, error, needs_review)
+- Fichiers retentes (erreurs precedentes retraitees) et fichiers ayant atteint `MAX_RETRIES`
+- Detail des skips par type de flux (R172, X14, HDM)
+- Volume de mesures par table staging (R4x, R171, R50, R151) — requetes DB post-ingestion, pattern identique a `ingest_real_db.py`
+- Liste des erreurs eventuelles (filename + message)
 
 **Mode dry-run** — rapport de ce qui *serait* fait :
 - Nombre de fichiers nouveaux par type de flux
-- Nombre de fichiers déjà traités
-- Aucune modification en base
+- Nombre de fichiers deja traites
+- Nombre de fichiers en erreur eligibles au retry (< `MAX_RETRIES`)
+- Aucune modification sur les donnees d'ingestion (flux files, mesures). Un enregistrement `IngestionRun` avec `dry_run=True` est cree pour l'audit
+
+Le dry-run utilise le parametre `dry_run=True` de `ingest_directory()` : meme logique de scan/classify/hash-check, mais sans commit ni processing.
 
 ---
 
@@ -81,46 +89,47 @@ python -m data_ingestion.enedis.cli ingest [OPTIONS]
 
 ### Objectif
 
-Exposer le déclenchement d'ingestion et la consultation d'état via REST. Doit fournir un scaffolding suffisant pour construire ultérieurement une feature UX complète de gestion des flux.
+Exposer le declenchement d'ingestion et la consultation d'etat via REST. Doit fournir un scaffolding suffisant pour construire ulterieurement une feature UX complete de gestion des flux.
 
 ### Router
 
-`/api/enedis` — cohérent avec le naming domaine-par-domaine du codebase.
+`/api/enedis` — coherent avec le naming domaine-par-domaine du codebase.
 
-### 2.1 Déclencher une ingestion
+### 2.1 Declencher une ingestion
 
 `POST /api/enedis/ingest`
 
-- Paramètres optionnels : répertoire source (override), mode récursif, mode dry-run
-- Exécution synchrone (suffisant pour le volume POC ~100 fichiers, <10 secondes)
-- Réponse : compteurs par statut, liste des erreurs, durée d'exécution
-- Le mode dry-run retourne les mêmes compteurs sans effectuer de modification
+- Parametres optionnels : repertoire source (override), mode recursif, mode dry-run
+- Execution synchrone (suffisant pour le volume POC ~100 fichiers, <10 secondes)
+- Cree un enregistrement `IngestionRun` (`triggered_by='api'`) avant l'execution, mis a jour avec les resultats apres
+- Reponse : `run_id`, compteurs par statut, liste des erreurs, duree d'execution
+- Le mode dry-run retourne les memes compteurs sans effectuer de modification sur les donnees
 
 ### 2.2 Lister les fichiers flux
 
 `GET /api/enedis/flux-files`
 
 - Filtrage par statut et par type de flux
-- Pagination (offset-based, cohérent avec les autres endpoints PROMEOS)
+- Pagination (offset-based, coherent avec les autres endpoints PROMEOS)
 - Chaque item expose : filename, hash, type, statut, nombre de mesures, version, lien de supersession, message d'erreur, timestamps
-- Extensible ultérieurement avec tri et recherche par nom sans casser le schéma
+- Extensible ulterieurement avec tri et recherche par nom sans casser le schema
 
 ### 2.3 Statistiques d'ingestion
 
 `GET /api/enedis/stats`
 
 Retourne en un seul appel :
-- **Fichiers** : total, répartition par statut, répartition par type de flux
-- **Mesures** : total, répartition par table staging (r4x, r171, r50, r151)
-- **PRMs** : nombre distinct et liste des identifiants PRM présents dans le staging (scaffolding pour le matching PRM→DeliveryPoint en SF5)
-- **Dernière ingestion** : timestamp et nombre de fichiers traités
+- **Fichiers** : total, repartition par statut, repartition par type de flux
+- **Mesures** : total, repartition par table staging (r4x, r171, r50, r151)
+- **PRMs** : nombre distinct et liste des identifiants PRM presents dans le staging (scaffolding pour le matching PRM→DeliveryPoint en SF5)
+- **Derniere ingestion** : `IngestionRun` le plus recent avec `status=completed` et `dry_run=False` — timestamp de fin et nombre de fichiers traites
 
-### 2.4 Détail d'un fichier flux
+### 2.4 Detail d'un fichier flux
 
 `GET /api/enedis/flux-files/{id}`
 
 - Toutes les informations de la liste + header XML brut (JSON) + historique d'erreurs complet
-- 404 si non trouvé
+- 404 si non trouve
 
 ---
 
@@ -128,38 +137,43 @@ Retourne en un seul appel :
 
 ### Variable d'environnement
 
-`ENEDIS_FLUX_DIR` — chemin absolu vers le répertoire contenant les fichiers flux chiffrés.
+`ENEDIS_FLUX_DIR` — chemin absolu vers le repertoire contenant les fichiers flux chiffres.
 
-- Ajouté dans `.env` et `.env.example`
-- Valeur par défaut : `flux_enedis/` au niveau racine du projet Promeos
-- Utilisé par le CLI et l'API comme répertoire par défaut
-- Le paramètre API `directory` permet de l'overrider ponctuellement
+- Ajoute dans `.env` et `.env.example`
+- Valeur par defaut : `flux_enedis/` au niveau racine du projet Promeos
+- Utilise par le CLI et l'API comme repertoire par defaut
+- Le parametre API `directory` permet de l'overrider ponctuellement
+
+### Constante `MAX_RETRIES`
+
+Nombre maximum de tentatives sur un fichier en erreur (default 3). Stocke dans `config.py`. Au-dela de cette limite, le fichier est ignore lors des executions batch et comptabilise comme `max_retries_reached`.
 
 ---
 
 ## 4. Correction de l'audit d'erreurs
 
-### Problème
+### Probleme
 
-Actuellement, quand un fichier en statut ERROR est re-traité, le pipeline **supprime** l'enregistrement existant et en crée un nouveau. Cela perd :
-- La date de la première erreur
+Actuellement, quand un fichier en statut ERROR est re-traite, le pipeline **supprime** l'enregistrement existant et en cree un nouveau. Cela perd :
+- La date de la premiere erreur
 - Le message d'erreur original
-- Le nombre de tentatives échouées
+- Le nombre de tentatives echouees
 
-Ce comportement est non-auditable et empêche toute analyse statistique des erreurs d'ingestion.
+Ce comportement est non-auditable et empeche toute analyse statistique des erreurs d'ingestion.
 
 ### Comportement cible
 
-- Au retry, l'erreur courante est **archivée** dans un historique (pas supprimée)
-- Le fichier est re-traité **in-place** (même enregistrement, même ID) au lieu d'être supprimé/recréé
-- L'historique complet des erreurs est consultable via l'API (endpoint détail 2.4)
-- Le nombre de tentatives est dérivable de l'historique
+- Au retry, l'erreur courante est **archivee** dans un historique (pas supprimee)
+- Le fichier est re-traite **in-place** (meme enregistrement, meme ID) au lieu d'etre supprime/recree
+- L'historique complet des erreurs est consultable via l'API (endpoint detail 2.4)
+- Le nombre de tentatives est derive de `len(flux_file.errors)` — pas de colonne dediee
+- En mode batch (`ingest_directory()`), les fichiers ERROR sont **automatiquement retentes** si `len(errors) < MAX_RETRIES`. Au-dela, ils sont comptabilises comme `max_retries_reached` et ignores
 
 ---
 
 ## 5. Wiring applicatif
 
-Le nouveau router Enedis est intégré dans l'application via le même pattern que tous les autres routers : déclaration dans `routes/`, enregistrement dans `main.py`.
+Le nouveau router Enedis est integre dans l'application via le meme pattern que tous les autres routers : declaration dans `routes/`, enregistrement dans `main.py`.
 
 ---
 
@@ -168,18 +182,18 @@ Le nouveau router Enedis est intégré dans l'application via le même pattern q
 | Asset | Path | Statut |
 |-------|------|--------|
 | Pipeline | `backend/data_ingestion/enedis/pipeline.py` | SF3 done |
-| Models | `backend/data_ingestion/enedis/models.py` | SF3 done, à enrichir (error_history) |
+| Models | `backend/data_ingestion/enedis/models.py` | SF3 done, a enrichir (EnedisFluxFileError, IngestionRun) |
 | Parsers | `backend/data_ingestion/enedis/parsers/` | SF3 done |
 | Decrypt | `backend/data_ingestion/enedis/decrypt.py` | SF1 done |
 | Enums | `backend/data_ingestion/enedis/enums.py` | SF3 done |
-| Scripts ad-hoc | `backend/data_ingestion/enedis/scripts/` | Supersédés par le CLI |
+| Scripts ad-hoc | `backend/data_ingestion/enedis/scripts/` | Supersedes par le CLI |
 | Tests (221) | `backend/data_ingestion/enedis/tests/` | SF3 done |
-| Fichiers flux réels | `flux_enedis/` (hors repo, 91 in-scope) | — |
+| Fichiers flux reels | `flux_enedis/` (hors repo, 91 in-scope) | — |
 | **Nouveau : CLI** | `backend/data_ingestion/enedis/cli.py` | **SF4** |
 | **Nouveau : Config** | `backend/data_ingestion/enedis/config.py` | **SF4** |
 | **Nouveau : Router** | `backend/routes/enedis.py` | **SF4** |
 
-## Ce qui vient après SF4
+## Ce qui vient apres SF4
 
-- **SF5 — Promotion staging → production** : matching PRM→DeliveryPoint, normalisation des données (string→float/datetime), résolution des republications, écriture dans les tables fonctionnelles.
+- **SF5 — Promotion staging → production** : matching PRM→DeliveryPoint, normalisation des donnees (string→float/datetime), resolution des republications, ecriture dans les tables fonctionnelles.
 - **Feature UX** : page frontend de gestion des flux (liste de fichiers, tableau de bord stats, bouton de re-ingestion) — s'appuie sur le scaffolding API de SF4.

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -100,7 +100,7 @@ def get_flux_dir(override: str | None = None) -> Path:
 
 ---
 
-## Phase 2 — Modeles d'audit (erreurs + suivi d'execution)
+## Phase 2 — Modeles d'audit (erreurs + suivi d'execution) [DONE]
 
 **Commit** : `feat(enedis): add EnedisFluxFileError, IngestionRun models and PERMANENTLY_FAILED status (SF4)`
 

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -1,0 +1,343 @@
+# SF4 — Operationalization Pipeline Enedis SGE — Plan d'implementation
+
+> **Status** : Plan v1 — approuve, pret pour implementation phase par phase
+> **Spec** : `docs/specs/feature-enedis-sge-4-operationalization.md`
+> **Branche** : `feat/enedis-sge-sf4-operationalization` (depuis `feat/enedis-sge-ingestion`)
+
+## Context
+
+SF1-SF3 ont livre un pipeline d'ingestion complet (decrypt, parse, store) pour 6 types de flux Enedis dans 5 tables staging. 221 tests passent, 91 fichiers reels ingeres. Deux scripts ad-hoc existent mais le pipeline n'a ni CLI propre, ni API REST, ni configuration externalisee, et un bug detruit l'historique d'erreurs au retry.
+
+SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error history, CLI, API REST, wiring applicatif.
+
+---
+
+## Decisions d'architecture (issues du Q&A)
+
+| Question | Decision | Justification |
+|----------|----------|---------------|
+| Historique d'erreurs | **Table separee** `enedis_flux_file_error` | Propre, extensible, requetable en SQL directement |
+| CLI scope | **Minimaliste** — `ingest` uniquement (+ `--dry-run`) | Les stats restent cote API, evite la duplication de logique |
+| Auth API | **Pas d'auth** pour le POC | Usage ops/admin, ajout facile ulterieurement |
+| Schemas Pydantic | **Dans le router** (`routes/enedis.py`) | Pattern dominant du codebase |
+| `.env.example` | **Les deux** fichiers (racine + `backend/`) | Coherence avec les conventions existantes |
+| Tests API | **`backend/tests/test_enedis_api.py`** | Coherent avec les autres tests d'API (`test_bacs_api.py`, etc.) |
+
+---
+
+## Phase 0 — Mise a jour de la spec
+
+**Commit** : `docs(enedis): update SF4 spec with architecture decisions`
+
+| Fichier | Action |
+|---------|--------|
+| `docs/specs/feature-enedis-sge-4-operationalization.md` | Ajouter section "Decisions d'architecture" avec les 6 decisions. Status → "Spec v4 — decisions validated, implementation plan ready" |
+
+---
+
+## Phase 1 — Configuration externalisee
+
+**Commit** : `feat(enedis): externalize flux directory config (SF4)`
+
+### Creer
+
+| Fichier | Description |
+|---------|-------------|
+| `backend/data_ingestion/enedis/config.py` | `get_flux_dir(override, validate) -> Path` |
+| `backend/data_ingestion/enedis/tests/test_config.py` | Tests unitaires |
+
+### Modifier
+
+| Fichier | Modification |
+|---------|-------------|
+| `.env.example` (racine) | Ajouter `ENEDIS_FLUX_DIR` section External Data Connectors |
+| `backend/.env.example` | Ajouter `ENEDIS_FLUX_DIR` |
+
+### Comportement `get_flux_dir()`
+
+```
+1. Si override fourni et non vide → Path(override)
+2. Sinon os.environ.get("ENEDIS_FLUX_DIR") → Path(env_value)
+3. Sinon fallback → Path(__file__).resolve().parents[4] / "flux_enedis"
+4. Si validate=True et le path n'est pas un repertoire → ValueError
+```
+
+### Tests
+
+| Classe | Cas |
+|--------|-----|
+| `TestGetFluxDir` | env var set, env var absent (fallback), override explicite, repertoire inexistant → ValueError, validate=False bypass |
+
+---
+
+## Phase 2 — Modele d'historique d'erreurs
+
+**Commit** : `feat(enedis): add EnedisFluxFileError model for error audit trail (SF4)`
+
+### Modifier
+
+| Fichier | Modification |
+|---------|-------------|
+| `backend/data_ingestion/enedis/models.py` | + classe `EnedisFluxFileError`, + relation `errors` sur `EnedisFluxFile`, + colonne `retry_count` |
+
+### Schema `EnedisFluxFileError`
+
+```
+Table: enedis_flux_file_error
+  id             Integer PK
+  flux_file_id   Integer FK → enedis_flux_file.id (CASCADE)
+  error_message  Text NOT NULL
+  created_at     DateTime (TimestampMixin)
+  updated_at     DateTime (TimestampMixin)
+
+Index: ix_enedis_flux_file_error_flux_file (flux_file_id)
+```
+
+Sur `EnedisFluxFile` :
+- `errors = relationship("EnedisFluxFileError", ..., order_by=created_at)`
+- `retry_count = Column(Integer, default=0)`
+
+### Tests
+
+| Fichier | Cas |
+|---------|-----|
+| `test_models.py` (extend) | Creation, cascade delete, ordering par `created_at`, `retry_count` increment |
+
+---
+
+## Phase 3 — Correction audit d'erreurs dans le pipeline
+
+**Commit** : `fix(enedis): preserve error history on retry instead of deleting (SF4)`
+
+### Modifier
+
+| Fichier | Modification |
+|---------|-------------|
+| `backend/data_ingestion/enedis/pipeline.py` | Remplacer `session.delete(existing)` par `_archive_error()` + reuse in-place |
+
+### Changement cle dans `ingest_file()`
+
+**Avant** (lignes 106-109) :
+```python
+if existing.status == FluxStatus.ERROR:
+    session.delete(existing)
+    session.flush()
+```
+
+**Apres** :
+```python
+if existing.status == FluxStatus.ERROR:
+    _archive_error(session, existing)
+    existing.error_message = None
+    pre_registered = existing  # reuse same record in-place
+```
+
+**Nouveau helper** `_archive_error(session, flux_file)` :
+- Si `flux_file.error_message` non vide : creer `EnedisFluxFileError` + incrementer `retry_count`
+- Sinon : no-op
+
+**Impact `_record_file()`** : si `existing` a un `error_message`, archiver avant de remplacer.
+
+**Impact `ingest_directory()`** : aucun changement structurel.
+
+### Tests
+
+| Fichier | Cas |
+|---------|-----|
+| `test_pipeline.py` (extend) | `TestErrorHistoryPreserved` : (1) echoue 2x → 2 entries, retry_count=2, (2) echoue puis reussit → history preservee + status=PARSED, (3) decrypt error puis parse error → 2 messages distincts |
+| `test_pipeline_full.py` (extend) | `TestErrorRetryInBatch` : retry dans un batch preserve l'historique. Regression check sur tous les tests existants |
+
+---
+
+## Phase 4 — CLI
+
+**Commit** : `feat(enedis): add CLI for ingestion with dry-run and structured report (SF4)`
+
+### Creer
+
+| Fichier | Description |
+|---------|-------------|
+| `backend/data_ingestion/enedis/cli.py` | `python -m data_ingestion.enedis.cli ingest [OPTIONS]` |
+| `backend/data_ingestion/enedis/tests/test_cli.py` | Tests CLI |
+
+### Interface
+
+```
+python -m data_ingestion.enedis.cli ingest [--dir PATH] [--recursive] [--dry-run] [--verbose]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--dir PATH` | env var ou fallback | Repertoire source |
+| `--recursive` | Active | Scanner les sous-repertoires |
+| `--dry-run` | Desactive | Scan + classify sans ingerer |
+| `--verbose` | Desactive | Logging DEBUG |
+
+### Architecture
+
+Pattern `argparse` (ref: `services.demo_seed.__main__`, `jobs.run`).
+
+```
+sys.path.insert + load_dotenv
+├── main() → argparse → dispatch
+├── cmd_ingest(args) → logique principale
+│   ├── mode normal: get_flux_dir → load_keys → ingest_directory → _print_report
+│   └── mode dry-run: get_flux_dir → scan → classify → _dry_run_report
+├── _print_report(counters, session, duration)
+└── _dry_run_report(directory, session, recursive)
+```
+
+### Rapport mode normal
+
+```
+=== ENEDIS SGE INGESTION REPORT ===
+Source:          /path/to/flux_enedis (recursive)
+Duration:        3.2s
+Files received:  45
+  parsed:        38
+  skipped:       5  (R172: 3, X14: 1, HDM: 1)
+  error:         1
+  needs_review:  1
+Already processed: 46
+Measures stored:
+  R4x:    98,432
+  R171:   12,310
+  R50:     8,450
+  R151:    4,654
+  TOTAL: 123,846
+ERRORS (1):
+  ENEDIS_23X_CORRUPT.zip: none of the 3 keys could decrypt
+```
+
+### Tests
+
+| Classe | Cas |
+|--------|-----|
+| `TestCliIngest` | Mode normal avec fichiers synthetiques, compteurs corrects |
+| `TestCliDryRun` | Aucune modification en base |
+| `TestCliVerbose` | Logging DEBUG active |
+| `TestCliMissingDir` | Repertoire inexistant → erreur propre |
+| `TestCliNoKeys` | Cles absentes → erreur propre |
+
+---
+
+## Phase 5 — API REST + Wiring applicatif
+
+**Commit** : `feat(enedis): add REST API endpoints and wire router into app (SF4)`
+
+### Creer
+
+| Fichier | Description |
+|---------|-------------|
+| `backend/routes/enedis.py` | Router `/api/enedis` + schemas Pydantic |
+| `backend/tests/test_enedis_api.py` | Tests API (TestClient) |
+
+### Modifier
+
+| Fichier | Modification |
+|---------|-------------|
+| `backend/routes/__init__.py` | + `from .enedis import router as enedis_router` + `__all__` |
+| `backend/main.py` | + import + `app.include_router(enedis_router)` |
+
+### Endpoints
+
+| Methode | Path | Description |
+|---------|------|-------------|
+| `POST` | `/api/enedis/ingest` | Declencher ingestion (sync, body JSON) |
+| `GET` | `/api/enedis/flux-files` | Liste paginee + filtres (status, flux_type) |
+| `GET` | `/api/enedis/stats` | Stats agregees (fichiers, mesures, PRMs) |
+| `GET` | `/api/enedis/flux-files/{id}` | Detail fichier + header_raw + error history |
+
+### Schemas Pydantic
+
+**Ingestion :**
+```python
+IngestRequest     { directory?, recursive=True, dry_run=False }
+IngestResponse    { received, parsed, needs_review, skipped, error,
+                    already_processed, errors: [IngestErrorDetail],
+                    duration_seconds, dry_run }
+IngestErrorDetail { filename, error_message }
+```
+
+**Flux files :**
+```python
+FluxFileResponse       { id, filename, file_hash, flux_type, status,
+                         error_message?, measures_count?, version,
+                         supersedes_file_id?, created_at, updated_at }
+FluxFileListResponse   { total, items: [FluxFileResponse] }
+FluxFileDetailResponse { ...FluxFileResponse, header_raw?, errors_history: [ErrorHistoryItem] }
+ErrorHistoryItem       { error_message, created_at }
+```
+
+**Stats :**
+```python
+StatsResponse    { files: FileStats, measures: MeasureStats,
+                   prms: PrmStats, last_ingestion?: LastIngestion }
+FileStats        { total, by_status: {}, by_flux_type: {} }
+MeasureStats     { total, r4x, r171, r50, r151 }
+PrmStats         { count, identifiers: [] }
+LastIngestion    { timestamp, files_count }
+```
+
+### Wiring
+
+`routes/__init__.py` : ajouter import + `__all__` entry
+`main.py` : ajouter dans le bloc d'imports et `app.include_router(enedis_router)  # Enedis SGE Flux`
+
+### Tests
+
+| Classe | Cas |
+|--------|-----|
+| `TestIngestEndpoint` | POST normal, POST dry-run, repertoire inexistant |
+| `TestFluxFilesEndpoint` | Liste paginee, filtre status, filtre flux_type |
+| `TestStatsEndpoint` | Stats correctes apres ingestion |
+| `TestFluxFileDetailEndpoint` | Detail + header_raw, detail + error_history, 404 |
+
+---
+
+## Fichiers de reference (patterns a suivre)
+
+| Pattern | Fichier |
+|---------|---------|
+| Router registration | `backend/routes/__init__.py`, `backend/main.py:20-73,114-168` |
+| Router structure | `backend/routes/sites.py` |
+| Pagination offset/limit | `backend/routes/billing.py` |
+| CLI argparse | `backend/services/demo_seed/__main__.py` |
+| DB test fixture | `backend/data_ingestion/enedis/tests/conftest.py` |
+| API test fixture | `backend/tests/test_bacs_api.py` |
+| Models + TimestampMixin | `backend/models/base.py` |
+
+---
+
+## Verification
+
+### Apres chaque phase (1-4)
+
+```bash
+cd promeos-poc && ./backend/venv/bin/pytest backend/data_ingestion/enedis/tests/ -x -v
+```
+
+### Apres Phase 5
+
+```bash
+cd promeos-poc && ./backend/venv/bin/pytest backend/tests/test_enedis_api.py -x -v
+```
+
+### Test complet final
+
+```bash
+cd promeos-poc && ./backend/venv/bin/pytest backend/tests/ backend/data_ingestion/enedis/tests/ -x -v
+```
+
+---
+
+## Sequence des commits
+
+| # | Commit | Phase |
+|---|--------|-------|
+| 0 | `docs(enedis): update SF4 spec with architecture decisions` | Spec |
+| 1 | `feat(enedis): externalize flux directory config (SF4)` | Config |
+| 2 | `feat(enedis): add EnedisFluxFileError model for error audit trail (SF4)` | Model |
+| 3 | `fix(enedis): preserve error history on retry instead of deleting (SF4)` | Pipeline |
+| 4 | `feat(enedis): add CLI for ingestion with dry-run and structured report (SF4)` | CLI |
+| 5 | `feat(enedis): add REST API endpoints and wire router into app (SF4)` | API + Wiring |

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -347,9 +347,10 @@ def ingest_directory(
 
 ---
 
-## Phase 4 — CLI
+## Phase 4 — CLI [DONE]
 
-**Commit** : `feat(enedis): add CLI for ingestion with dry-run, pre-flight validation and structured report (SF4)`
+**Commit** : `feat(enedis): add CLI for ingestion with dry-run, pre-flight validation and structured report (SF4)` (8bfee2d)
+**Fix** : `fix(enedis): display permanently_failed counter in CLI reports (SF4)` (c49fb0b)
 
 ### Creer
 
@@ -442,6 +443,7 @@ Files received:  45
   needs_review:  1
 Retried:         2  (from previous errors)
 Max retries:     0  (permanently failed — skipped)
+Perm. failed:    0  (status set this run)
 Already processed: 46
 Measures stored (staging totals):
   R4x:    98,432
@@ -462,6 +464,7 @@ Source:          /path/to/flux_enedis (recursive)
 New files:       12
 Retryable errors: 2  (eligible for retry, < MAX_RETRIES)
 Max retries:     1   (permanently failed — will be skipped)
+Perm. failed:    0  (status set this run)
 Already processed: 46
 No data modifications made.
 ```

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -38,14 +38,14 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 
 ---
 
-## Phase 0 — Mise a jour de la spec
+## Phase 0 — Mise a jour de la spec [DONE]
 
-**Commit** : `docs(enedis): update SF4 spec v6 with final architecture decisions`
+**Commit** : `docs(enedis): update SF4 spec v7 and plan v4 with review decisions` (c00738b)
 
-| Fichier | Action |
-|---------|--------|
-| `docs/specs/feature-enedis-sge-4-operationalization.md` | Aligner sur spec v6 (toutes decisions finales integrees) |
-| `docs/specs/plan-enedis-sge-4-implementation.md` | Aligner sur plan v3 |
+| Fichier | Action | Statut |
+|---------|--------|--------|
+| `docs/specs/feature-enedis-sge-4-operationalization.md` | Aligner sur spec v7 (toutes decisions finales integrees) | Done |
+| `docs/specs/plan-enedis-sge-4-implementation.md` | Aligner sur plan v4 | Done |
 
 ---
 

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -49,9 +49,9 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 
 ---
 
-## Phase 1 — Configuration externalisee
+## Phase 1 — Configuration externalisee [DONE]
 
-**Commit** : `feat(enedis): externalize flux directory config (SF4)`
+**Commit** : `feat(enedis): externalize flux directory config (SF4)` (78adbe8)
 
 ### Creer
 

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -1,6 +1,6 @@
 # SF4 — Operationalization Pipeline Enedis SGE — Plan d'implementation
 
-> **Status** : Plan v1 — approuve, pret pour implementation phase par phase
+> **Status** : Plan v2 — aligne avec spec v5, pret pour implementation phase par phase
 > **Spec** : `docs/specs/feature-enedis-sge-4-operationalization.md`
 > **Branche** : `feat/enedis-sge-sf4-operationalization` (depuis `feat/enedis-sge-ingestion`)
 
@@ -17,6 +17,11 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 | Question | Decision | Justification |
 |----------|----------|---------------|
 | Historique d'erreurs | **Table separee** `enedis_flux_file_error` | Propre, extensible, requetable en SQL directement |
+| Compteur de tentatives | **Derive** de `len(flux_file.errors)` — pas de colonne `retry_count` | Pas de desynchronisation, source unique de verite |
+| Retry ERROR en batch | **Auto-retry** dans `ingest_directory()` si `len(errors) < MAX_RETRIES` (default 3) | Un seul point d'entree fait tout, pas de fichiers oublies. Garde max_retries empeche les boucles infinies |
+| Suivi d'execution | **Table `IngestionRun`** (1 row par execution CLI/API) | Audit trail lisible, `LastIngestion` = latest completed run |
+| Session API | **`Depends(get_db)`** standard | Pipeline commits per-file (by design). Tracabilite via `IngestionRun` |
+| Rapport CLI mesures | **Requetes DB post-ingestion** (pattern `ingest_real_db.py`) | `ingest_directory()` retourne des compteurs de fichiers, pas de mesures. `_print_report()` calcule les volumes via queries sur les tables staging |
 | CLI scope | **Minimaliste** — `ingest` uniquement (+ `--dry-run`) | Les stats restent cote API, evite la duplication de logique |
 | Auth API | **Pas d'auth** pour le POC | Usage ops/admin, ajout facile ulterieurement |
 | Schemas Pydantic | **Dans le router** (`routes/enedis.py`) | Pattern dominant du codebase |
@@ -27,11 +32,11 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 
 ## Phase 0 — Mise a jour de la spec
 
-**Commit** : `docs(enedis): update SF4 spec with architecture decisions`
+**Commit** : `docs(enedis): update SF4 spec v5 with full architecture decisions`
 
 | Fichier | Action |
 |---------|--------|
-| `docs/specs/feature-enedis-sge-4-operationalization.md` | Ajouter section "Decisions d'architecture" avec les 6 decisions. Status → "Spec v4 — decisions validated, implementation plan ready" |
+| `docs/specs/feature-enedis-sge-4-operationalization.md` | Aligner sur spec v5 (decisions architecture completes, IngestionRun, MAX_RETRIES, retry batch, session API) |
 
 ---
 
@@ -43,7 +48,7 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 
 | Fichier | Description |
 |---------|-------------|
-| `backend/data_ingestion/enedis/config.py` | `get_flux_dir(override, validate) -> Path` |
+| `backend/data_ingestion/enedis/config.py` | `get_flux_dir()`, `MAX_RETRIES`, constantes |
 | `backend/data_ingestion/enedis/tests/test_config.py` | Tests unitaires |
 
 ### Modifier
@@ -53,39 +58,52 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 | `.env.example` (racine) | Ajouter `ENEDIS_FLUX_DIR` section External Data Connectors |
 | `backend/.env.example` | Ajouter `ENEDIS_FLUX_DIR` |
 
+### Contenu de `config.py`
+
+```python
+MAX_RETRIES: int = 3  # Nombre max de tentatives sur un fichier en erreur
+
+def get_flux_dir(override: str | None = None, validate: bool = True) -> Path:
+    """Resolve le repertoire de flux Enedis.
+
+    Priorite : override > env var ENEDIS_FLUX_DIR > fallback projet.
+    """
+```
+
 ### Comportement `get_flux_dir()`
 
 ```
-1. Si override fourni et non vide → Path(override)
-2. Sinon os.environ.get("ENEDIS_FLUX_DIR") → Path(env_value)
-3. Sinon fallback → Path(__file__).resolve().parents[4] / "flux_enedis"
-4. Si validate=True et le path n'est pas un repertoire → ValueError
+1. Si override fourni et non vide -> Path(override)
+2. Sinon os.environ.get("ENEDIS_FLUX_DIR") -> Path(env_value)
+3. Sinon fallback -> Path(__file__).resolve().parents[4] / "flux_enedis"
+4. Si validate=True et le path n'est pas un repertoire -> ValueError
 ```
 
 ### Tests
 
 | Classe | Cas |
 |--------|-----|
-| `TestGetFluxDir` | env var set, env var absent (fallback), override explicite, repertoire inexistant → ValueError, validate=False bypass |
+| `TestGetFluxDir` | env var set, env var absent (fallback), override explicite, repertoire inexistant -> ValueError, validate=False bypass |
+| `TestMaxRetries` | Constante accessible et correctement typee |
 
 ---
 
-## Phase 2 — Modele d'historique d'erreurs
+## Phase 2 — Modeles d'audit (erreurs + suivi d'execution)
 
-**Commit** : `feat(enedis): add EnedisFluxFileError model for error audit trail (SF4)`
+**Commit** : `feat(enedis): add EnedisFluxFileError and IngestionRun models (SF4)`
 
 ### Modifier
 
 | Fichier | Modification |
 |---------|-------------|
-| `backend/data_ingestion/enedis/models.py` | + classe `EnedisFluxFileError`, + relation `errors` sur `EnedisFluxFile`, + colonne `retry_count` |
+| `backend/data_ingestion/enedis/models.py` | + classe `EnedisFluxFileError`, + classe `IngestionRun`, + relation `errors` sur `EnedisFluxFile` |
 
 ### Schema `EnedisFluxFileError`
 
 ```
 Table: enedis_flux_file_error
   id             Integer PK
-  flux_file_id   Integer FK → enedis_flux_file.id (CASCADE)
+  flux_file_id   Integer FK -> enedis_flux_file.id (CASCADE)
   error_message  Text NOT NULL
   created_at     DateTime (TimestampMixin)
   updated_at     DateTime (TimestampMixin)
@@ -94,30 +112,57 @@ Index: ix_enedis_flux_file_error_flux_file (flux_file_id)
 ```
 
 Sur `EnedisFluxFile` :
-- `errors = relationship("EnedisFluxFileError", ..., order_by=created_at)`
-- `retry_count = Column(Integer, default=0)`
+- `errors = relationship("EnedisFluxFileError", ..., order_by=created_at, cascade="all, delete-orphan")`
+
+### Schema `IngestionRun`
+
+```
+Table: enedis_ingestion_run
+  id                      Integer PK
+  started_at              DateTime NOT NULL
+  finished_at             DateTime (nullable — null while running)
+  directory               String(500) NOT NULL
+  recursive               Boolean NOT NULL default True
+  dry_run                 Boolean NOT NULL default False
+  status                  String(20) NOT NULL default "running"  (running / completed / failed)
+  triggered_by            String(10) NOT NULL  (cli / api)
+  files_received          Integer default 0
+  files_parsed            Integer default 0
+  files_skipped           Integer default 0
+  files_error             Integer default 0
+  files_needs_review      Integer default 0
+  files_already_processed Integer default 0
+  files_retried           Integer default 0
+  files_max_retries       Integer default 0
+  error_message           Text (nullable — for run-level errors)
+  created_at              DateTime (TimestampMixin)
+  updated_at              DateTime (TimestampMixin)
+```
 
 ### Tests
 
 | Fichier | Cas |
 |---------|-----|
-| `test_models.py` (extend) | Creation, cascade delete, ordering par `created_at`, `retry_count` increment |
+| `test_models.py` (extend) | `EnedisFluxFileError` : creation, cascade delete, ordering par `created_at` |
+| `test_models.py` (extend) | `IngestionRun` : creation, status transitions, default values, all counter columns |
 
 ---
 
-## Phase 3 — Correction audit d'erreurs dans le pipeline
+## Phase 3 — Correction audit d'erreurs + retry batch + dry-run dans le pipeline
 
-**Commit** : `fix(enedis): preserve error history on retry instead of deleting (SF4)`
+**Commit** : `fix(enedis): preserve error history, enable batch retry and dry-run (SF4)`
 
 ### Modifier
 
 | Fichier | Modification |
 |---------|-------------|
-| `backend/data_ingestion/enedis/pipeline.py` | Remplacer `session.delete(existing)` par `_archive_error()` + reuse in-place |
+| `backend/data_ingestion/enedis/pipeline.py` | (1) Fix retry dans `ingest_file()`. (2) Retry ERROR + garde MAX_RETRIES dans `ingest_directory()`. (3) Parametre `dry_run` dans `ingest_directory()`. |
 
-### Changement cle dans `ingest_file()`
+### Changement 1 : Fix du retry dans `ingest_file()`
 
-**Avant** (lignes 106-109) :
+**Localisation** : le bloc `if existing.status == FluxStatus.ERROR` dans la fonction `ingest_file()` (actuellement un `session.delete(existing)` + `session.flush()`).
+
+**Avant** :
 ```python
 if existing.status == FluxStatus.ERROR:
     session.delete(existing)
@@ -133,19 +178,59 @@ if existing.status == FluxStatus.ERROR:
 ```
 
 **Nouveau helper** `_archive_error(session, flux_file)` :
-- Si `flux_file.error_message` non vide : creer `EnedisFluxFileError` + incrementer `retry_count`
+- Si `flux_file.error_message` non vide : creer `EnedisFluxFileError(flux_file_id=flux_file.id, error_message=flux_file.error_message)`
 - Sinon : no-op
 
-**Impact `_record_file()`** : si `existing` a un `error_message`, archiver avant de remplacer.
+### Changement 2 : Retry ERROR dans `ingest_directory()`
 
-**Impact `ingest_directory()`** : aucun changement structurel.
+**Localisation** : Phase 1 de `ingest_directory()`, le bloc `else` apres le check `if existing.status == FluxStatus.RECEIVED` qui compte actuellement tous les autres statuts comme `already_processed`.
+
+**Avant** :
+```python
+else:
+    # Already processed (PARSED/ERROR/SKIPPED/NEEDS_REVIEW)
+    counters["already_processed"] += 1
+```
+
+**Apres** :
+```python
+elif existing.status == FluxStatus.ERROR:
+    error_count = len(existing.errors)
+    if error_count < MAX_RETRIES:
+        logger.info("Retrying ERROR file %s (attempt %d/%d)",
+                     file_path.name, error_count + 1, MAX_RETRIES)
+        to_process.append((file_path, file_hash, existing))
+        counters["retried"] += 1
+    else:
+        logger.info("Skipping %s — max retries reached (%d)",
+                     file_path.name, MAX_RETRIES)
+        counters["max_retries_reached"] += 1
+else:
+    counters["already_processed"] += 1
+```
+
+**Compteurs ajoutes** dans le dict de retour de `ingest_directory()` :
+- `retried: int` — fichiers ERROR retentes dans cette execution
+- `max_retries_reached: int` — fichiers ignores car MAX_RETRIES atteint
+
+**Import necessaire** : `from data_ingestion.enedis.config import MAX_RETRIES`
+
+### Changement 3 : Parametre `dry_run` dans `ingest_directory()`
+
+**Signature** : ajouter `dry_run: bool = False` a `ingest_directory()`.
+
+**Comportement** :
+- Phase 1 : scan, hash, classify, check DB — identique, mais **pas de commit** des enregistrements RECEIVED, pas de creation de nouveaux records. Seulement compter.
+- Phase 2 : **skipped entierement** en mode dry_run
+- Retour : meme dict de compteurs (`received` = nombre de fichiers qui seraient traites, `retried` et `max_retries_reached` comme en mode normal, les compteurs de processing a 0)
 
 ### Tests
 
 | Fichier | Cas |
 |---------|-----|
-| `test_pipeline.py` (extend) | `TestErrorHistoryPreserved` : (1) echoue 2x → 2 entries, retry_count=2, (2) echoue puis reussit → history preservee + status=PARSED, (3) decrypt error puis parse error → 2 messages distincts |
-| `test_pipeline_full.py` (extend) | `TestErrorRetryInBatch` : retry dans un batch preserve l'historique. Regression check sur tous les tests existants |
+| `test_pipeline.py` (extend) | `TestErrorHistoryPreserved` : (1) echoue 2x -> 2 entries error history + `len(errors)==2`, (2) echoue puis reussit -> history preservee + status=PARSED, (3) decrypt error puis parse error -> 2 messages distincts |
+| `test_pipeline_full.py` (extend) | `TestErrorRetryInBatch` : fichier ERROR dans `ingest_directory()` est retente automatiquement, history preservee. Fichier avec `MAX_RETRIES` atteint est ignore (compteur `max_retries_reached`). |
+| `test_pipeline.py` (extend) | `TestDryRun` : `ingest_directory(dry_run=True)` retourne les bons compteurs sans modifier la DB |
 
 ---
 
@@ -175,22 +260,45 @@ python -m data_ingestion.enedis.cli ingest [--dir PATH] [--recursive] [--dry-run
 
 ### Architecture
 
-Pattern `argparse` (ref: `services.demo_seed.__main__`, `jobs.run`).
+Pattern `argparse` (ref: `services.demo_seed.__main__`).
 
 ```
 sys.path.insert + load_dotenv
-├── main() → argparse → dispatch
-├── cmd_ingest(args) → logique principale
-│   ├── mode normal: get_flux_dir → load_keys → ingest_directory → _print_report
-│   └── mode dry-run: get_flux_dir → scan → classify → _dry_run_report
-├── _print_report(counters, session, duration)
-└── _dry_run_report(directory, session, recursive)
+from database import SessionLocal, engine
+from database import run_migrations
+from models.base import Base
+
+main() -> argparse -> dispatch
+  cmd_ingest(args):
+    _ensure_tables(engine)            # Base.metadata.create_all() + run_migrations()
+    session = SessionLocal()
+    run = IngestionRun(triggered_by="cli", directory=..., dry_run=args.dry_run, ...)
+    session.add(run) ; session.commit()
+    try:
+      mode normal  -> get_flux_dir -> load_keys -> ingest_directory(session, ...) -> _print_report
+      mode dry-run -> get_flux_dir -> ingest_directory(session, ..., dry_run=True) -> _dry_run_report
+      update run (status="completed", counters, finished_at) -> session.commit()
+    except Exception:
+      run.status = "failed" ; run.error_message = str(exc) ; session.commit()
+      sys.exit(1)
+    finally:
+      session.close()
+
+  _print_report(counters, session, run, duration)
+    # Affiche les compteurs de ingest_directory()
+    # + requetes DB pour les volumes de mesures par table staging :
+    #   session.query(EnedisFluxMesureR4x).count(), etc.
+    #   (pattern identique a scripts/ingest_real_db.py)
+
+  _dry_run_report(counters)
+    # Affiche received, retried, max_retries_reached, already_processed
 ```
 
 ### Rapport mode normal
 
 ```
 === ENEDIS SGE INGESTION REPORT ===
+Run #42        triggered_by: cli
 Source:          /path/to/flux_enedis (recursive)
 Duration:        3.2s
 Files received:  45
@@ -198,6 +306,8 @@ Files received:  45
   skipped:       5  (R172: 3, X14: 1, HDM: 1)
   error:         1
   needs_review:  1
+Retried:         2  (from previous errors)
+Max retries:     0  (skipped — limit reached)
 Already processed: 46
 Measures stored:
   R4x:    98,432
@@ -209,15 +319,28 @@ ERRORS (1):
   ENEDIS_23X_CORRUPT.zip: none of the 3 keys could decrypt
 ```
 
+### Rapport mode dry-run
+
+```
+=== ENEDIS SGE DRY-RUN REPORT ===
+Run #43        triggered_by: cli  (dry-run)
+Source:          /path/to/flux_enedis (recursive)
+New files:       12
+Retryable errors: 2  (eligible for retry, < MAX_RETRIES)
+Max retries:     1   (will be skipped — limit reached)
+Already processed: 46
+No data modifications made.
+```
+
 ### Tests
 
 | Classe | Cas |
 |--------|-----|
-| `TestCliIngest` | Mode normal avec fichiers synthetiques, compteurs corrects |
-| `TestCliDryRun` | Aucune modification en base |
+| `TestCliIngest` | Mode normal avec fichiers synthetiques, compteurs corrects, IngestionRun created avec status=completed |
+| `TestCliDryRun` | Aucune modification sur les donnees d'ingestion, IngestionRun avec dry_run=True |
 | `TestCliVerbose` | Logging DEBUG active |
-| `TestCliMissingDir` | Repertoire inexistant → erreur propre |
-| `TestCliNoKeys` | Cles absentes → erreur propre |
+| `TestCliMissingDir` | Repertoire inexistant -> erreur propre, sys.exit(1) |
+| `TestCliNoKeys` | Cles absentes -> erreur propre, sys.exit(1) |
 
 ---
 
@@ -230,14 +353,14 @@ ERRORS (1):
 | Fichier | Description |
 |---------|-------------|
 | `backend/routes/enedis.py` | Router `/api/enedis` + schemas Pydantic |
-| `backend/tests/test_enedis_api.py` | Tests API (TestClient) |
+| `backend/tests/test_enedis_api.py` | Tests API |
 
 ### Modifier
 
 | Fichier | Modification |
 |---------|-------------|
-| `backend/routes/__init__.py` | + `from .enedis import router as enedis_router` + `__all__` |
-| `backend/main.py` | + import + `app.include_router(enedis_router)` |
+| `backend/routes/__init__.py` | + `from .enedis import router as enedis_router` dans le bloc d'imports + `"enedis_router"` dans `__all__` |
+| `backend/main.py` | + `enedis_router` dans le tuple `from routes import (...)` + `app.include_router(enedis_router)  # Enedis SGE Flux` dans le bloc d'enregistrement |
 
 ### Endpoints
 
@@ -245,7 +368,7 @@ ERRORS (1):
 |---------|------|-------------|
 | `POST` | `/api/enedis/ingest` | Declencher ingestion (sync, body JSON) |
 | `GET` | `/api/enedis/flux-files` | Liste paginee + filtres (status, flux_type) |
-| `GET` | `/api/enedis/stats` | Stats agregees (fichiers, mesures, PRMs) |
+| `GET` | `/api/enedis/stats` | Stats agregees (fichiers, mesures, PRMs, dernier run) |
 | `GET` | `/api/enedis/flux-files/{id}` | Detail fichier + header_raw + error history |
 
 ### Schemas Pydantic
@@ -253,9 +376,9 @@ ERRORS (1):
 **Ingestion :**
 ```python
 IngestRequest     { directory?, recursive=True, dry_run=False }
-IngestResponse    { received, parsed, needs_review, skipped, error,
-                    already_processed, errors: [IngestErrorDetail],
-                    duration_seconds, dry_run }
+IngestResponse    { run_id, received, parsed, needs_review, skipped, error,
+                    retried, max_retries_reached, already_processed,
+                    errors: [IngestErrorDetail], duration_seconds, dry_run }
 IngestErrorDetail { filename, error_message }
 ```
 
@@ -265,7 +388,8 @@ FluxFileResponse       { id, filename, file_hash, flux_type, status,
                          error_message?, measures_count?, version,
                          supersedes_file_id?, created_at, updated_at }
 FluxFileListResponse   { total, items: [FluxFileResponse] }
-FluxFileDetailResponse { ...FluxFileResponse, header_raw?, errors_history: [ErrorHistoryItem] }
+FluxFileDetailResponse { ...FluxFileResponse, header_raw?,
+                         errors_history: [ErrorHistoryItem] }
 ErrorHistoryItem       { error_message, created_at }
 ```
 
@@ -276,36 +400,80 @@ StatsResponse    { files: FileStats, measures: MeasureStats,
 FileStats        { total, by_status: {}, by_flux_type: {} }
 MeasureStats     { total, r4x, r171, r50, r151 }
 PrmStats         { count, identifiers: [] }
-LastIngestion    { timestamp, files_count }
+LastIngestion    { run_id, timestamp, files_count, triggered_by }
+```
+
+**Logique `LastIngestion`** : query `IngestionRun` le plus recent avec `status='completed'` et `dry_run=False`, ordonne par `finished_at DESC`, limit 1. Champ nullable dans `StatsResponse` (null si aucune ingestion reussie).
+
+**Note `PrmStats`** : la requete exacte (UNION DISTINCT de `point_id` sur les 4 tables mesure) est laissee a l'architecte d'implementation. Hint : `union_all()` sur `select(distinct(Table.point_id))` pour chaque table.
+
+### Pattern de l'endpoint `POST /api/enedis/ingest`
+
+```python
+@router.post("/ingest", response_model=IngestResponse)
+def trigger_ingest(body: IngestRequest, db: Session = Depends(get_db)):
+    flux_dir = get_flux_dir(override=body.directory)
+    keys = load_keys_from_env()
+
+    # 1. Create IngestionRun record
+    run = IngestionRun(
+        triggered_by="api", directory=str(flux_dir),
+        recursive=body.recursive, dry_run=body.dry_run,
+    )
+    db.add(run)
+    db.commit()
+
+    # 2. Execute pipeline (pipeline commits per-file internally — by design)
+    t0 = time.time()
+    counters = ingest_directory(
+        flux_dir, db, keys,
+        recursive=body.recursive, dry_run=body.dry_run,
+    )
+    duration = time.time() - t0
+
+    # 3. Update IngestionRun with results
+    run.status = "completed"
+    run.finished_at = datetime.now(timezone.utc)
+    run.files_received = counters["received"]
+    # ... (all counters)
+    db.commit()
+
+    # 4. Return response with run_id
+    return IngestResponse(run_id=run.id, duration_seconds=round(duration, 2), ...)
 ```
 
 ### Wiring
 
-`routes/__init__.py` : ajouter import + `__all__` entry
-`main.py` : ajouter dans le bloc d'imports et `app.include_router(enedis_router)  # Enedis SGE Flux`
+**`routes/__init__.py`** : ajouter `from .enedis import router as enedis_router` dans le bloc d'imports existant + `"enedis_router"` dans la liste `__all__`.
+
+**`main.py`** : ajouter `enedis_router` dans le tuple `from routes import (...)` + `app.include_router(enedis_router)  # Enedis SGE Flux` apres la derniere ligne `app.include_router(...)`.
 
 ### Tests
 
+**Fixture** : pattern identique a `test_bacs_api.py` — le fixture `client` yield un tuple `(TestClient(app), session)`. Chaque test depack : `c, session = client`. Seed helpers sont des fonctions plain qui prennent `session`.
+
 | Classe | Cas |
 |--------|-----|
-| `TestIngestEndpoint` | POST normal, POST dry-run, repertoire inexistant |
+| `TestIngestEndpoint` | POST normal (IngestionRun created, run_id dans la reponse), POST dry-run, repertoire inexistant |
 | `TestFluxFilesEndpoint` | Liste paginee, filtre status, filtre flux_type |
-| `TestStatsEndpoint` | Stats correctes apres ingestion |
+| `TestStatsEndpoint` | Stats correctes apres ingestion, last_ingestion populated avec run_id |
 | `TestFluxFileDetailEndpoint` | Detail + header_raw, detail + error_history, 404 |
 
 ---
 
 ## Fichiers de reference (patterns a suivre)
 
-| Pattern | Fichier |
-|---------|---------|
-| Router registration | `backend/routes/__init__.py`, `backend/main.py:20-73,114-168` |
-| Router structure | `backend/routes/sites.py` |
-| Pagination offset/limit | `backend/routes/billing.py` |
-| CLI argparse | `backend/services/demo_seed/__main__.py` |
-| DB test fixture | `backend/data_ingestion/enedis/tests/conftest.py` |
-| API test fixture | `backend/tests/test_bacs_api.py` |
-| Models + TimestampMixin | `backend/models/base.py` |
+| Pattern | Reference |
+|---------|-----------|
+| Router registration | `backend/routes/__init__.py` (bloc imports + `__all__`), `backend/main.py` (bloc `from routes import (...)` + bloc `app.include_router(...)`) |
+| Router structure | `backend/routes/sites.py` (prefix, tags, Depends, schemas inline) |
+| Pagination offset/limit | `backend/routes/billing.py` (Query params avec bornes ge/le) |
+| CLI argparse + _ensure_tables | `backend/services/demo_seed/__main__.py` (`_ensure_tables`, argparse, SessionLocal, sys.exit) |
+| DB imports pour CLI/scripts | `from database import SessionLocal, engine` (via `database/__init__.py` re-export) |
+| DB test fixture (pipeline) | `backend/data_ingestion/enedis/tests/conftest.py` (in-memory SQLite, create_all) |
+| API test fixture | `backend/tests/test_bacs_api.py` (yield `(TestClient(app), session)` tuple, `Depends` override, unpack `c, session = client`) |
+| Models + TimestampMixin | `backend/models/base.py` (TimestampMixin -> created_at, updated_at UTC) |
+| Rapport mesures post-ingestion | `backend/data_ingestion/enedis/scripts/ingest_real_db.py` (queries count sur tables staging) |
 
 ---
 
@@ -335,9 +503,9 @@ cd promeos-poc && ./backend/venv/bin/pytest backend/tests/ backend/data_ingestio
 
 | # | Commit | Phase |
 |---|--------|-------|
-| 0 | `docs(enedis): update SF4 spec with architecture decisions` | Spec |
+| 0 | `docs(enedis): update SF4 spec v5 with full architecture decisions` | Spec |
 | 1 | `feat(enedis): externalize flux directory config (SF4)` | Config |
-| 2 | `feat(enedis): add EnedisFluxFileError model for error audit trail (SF4)` | Model |
-| 3 | `fix(enedis): preserve error history on retry instead of deleting (SF4)` | Pipeline |
+| 2 | `feat(enedis): add EnedisFluxFileError and IngestionRun models (SF4)` | Models |
+| 3 | `fix(enedis): preserve error history, enable batch retry and dry-run (SF4)` | Pipeline |
 | 4 | `feat(enedis): add CLI for ingestion with dry-run and structured report (SF4)` | CLI |
 | 5 | `feat(enedis): add REST API endpoints and wire router into app (SF4)` | API + Wiring |

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -1,6 +1,6 @@
 # SF4 — Operationalization Pipeline Enedis SGE — Plan d'implementation
 
-> **Status** : Plan v2 — aligne avec spec v5, pret pour implementation phase par phase
+> **Status** : Plan v3 — aligne avec spec v6, pret pour implementation phase par phase
 > **Spec** : `docs/specs/feature-enedis-sge-4-operationalization.md`
 > **Branche** : `feat/enedis-sge-sf4-operationalization` (depuis `feat/enedis-sge-ingestion`)
 
@@ -19,24 +19,33 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 | Historique d'erreurs | **Table separee** `enedis_flux_file_error` | Propre, extensible, requetable en SQL directement |
 | Compteur de tentatives | **Derive** de `len(flux_file.errors)` — pas de colonne `retry_count` | Pas de desynchronisation, source unique de verite |
 | Retry ERROR en batch | **Auto-retry** dans `ingest_directory()` si `len(errors) < MAX_RETRIES` (default 3) | Un seul point d'entree fait tout, pas de fichiers oublies. Garde max_retries empeche les boucles infinies |
-| Suivi d'execution | **Table `IngestionRun`** (1 row par execution CLI/API) | Audit trail lisible, `LastIngestion` = latest completed run |
+| Fichiers PERMANENTLY_FAILED | **Nouveau statut `FluxStatus.PERMANENTLY_FAILED`** quand MAX_RETRIES atteint | Identification immediate par le data manager. Plus de retry automatique |
+| Fichiers NEEDS_REVIEW | **Pas de retry automatique** — donnees chargees, attente review humaine | Traitement initial reussi, republication detectee. Pas un cas d'erreur |
+| Suivi d'execution | **Table `IngestionRun`** avec **compteurs incrementaux** fichier par fichier | Si crash mid-run : compteurs fiables, status "partial", run suivant traite les restants |
+| Statuts IngestionRun | **running / completed / partial / failed** | partial = crash avec compteurs utiles, failed = erreur avant tout traitement |
 | Session API | **`Depends(get_db)`** standard | Pipeline commits per-file (by design). Tracabilite via `IngestionRun` |
+| Concurrence | **Verrou simple** : refuser si IngestionRun en status "running" | 5 lignes, empeche compteurs incoherents en parallele |
+| Validation pre-flight | **Verifier cles + repertoire AVANT creation d'IngestionRun** | Fail fast, pas de run "failed" inutile dans l'historique |
+| Variable ENEDIS_FLUX_DIR | **Obligatoire** dans `.env` — pas de fallback | La clarte prime. Les chemins relatifs sont source d'erreurs |
 | Rapport CLI mesures | **Requetes DB post-ingestion** (pattern `ingest_real_db.py`) | `ingest_directory()` retourne des compteurs de fichiers, pas de mesures. `_print_report()` calcule les volumes via queries sur les tables staging |
+| Mesures dans IngestResponse | **Non** — compteurs fichiers uniquement | Les volumes de mesures sont des totaux staging, pas des deltas du run. Disponibles via GET /stats |
 | CLI scope | **Minimaliste** — `ingest` uniquement (+ `--dry-run`) | Les stats restent cote API, evite la duplication de logique |
 | Auth API | **Pas d'auth** pour le POC | Usage ops/admin, ajout facile ulterieurement |
 | Schemas Pydantic | **Dans le router** (`routes/enedis.py`) | Pattern dominant du codebase |
 | `.env.example` | **Les deux** fichiers (racine + `backend/`) | Coherence avec les conventions existantes |
 | Tests API | **`backend/tests/test_enedis_api.py`** | Coherent avec les autres tests d'API (`test_bacs_api.py`, etc.) |
+| Scripts ad-hoc | **Deprecation** phase 1, suppression apres validation SF4 complete | Reference pendant la transition |
 
 ---
 
 ## Phase 0 — Mise a jour de la spec
 
-**Commit** : `docs(enedis): update SF4 spec v5 with full architecture decisions`
+**Commit** : `docs(enedis): update SF4 spec v6 with final architecture decisions`
 
 | Fichier | Action |
 |---------|--------|
-| `docs/specs/feature-enedis-sge-4-operationalization.md` | Aligner sur spec v5 (decisions architecture completes, IngestionRun, MAX_RETRIES, retry batch, session API) |
+| `docs/specs/feature-enedis-sge-4-operationalization.md` | Aligner sur spec v6 (toutes decisions finales integrees) |
+| `docs/specs/plan-enedis-sge-4-implementation.md` | Aligner sur plan v3 |
 
 ---
 
@@ -57,16 +66,19 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 |---------|-------------|
 | `.env.example` (racine) | Ajouter `ENEDIS_FLUX_DIR` section External Data Connectors |
 | `backend/.env.example` | Ajouter `ENEDIS_FLUX_DIR` |
+| `backend/data_ingestion/enedis/scripts/ingest_real_db.py` | Ajouter commentaire de deprecation en tete de fichier |
+| `backend/data_ingestion/enedis/scripts/decrypt_samples.py` | Ajouter commentaire de deprecation en tete de fichier |
 
 ### Contenu de `config.py`
 
 ```python
-MAX_RETRIES: int = 3  # Nombre max de tentatives sur un fichier en erreur
+MAX_RETRIES: int = 3  # Nombre max de retries sur un fichier en erreur (4 tentatives au total)
 
-def get_flux_dir(override: str | None = None, validate: bool = True) -> Path:
+def get_flux_dir(override: str | None = None) -> Path:
     """Resolve le repertoire de flux Enedis.
 
-    Priorite : override > env var ENEDIS_FLUX_DIR > fallback projet.
+    Priorite : override > env var ENEDIS_FLUX_DIR.
+    Pas de fallback — ENEDIS_FLUX_DIR est obligatoire si pas d'override.
     """
 ```
 
@@ -75,28 +87,29 @@ def get_flux_dir(override: str | None = None, validate: bool = True) -> Path:
 ```
 1. Si override fourni et non vide -> Path(override)
 2. Sinon os.environ.get("ENEDIS_FLUX_DIR") -> Path(env_value)
-3. Sinon fallback -> Path(__file__).resolve().parents[4] / "flux_enedis"
-4. Si validate=True et le path n'est pas un repertoire -> ValueError
+3. Sinon -> ValueError("ENEDIS_FLUX_DIR environment variable is required — set it in .env")
+4. Dans tous les cas : si le path n'est pas un repertoire -> ValueError("... is not a directory")
 ```
 
 ### Tests
 
 | Classe | Cas |
 |--------|-----|
-| `TestGetFluxDir` | env var set, env var absent (fallback), override explicite, repertoire inexistant -> ValueError, validate=False bypass |
+| `TestGetFluxDir` | env var set → correct path, env var absent + no override → ValueError avec message explicite, override explicite → correct path, repertoire inexistant → ValueError, override vide string → fallback sur env var |
 | `TestMaxRetries` | Constante accessible et correctement typee |
 
 ---
 
 ## Phase 2 — Modeles d'audit (erreurs + suivi d'execution)
 
-**Commit** : `feat(enedis): add EnedisFluxFileError and IngestionRun models (SF4)`
+**Commit** : `feat(enedis): add EnedisFluxFileError, IngestionRun models and PERMANENTLY_FAILED status (SF4)`
 
 ### Modifier
 
 | Fichier | Modification |
 |---------|-------------|
 | `backend/data_ingestion/enedis/models.py` | + classe `EnedisFluxFileError`, + classe `IngestionRun`, + relation `errors` sur `EnedisFluxFile` |
+| `backend/data_ingestion/enedis/enums.py` | + `PERMANENTLY_FAILED = "permanently_failed"` dans `FluxStatus` |
 
 ### Schema `EnedisFluxFileError`
 
@@ -124,7 +137,7 @@ Table: enedis_ingestion_run
   directory               String(500) NOT NULL
   recursive               Boolean NOT NULL default True
   dry_run                 Boolean NOT NULL default False
-  status                  String(20) NOT NULL default "running"  (running / completed / failed)
+  status                  String(20) NOT NULL default "running"  (running / completed / partial / failed)
   triggered_by            String(10) NOT NULL  (cli / api)
   files_received          Integer default 0
   files_parsed            Integer default 0
@@ -139,24 +152,39 @@ Table: enedis_ingestion_run
   updated_at              DateTime (TimestampMixin)
 ```
 
+Note : `files_max_retries` comptabilise tous les fichiers non-retentables (nouvellement PERMANENTLY_FAILED + deja en PERMANENTLY_FAILED).
+
+### Enum `FluxStatus` — extension
+
+```python
+class FluxStatus(str, Enum):
+    RECEIVED = "received"
+    PARSED = "parsed"
+    ERROR = "error"
+    SKIPPED = "skipped"
+    NEEDS_REVIEW = "needs_review"
+    PERMANENTLY_FAILED = "permanently_failed"  # NEW — MAX_RETRIES atteint
+```
+
 ### Tests
 
 | Fichier | Cas |
 |---------|-----|
 | `test_models.py` (extend) | `EnedisFluxFileError` : creation, cascade delete, ordering par `created_at` |
-| `test_models.py` (extend) | `IngestionRun` : creation, status transitions, default values, all counter columns |
+| `test_models.py` (extend) | `IngestionRun` : creation, status transitions (running→completed, running→partial, running→failed), default values, all counter columns |
+| `test_models.py` (extend) | `FluxStatus.PERMANENTLY_FAILED` : valeur accessible, distinct de ERROR |
 
 ---
 
-## Phase 3 — Correction audit d'erreurs + retry batch + dry-run dans le pipeline
+## Phase 3 — Correction audit d'erreurs + retry batch + dry-run + compteurs incrementaux
 
-**Commit** : `fix(enedis): preserve error history, enable batch retry and dry-run (SF4)`
+**Commit** : `fix(enedis): preserve error history, enable batch retry, dry-run and incremental run tracking (SF4)`
 
 ### Modifier
 
 | Fichier | Modification |
 |---------|-------------|
-| `backend/data_ingestion/enedis/pipeline.py` | (1) Fix retry dans `ingest_file()`. (2) Retry ERROR + garde MAX_RETRIES dans `ingest_directory()`. (3) Parametre `dry_run` dans `ingest_directory()`. |
+| `backend/data_ingestion/enedis/pipeline.py` | (1) Fix retry dans `ingest_file()`. (2) Retry ERROR + PERMANENTLY_FAILED + NEEDS_REVIEW dans `ingest_directory()`. (3) Parametre `dry_run`. (4) Parametre `run` pour compteurs incrementaux. |
 
 ### Changement 1 : Fix du retry dans `ingest_file()`
 
@@ -181,7 +209,7 @@ if existing.status == FluxStatus.ERROR:
 - Si `flux_file.error_message` non vide : creer `EnedisFluxFileError(flux_file_id=flux_file.id, error_message=flux_file.error_message)`
 - Sinon : no-op
 
-### Changement 2 : Retry ERROR dans `ingest_directory()`
+### Changement 2 : Retry ERROR + gestion PERMANENTLY_FAILED et NEEDS_REVIEW dans `ingest_directory()`
 
 **Localisation** : Phase 1 de `ingest_directory()`, le bloc `else` apres le check `if existing.status == FluxStatus.RECEIVED` qui compte actuellement tous les autres statuts comme `already_processed`.
 
@@ -194,6 +222,12 @@ else:
 
 **Apres** :
 ```python
+elif existing.status == FluxStatus.NEEDS_REVIEW:
+    # Data loaded, awaiting human review (republication) — no retry
+    counters["already_processed"] += 1
+elif existing.status == FluxStatus.PERMANENTLY_FAILED:
+    # Max retries reached — skip, needs manual intervention
+    counters["max_retries_reached"] += 1
 elif existing.status == FluxStatus.ERROR:
     error_count = len(existing.errors)
     if error_count < MAX_RETRIES:
@@ -202,16 +236,20 @@ elif existing.status == FluxStatus.ERROR:
         to_process.append((file_path, file_hash, existing))
         counters["retried"] += 1
     else:
-        logger.info("Skipping %s — max retries reached (%d)",
+        # Transition to PERMANENTLY_FAILED
+        existing.status = FluxStatus.PERMANENTLY_FAILED
+        session.commit()
+        logger.info("File %s reached MAX_RETRIES (%d) — marked PERMANENTLY_FAILED",
                      file_path.name, MAX_RETRIES)
         counters["max_retries_reached"] += 1
 else:
+    # PARSED, SKIPPED
     counters["already_processed"] += 1
 ```
 
 **Compteurs ajoutes** dans le dict de retour de `ingest_directory()` :
 - `retried: int` — fichiers ERROR retentes dans cette execution
-- `max_retries_reached: int` — fichiers ignores car MAX_RETRIES atteint
+- `max_retries_reached: int` — fichiers ignores car PERMANENTLY_FAILED (nouveau ou existant)
 
 **Import necessaire** : `from data_ingestion.enedis.config import MAX_RETRIES`
 
@@ -224,19 +262,72 @@ else:
 - Phase 2 : **skipped entierement** en mode dry_run
 - Retour : meme dict de compteurs (`received` = nombre de fichiers qui seraient traites, `retried` et `max_retries_reached` comme en mode normal, les compteurs de processing a 0)
 
+### Changement 4 : Parametre `run` pour compteurs incrementaux
+
+**Signature** : ajouter `run: IngestionRun | None = None` a `ingest_directory()`.
+
+**Comportement** :
+- Si `run` est fourni, les compteurs de l'IngestionRun sont mis a jour **apres chaque fichier traite** dans Phase 2 :
+```python
+# After each file in Phase 2 processing loop:
+if run:
+    if status == FluxStatus.PARSED:
+        run.files_parsed += 1
+    elif status == FluxStatus.ERROR:
+        run.files_error += 1
+    elif status == FluxStatus.SKIPPED:
+        run.files_skipped += 1
+    elif status == FluxStatus.NEEDS_REVIEW:
+        run.files_needs_review += 1
+    session.commit()  # commit incremental counter update
+```
+- Apres Phase 1 (scan), les compteurs de scan sont aussi mis a jour sur le run :
+```python
+if run:
+    run.files_received = counters["received"]
+    run.files_already_processed = counters["already_processed"]
+    run.files_retried = counters["retried"]
+    run.files_max_retries = counters["max_retries_reached"]
+    session.commit()
+```
+- A la fin de `ingest_directory()`, si tout s'est bien passe :
+```python
+if run:
+    run.status = "completed"
+    run.finished_at = datetime.now(timezone.utc)
+    session.commit()
+```
+- Si une exception non geree survient, elle remonte au caller (CLI/API) qui mettra `run.status = "partial"`.
+
+### Signature finale de `ingest_directory()`
+
+```python
+def ingest_directory(
+    dir_path: Path,
+    session: Session,
+    keys: list[tuple[bytes, bytes]],
+    *,
+    recursive: bool = True,
+    dry_run: bool = False,
+    run: IngestionRun | None = None,
+) -> dict[str, int]:
+```
+
 ### Tests
 
 | Fichier | Cas |
 |---------|-----|
-| `test_pipeline.py` (extend) | `TestErrorHistoryPreserved` : (1) echoue 2x -> 2 entries error history + `len(errors)==2`, (2) echoue puis reussit -> history preservee + status=PARSED, (3) decrypt error puis parse error -> 2 messages distincts |
-| `test_pipeline_full.py` (extend) | `TestErrorRetryInBatch` : fichier ERROR dans `ingest_directory()` est retente automatiquement, history preservee. Fichier avec `MAX_RETRIES` atteint est ignore (compteur `max_retries_reached`). |
+| `test_pipeline.py` (extend) | `TestErrorHistoryPreserved` : (1) echoue 2x → 2 entries error history + `len(errors)==2`, (2) echoue puis reussit → history preservee + status=PARSED, (3) decrypt error puis parse error → 2 messages distincts |
+| `test_pipeline_full.py` (extend) | `TestErrorRetryInBatch` : fichier ERROR dans `ingest_directory()` est retente, history preservee. Fichier avec MAX_RETRIES atteint → status PERMANENTLY_FAILED, compteur `max_retries_reached`. Fichier PERMANENTLY_FAILED dans un run suivant → skip + compteur `max_retries_reached`. |
+| `test_pipeline_full.py` (extend) | `TestNeedsReviewNoRetry` : fichier NEEDS_REVIEW dans `ingest_directory()` → comptabilise comme `already_processed`, pas retente |
 | `test_pipeline.py` (extend) | `TestDryRun` : `ingest_directory(dry_run=True)` retourne les bons compteurs sans modifier la DB |
+| `test_pipeline_full.py` (extend) | `TestIncrementalCounters` : passer un `IngestionRun` a `ingest_directory()`, verifier que les compteurs sont mis a jour apres chaque fichier (pas seulement a la fin). Simuler un crash mid-run et verifier que les compteurs refletent le travail partiel |
 
 ---
 
 ## Phase 4 — CLI
 
-**Commit** : `feat(enedis): add CLI for ingestion with dry-run and structured report (SF4)`
+**Commit** : `feat(enedis): add CLI for ingestion with dry-run, pre-flight validation and structured report (SF4)`
 
 ### Creer
 
@@ -253,7 +344,7 @@ python -m data_ingestion.enedis.cli ingest [--dir PATH] [--recursive] [--dry-run
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--dir PATH` | env var ou fallback | Repertoire source |
+| `--dir PATH` | env var `ENEDIS_FLUX_DIR` (obligatoire) | Repertoire source |
 | `--recursive` | Active | Scanner les sous-repertoires |
 | `--dry-run` | Desactive | Scan + classify sans ingerer |
 | `--verbose` | Desactive | Logging DEBUG |
@@ -271,15 +362,36 @@ from models.base import Base
 main() -> argparse -> dispatch
   cmd_ingest(args):
     _ensure_tables(engine)            # Base.metadata.create_all() + run_migrations()
+
+    # === PRE-FLIGHT VALIDATION ===
+    flux_dir = get_flux_dir(override=args.dir)      # ValueError if missing
+    keys = load_keys_from_env()                       # MissingKeyError if missing
+
     session = SessionLocal()
-    run = IngestionRun(triggered_by="cli", directory=..., dry_run=args.dry_run, ...)
+
+    # === CONCURRENCY GUARD ===
+    running = session.query(IngestionRun).filter_by(status="running").first()
+    if running:
+      print(f"ERROR: Run #{running.id} is already in progress (started {running.started_at})")
+      sys.exit(1)
+
+    # === CREATE RUN (only after all validations pass) ===
+    run = IngestionRun(triggered_by="cli", directory=str(flux_dir),
+                       recursive=args.recursive, dry_run=args.dry_run,
+                       started_at=datetime.now(timezone.utc))
     session.add(run) ; session.commit()
+
     try:
-      mode normal  -> get_flux_dir -> load_keys -> ingest_directory(session, ...) -> _print_report
-      mode dry-run -> get_flux_dir -> ingest_directory(session, ..., dry_run=True) -> _dry_run_report
-      update run (status="completed", counters, finished_at) -> session.commit()
-    except Exception:
-      run.status = "failed" ; run.error_message = str(exc) ; session.commit()
+      mode normal  -> ingest_directory(session, keys, ..., run=run) -> _print_report
+      mode dry-run -> ingest_directory(session, keys, ..., dry_run=True, run=run) -> _dry_run_report
+      # run.status already set to "completed" by ingest_directory()
+    except Exception as exc:
+      run.status = "partial"  # counters are already incremental
+      run.finished_at = datetime.now(timezone.utc)
+      run.error_message = str(exc)
+      session.commit()
+      print(f"ERROR: Run #{run.id} interrupted — status: partial")
+      traceback.print_exc()
       sys.exit(1)
     finally:
       session.close()
@@ -298,7 +410,7 @@ main() -> argparse -> dispatch
 
 ```
 === ENEDIS SGE INGESTION REPORT ===
-Run #42        triggered_by: cli
+Run #42        triggered_by: cli        status: completed
 Source:          /path/to/flux_enedis (recursive)
 Duration:        3.2s
 Files received:  45
@@ -307,9 +419,9 @@ Files received:  45
   error:         1
   needs_review:  1
 Retried:         2  (from previous errors)
-Max retries:     0  (skipped — limit reached)
+Max retries:     0  (permanently failed — skipped)
 Already processed: 46
-Measures stored:
+Measures stored (staging totals):
   R4x:    98,432
   R171:   12,310
   R50:     8,450
@@ -327,7 +439,7 @@ Run #43        triggered_by: cli  (dry-run)
 Source:          /path/to/flux_enedis (recursive)
 New files:       12
 Retryable errors: 2  (eligible for retry, < MAX_RETRIES)
-Max retries:     1   (will be skipped — limit reached)
+Max retries:     1   (permanently failed — will be skipped)
 Already processed: 46
 No data modifications made.
 ```
@@ -339,8 +451,10 @@ No data modifications made.
 | `TestCliIngest` | Mode normal avec fichiers synthetiques, compteurs corrects, IngestionRun created avec status=completed |
 | `TestCliDryRun` | Aucune modification sur les donnees d'ingestion, IngestionRun avec dry_run=True |
 | `TestCliVerbose` | Logging DEBUG active |
-| `TestCliMissingDir` | Repertoire inexistant -> erreur propre, sys.exit(1) |
-| `TestCliNoKeys` | Cles absentes -> erreur propre, sys.exit(1) |
+| `TestCliMissingDir` | ENEDIS_FLUX_DIR absent + no --dir → erreur propre "ENEDIS_FLUX_DIR environment variable is required", sys.exit(1), pas d'IngestionRun cree |
+| `TestCliMissingKeys` | Cles absentes → erreur propre, sys.exit(1), pas d'IngestionRun cree |
+| `TestCliConcurrentRun` | IngestionRun en status "running" existe deja → erreur propre, sys.exit(1), pas de nouveau run cree |
+| `TestCliPartialRun` | Simuler crash mid-ingestion → run.status="partial", compteurs incrementaux corrects |
 
 ---
 
@@ -367,7 +481,7 @@ No data modifications made.
 | Methode | Path | Description |
 |---------|------|-------------|
 | `POST` | `/api/enedis/ingest` | Declencher ingestion (sync, body JSON) |
-| `GET` | `/api/enedis/flux-files` | Liste paginee + filtres (status, flux_type) |
+| `GET` | `/api/enedis/flux-files` | Liste paginee + filtres (status incluant PERMANENTLY_FAILED, flux_type) |
 | `GET` | `/api/enedis/stats` | Stats agregees (fichiers, mesures, PRMs, dernier run) |
 | `GET` | `/api/enedis/flux-files/{id}` | Detail fichier + header_raw + error history |
 
@@ -376,11 +490,13 @@ No data modifications made.
 **Ingestion :**
 ```python
 IngestRequest     { directory?, recursive=True, dry_run=False }
-IngestResponse    { run_id, received, parsed, needs_review, skipped, error,
+IngestResponse    { run_id, status, received, parsed, needs_review, skipped, error,
                     retried, max_retries_reached, already_processed,
                     errors: [IngestErrorDetail], duration_seconds, dry_run }
 IngestErrorDetail { filename, error_message }
 ```
+
+Note : `IngestResponse` ne contient PAS de volumes de mesures — ceux-ci sont des totaux staging disponibles via GET /stats.
 
 **Flux files :**
 ```python
@@ -405,41 +521,67 @@ LastIngestion    { run_id, timestamp, files_count, triggered_by }
 
 **Logique `LastIngestion`** : query `IngestionRun` le plus recent avec `status='completed'` et `dry_run=False`, ordonne par `finished_at DESC`, limit 1. Champ nullable dans `StatsResponse` (null si aucune ingestion reussie).
 
-**Note `PrmStats`** : la requete exacte (UNION DISTINCT de `point_id` sur les 4 tables mesure) est laissee a l'architecte d'implementation. Hint : `union_all()` sur `select(distinct(Table.point_id))` pour chaque table.
+**Note `PrmStats`** : la requete exacte (UNION DISTINCT de `point_id` sur les 4 tables mesure) est laissee a l'architecte d'implementation. Hint : `union_all()` sur `select(distinct(Table.point_id))` pour chaque table. Dans le POC, la liste PRM est globale. En production, filtrer par contrat/portefeuille — point d'attention futur.
 
 ### Pattern de l'endpoint `POST /api/enedis/ingest`
 
 ```python
 @router.post("/ingest", response_model=IngestResponse)
 def trigger_ingest(body: IngestRequest, db: Session = Depends(get_db)):
-    flux_dir = get_flux_dir(override=body.directory)
-    keys = load_keys_from_env()
+    # === PRE-FLIGHT VALIDATION ===
+    try:
+        flux_dir = get_flux_dir(override=body.directory)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
 
-    # 1. Create IngestionRun record
+    try:
+        keys = load_keys_from_env()
+    except MissingKeyError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    # === CONCURRENCY GUARD ===
+    running = db.query(IngestionRun).filter_by(status="running").first()
+    if running:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Run #{running.id} is already in progress (started {running.started_at})"
+        )
+
+    # === CREATE RUN (only after all validations pass) ===
     run = IngestionRun(
         triggered_by="api", directory=str(flux_dir),
         recursive=body.recursive, dry_run=body.dry_run,
+        started_at=datetime.now(timezone.utc),
     )
     db.add(run)
     db.commit()
 
-    # 2. Execute pipeline (pipeline commits per-file internally — by design)
+    # === EXECUTE PIPELINE ===
     t0 = time.time()
-    counters = ingest_directory(
-        flux_dir, db, keys,
-        recursive=body.recursive, dry_run=body.dry_run,
-    )
+    try:
+        counters = ingest_directory(
+            flux_dir, db, keys,
+            recursive=body.recursive, dry_run=body.dry_run,
+            run=run,
+        )
+    except Exception as exc:
+        # Incremental counters are already committed
+        run.status = "partial"
+        run.finished_at = datetime.now(timezone.utc)
+        run.error_message = str(exc)
+        db.commit()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Run #{run.id} interrupted (status: partial) — {str(exc)}"
+        )
     duration = time.time() - t0
 
-    # 3. Update IngestionRun with results
-    run.status = "completed"
-    run.finished_at = datetime.now(timezone.utc)
-    run.files_received = counters["received"]
-    # ... (all counters)
-    db.commit()
+    # run.status already set to "completed" by ingest_directory()
 
-    # 4. Return response with run_id
-    return IngestResponse(run_id=run.id, duration_seconds=round(duration, 2), ...)
+    return IngestResponse(
+        run_id=run.id, status=run.status,
+        duration_seconds=round(duration, 2), ...
+    )
 ```
 
 ### Wiring
@@ -454,9 +596,11 @@ def trigger_ingest(body: IngestRequest, db: Session = Depends(get_db)):
 
 | Classe | Cas |
 |--------|-----|
-| `TestIngestEndpoint` | POST normal (IngestionRun created, run_id dans la reponse), POST dry-run, repertoire inexistant |
-| `TestFluxFilesEndpoint` | Liste paginee, filtre status, filtre flux_type |
-| `TestStatsEndpoint` | Stats correctes apres ingestion, last_ingestion populated avec run_id |
+| `TestIngestEndpoint` | POST normal (IngestionRun created, run_id + status dans la reponse), POST dry-run, repertoire inexistant → 422 |
+| `TestIngestPreFlight` | POST sans cles → 422 avec message explicite, POST sans ENEDIS_FLUX_DIR → 422, POST avec run concurrent → 409 avec run_id existant |
+| `TestIngestPartial` | Simuler erreur mid-ingestion → status "partial", compteurs incrementaux dans la reponse 500 |
+| `TestFluxFilesEndpoint` | Liste paginee, filtre status (incluant PERMANENTLY_FAILED), filtre flux_type |
+| `TestStatsEndpoint` | Stats correctes apres ingestion, last_ingestion populated avec run_id, PRM count et identifiers |
 | `TestFluxFileDetailEndpoint` | Detail + header_raw, detail + error_history, 404 |
 
 ---
@@ -503,9 +647,9 @@ cd promeos-poc && ./backend/venv/bin/pytest backend/tests/ backend/data_ingestio
 
 | # | Commit | Phase |
 |---|--------|-------|
-| 0 | `docs(enedis): update SF4 spec v5 with full architecture decisions` | Spec |
+| 0 | `docs(enedis): update SF4 spec v6 with final architecture decisions` | Spec |
 | 1 | `feat(enedis): externalize flux directory config (SF4)` | Config |
-| 2 | `feat(enedis): add EnedisFluxFileError and IngestionRun models (SF4)` | Models |
-| 3 | `fix(enedis): preserve error history, enable batch retry and dry-run (SF4)` | Pipeline |
-| 4 | `feat(enedis): add CLI for ingestion with dry-run and structured report (SF4)` | CLI |
+| 2 | `feat(enedis): add EnedisFluxFileError, IngestionRun models and PERMANENTLY_FAILED status (SF4)` | Models |
+| 3 | `fix(enedis): preserve error history, enable batch retry, dry-run and incremental run tracking (SF4)` | Pipeline |
+| 4 | `feat(enedis): add CLI for ingestion with dry-run, pre-flight validation and structured report (SF4)` | CLI |
 | 5 | `feat(enedis): add REST API endpoints and wire router into app (SF4)` | API + Wiring |

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -1,6 +1,6 @@
 # SF4 — Operationalization Pipeline Enedis SGE — Plan d'implementation
 
-> **Status** : Plan v3 — aligne avec spec v6, pret pour implementation phase par phase
+> **Status** : Plan v4 — aligne avec spec v7, integre decisions revue finale
 > **Spec** : `docs/specs/feature-enedis-sge-4-operationalization.md`
 > **Branche** : `feat/enedis-sge-sf4-operationalization` (depuis `feat/enedis-sge-ingestion`)
 
@@ -21,8 +21,8 @@ SF4 rend le pipeline **fiable, complet et auditable** en livrant : config, error
 | Retry ERROR en batch | **Auto-retry** dans `ingest_directory()` si `len(errors) < MAX_RETRIES` (default 3) | Un seul point d'entree fait tout, pas de fichiers oublies. Garde max_retries empeche les boucles infinies |
 | Fichiers PERMANENTLY_FAILED | **Nouveau statut `FluxStatus.PERMANENTLY_FAILED`** quand MAX_RETRIES atteint | Identification immediate par le data manager. Plus de retry automatique |
 | Fichiers NEEDS_REVIEW | **Pas de retry automatique** — donnees chargees, attente review humaine | Traitement initial reussi, republication detectee. Pas un cas d'erreur |
-| Suivi d'execution | **Table `IngestionRun`** avec **compteurs incrementaux** fichier par fichier | Si crash mid-run : compteurs fiables, status "partial", run suivant traite les restants |
-| Statuts IngestionRun | **running / completed / partial / failed** | partial = crash avec compteurs utiles, failed = erreur avant tout traitement |
+| Suivi d'execution | **Table `IngestionRun`** avec **compteurs incrementaux** fichier par fichier | Si crash mid-run : compteurs fiables, status "failed", run suivant traite les restants |
+| Statuts IngestionRun | **running / completed / failed** | failed = crash ou erreur apres creation du run. Compteurs incrementaux fiables |
 | Session API | **`Depends(get_db)`** standard | Pipeline commits per-file (by design). Tracabilite via `IngestionRun` |
 | Concurrence | **Verrou simple** : refuser si IngestionRun en status "running" | 5 lignes, empeche compteurs incoherents en parallele |
 | Validation pre-flight | **Verifier cles + repertoire AVANT creation d'IngestionRun** | Fail fast, pas de run "failed" inutile dans l'historique |
@@ -109,7 +109,7 @@ def get_flux_dir(override: str | None = None) -> Path:
 | Fichier | Modification |
 |---------|-------------|
 | `backend/data_ingestion/enedis/models.py` | + classe `EnedisFluxFileError`, + classe `IngestionRun`, + relation `errors` sur `EnedisFluxFile` |
-| `backend/data_ingestion/enedis/enums.py` | + `PERMANENTLY_FAILED = "permanently_failed"` dans `FluxStatus` |
+| `backend/data_ingestion/enedis/enums.py` | + `PERMANENTLY_FAILED = "permanently_failed"` dans `FluxStatus`, + classe `IngestionRunStatus(str, Enum)` avec `RUNNING/COMPLETED/FAILED` |
 
 ### Schema `EnedisFluxFileError`
 
@@ -137,7 +137,7 @@ Table: enedis_ingestion_run
   directory               String(500) NOT NULL
   recursive               Boolean NOT NULL default True
   dry_run                 Boolean NOT NULL default False
-  status                  String(20) NOT NULL default "running"  (running / completed / partial / failed)
+  status                  String(20) NOT NULL default "running"  (IngestionRunStatus: running / completed / failed)
   triggered_by            String(10) NOT NULL  (cli / api)
   files_received          Integer default 0
   files_parsed            Integer default 0
@@ -164,6 +164,12 @@ class FluxStatus(str, Enum):
     SKIPPED = "skipped"
     NEEDS_REVIEW = "needs_review"
     PERMANENTLY_FAILED = "permanently_failed"  # NEW — MAX_RETRIES atteint
+
+
+class IngestionRunStatus(str, Enum):
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
 ```
 
 ### Tests
@@ -171,8 +177,9 @@ class FluxStatus(str, Enum):
 | Fichier | Cas |
 |---------|-----|
 | `test_models.py` (extend) | `EnedisFluxFileError` : creation, cascade delete, ordering par `created_at` |
-| `test_models.py` (extend) | `IngestionRun` : creation, status transitions (running→completed, running→partial, running→failed), default values, all counter columns |
+| `test_models.py` (extend) | `IngestionRun` : creation, status transitions (running→completed, running→failed), default values, all counter columns |
 | `test_models.py` (extend) | `FluxStatus.PERMANENTLY_FAILED` : valeur accessible, distinct de ERROR |
+| `test_models.py` (extend) | `IngestionRunStatus` : valeurs RUNNING/COMPLETED/FAILED accessibles |
 
 ---
 
@@ -186,12 +193,15 @@ class FluxStatus(str, Enum):
 |---------|-------------|
 | `backend/data_ingestion/enedis/pipeline.py` | (1) Fix retry dans `ingest_file()`. (2) Retry ERROR + PERMANENTLY_FAILED + NEEDS_REVIEW dans `ingest_directory()`. (3) Parametre `dry_run`. (4) Parametre `run` pour compteurs incrementaux. |
 
-### Changement 1 : Fix du retry dans `ingest_file()`
+### Changement 1 : Fix du retry + garde MAX_RETRIES + skip PERMANENTLY_FAILED dans `ingest_file()`
 
-**Localisation** : le bloc `if existing.status == FluxStatus.ERROR` dans la fonction `ingest_file()` (actuellement un `session.delete(existing)` + `session.flush()`).
+**Localisation** : les blocs d'idempotence et de retry dans la fonction `ingest_file()`.
 
 **Avant** :
 ```python
+if existing.status in (FluxStatus.PARSED, FluxStatus.SKIPPED, FluxStatus.NEEDS_REVIEW):
+    ...
+    return FluxStatus(existing.status)
 if existing.status == FluxStatus.ERROR:
     session.delete(existing)
     session.flush()
@@ -199,11 +209,21 @@ if existing.status == FluxStatus.ERROR:
 
 **Apres** :
 ```python
+if existing.status in (FluxStatus.PARSED, FluxStatus.SKIPPED, FluxStatus.NEEDS_REVIEW, FluxStatus.PERMANENTLY_FAILED):
+    ...
+    return FluxStatus(existing.status)
 if existing.status == FluxStatus.ERROR:
+    if len(existing.errors) >= MAX_RETRIES:
+        existing.status = FluxStatus.PERMANENTLY_FAILED
+        session.commit()
+        logger.info("File %s reached MAX_RETRIES — marked PERMANENTLY_FAILED", filename)
+        return FluxStatus.PERMANENTLY_FAILED
     _archive_error(session, existing)
     existing.error_message = None
     pre_registered = existing  # reuse same record in-place
 ```
+
+La garde `MAX_RETRIES` dans `ingest_file()` est necessaire pour les appels directs (futur endpoint UX de re-ingestion fichier par fichier). `ingest_directory()` a sa propre garde en Phase 1 pour eviter d'ajouter le fichier a `to_process`.
 
 **Nouveau helper** `_archive_error(session, flux_file)` :
 - Si `flux_file.error_message` non vide : creer `EnedisFluxFileError(flux_file_id=flux_file.id, error_message=flux_file.error_message)`
@@ -236,11 +256,13 @@ elif existing.status == FluxStatus.ERROR:
         to_process.append((file_path, file_hash, existing))
         counters["retried"] += 1
     else:
-        # Transition to PERMANENTLY_FAILED
-        existing.status = FluxStatus.PERMANENTLY_FAILED
-        session.commit()
-        logger.info("File %s reached MAX_RETRIES (%d) — marked PERMANENTLY_FAILED",
-                     file_path.name, MAX_RETRIES)
+        # Transition to PERMANENTLY_FAILED (skip in dry-run)
+        if not dry_run:
+            existing.status = FluxStatus.PERMANENTLY_FAILED
+            session.commit()
+        logger.info("File %s reached MAX_RETRIES (%d) — %s",
+                     file_path.name, MAX_RETRIES,
+                     "marked PERMANENTLY_FAILED" if not dry_run else "would mark PERMANENTLY_FAILED (dry-run)")
         counters["max_retries_reached"] += 1
 else:
     # PARSED, SKIPPED
@@ -258,7 +280,7 @@ else:
 **Signature** : ajouter `dry_run: bool = False` a `ingest_directory()`.
 
 **Comportement** :
-- Phase 1 : scan, hash, classify, check DB — identique, mais **pas de commit** des enregistrements RECEIVED, pas de creation de nouveaux records. Seulement compter.
+- Phase 1 : scan, hash, classify, check DB — identique, mais **pas de commit** des enregistrements RECEIVED, pas de creation de nouveaux records. Les transitions ERROR → PERMANENTLY_FAILED ne sont **pas commitees** en dry-run (comptees mais pas appliquees). Seulement compter.
 - Phase 2 : **skipped entierement** en mode dry_run
 - Retour : meme dict de compteurs (`received` = nombre de fichiers qui seraient traites, `retried` et `max_retries_reached` comme en mode normal, les compteurs de processing a 0)
 
@@ -297,7 +319,7 @@ if run:
     run.finished_at = datetime.now(timezone.utc)
     session.commit()
 ```
-- Si une exception non geree survient, elle remonte au caller (CLI/API) qui mettra `run.status = "partial"`.
+- Si une exception non geree survient, elle remonte au caller (CLI/API) qui mettra `run.status = IngestionRunStatus.FAILED`.
 
 ### Signature finale de `ingest_directory()`
 
@@ -386,11 +408,11 @@ main() -> argparse -> dispatch
       mode dry-run -> ingest_directory(session, keys, ..., dry_run=True, run=run) -> _dry_run_report
       # run.status already set to "completed" by ingest_directory()
     except Exception as exc:
-      run.status = "partial"  # counters are already incremental
+      run.status = IngestionRunStatus.FAILED  # counters are already incremental
       run.finished_at = datetime.now(timezone.utc)
       run.error_message = str(exc)
       session.commit()
-      print(f"ERROR: Run #{run.id} interrupted — status: partial")
+      print(f"ERROR: Run #{run.id} interrupted — status: failed")
       traceback.print_exc()
       sys.exit(1)
     finally:
@@ -454,7 +476,7 @@ No data modifications made.
 | `TestCliMissingDir` | ENEDIS_FLUX_DIR absent + no --dir → erreur propre "ENEDIS_FLUX_DIR environment variable is required", sys.exit(1), pas d'IngestionRun cree |
 | `TestCliMissingKeys` | Cles absentes → erreur propre, sys.exit(1), pas d'IngestionRun cree |
 | `TestCliConcurrentRun` | IngestionRun en status "running" existe deja → erreur propre, sys.exit(1), pas de nouveau run cree |
-| `TestCliPartialRun` | Simuler crash mid-ingestion → run.status="partial", compteurs incrementaux corrects |
+| `TestCliCrashRun` | Simuler crash mid-ingestion → run.status="failed", compteurs incrementaux corrects |
 
 ---
 
@@ -566,13 +588,13 @@ def trigger_ingest(body: IngestRequest, db: Session = Depends(get_db)):
         )
     except Exception as exc:
         # Incremental counters are already committed
-        run.status = "partial"
+        run.status = IngestionRunStatus.FAILED
         run.finished_at = datetime.now(timezone.utc)
         run.error_message = str(exc)
         db.commit()
         raise HTTPException(
             status_code=500,
-            detail=f"Run #{run.id} interrupted (status: partial) — {str(exc)}"
+            detail=f"Run #{run.id} interrupted (status: failed) — {str(exc)}"
         )
     duration = time.time() - t0
 
@@ -598,7 +620,7 @@ def trigger_ingest(body: IngestRequest, db: Session = Depends(get_db)):
 |--------|-----|
 | `TestIngestEndpoint` | POST normal (IngestionRun created, run_id + status dans la reponse), POST dry-run, repertoire inexistant → 422 |
 | `TestIngestPreFlight` | POST sans cles → 422 avec message explicite, POST sans ENEDIS_FLUX_DIR → 422, POST avec run concurrent → 409 avec run_id existant |
-| `TestIngestPartial` | Simuler erreur mid-ingestion → status "partial", compteurs incrementaux dans la reponse 500 |
+| `TestIngestCrash` | Simuler erreur mid-ingestion → status "failed", compteurs incrementaux dans la reponse 500 |
 | `TestFluxFilesEndpoint` | Liste paginee, filtre status (incluant PERMANENTLY_FAILED), filtre flux_type |
 | `TestStatsEndpoint` | Stats correctes apres ingestion, last_ingestion populated avec run_id, PRM count et identifiers |
 | `TestFluxFileDetailEndpoint` | Detail + header_raw, detail + error_history, 404 |

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -483,7 +483,7 @@ No data modifications made.
 
 ---
 
-## Phase 5 — API REST + Wiring applicatif
+## Phase 5 — API REST + Wiring applicatif [DONE]
 
 **Commit** : `feat(enedis): add REST API endpoints and wire router into app (SF4)`
 

--- a/docs/specs/plan-enedis-sge-4-implementation.md
+++ b/docs/specs/plan-enedis-sge-4-implementation.md
@@ -183,9 +183,9 @@ class IngestionRunStatus(str, Enum):
 
 ---
 
-## Phase 3 — Correction audit d'erreurs + retry batch + dry-run + compteurs incrementaux
+## Phase 3 — Correction audit d'erreurs + retry batch + dry-run + compteurs incrementaux [DONE]
 
-**Commit** : `fix(enedis): preserve error history, enable batch retry, dry-run and incremental run tracking (SF4)`
+**Commit** : `fix(enedis): preserve error history, batch retry, dry-run & run tracking (SF4 P3) (#176)` (ba02560)
 
 ### Modifier
 


### PR DESCRIPTION
## Summary

SF4 rend le pipeline d'ingestion Enedis SGE **fiable, complet et auditable** en livrant 5 capacités :

- **Configuration externalisée** — `ENEDIS_FLUX_DIR` obligatoire, `MAX_RETRIES` configurable, plus de chemins hardcodés
- **Audit d'erreurs corrigé** — historique préservé dans `enedis_flux_file_error`, retry in-place (plus de delete/recreate), statut `PERMANENTLY_FAILED` quand `MAX_RETRIES` atteint
- **Suivi d'exécution** — table `IngestionRun` avec compteurs incrémentaux fichier par fichier (fiables même en cas de crash mid-run)
- **CLI** — `python -m data_ingestion.enedis.cli ingest` avec `--dry-run`, validation pre-flight (clés, répertoire, concurrence), rapport structuré
- **API REST** — 4 endpoints sous `/api/enedis` : `POST /ingest`, `GET /flux-files`, `GET /flux-files/{id}`, `GET /stats` (avec wiring dans `main.py`)

### Commits (18)

| Phase | Description |
|-------|-------------|
| P0 | Spec v7 + plan d'implémentation v4 (décisions architecture finales) |
| P1 | Config externalisée (`config.py`, `.env.example`) |
| P2 | Modèles audit (`EnedisFluxFileError`, `IngestionRun`, `PERMANENTLY_FAILED`) |
| P3 | Fix error history + batch retry + dry-run + compteurs incrémentaux |
| P4 | CLI argparse avec pre-flight, rapport normal/dry-run |
| P5 | API REST (4 endpoints) + wiring router |

### Chiffres

- **20 fichiers** modifiés/créés (+3664 / −103 lignes)
- **297 tests** passent (enedis pipeline + API)
- Scripts ad-hoc marqués deprecated (suppression après validation)

## Test plan

- [x] `pytest backend/data_ingestion/enedis/tests/ -x -v` — 273 passed
- [x] `pytest backend/tests/test_enedis_api.py -x -v` — 24 passed
- [ ] Review manuelle des endpoints via `httpie` ou Swagger UI (`/docs`)
- [ ] Vérifier le CLI en dry-run : `python -m data_ingestion.enedis.cli ingest --dry-run`
- [ ] Vérifier le CLI en mode normal avec fichiers réels
- [ ] Confirmer le verrou de concurrence (lancer 2 runs simultanés → 409)

🤖 Generated with [Claude Code](https://claude.com/claude-code)