### PR TITLE
feat(site360): onglets Conso + Actions + kWh/m² + E2E 28 tests

### DIFF
--- a/backend/connectors/entsoe_connector.py
+++ b/backend/connectors/entsoe_connector.py
@@ -13,9 +13,13 @@ from typing import Optional
 import pandas as pd
 
 from models.market_models import (
-    MktPrice, MarketDataSource, MarketType,
-    ProductType, PriceZone, Resolution,
-    MarketDataFetchLog
+    MktPrice,
+    MarketDataSource,
+    MarketType,
+    ProductType,
+    PriceZone,
+    Resolution,
+    MarketDataFetchLog,
 )
 
 logger = logging.getLogger(__name__)
@@ -41,6 +45,7 @@ class EntsoeConnector:
 
     def __init__(self, api_key: str):
         from entsoe import EntsoePandasClient
+
         self.client = EntsoePandasClient(api_key=api_key)
         self.source = MarketDataSource.ENTSOE
 
@@ -59,9 +64,7 @@ class EntsoeConnector:
         end_ts = pd.Timestamp(end, tz="Europe/Paris")
 
         try:
-            series = self.client.query_day_ahead_prices(
-                country_code, start=start_ts, end=end_ts
-            )
+            series = self.client.query_day_ahead_prices(country_code, start=start_ts, end=end_ts)
         except Exception as e:
             logger.error(f"ENTSO-E fetch failed: {e}")
             raise
@@ -71,21 +74,22 @@ class EntsoeConnector:
             dt = ts.to_pydatetime()
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
-            records.append({
-                "source": self.source,
-                "market_type": MarketType.SPOT_DAY_AHEAD,
-                "product_type": ProductType.HOURLY,
-                "zone": zone,
-                "delivery_start": dt,
-                "delivery_end": dt + timedelta(hours=1),
-                "price_eur_mwh": float(price),
-                "resolution": Resolution.PT60M,
-                "fetched_at": datetime.now(timezone.utc),
-                "quality_flag": "GOOD",
-            })
+            records.append(
+                {
+                    "source": self.source,
+                    "market_type": MarketType.SPOT_DAY_AHEAD,
+                    "product_type": ProductType.HOURLY,
+                    "zone": zone,
+                    "delivery_start": dt,
+                    "delivery_end": dt + timedelta(hours=1),
+                    "price_eur_mwh": float(price),
+                    "resolution": Resolution.PT60M,
+                    "fetched_at": datetime.now(timezone.utc),
+                    "quality_flag": "GOOD",
+                }
+            )
 
-        logger.info(f"ENTSO-E: fetched {len(records)} prices for {zone.value} "
-                     f"from {start.date()} to {end.date()}")
+        logger.info(f"ENTSO-E: fetched {len(records)} prices for {zone.value} from {start.date()} to {end.date()}")
         return records
 
     def fetch_generation_by_type(

--- a/backend/routes/actions.py
+++ b/backend/routes/actions.py
@@ -346,6 +346,7 @@ def sync_action_hub(
     return {"status": "ok", **result}
 
 
+@router.get("")
 @router.get("/list")
 def list_actions(
     request: Request,

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -997,6 +997,18 @@ def list_insights(
         )
         action_map = {a.source_id: a.id for a in actions}
 
+    # P1.5: Resolve supplier name for each insight via invoice → contract
+    supplier_map = {}
+    invoice_ids = [i.invoice_id for i in insights if i.invoice_id]
+    if invoice_ids:
+        inv_rows = (
+            db.query(EnergyInvoice.id, EnergyContract.supplier_name)
+            .outerjoin(EnergyContract, EnergyInvoice.contract_id == EnergyContract.id)
+            .filter(EnergyInvoice.id.in_(invoice_ids))
+            .all()
+        )
+        supplier_map = {r[0]: r[1] for r in inv_rows if r[1]}
+
     return {
         "insights": [
             {
@@ -1011,6 +1023,7 @@ def list_insights(
                 "owner": i.owner,
                 "notes": i.notes,
                 "action_id": action_map.get(str(i.id)),
+                "supplier": supplier_map.get(i.invoice_id),
             }
             for i in insights
         ],
@@ -1588,6 +1601,7 @@ def get_billing_periods(
     }
 
 
+@router.get("/coverage")
 @router.get("/coverage-summary")
 def get_coverage_summary(
     request: Request,

--- a/backend/routes/cockpit.py
+++ b/backend/routes/cockpit.py
@@ -277,6 +277,7 @@ def get_kpi_catalog():
 def get_benchmark(
     db: Session = Depends(get_db),
     request: Request = None,
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
     """
     [V110] Positionnement des sites par rapport aux benchmarks ADEME (kWh/m²/an).
@@ -284,9 +285,9 @@ def get_benchmark(
     from config.patrimoine_assumptions import BENCHMARK_ADEME_KWH_M2_AN
     from models import not_deleted
 
-    org_id = int(request.headers.get("X-Org-Id", "0")) if request else 0
-    # Scoper aux sites de l'org demandée (fix data leak multi-tenant CRIT-1)
-    site_ids = [s.id for s in _sites_for_org(db, org_id if org_id else None).with_entities(Site.id).all()]
+    # I8 FIX: utiliser resolve_org_id (chaîne de fallback standard)
+    org_id = resolve_org_id(request, auth, db)
+    site_ids = [s.id for s in _sites_for_org(db, org_id).with_entities(Site.id).all()]
     sites = not_deleted(db.query(Site), Site).filter(Site.id.in_(site_ids), Site.actif == True).all()
 
     # Unified consumption for each site (single source of truth for IPE)

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -259,7 +259,7 @@ def get_portfolio_summary(
     kwh_total = 0.0
     sites_total = len(sites)
     sites_with_data = 0
-    confidence_split = {"high": 0, "medium": 0, "low": 0}
+    confidence_split = {"high": 0, "medium": 0, "low": 0, "none": 0}
     site_rows = []
 
     for site in sites:

--- a/backend/scripts/seed_market_demo.py
+++ b/backend/scripts/seed_market_demo.py
@@ -15,10 +15,16 @@ from datetime import datetime, timezone, timedelta
 from database.connection import SessionLocal, engine
 from models.base import Base
 from models.market_models import (  # noqa: F401 — register models on Base
-    MktPrice, RegulatedTariff, PriceSignal,
-    MarketDataFetchLog, PriceDecomposition,
-    MarketDataSource, MarketType,
-    ProductType, PriceZone, Resolution,
+    MktPrice,
+    RegulatedTariff,
+    PriceSignal,
+    MarketDataFetchLog,
+    PriceDecomposition,
+    MarketDataSource,
+    MarketType,
+    ProductType,
+    PriceZone,
+    Resolution,
 )
 from services.market_data_service import MarketDataService
 from services.market_tariff_loader import load_tariffs_from_yaml
@@ -30,9 +36,7 @@ def generate_spot_prices(days: int = 90) -> list[dict]:
     Pattern: base ~70 EUR/MWh, pointe matin/soir, bruit, saisonnalite.
     """
     records = []
-    base_date = datetime.now(timezone.utc).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    ) - timedelta(days=days)
+    base_date = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=days)
 
     for day in range(days):
         date = base_date + timedelta(days=day)
@@ -65,18 +69,20 @@ def generate_spot_prices(days: int = 90) -> list[dict]:
             if is_weekend and 11 <= hour <= 14 and random.random() < 0.05:
                 price = round(random.uniform(-20, -1), 2)
 
-            records.append({
-                "source": MarketDataSource.ENTSOE,
-                "market_type": MarketType.SPOT_DAY_AHEAD,
-                "product_type": ProductType.HOURLY,
-                "zone": PriceZone.FR,
-                "delivery_start": date + timedelta(hours=hour),
-                "delivery_end": date + timedelta(hours=hour + 1),
-                "price_eur_mwh": price,
-                "resolution": Resolution.PT60M,
-                "fetched_at": datetime.now(timezone.utc),
-                "quality_flag": "GOOD",
-            })
+            records.append(
+                {
+                    "source": MarketDataSource.ENTSOE,
+                    "market_type": MarketType.SPOT_DAY_AHEAD,
+                    "product_type": ProductType.HOURLY,
+                    "zone": PriceZone.FR,
+                    "delivery_start": date + timedelta(hours=hour),
+                    "delivery_end": date + timedelta(hours=hour + 1),
+                    "price_eur_mwh": price,
+                    "resolution": Resolution.PT60M,
+                    "fetched_at": datetime.now(timezone.utc),
+                    "quality_flag": "GOOD",
+                }
+            )
 
     return records
 
@@ -99,21 +105,25 @@ def generate_forward_curves() -> list[dict]:
     ]
 
     for mtype, start, end, price, product in forwards:
-        records.append({
-            "source": MarketDataSource.MANUAL,
-            "market_type": mtype,
-            "product_type": product,
-            "zone": PriceZone.FR,
-            "delivery_start": datetime.fromisoformat(start).replace(tzinfo=timezone.utc),
-            "delivery_end": datetime.fromisoformat(end).replace(tzinfo=timezone.utc),
-            "price_eur_mwh": price,
-            "resolution": Resolution.P1Y if mtype == MarketType.FORWARD_YEAR
-                         else Resolution.P3M if mtype == MarketType.FORWARD_QUARTER
-                         else Resolution.P1M,
-            "fetched_at": now,
-            "quality_flag": "GOOD",
-            "source_reference": "Pilott/Sirenergies freemium -- mars 2026",
-        })
+        records.append(
+            {
+                "source": MarketDataSource.MANUAL,
+                "market_type": mtype,
+                "product_type": product,
+                "zone": PriceZone.FR,
+                "delivery_start": datetime.fromisoformat(start).replace(tzinfo=timezone.utc),
+                "delivery_end": datetime.fromisoformat(end).replace(tzinfo=timezone.utc),
+                "price_eur_mwh": price,
+                "resolution": Resolution.P1Y
+                if mtype == MarketType.FORWARD_YEAR
+                else Resolution.P3M
+                if mtype == MarketType.FORWARD_QUARTER
+                else Resolution.P1M,
+                "fetched_at": now,
+                "quality_flag": "GOOD",
+                "source_reference": "Pilott/Sirenergies freemium -- mars 2026",
+            }
+        )
 
     return records
 

--- a/backend/services/co2_service.py
+++ b/backend/services/co2_service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, asdict
+from datetime import date
 from typing import Optional, List
 
 from sqlalchemy.orm import Session
@@ -67,12 +68,15 @@ class Co2Result:
         return asdict(self)
 
 
-def compute_site_co2(db: Session, site_id: int) -> Co2Result:
+def compute_site_co2(db: Session, site_id: int, start: date = None, end: date = None) -> Co2Result:
     """
-    Calcule l'empreinte CO₂ annuelle d'un site.
+    Calcule l'empreinte CO₂ d'un site sur une période.
 
     Utilise le modele Meter (source de verite) pour decouvrir les vecteurs
     energetiques et lire les MeterReading. Fallback Site.annual_kwh_total.
+
+    Args:
+        start/end: période de calcul. Si None → 365 derniers jours.
     """
     from models import Site
     from models.energy_models import Meter, MeterReading
@@ -83,11 +87,17 @@ def compute_site_co2(db: Session, site_id: int) -> Co2Result:
         return Co2Result(site_id=site_id, total_kg_co2=0, total_t_co2=0, breakdown=[], confidence="low")
 
     # Consommation par vecteur via unified service (single source of truth)
-    from datetime import date, timedelta
+    from datetime import timedelta
     from services.consumption_unified_service import get_consumption_summary
 
-    today = date.today()
-    y_ago = today - timedelta(days=365)
+    if end is None:
+        end = date.today()
+    if start is None:
+        start = end - timedelta(days=365)
+
+    # Alias pour le reste du code (y_ago/today → start/end)
+    y_ago = start
+    today = end
 
     # Vecteurs a calculer : elec toujours, gaz si compteur present
     vector_map = {"elec": EnergyVector.ELECTRICITY, "gaz": EnergyVector.GAS}
@@ -150,38 +160,18 @@ def compute_site_co2(db: Session, site_id: int) -> Co2Result:
     )
 
 
-def compute_portfolio_co2(db: Session, org_id: int) -> dict:
-    """Calcule l'empreinte CO₂ portfolio (tous sites actifs)."""
-    from models import Site, not_deleted
-
-    sites = not_deleted(db.query(Site), Site).filter(Site.actif == True).all()
-    if org_id:
-        # Filter by org via portefeuille chain
-        site_ids_in_org = _get_org_site_ids(db, org_id)
-        sites = [s for s in sites if s.id in site_ids_in_org]
-
-    results = []
-    total_kg = 0
-    for site in sites:
-        r = compute_site_co2(db, site.id)
-        total_kg += r.total_kg_co2
-        results.append(
-            {
-                "site_id": site.id,
-                "site_nom": site.nom,
-                "t_co2": r.total_t_co2,
-                "breakdown": r.breakdown,
-                "confidence": r.confidence,
-            }
-        )
-
-    # Agrégats par vecteur — calculés backend (le front ne doit PAS agréger)
+def _aggregate_co2_results(results: list) -> dict:
+    """Agrège les résultats CO₂ par vecteur et scope. Retourne les totaux."""
     vectors_agg: dict[str, dict] = {}
     scope1_kg = 0.0
     scope2_kg = 0.0
+    total_kg = 0.0
     total_kwh_all = 0.0
+
     for r in results:
-        for bd in r.get("breakdown", []):
+        total_kg += r.get("total_kg_co2", 0) if isinstance(r, dict) else r.total_kg_co2
+        breakdowns = r.get("breakdown", []) if isinstance(r, dict) else r.breakdown
+        for bd in breakdowns:
             key = bd.get("energy_type", "autres")
             if key not in vectors_agg:
                 vectors_agg[key] = {"kwh": 0.0, "kg_co2": 0.0}
@@ -194,10 +184,96 @@ def compute_portfolio_co2(db: Session, org_id: int) -> dict:
             else:
                 scope2_kg += bd.get("kg_co2", 0)
 
+    return {
+        "total_kg": total_kg,
+        "scope1_kg": scope1_kg,
+        "scope2_kg": scope2_kg,
+        "total_kwh": total_kwh_all,
+        "vectors_agg": vectors_agg,
+    }
+
+
+def _delta_pct(current: float, previous: float) -> float | None:
+    """Écart en %. Négatif = amélioration (baisse). None si données manquantes."""
+    if previous is None or previous == 0 or current is None:
+        return None
+    return round((current - previous) / previous * 100, 1)
+
+
+def _safe_prev_date(year: int, month: int, day: int) -> date:
+    """Construit une date en gérant le 29 février (fallback au 28)."""
+    try:
+        return date(year, month, day)
+    except ValueError:
+        return date(year, month, 28)
+
+
+MONTH_NAMES_FR = {
+    1: "Janv",
+    2: "Fév",
+    3: "Mars",
+    4: "Avr",
+    5: "Mai",
+    6: "Juin",
+    7: "Juil",
+    8: "Août",
+    9: "Sept",
+    10: "Oct",
+    11: "Nov",
+    12: "Déc",
+}
+
+
+def compute_portfolio_co2(db: Session, org_id: int) -> dict:
+    """
+    Calcule l'empreinte CO₂ portfolio (tous sites actifs) + comparaison N-1.
+
+    Comparaison sur même période calendaire : janv→aujourd'hui N vs janv→même jour N-1.
+    Facteurs ADEME centralisés — zéro calcul côté frontend.
+    """
+    from models import Site, not_deleted
+
+    sites = not_deleted(db.query(Site), Site).filter(Site.actif == True).all()
+    if org_id:
+        site_ids_in_org = _get_org_site_ids(db, org_id)
+        sites = [s for s in sites if s.id in site_ids_in_org]
+
+    # ── Périodes N et N-1 (même plage calendaire) ──
+    today = date.today()
+    year_n = today.year
+    start_n = date(year_n, 1, 1)
+    end_n = today
+
+    start_n1 = date(year_n - 1, 1, 1)
+    end_n1 = _safe_prev_date(year_n - 1, today.month, today.day)
+
+    # ── Calcul CO₂ par site pour N et N-1 ──
+    results_n = []
+    results_n1 = []
+    for site in sites:
+        r_n = compute_site_co2(db, site.id, start=start_n, end=end_n)
+        results_n.append(
+            {
+                "site_id": site.id,
+                "site_nom": site.nom,
+                "t_co2": r_n.total_t_co2,
+                "total_kg_co2": r_n.total_kg_co2,
+                "breakdown": r_n.breakdown,
+                "confidence": r_n.confidence,
+            }
+        )
+
+        r_n1 = compute_site_co2(db, site.id, start=start_n1, end=end_n1)
+        results_n1.append(r_n1)
+
+    # ── Agrégation N ──
+    agg_n = _aggregate_co2_results(results_n)
+
+    # Vecteurs display (pour les barres du frontend)
     vectors_display = []
-    for key, val in sorted(vectors_agg.items(), key=lambda x: -x[1]["kwh"]):
+    for key, val in sorted(agg_n["vectors_agg"].items(), key=lambda x: -x[1]["kwh"]):
         mwh = round(val["kwh"] / 1000, 1) if val["kwh"] else 0
-        pct = round((val["kwh"] / total_kwh_all) * 100) if total_kwh_all > 0 else 0
+        pct = round((val["kwh"] / agg_n["total_kwh"]) * 100) if agg_n["total_kwh"] > 0 else 0
         vectors_display.append(
             {
                 "key": key,
@@ -207,17 +283,54 @@ def compute_portfolio_co2(db: Session, org_id: int) -> dict:
             }
         )
 
+    # ── Agrégation N-1 ──
+    agg_n1 = _aggregate_co2_results(results_n1)
+    has_n1 = agg_n1["total_kg"] > 0
+
+    # ── Deltas (négatif = amélioration = baisse des émissions) ──
+    total_t_n = round(agg_n["total_kg"] / 1000, 1)
+    scope1_t_n = round(agg_n["scope1_kg"] / 1000, 1)
+    scope2_t_n = round(agg_n["scope2_kg"] / 1000, 1)
+
+    total_t_n1 = round(agg_n1["total_kg"] / 1000, 1) if has_n1 else None
+    scope1_t_n1 = round(agg_n1["scope1_kg"] / 1000, 1) if has_n1 else None
+    scope2_t_n1 = round(agg_n1["scope2_kg"] / 1000, 1) if has_n1 else None
+
+    # ── Labels de période ──
+    month_end = MONTH_NAMES_FR.get(today.month, str(today.month))
+    period_label_n = f"Janv – {month_end} {year_n}"
+    period_label_n1 = f"Janv – {month_end} {year_n - 1}"
+
     return {
         "org_id": org_id,
-        "total_t_co2": round(total_kg / 1000, 1),
-        "total_kg_co2": round(total_kg, 1),
-        "scope1_t_co2": round(scope1_kg / 1000, 1),
-        "scope2_t_co2": round(scope2_kg / 1000, 1),
+        # Champs existants (rétro-compatibilité)
+        "total_t_co2": total_t_n,
+        "total_kg_co2": round(agg_n["total_kg"], 1),
+        "scope1_t_co2": scope1_t_n,
+        "scope2_t_co2": scope2_t_n,
         "vectors": vectors_display,
-        "total_kwh": round(total_kwh_all, 0),
-        "sites": results,
+        "total_kwh": round(agg_n["total_kwh"], 0),
+        "sites": results_n,
         "emission_factors": {k: v["factor_kg_per_kwh"] for k, v in EMISSION_FACTORS.items()},
         "source": "ADEME Base Carbone 2024",
+        # Nouveaux champs N-1
+        "year": year_n,
+        "period_label": period_label_n,
+        "prev_year": year_n - 1,
+        "prev_period_label": period_label_n1,
+        "prev_total_tco2": total_t_n1,
+        "prev_scope1_tco2": scope1_t_n1,
+        "prev_scope2_tco2": scope2_t_n1,
+        # Deltas (négatif = amélioration)
+        "delta_total_pct": _delta_pct(total_t_n, total_t_n1),
+        "delta_scope1_pct": _delta_pct(scope1_t_n, scope1_t_n1),
+        "delta_scope2_pct": _delta_pct(scope2_t_n, scope2_t_n1),
+        # Traçabilité facteurs
+        "co2_factors": {
+            "elec_kgco2_per_kwh": EMISSION_FACTORS["elec"]["factor_kg_per_kwh"],
+            "gaz_kgco2_per_kwh": EMISSION_FACTORS["gaz"]["factor_kg_per_kwh"],
+            "source": "ADEME Base Empreinte V23.6",
+        },
     }
 
 

--- a/backend/services/compliance_engine.py
+++ b/backend/services/compliance_engine.py
@@ -770,8 +770,8 @@ from models.enums import (
     MVAlertType,
     ActionSourceType,
     ActionStatus,
-    FrequencyType,
 )
+from models.energy_models import FrequencyType
 
 
 # Required evidence pieces for a CEE dossier

--- a/backend/services/consumption_unified_service.py
+++ b/backend/services/consumption_unified_service.py
@@ -182,6 +182,11 @@ def get_consumption_summary(
             value_kwh = billed_kwh
             source_used = "billed"
             coverage = billed_coverage
+        elif metered_kwh > 0:
+            # Metered data exists but coverage < threshold — use it with low confidence
+            value_kwh = metered_kwh
+            source_used = "metered"
+            coverage = metered_coverage
         else:
             # Fallback: use site.annual_kwh_total as estimate
             site = db.query(Site).filter(Site.id == site_id).first()

--- a/backend/services/demo_seed/gen_billing.py
+++ b/backend/services/demo_seed/gen_billing.py
@@ -38,7 +38,7 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
 
     _ENERGY_TYPE_MAP = {"elec": BillingEnergyType.ELEC, "gaz": BillingEnergyType.GAZ}
 
-    contract_map = {}  # site_id → contract (first per site, for invoices)
+    contract_map = {}  # site_id → list[contract] (all contracts per site, for invoices)
 
     if pack_def and "contracts_spec" in pack_def:
         # ── Explicit contracts (helios) ──────────────────────────────
@@ -128,9 +128,8 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
                 if not existing:
                     db.add(ContractDeliveryPoint(contract_id=contract.id, delivery_point_id=dp.id))
 
-            # Keep first contract per site for invoice generation
-            if site.id not in contract_map:
-                contract_map[site.id] = contract
+            # Store all contracts per site for invoice generation (ELEC + GAZ)
+            contract_map.setdefault(site.id, []).append(contract)
             contracts_created += 1
     else:
         # ── Randomized contracts (tertiaire) ────────────────
@@ -150,14 +149,20 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
             )
             db.add(contract)
             db.flush()
-            contract_map[site.id] = contract
+            contract_map.setdefault(site.id, []).append(contract)
             contracts_created += 1
 
-    # Generate invoices — spread across sites
-    sites_for_inv = rng.sample(sites, min(invoices_count, len(sites)))
+    # Generate invoices — spread across sites and ALL their contracts (ELEC + GAZ)
+    # Build flat list of (site, contract) pairs
+    site_contract_pairs = []
+    for site in sites:
+        for ct in contract_map.get(site.id, []):
+            site_contract_pairs.append((site, ct))
+    if not site_contract_pairs:
+        site_contract_pairs = [(s, None) for s in sites]
+
     for inv_idx in range(invoices_count):
-        site = sites_for_inv[inv_idx % len(sites_for_inv)]
-        contract = contract_map.get(site.id)
+        site, contract = site_contract_pairs[inv_idx % len(site_contract_pairs)]
         if not contract:
             continue
 
@@ -189,16 +194,23 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
             continue
 
         # Realistic energy — aligned with shadow billing rates to avoid false anomalies
+        is_gaz = contract.energy_type == BillingEnergyType.GAZ if contract.energy_type else False
         annual = site.annual_kwh_total or 500000
-        monthly_kwh = round(annual / 12 * rng.uniform(0.8, 1.2), 0)
-        price = contract.price_ref_eur_per_kwh or 0.15
+        # GAZ: lower volume (~30-40% of ELEC for tertiaire)
+        annual_for_vector = annual * 0.35 if is_gaz else annual
+        monthly_kwh = round(annual_for_vector / 12 * rng.uniform(0.8, 1.2), 0)
+        price = contract.price_ref_eur_per_kwh or (0.08 if is_gaz else 0.15)
         energy_eur = round(monthly_kwh * price, 2)
-        # Use realistic TURPE/accise rates (aligned with shadow billing V2 expectations)
-        turpe_rate = 0.0453  # TURPE C5 BT
-        accise_rate = 0.0225  # Accise ELEC (TIEE)
+        # Rates differ by energy vector
+        if is_gaz:
+            network_rate = 0.032  # ATRD/ATRT gaz
+            tax_rate = 0.016  # TICGN
+        else:
+            network_rate = 0.0453  # TURPE C5 BT
+            tax_rate = 0.0225  # Accise ELEC (TIEE)
         # Add small variance ±8% to look realistic without triggering 20% shadow_gap
-        network_eur = round(monthly_kwh * turpe_rate * rng.uniform(0.92, 1.08), 2)
-        tax_eur = round(monthly_kwh * accise_rate * rng.uniform(0.92, 1.08), 2)
+        network_eur = round(monthly_kwh * network_rate * rng.uniform(0.92, 1.08), 2)
+        tax_eur = round(monthly_kwh * tax_rate * rng.uniform(0.92, 1.08), 2)
         abo_eur = contract.fixed_fee_eur_per_month or 0
         # TTC = HT components + TVA (20% on energy/network/taxes, 5.5% on abonnement)
         ht = energy_eur + network_eur + tax_eur + abo_eur
@@ -271,7 +283,7 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
                 EnergyInvoiceLine(
                     invoice_id=invoice.id,
                     line_type=InvoiceLineType.ENERGY,
-                    label="Fourniture electricite",
+                    label="Fourniture gaz naturel" if is_gaz else "Fourniture electricite",
                     amount_eur=energy_eur,
                     qty=monthly_kwh,
                     unit="kWh",
@@ -281,8 +293,8 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
             lines_created += 1
 
         for lt, label, amount in [
-            (InvoiceLineType.NETWORK, "Acheminement (TURPE)", network_eur),
-            (InvoiceLineType.TAX, "Taxes et contributions", tax_eur),
+            (InvoiceLineType.NETWORK, "Acheminement (ATRD)" if is_gaz else "Acheminement (TURPE)", network_eur),
+            (InvoiceLineType.TAX, "TICGN" if is_gaz else "Taxes et contributions", tax_eur),
             (InvoiceLineType.OTHER, "Abonnement mensuel", contract.fixed_fee_eur_per_month or 0),
             (InvoiceLineType.OTHER, "TVA", tva_line),
         ]:
@@ -328,6 +340,29 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
                 },
             }
             tpl = _ANOMALY_TEMPLATES[anomaly_type]
+            # P1.3: Statuts variés — 60% OPEN, 15% ACK, 15% RESOLVED, 10% FALSE_POSITIVE
+            _status_roll = rng.random()
+            if _status_roll < 0.60:
+                _insight_status = InsightStatus.OPEN
+                _owner, _notes = None, None
+            elif _status_roll < 0.75:
+                _insight_status = InsightStatus.ACK
+                _owner = rng.choice(["claire@atlas.demo", "lucas@atlas.demo"])
+                _notes = None
+            elif _status_roll < 0.90:
+                _insight_status = InsightStatus.RESOLVED
+                _owner = rng.choice(["claire@atlas.demo", "lucas@atlas.demo"])
+                _notes = rng.choice(
+                    [
+                        "Verifie — facture correcte apres rapprochement compteur",
+                        "Ecart justifie par changement tarifaire",
+                        "Regularisation obtenue du fournisseur",
+                    ]
+                )
+            else:
+                _insight_status = InsightStatus.FALSE_POSITIVE
+                _owner = "lucas@atlas.demo"
+                _notes = "Faux positif — ecart lie a une estimation fournisseur"
             db.add(
                 BillingInsight(
                     site_id=site.id,
@@ -336,7 +371,9 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
                     severity=tpl["severity"],
                     message=tpl["msg"],
                     estimated_loss_eur=round(total * rng.uniform(0.05, 0.20), 2),
-                    insight_status=InsightStatus.OPEN,
+                    insight_status=_insight_status,
+                    owner=_owner,
+                    notes=_notes,
                 )
             )
             insights_created += 1

--- a/backend/services/demo_seed/gen_targets.py
+++ b/backend/services/demo_seed/gen_targets.py
@@ -25,6 +25,7 @@ from config.default_prices import DEFAULT_PRICE_ELEC_EUR_KWH, DEFAULT_PRICE_GAZ_
 
 EUR_PER_KWH = {"electricity": DEFAULT_PRICE_ELEC_EUR_KWH, "gas": DEFAULT_PRICE_GAZ_EUR_KWH}
 from config.emission_factors import get_emission_factor
+
 CO2_KG_PER_KWH = {"electricity": get_emission_factor("ELEC"), "gas": get_emission_factor("GAZ")}
 
 # ── Seasonal weight profiles (Jan-Dec, sum ~12.0) ─────────────────────────────

--- a/backend/services/demo_seed/orchestrator.py
+++ b/backend/services/demo_seed/orchestrator.py
@@ -272,6 +272,36 @@ class SeedOrchestrator:
         self.db.flush()
         result["billing_audit"] = {"audited": audit_count}
 
+        # 6c. Vary insight statuses for demo realism (60% open, 15% ack, 15% resolved, 10% false_positive)
+        from models.billing_models import BillingInsight
+        from models.enums import InsightStatus
+
+        all_insights = (
+            self.db.query(BillingInsight).filter(BillingInsight.site_id.in_([s.id for s in master["sites"]])).all()
+        )
+        for bi in all_insights:
+            roll = rng.random()
+            if roll < 0.60:
+                bi.insight_status = InsightStatus.OPEN
+            elif roll < 0.75:
+                bi.insight_status = InsightStatus.ACK
+                bi.owner = rng.choice(["claire@atlas.demo", "lucas@atlas.demo"])
+            elif roll < 0.90:
+                bi.insight_status = InsightStatus.RESOLVED
+                bi.owner = rng.choice(["claire@atlas.demo", "lucas@atlas.demo"])
+                bi.notes = rng.choice(
+                    [
+                        "Verifie - facture correcte apres rapprochement compteur",
+                        "Ecart justifie par changement tarifaire",
+                        "Regularisation obtenue du fournisseur",
+                    ]
+                )
+            else:
+                bi.insight_status = InsightStatus.FALSE_POSITIVE
+                bi.owner = "lucas@atlas.demo"
+                bi.notes = "Faux positif - estimation fournisseur"
+        self.db.flush()
+
         # 7. Actions (pass compliance findings for linking)
         from .gen_actions import generate_actions
         from models import ComplianceFinding

--- a/backend/services/market_data_service.py
+++ b/backend/services/market_data_service.py
@@ -10,16 +10,19 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func
 
 from models.market_models import (
-    MktPrice, MarketDataSource, MarketType,
-    ProductType, PriceZone, Resolution,
-    MarketDataFetchLog
+    MktPrice,
+    MarketDataSource,
+    MarketType,
+    ProductType,
+    PriceZone,
+    Resolution,
+    MarketDataFetchLog,
 )
 
 logger = logging.getLogger(__name__)
 
 
 class MarketDataService:
-
     def __init__(self, db: Session):
         self.db = db
 
@@ -34,14 +37,18 @@ class MarketDataService:
         skipped = 0
 
         for record in records:
-            existing = self.db.query(MktPrice).filter(
-                MktPrice.source == record["source"],
-                MktPrice.market_type == record["market_type"],
-                MktPrice.product_type == record["product_type"],
-                MktPrice.zone == record["zone"],
-                MktPrice.delivery_start == record["delivery_start"],
-                MktPrice.resolution == record["resolution"],
-            ).first()
+            existing = (
+                self.db.query(MktPrice)
+                .filter(
+                    MktPrice.source == record["source"],
+                    MktPrice.market_type == record["market_type"],
+                    MktPrice.product_type == record["product_type"],
+                    MktPrice.zone == record["zone"],
+                    MktPrice.delivery_start == record["delivery_start"],
+                    MktPrice.resolution == record["resolution"],
+                )
+                .first()
+            )
 
             if existing:
                 skipped += 1
@@ -55,10 +62,15 @@ class MarketDataService:
         return {"inserted": inserted, "skipped": skipped}
 
     def log_fetch(
-        self, connector_name: str, fetch_type: str,
-        zone: PriceZone, status: str,
-        records_fetched: int = 0, records_inserted: int = 0,
-        period_start: datetime = None, period_end: datetime = None,
+        self,
+        connector_name: str,
+        fetch_type: str,
+        zone: PriceZone,
+        status: str,
+        records_fetched: int = 0,
+        records_inserted: int = 0,
+        period_start: datetime = None,
+        period_end: datetime = None,
         error_message: str = None,
     ) -> MarketDataFetchLog:
         """Enregistre un log de fetch."""
@@ -106,11 +118,15 @@ class MarketDataService:
     ) -> Optional[float]:
         """Moyenne spot sur N jours glissants."""
         cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-        result = self.db.query(func.avg(MktPrice.price_eur_mwh)).filter(
-            MktPrice.zone == zone,
-            MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
-            MktPrice.delivery_start >= cutoff,
-        ).scalar()
+        result = (
+            self.db.query(func.avg(MktPrice.price_eur_mwh))
+            .filter(
+                MktPrice.zone == zone,
+                MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
+                MktPrice.delivery_start >= cutoff,
+            )
+            .scalar()
+        )
         return round(result, 2) if result else None
 
     def get_forward_curves(
@@ -119,15 +135,22 @@ class MarketDataService:
         product: ProductType = ProductType.BASELOAD,
     ) -> list[MktPrice]:
         """Retourne les forward curves (CAL, Q, M)."""
-        return self.db.query(MktPrice).filter(
-            MktPrice.zone == zone,
-            MktPrice.product_type == product,
-            MktPrice.market_type.in_([
-                MarketType.FORWARD_YEAR,
-                MarketType.FORWARD_QUARTER,
-                MarketType.FORWARD_MONTH,
-            ]),
-        ).order_by(MktPrice.delivery_start.asc()).all()
+        return (
+            self.db.query(MktPrice)
+            .filter(
+                MktPrice.zone == zone,
+                MktPrice.product_type == product,
+                MktPrice.market_type.in_(
+                    [
+                        MarketType.FORWARD_YEAR,
+                        MarketType.FORWARD_QUARTER,
+                        MarketType.FORWARD_MONTH,
+                    ]
+                ),
+            )
+            .order_by(MktPrice.delivery_start.asc())
+            .all()
+        )
 
     def get_latest_price(
         self,
@@ -135,10 +158,15 @@ class MarketDataService:
         market_type: MarketType = MarketType.SPOT_DAY_AHEAD,
     ) -> Optional[MktPrice]:
         """Retourne le dernier prix connu."""
-        return self.db.query(MktPrice).filter(
-            MktPrice.zone == zone,
-            MktPrice.market_type == market_type,
-        ).order_by(MktPrice.delivery_start.desc()).first()
+        return (
+            self.db.query(MktPrice)
+            .filter(
+                MktPrice.zone == zone,
+                MktPrice.market_type == market_type,
+            )
+            .order_by(MktPrice.delivery_start.desc())
+            .first()
+        )
 
     def get_price_stats(
         self,
@@ -147,16 +175,20 @@ class MarketDataService:
     ) -> dict:
         """Statistiques prix spot sur N jours."""
         cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-        q = self.db.query(
-            func.avg(MktPrice.price_eur_mwh).label("avg"),
-            func.min(MktPrice.price_eur_mwh).label("min"),
-            func.max(MktPrice.price_eur_mwh).label("max"),
-            func.count(MktPrice.id).label("count"),
-        ).filter(
-            MktPrice.zone == zone,
-            MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
-            MktPrice.delivery_start >= cutoff,
-        ).first()
+        q = (
+            self.db.query(
+                func.avg(MktPrice.price_eur_mwh).label("avg"),
+                func.min(MktPrice.price_eur_mwh).label("min"),
+                func.max(MktPrice.price_eur_mwh).label("max"),
+                func.count(MktPrice.id).label("count"),
+            )
+            .filter(
+                MktPrice.zone == zone,
+                MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
+                MktPrice.delivery_start >= cutoff,
+            )
+            .first()
+        )
 
         return {
             "zone": zone.value,
@@ -169,11 +201,15 @@ class MarketDataService:
 
     def get_data_freshness(self) -> dict:
         """Verifie la fraicheur des donnees par source."""
-        sources = self.db.query(
-            MktPrice.source,
-            func.max(MktPrice.fetched_at).label("last_fetch"),
-            func.count(MktPrice.id).label("total"),
-        ).group_by(MktPrice.source).all()
+        sources = (
+            self.db.query(
+                MktPrice.source,
+                func.max(MktPrice.fetched_at).label("last_fetch"),
+                func.count(MktPrice.id).label("total"),
+            )
+            .group_by(MktPrice.source)
+            .all()
+        )
 
         return {
             s.source.value: {

--- a/backend/tests/test_action_hub_service.py
+++ b/backend/tests/test_action_hub_service.py
@@ -253,9 +253,7 @@ class TestSyncActionsDedup:
         sync_actions(db_session, org.id)
 
         # L'utilisateur change le status de l'action
-        action = db_session.query(ActionItem).filter(
-            ActionItem.source_type == ActionSourceType.COMPLIANCE
-        ).first()
+        action = db_session.query(ActionItem).filter(ActionItem.source_type == ActionSourceType.COMPLIANCE).first()
         assert action is not None
         action.status = ActionStatus.IN_PROGRESS
         action.owner = "jean@promeos.io"
@@ -268,9 +266,9 @@ class TestSyncActionsDedup:
         r = sync_actions(db_session, org.id)
 
         # L'action est mise à jour MAIS le status/owner sont préservés
-        action_after = db_session.query(ActionItem).filter(
-            ActionItem.source_type == ActionSourceType.COMPLIANCE
-        ).first()
+        action_after = (
+            db_session.query(ActionItem).filter(ActionItem.source_type == ActionSourceType.COMPLIANCE).first()
+        )
         assert action_after.severity == "critical"  # Mis à jour
         assert action_after.status == ActionStatus.IN_PROGRESS  # Préservé
         assert action_after.owner == "jean@promeos.io"  # Préservé

--- a/backend/tests/test_co2_service.py
+++ b/backend/tests/test_co2_service.py
@@ -100,3 +100,88 @@ class TestBenchmarkAssumptions:
         assert 120 <= bench["bon"]
         # Site au-dessus : 250 kWh/m²/an
         assert 250 > bench["median"]
+
+
+class TestCo2N1Comparison:
+    """Comparaison N-1 — helpers et shape de réponse."""
+
+    def test_delta_pct_improvement(self):
+        """Baisse = delta négatif."""
+        from services.co2_service import _delta_pct
+
+        assert _delta_pct(90, 100) == pytest.approx(-10.0)
+
+    def test_delta_pct_degradation(self):
+        """Hausse = delta positif."""
+        from services.co2_service import _delta_pct
+
+        assert _delta_pct(110, 100) == pytest.approx(10.0)
+
+    def test_delta_pct_no_change(self):
+        """Aucun changement = 0."""
+        from services.co2_service import _delta_pct
+
+        assert _delta_pct(100, 100) == pytest.approx(0.0)
+
+    def test_delta_pct_no_prev_data(self):
+        """Pas de données N-1 → None."""
+        from services.co2_service import _delta_pct
+
+        assert _delta_pct(100, None) is None
+        assert _delta_pct(100, 0) is None
+        assert _delta_pct(None, 100) is None
+
+    def test_safe_prev_date_normal(self):
+        """Date normale → OK."""
+        from services.co2_service import _safe_prev_date
+        from datetime import date
+
+        assert _safe_prev_date(2025, 3, 15) == date(2025, 3, 15)
+
+    def test_safe_prev_date_leap_year(self):
+        """29 février N-1 non bissextile → fallback 28."""
+        from services.co2_service import _safe_prev_date
+        from datetime import date
+
+        # 2025 n'est pas bissextile
+        assert _safe_prev_date(2025, 2, 29) == date(2025, 2, 28)
+
+    def test_safe_prev_date_leap_year_ok(self):
+        """29 février année bissextile → OK."""
+        from services.co2_service import _safe_prev_date
+        from datetime import date
+
+        # 2024 est bissextile
+        assert _safe_prev_date(2024, 2, 29) == date(2024, 2, 29)
+
+    def test_month_names_fr_complete(self):
+        """12 mois en français."""
+        from services.co2_service import MONTH_NAMES_FR
+
+        assert len(MONTH_NAMES_FR) == 12
+        assert MONTH_NAMES_FR[1] == "Janv"
+        assert MONTH_NAMES_FR[12] == "Déc"
+
+    def test_aggregate_co2_results_scopes(self):
+        """Scope 1 = gaz/fioul, Scope 2 = elec/réseau chaleur."""
+        from services.co2_service import _aggregate_co2_results
+
+        results = [
+            {
+                "total_kg_co2": 100.0,
+                "breakdown": [
+                    {"energy_type": "elec", "kwh": 1000, "kg_co2": 52.0},
+                    {"energy_type": "gaz", "kwh": 200, "kg_co2": 45.4},
+                ],
+            },
+        ]
+        agg = _aggregate_co2_results(results)
+        assert agg["scope2_kg"] == pytest.approx(52.0)
+        assert agg["scope1_kg"] == pytest.approx(45.4)
+        assert agg["total_kg"] == pytest.approx(100.0)
+
+    def test_co2_factors_in_portfolio_response(self):
+        """La réponse portfolio doit contenir les facteurs ADEME traçables."""
+        # Vérification statique des facteurs exposés
+        assert EMISSION_FACTORS["elec"]["factor_kg_per_kwh"] == pytest.approx(0.052)
+        assert EMISSION_FACTORS["gaz"]["factor_kg_per_kwh"] == pytest.approx(0.227)

--- a/backend/tests/test_cockpit_p0.py
+++ b/backend/tests/test_cockpit_p0.py
@@ -182,3 +182,74 @@ class TestCo2Factor:
 
         assert CO2_FACTOR_ELEC_KG_KWH == get_emission_factor("ELEC")
         assert CO2_FACTOR_GAZ_KG_KWH == get_emission_factor("GAZ")
+
+
+# ── P0-5 : CO2 N-1 Comparison ────────────────────────────────────────
+
+
+class TestCo2N1Endpoint:
+    """Vérifie la shape enrichie de GET /api/cockpit/co2 avec N-1."""
+
+    def test_co2_endpoint_returns_n1_fields(self, client):
+        """L'endpoint retourne les champs N-1 et deltas."""
+        response = client.get("/api/cockpit/co2", headers={"X-Org-Id": "1"})
+        assert response.status_code == 200
+        data = response.json()
+
+        # Champs N existants
+        assert "total_t_co2" in data
+        assert "scope1_t_co2" in data
+        assert "scope2_t_co2" in data
+
+        # Champs N-1 (nouveaux)
+        assert "prev_total_tco2" in data
+        assert "prev_scope1_tco2" in data
+        assert "prev_scope2_tco2" in data
+
+        # Deltas (nouveaux)
+        assert "delta_total_pct" in data
+        assert "delta_scope1_pct" in data
+        assert "delta_scope2_pct" in data
+
+        # Métadonnées période
+        assert "year" in data
+        assert "period_label" in data
+        assert "prev_year" in data
+        assert "prev_period_label" in data
+        assert data["prev_year"] == data["year"] - 1
+
+    def test_co2_endpoint_factors_tracability(self, client):
+        """La réponse contient les facteurs ADEME pour traçabilité."""
+        data = client.get("/api/cockpit/co2", headers={"X-Org-Id": "1"}).json()
+
+        assert "co2_factors" in data
+        assert data["co2_factors"]["elec_kgco2_per_kwh"] == 0.052
+        assert data["co2_factors"]["gaz_kgco2_per_kwh"] == 0.227
+        assert "ADEME" in data["co2_factors"]["source"]
+
+    def test_co2_endpoint_coherence_total_eq_scopes(self, client):
+        """total = scope1 + scope2 (à 0.2 tCO₂ près pour arrondis)."""
+        data = client.get("/api/cockpit/co2", headers={"X-Org-Id": "1"}).json()
+
+        if data["total_t_co2"] > 0:
+            assert abs(data["total_t_co2"] - (data["scope1_t_co2"] + data["scope2_t_co2"])) < 0.2
+
+    def test_co2_endpoint_delta_formula(self, client):
+        """delta = (N - N-1) / N-1 × 100, arrondi à 1 décimale."""
+        data = client.get("/api/cockpit/co2", headers={"X-Org-Id": "1"}).json()
+
+        if data.get("prev_total_tco2") and data["prev_total_tco2"] > 0:
+            expected = round((data["total_t_co2"] - data["prev_total_tco2"]) / data["prev_total_tco2"] * 100, 1)
+            assert data["delta_total_pct"] == pytest.approx(expected, abs=0.1)
+
+    def test_co2_endpoint_period_labels_same_months(self, client):
+        """Les labels N et N-1 couvrent les mêmes mois."""
+        data = client.get("/api/cockpit/co2", headers={"X-Org-Id": "1"}).json()
+
+        # Les deux labels commencent par "Janv" et finissent par le même mois
+        assert data["period_label"].startswith("Janv")
+        assert data["prev_period_label"].startswith("Janv")
+        # Même mois fin (ex: "Janv – Mars 2026" vs "Janv – Mars 2025")
+        month_n = data["period_label"].split(" – ")[1].split(" ")[0]
+        month_n1 = data["prev_period_label"].split(" – ")[1].split(" ")[0]
+        assert month_n == month_n1

--- a/backend/tests/test_market_api.py
+++ b/backend/tests/test_market_api.py
@@ -44,7 +44,6 @@ def client(db_session):
 
 
 class TestMarketAPI:
-
     def test_spot_latest_empty(self, client):
         resp = client.get("/api/market/spot/latest")
         assert resp.status_code == 200

--- a/backend/tests/test_market_data_service.py
+++ b/backend/tests/test_market_data_service.py
@@ -13,10 +13,7 @@ from sqlalchemy.pool import StaticPool
 
 from models.base import Base
 from services.market_data_service import MarketDataService
-from models.market_models import (
-    MarketDataSource, MarketType, ProductType,
-    PriceZone, Resolution
-)
+from models.market_models import MarketDataSource, MarketType, ProductType, PriceZone, Resolution
 
 
 @pytest.fixture
@@ -60,7 +57,6 @@ def sample_prices():
 
 
 class TestIngestion:
-
     def test_ingest_inserts_records(self, service, sample_prices):
         result = service.ingest_prices(sample_prices)
         assert result["inserted"] == 24
@@ -80,7 +76,6 @@ class TestIngestion:
 
 
 class TestQueries:
-
     def test_get_spot_prices(self, service, sample_prices):
         service.ingest_prices(sample_prices)
         prices = service.get_spot_prices(limit=10)
@@ -120,7 +115,6 @@ class TestQueries:
 
 
 class TestFetchLog:
-
     def test_log_fetch_success(self, service):
         log = service.log_fetch(
             connector_name="entsoe",

--- a/backend/tests/test_market_models.py
+++ b/backend/tests/test_market_models.py
@@ -13,10 +13,19 @@ from sqlalchemy.pool import StaticPool
 
 from models.base import Base
 from models.market_models import (
-    MktPrice, RegulatedTariff, PriceSignal,
-    MarketDataFetchLog, PriceDecomposition,
-    MarketDataSource, MarketType, ProductType, PriceZone,
-    TariffType, TariffComponent, SignalType, Resolution,
+    MktPrice,
+    RegulatedTariff,
+    PriceSignal,
+    MarketDataFetchLog,
+    PriceDecomposition,
+    MarketDataSource,
+    MarketType,
+    ProductType,
+    PriceZone,
+    TariffType,
+    TariffComponent,
+    SignalType,
+    Resolution,
 )
 
 
@@ -145,22 +154,33 @@ class TestRegulatedTariffCRUD:
             source_name="LOI_FINANCES",
         )
         # Version 2025
-        db_session.add(RegulatedTariff(
-            **base, value=25.79, version="2025-08",
-            valid_from=datetime(2025, 8, 1, tzinfo=timezone.utc),
-            valid_to=datetime(2026, 1, 31, tzinfo=timezone.utc),
-        ))
+        db_session.add(
+            RegulatedTariff(
+                **base,
+                value=25.79,
+                version="2025-08",
+                valid_from=datetime(2025, 8, 1, tzinfo=timezone.utc),
+                valid_to=datetime(2026, 1, 31, tzinfo=timezone.utc),
+            )
+        )
         # Version 2026
-        db_session.add(RegulatedTariff(
-            **base, value=26.58, version="2026-02",
-            valid_from=datetime(2026, 2, 1, tzinfo=timezone.utc),
-            valid_to=None,
-        ))
+        db_session.add(
+            RegulatedTariff(
+                **base,
+                value=26.58,
+                version="2026-02",
+                valid_from=datetime(2026, 2, 1, tzinfo=timezone.utc),
+                valid_to=None,
+            )
+        )
         db_session.commit()
         from sqlalchemy import func
-        count = db_session.query(func.count(RegulatedTariff.id)).filter(
-            RegulatedTariff.component == TariffComponent.CSPE_C4
-        ).scalar()
+
+        count = (
+            db_session.query(func.count(RegulatedTariff.id))
+            .filter(RegulatedTariff.component == TariffComponent.CSPE_C4)
+            .scalar()
+        )
         assert count == 2
 
 
@@ -177,7 +197,7 @@ class TestEnumsCompleteness:
 
     def test_tariff_types_cover_post_arenh(self):
         names = [e.value for e in TariffType]
-        assert "VNU" in names       # Post-ARENH 2026
+        assert "VNU" in names  # Post-ARENH 2026
         assert "TURPE" in names
         assert "CSPE" in names
         assert "CAPACITY" in names

--- a/backend/tests/test_portfolio.py
+++ b/backend/tests/test_portfolio.py
@@ -446,7 +446,7 @@ class TestPortfolioV13:
             assert row["kwh"] is not None
             assert row["eur"] is not None
             assert row["co2"] is not None
-            assert row["confidence"] in ("high", "medium", "low")
+            assert row["confidence"] in ("high", "medium", "low", "none")
             assert row["diagnostics_count"] is not None
             assert row["impact_eur_estimated"] is not None
             assert row["open_actions_count"] is not None

--- a/backend/tests/test_purchase_actions_engine.py
+++ b/backend/tests/test_purchase_actions_engine.py
@@ -259,16 +259,24 @@ class TestPriorityAndOrdering:
         site = db_session.query(Site).first()
 
         # Créer 2 contrats : un urgent (prio 100) + un plan (prio 40)
-        db_session.add(EnergyContract(
-            site_id=site.id, energy_type=BillingEnergyType.ELEC,
-            supplier_name="Urgent", end_date=date.today() + timedelta(days=30),
-            notice_period_days=90,
-        ))
-        db_session.add(EnergyContract(
-            site_id=site.id, energy_type=BillingEnergyType.ELEC,
-            supplier_name="Plan", end_date=date.today() + timedelta(days=165),
-            notice_period_days=90,
-        ))
+        db_session.add(
+            EnergyContract(
+                site_id=site.id,
+                energy_type=BillingEnergyType.ELEC,
+                supplier_name="Urgent",
+                end_date=date.today() + timedelta(days=30),
+                notice_period_days=90,
+            )
+        )
+        db_session.add(
+            EnergyContract(
+                site_id=site.id,
+                energy_type=BillingEnergyType.ELEC,
+                supplier_name="Plan",
+                end_date=date.today() + timedelta(days=165),
+                notice_period_days=90,
+            )
+        )
         db_session.flush()
 
         result = compute_purchase_actions(db_session)

--- a/e2e/sprint-cockpit-complet.spec.js
+++ b/e2e/sprint-cockpit-complet.spec.js
@@ -1,0 +1,307 @@
+/**
+ * PROMEOS — E2E Sprint Cockpit Complet
+ * Couvre : C1-C6 + I1-I9 + V1-V5 + P0-A/B + P2-A
+ *
+ * Parcours validés :
+ * 1. Cockpit → KPIs cohérents + gauge + kWh/m²
+ * 2. Cockpit → clic site → Site360 → onglets Conso + Actions (plus de stub)
+ * 3. Cockpit → "Surcoût facture" → BillIntel (accessible en simple)
+ * 4. Mode simple → KPIs exécutifs visibles (I9)
+ * 5. Conformité, Consommations, Actions — pages fonctionnelles
+ * 6. Navigation — 10 routes, zéro 404/crash
+ *
+ * Pré-requis :
+ *   - Backend sur localhost:8001, Frontend sur localhost:5173
+ *   - Seed HELIOS : python -m services.demo_seed --pack helios --size S --reset
+ *   - npx playwright install
+ *
+ * Lancer :
+ *   cd e2e && npx playwright test sprint-cockpit-complet.spec.js --headed
+ */
+import { test, expect } from '@playwright/test';
+import { login, waitForPageReady, assertCleanBody } from './helpers.js';
+
+// ── Helpers ─────────────────────────────────────────────────
+
+async function getBody(page, timeout = 5000) {
+  await waitForPageReady(page, timeout);
+  const body = await page.textContent('body');
+  expect(body.length).toBeGreaterThan(200);
+  return body;
+}
+
+/**
+ * Navigate to Site360 for the first HELIOS site (id=1).
+ * Direct navigation — more reliable than click-through patrimoine drawer.
+ */
+async function navigateToFirstSite360(page) {
+  await page.goto('/sites/1');
+  await waitForPageReady(page, 6000);
+  return page.textContent('body');
+}
+
+// ═════════════════════════════════════════════════════════════
+// 1. COCKPIT EXÉCUTIF — Intégrité post-sprint
+// ═════════════════════════════════════════════════════════════
+
+test.describe('1. Cockpit exécutif — intégrité', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto('/cockpit');
+    await waitForPageReady(page);
+  });
+
+  test('Page charge avec titre et KPIs', async ({ page }) => {
+    const body = await getBody(page);
+    expect(body).toContain('Conformité');
+    expect(body).toContain('Risque');
+  });
+
+  test('Gauge Score Santé visible (V1)', async ({ page }) => {
+    const svgCount = await page.locator('svg').count();
+    expect(svgCount).toBeGreaterThan(0);
+  });
+
+  test('Performance par site — barres kWh/m² visibles (V2)', async ({ page }) => {
+    const body = await getBody(page);
+    expect(body).not.toContain('Données benchmark non disponibles');
+    expect(body).not.toContain('Données non disponibles');
+    const hasKwhM2 = body.includes('kWh/m²') || body.includes('kWh/m');
+    expect(hasKwhM2).toBe(true);
+  });
+
+  test('Alertes avec countdown J-X (V3)', async ({ page }) => {
+    const body = await getBody(page);
+    const hasCountdown = body.includes('J-') || body.includes('Dépassé') || body.includes('Échu');
+    expect(hasCountdown).toBe(true);
+  });
+
+  test('Trajectoire DT avec toggle KWH/% RÉDUCTION', async ({ page }) => {
+    const body = await getBody(page);
+    const hasToggle =
+      body.includes('KWH') ||
+      body.includes('% RÉDUCTION') ||
+      body.includes('% Réduction') ||
+      body.includes('MWh');
+    expect(hasToggle).toBe(true);
+  });
+
+  test('Émissions CO₂ avec facteurs ADEME (V4)', async ({ page }) => {
+    const body = await getBody(page);
+    const hasCO2 = body.includes('CO₂') || body.includes('CO2') || body.includes('tCO₂');
+    expect(hasCO2).toBe(true);
+  });
+
+  test('Actions impact avec CTA (V5)', async ({ page }) => {
+    const body = await getBody(page);
+    expect(body).toContain('Actions');
+    const hasActionsLink = body.includes('toutes les actions') || body.includes('plan complet');
+    expect(hasActionsLink).toBe(true);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════
+// 2. PARCOURS SITE360 — Onglets débloqués (P0-A, P0-B, P2-A)
+// ═════════════════════════════════════════════════════════════
+
+test.describe('2. Parcours Cockpit → Site360', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('Site360 affiche 6 onglets', async ({ page }) => {
+    const body = await navigateToFirstSite360(page);
+    expect(body).not.toContain('Site introuvable');
+    expect(body).toContain('Résumé');
+    expect(body).toContain('Consommation');
+    expect(body).toContain('Factures');
+    expect(body).toContain('Réconciliation');
+    expect(body).toContain('Conformité');
+    expect(body).toContain('Actions');
+  });
+
+  test('P2-A : kWh/m² visible dans header Site360', async ({ page }) => {
+    const body = await navigateToFirstSite360(page);
+    const hasIntensity = body.includes('kWh/m²') || body.includes('Intensité');
+    expect(hasIntensity).toBe(true);
+  });
+
+  test('P0-A : Onglet Consommation ≠ stub "à venir"', async ({ page }) => {
+    await navigateToFirstSite360(page);
+
+    const consoTab = page.locator('button, [role="tab"]').filter({ hasText: 'Consommation' });
+    await expect(consoTab).toBeVisible({ timeout: 5000 });
+    await consoTab.click();
+    await waitForPageReady(page, 4000);
+
+    const body = await page.textContent('body');
+    expect(body).not.toContain('Courbes de charge, historique et benchmark à venir');
+    expect(body).not.toContain('Bientôt disponible');
+    // Doit afficher du contenu réel (chart ou KPIs conso)
+    const hasConsoContent =
+      body.includes('kWh') ||
+      body.includes('Total 30 jours') ||
+      body.includes('Aucune donnée de consommation');
+    expect(hasConsoContent).toBe(true);
+  });
+
+  test('P0-B : Onglet Actions ≠ stub "à venir"', async ({ page }) => {
+    await navigateToFirstSite360(page);
+
+    const actionsTab = page.locator('button, [role="tab"]').filter({ hasText: 'Actions' });
+    await expect(actionsTab).toBeVisible({ timeout: 5000 });
+    await actionsTab.click();
+    await waitForPageReady(page, 4000);
+
+    const body = await page.textContent('body');
+    expect(body).not.toContain("Plan d'action et suivi des recommandations à venir");
+    expect(body).not.toContain('Bientôt disponible');
+    // Doit afficher du contenu réel (liste ou empty state)
+    const hasActionsContent =
+      body.includes('En cours') ||
+      body.includes('Ouvertes') ||
+      body.includes('Créer une action') ||
+      body.includes('Aucune action');
+    expect(hasActionsContent).toBe(true);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════
+// 3. PARCOURS BILL INTELLIGENCE — Accessible en simple
+// ═════════════════════════════════════════════════════════════
+
+test.describe('3. Parcours Cockpit → BillIntel', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('BillIntel accessible sans mode expert', async ({ page }) => {
+    await page.goto('/bill-intel');
+    await waitForPageReady(page);
+    const body = await getBody(page);
+
+    expect(body).not.toContain('Mode Expert requis');
+    expect(body).not.toContain('Cette fonctionnalité nécessite le mode Expert');
+
+    const hasBillingContent =
+      body.includes('Factur') || body.includes('factur') || body.includes('Anomal');
+    expect(hasBillingContent).toBe(true);
+  });
+
+  test('Deep-link cockpit → BillIntel avec filtre anomalies', async ({ page }) => {
+    await page.goto('/bill-intel?filter=anomalies');
+    await waitForPageReady(page);
+    const body = await getBody(page);
+    expect(body).not.toContain('Something went wrong');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════
+// 4. MODE SIMPLE — KPIs exécutifs visibles (I9)
+// ═════════════════════════════════════════════════════════════
+
+test.describe('4. Mode simple — visibilité KPIs (I9)', () => {
+  test('Vue exécutive montre les KPIs même sans expert toggle', async ({ page }) => {
+    await login(page);
+    await page.goto('/cockpit');
+    await waitForPageReady(page);
+    const body = await getBody(page);
+
+    expect(body).toContain('Conformité');
+    const hasImpact = body.includes('Impact') || body.includes('Risque') || body.includes('k€');
+    expect(hasImpact).toBe(true);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════
+// 5. CONFORMITÉ — Page fonctionnelle
+// ═════════════════════════════════════════════════════════════
+
+test.describe('5. Conformité — parcours complet', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('Page conformité charge avec scanner et obligations', async ({ page }) => {
+    await page.goto('/conformite');
+    const body = await getBody(page);
+    expect(body).toContain('Conformité');
+    const hasReg =
+      body.includes('Tertiaire') || body.includes('BACS') || body.includes('Obligation');
+    expect(hasReg).toBe(true);
+  });
+
+  test('Deep-link cockpit hero → conformité', async ({ page }) => {
+    await page.goto('/cockpit');
+    await waitForPageReady(page);
+
+    const ctaConf = page.locator('text=Voir conformité').first();
+    if (await ctaConf.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await ctaConf.click();
+      await page.waitForURL(/\/conformite/, { timeout: 10_000 });
+      const body = await page.textContent('body');
+      expect(body).not.toContain('Something went wrong');
+      expect(body).toContain('Conformité');
+    }
+  });
+});
+
+// ═════════════════════════════════════════════════════════════
+// 6. CONSOMMATIONS — Explorer fonctionnel
+// ═════════════════════════════════════════════════════════════
+
+test.describe('6. Consommations Explorer', () => {
+  test('Page consommations charge', async ({ page }) => {
+    await login(page);
+    await page.goto('/consommations');
+    const body = await getBody(page);
+    expect(body).not.toContain('Something went wrong');
+    const hasConso = body.includes('Consommation') || body.includes('kWh') || body.includes('Électricité');
+    expect(hasConso).toBe(true);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════
+// 7. ACTIONS — Plan d'actions fonctionnel
+// ═════════════════════════════════════════════════════════════
+
+test.describe('7. Actions', () => {
+  test('Page actions charge avec liste', async ({ page }) => {
+    await login(page);
+    await page.goto('/actions');
+    const body = await getBody(page);
+    expect(body).not.toContain('Something went wrong');
+    expect(body).toContain('Actions');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════
+// 8. NAVIGATION — Zéro dead link
+// ═════════════════════════════════════════════════════════════
+
+test.describe('8. Navigation — zéro 404', () => {
+  const routes = [
+    '/',
+    '/cockpit',
+    '/patrimoine',
+    '/conformite',
+    '/actions',
+    '/consommations',
+    '/monitoring',
+    '/bill-intel',
+    '/notifications',
+    '/diagnostic-conso',
+  ];
+
+  for (const route of routes) {
+    test(`${route} ne retourne pas 404 ni crash`, async ({ page }) => {
+      await login(page);
+      await page.goto(route);
+      await waitForPageReady(page);
+      const body = await page.textContent('body');
+      expect(body).not.toContain('Page non trouvée');
+      expect(body).not.toContain('Something went wrong');
+      expect(body.length).toBeGreaterThan(100);
+    });
+  }
+});

--- a/frontend/src/__tests__/step4_co2_guard.test.js
+++ b/frontend/src/__tests__/step4_co2_guard.test.js
@@ -78,3 +78,32 @@ describe('Step4 — No hardcoded 0.052 in backend', () => {
     expect(codeLines.join('\n')).not.toContain('0.052');
   });
 });
+
+// ── D. VecteurEnergetiqueCard — source guard + N-1 delta display ──────────
+
+describe('Step4 — VecteurEnergetiqueCard architecture', () => {
+  const cardPath = join(__dirname, '..', 'pages', 'cockpit', 'VecteurEnergetiqueCard.jsx');
+  const src = readFileSync(cardPath, 'utf-8');
+
+  it('ne contient aucun facteur CO₂ hardcodé', () => {
+    expect(src).not.toMatch(/\*\s*0\.052/);
+    expect(src).not.toMatch(/\*\s*0\.0569/);
+    expect(src).not.toMatch(/\*\s*0\.227/);
+  });
+
+  it('utilise getCockpitCo2 depuis le backend', () => {
+    expect(src).toMatch(/getCockpitCo2/);
+  });
+
+  it('affiche les deltas N-1 via DeltaLine', () => {
+    expect(src).toMatch(/DeltaLine/);
+    expect(src).toMatch(/delta_total_pct|delta_scope/);
+    expect(src).toMatch(/prev_total_tco2|prev_scope/);
+  });
+
+  it('affiche la légende période et source ADEME', () => {
+    expect(src).toMatch(/period_label/);
+    expect(src).toMatch(/prev_period_label/);
+    expect(src).toMatch(/co2_factors/);
+  });
+});

--- a/frontend/src/components/TabActionsSite.jsx
+++ b/frontend/src/components/TabActionsSite.jsx
@@ -1,0 +1,209 @@
+/**
+ * PROMEOS — TabActionsSite
+ * Onglet Actions dans Site360 : liste des actions du site avec priorité/statut/impact
+ * Remplace le TabStub "à venir"
+ */
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { CheckCircle, Clock, AlertTriangle, XCircle, Plus, ArrowRight, Target } from 'lucide-react';
+import { Card, CardBody, Badge, EmptyState } from '../ui';
+import { SkeletonCard } from '../ui/Skeleton';
+import { getActionsList } from '../services/api';
+import { fmtEurFull } from '../utils/format';
+
+const STATUS_CONFIG = {
+  open: { label: 'Ouverte', variant: 'warning', icon: Clock },
+  in_progress: { label: 'En cours', variant: 'info', icon: Target },
+  done: { label: 'Terminée', variant: 'success', icon: CheckCircle },
+  blocked: { label: 'Bloquée', variant: 'error', icon: XCircle },
+  false_positive: { label: 'Faux positif', variant: 'neutral', icon: XCircle },
+};
+
+const PRIORITY_COLORS = {
+  1: 'bg-red-100 text-red-800',
+  2: 'bg-orange-100 text-orange-800',
+  3: 'bg-amber-100 text-amber-800',
+  4: 'bg-blue-100 text-blue-800',
+  5: 'bg-gray-100 text-gray-600',
+};
+
+function getCountdown(dueDateStr) {
+  if (!dueDateStr) return null;
+  const due = new Date(dueDateStr);
+  const now = new Date();
+  const diffMs = due - now;
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  return diffDays;
+}
+
+function CountdownBadge({ dueDate }) {
+  const days = getCountdown(dueDate);
+  if (days === null) return null;
+
+  let className = 'text-xs font-medium px-1.5 py-0.5 rounded';
+  if (days < 0) className += ' bg-red-100 text-red-700';
+  else if (days <= 7) className += ' bg-amber-100 text-amber-700';
+  else if (days <= 30) className += ' bg-blue-100 text-blue-700';
+  else className += ' bg-gray-100 text-gray-500';
+
+  return <span className={className}>{days < 0 ? `J${days}` : `J-${days}`}</span>;
+}
+
+export default function TabActionsSite({ siteId }) {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState('loading');
+  const [actions, setActions] = useState([]);
+
+  useEffect(() => {
+    if (!siteId) return;
+    setStatus('loading');
+
+    getActionsList({ site_id: siteId })
+      .then((res) => {
+        const list = Array.isArray(res) ? res : (res?.items ?? []);
+        setActions(list);
+        setStatus(list.length > 0 ? 'ready' : 'empty');
+      })
+      .catch(() => setStatus('error'));
+  }, [siteId]);
+
+  if (status === 'loading') {
+    return (
+      <div className="pt-6 space-y-3">
+        <SkeletonCard lines={2} />
+        <SkeletonCard lines={2} />
+        <SkeletonCard lines={2} />
+      </div>
+    );
+  }
+
+  if (status === 'empty') {
+    return (
+      <div className="pt-6">
+        <EmptyState
+          title="Actions"
+          text="Aucune action sur ce site. Créez-en une pour commencer."
+          ctaLabel="Créer une action"
+          onCtaClick={() => navigate(`/actions/new?site_id=${siteId}`)}
+        />
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="pt-6">
+        <EmptyState title="Actions" text="Erreur lors du chargement des actions." />
+      </div>
+    );
+  }
+
+  // Trier : in_progress d'abord, puis open, puis le reste, par priorité croissante
+  const statusOrder = { in_progress: 0, open: 1, blocked: 2, done: 3, false_positive: 4 };
+  const sorted = [...actions].sort((a, b) => {
+    const sa = statusOrder[a.status] ?? 9;
+    const sb = statusOrder[b.status] ?? 9;
+    if (sa !== sb) return sa - sb;
+    return (a.priority ?? 5) - (b.priority ?? 5);
+  });
+
+  // KPIs rapides
+  const enCours = actions.filter((a) => a.status === 'in_progress').length;
+  const ouvertes = actions.filter((a) => a.status === 'open').length;
+  const totalGain = actions.reduce((s, a) => s + (a.estimated_gain_eur ?? 0), 0);
+
+  return (
+    <div className="pt-6 space-y-4">
+      {/* KPI strip */}
+      <div className="grid grid-cols-3 gap-4">
+        <div className="flex items-center gap-3 px-4 py-3 bg-blue-50 rounded-lg">
+          <Target size={18} className="text-blue-600" />
+          <div>
+            <p className="text-xs text-gray-500">En cours</p>
+            <p className="text-sm font-bold text-gray-800">{enCours}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 px-4 py-3 bg-amber-50 rounded-lg">
+          <Clock size={18} className="text-amber-600" />
+          <div>
+            <p className="text-xs text-gray-500">Ouvertes</p>
+            <p className="text-sm font-bold text-gray-800">{ouvertes}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 px-4 py-3 bg-green-50 rounded-lg">
+          <AlertTriangle size={18} className="text-green-600" />
+          <div>
+            <p className="text-xs text-gray-500">Gain estimé</p>
+            <p className="text-sm font-bold text-gray-800">{fmtEurFull(totalGain)}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Liste des actions */}
+      <Card>
+        <CardBody className="divide-y divide-gray-100">
+          {sorted.map((action) => {
+            const cfg = STATUS_CONFIG[action.status] || STATUS_CONFIG.open;
+            const StatusIcon = cfg.icon;
+            return (
+              <div
+                key={action.id}
+                className="flex items-center gap-3 py-3 first:pt-0 last:pb-0 cursor-pointer hover:bg-gray-50 -mx-4 px-4 rounded transition-colors"
+                onClick={() => navigate(`/actions?highlight=${action.id}`)}
+              >
+                {/* Priorité */}
+                <span
+                  className={`flex-shrink-0 text-xs font-bold w-7 h-7 rounded-full flex items-center justify-center ${PRIORITY_COLORS[action.priority] ?? PRIORITY_COLORS[5]}`}
+                >
+                  P{action.priority ?? '?'}
+                </span>
+
+                {/* Contenu */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-800 truncate">{action.title}</p>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    {action.source_type && (
+                      <span className="text-xs text-gray-400 capitalize">{action.source_type}</span>
+                    )}
+                    {action.estimated_gain_eur > 0 && (
+                      <span className="text-xs text-green-600 font-medium">
+                        +{fmtEurFull(action.estimated_gain_eur)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Statut */}
+                <Badge variant={cfg.variant} size="sm">
+                  <StatusIcon size={12} className="mr-1" />
+                  {cfg.label}
+                </Badge>
+
+                {/* Countdown */}
+                <CountdownBadge dueDate={action.due_date} />
+              </div>
+            );
+          })}
+        </CardBody>
+      </Card>
+
+      {/* CTAs */}
+      <div className="flex items-center justify-between">
+        <button
+          onClick={() => navigate(`/actions/new?site_id=${siteId}`)}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:text-blue-800"
+        >
+          <Plus size={14} />
+          Créer une action
+        </button>
+        <button
+          onClick={() => navigate('/actions')}
+          className="inline-flex items-center gap-1 text-sm font-medium text-gray-500 hover:text-gray-700"
+        >
+          Voir le plan d&apos;actions complet
+          <ArrowRight size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TabConsoSite.jsx
+++ b/frontend/src/components/TabConsoSite.jsx
@@ -1,0 +1,202 @@
+/**
+ * PROMEOS — TabConsoSite
+ * Onglet Consommation dans Site360 : mini-chart 30j + KPI strip
+ * Remplace le TabStub "à venir"
+ */
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Zap, TrendingUp, Activity } from 'lucide-react';
+import { Card, CardBody, EmptyState } from '../ui';
+import { SkeletonCard } from '../ui/Skeleton';
+import { getEmsTimeseries } from '../services/api';
+import { fmtNum } from '../utils/format';
+
+function formatDateLabel(isoStr) {
+  if (!isoStr) return '';
+  const normalized = typeof isoStr === 'string' ? isoStr.replace(' ', 'T') : isoStr;
+  const d = new Date(normalized);
+  if (isNaN(d.getTime())) return isoStr;
+  return d.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short' });
+}
+
+function CustomTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg shadow-lg px-3 py-2 text-xs">
+      <p className="font-medium text-gray-700 mb-1">{label}</p>
+      <p className="text-blue-600">{fmtNum(payload[0].value, 0, 'kWh')}</p>
+    </div>
+  );
+}
+
+export default function TabConsoSite({ siteId, siteName }) {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState('loading'); // loading | ready | empty | error
+  const [rawSeries, setRawSeries] = useState([]);
+  const [meta, setMeta] = useState(null);
+
+  useEffect(() => {
+    if (!siteId) return;
+    setStatus('loading');
+
+    const dateTo = new Date();
+    const dateFrom = new Date();
+    dateFrom.setDate(dateFrom.getDate() - 30);
+
+    getEmsTimeseries({
+      site_ids: String(siteId),
+      date_from: dateFrom.toISOString(),
+      date_to: dateTo.toISOString(),
+      granularity: 'daily',
+      mode: 'aggregate',
+      metric: 'kwh',
+    })
+      .then((res) => {
+        const series = res?.series ?? [];
+        setRawSeries(series);
+        setMeta(res?.meta ?? null);
+        const hasData = series.some((s) => s.data?.length > 0);
+        setStatus(hasData ? 'ready' : 'empty');
+      })
+      .catch(() => setStatus('error'));
+  }, [siteId]);
+
+  const chartData = useMemo(() => {
+    if (!rawSeries.length) return [];
+    // Aggregate series : une seule série
+    const mainSeries = rawSeries[0];
+    if (!mainSeries?.data) return [];
+    return mainSeries.data.map((pt) => ({
+      date: formatDateLabel(pt.t),
+      rawDate: pt.t,
+      value: pt.v != null ? Math.round(pt.v) : null,
+    }));
+  }, [rawSeries]);
+
+  const kpis = useMemo(() => {
+    if (!chartData.length) return { totalKwh: 0, peakKw: 0 };
+    const totalKwh = chartData.reduce((sum, pt) => sum + (pt.value || 0), 0);
+    // Pic journalier (kWh/jour max)
+    const peakKwhDay = Math.max(...chartData.map((pt) => pt.value || 0));
+    return { totalKwh, peakKwhDay };
+  }, [chartData]);
+
+  if (status === 'loading') {
+    return (
+      <div className="pt-6 space-y-4">
+        <SkeletonCard lines={1} />
+        <SkeletonCard lines={6} />
+      </div>
+    );
+  }
+
+  if (status === 'empty' || status === 'error') {
+    return (
+      <div className="pt-6">
+        <EmptyState
+          title="Consommation"
+          text={
+            status === 'error'
+              ? 'Erreur lors du chargement des données de consommation.'
+              : 'Aucune donnée de consommation disponible. Connectez un compteur pour visualiser les courbes.'
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-6 space-y-4">
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex items-center gap-3 px-4 py-3 bg-blue-50 rounded-lg">
+          <Zap size={18} className="text-blue-600" />
+          <div>
+            <p className="text-xs text-gray-500">Total 30 jours</p>
+            <p className="text-sm font-bold text-gray-800">{fmtNum(kpis.totalKwh, 0, 'kWh')}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 px-4 py-3 bg-indigo-50 rounded-lg">
+          <TrendingUp size={18} className="text-indigo-600" />
+          <div>
+            <p className="text-xs text-gray-500">Pic journalier</p>
+            <p className="text-sm font-bold text-gray-800">{fmtNum(kpis.peakKwhDay, 0, 'kWh/j')}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Chart */}
+      <Card>
+        <CardBody>
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <Activity size={16} className="text-blue-600" />
+              <h3 className="text-sm font-semibold text-gray-700">
+                Consommation journalière — 30 derniers jours
+              </h3>
+            </div>
+            {meta && (
+              <span className="text-xs text-gray-400">
+                {meta.n_meters ?? '?'} compteur{(meta.n_meters ?? 0) > 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+          <ResponsiveContainer width="100%" height={260}>
+            <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+              <defs>
+                <linearGradient id="colorConso" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#3B82F6" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#3B82F6" stopOpacity={0.05} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 11, fill: '#6B7280' }}
+                tickLine={false}
+                axisLine={{ stroke: '#E5E7EB' }}
+              />
+              <YAxis
+                tick={{ fontSize: 11, fill: '#6B7280' }}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(v) => `${v}`}
+                width={50}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Area
+                type="monotone"
+                dataKey="value"
+                stroke="#3B82F6"
+                strokeWidth={2}
+                fill="url(#colorConso)"
+                dot={false}
+                activeDot={{ r: 4, stroke: '#3B82F6', strokeWidth: 2, fill: '#fff' }}
+                connectNulls
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </CardBody>
+      </Card>
+
+      {/* CTA Explorer */}
+      <div className="flex justify-end">
+        <button
+          onClick={() => navigate(`/consommations/explorer?sites=${siteId}`)}
+          className="text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline"
+        >
+          Explorer en détail →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TabConsoSite.jsx
+++ b/frontend/src/components/TabConsoSite.jsx
@@ -38,7 +38,7 @@ function CustomTooltip({ active, payload, label }) {
   );
 }
 
-export default function TabConsoSite({ siteId, siteName }) {
+export default function TabConsoSite({ siteId }) {
   const navigate = useNavigate();
   const [status, setStatus] = useState('loading'); // loading | ready | empty | error
   const [rawSeries, setRawSeries] = useState([]);

--- a/frontend/src/contexts/ScopeContext.jsx
+++ b/frontend/src/contexts/ScopeContext.jsx
@@ -90,6 +90,7 @@ export function ScopeProvider({ children }) {
   // ── child useEffects, ensuring _apiScope.orgId is set before any child   ──
   // ── effect fetches data. No render-time side-effects.                    ──
   useLayoutEffect(() => {
+    clearApiCache(); // C1 FIX: flush cache au changement de scope (évite cross-tenant)
     setApiScope({ orgId: effectiveOrgId ?? null, siteId: scope.siteId ?? null });
   }, [effectiveOrgId, scope.siteId]);
 

--- a/frontend/src/hooks/useCockpitData.js
+++ b/frontend/src/hooks/useCockpitData.js
@@ -42,6 +42,8 @@ function normalizeCockpitKpis(raw) {
     sitesActifs: s.sites_actifs ?? 0,
     avancementDecretPct: s.avancement_decret_pct ?? null,
     orgNom: raw.organisation?.nom ?? null,
+    // I3 FIX: exposer consoSource pour éviter un double fetch /api/cockpit
+    consoSource: s.conso_source && s.conso_source !== 'none' ? s.conso_source : null,
   };
 }
 
@@ -74,6 +76,8 @@ function normalizeTrajectory(raw) {
     refYear: raw.ref_year,
     refKwh: raw.ref_kwh,
     reductionPctActuelle: raw.reduction_pct_actuelle,
+    // C3 FIX: toujours extraire objectifPremierJalonPct (sinon bannière retard jamais affichée)
+    objectifPremierJalonPct: raw.objectif_2030_pct ?? raw.jalons?.[0]?.pct ?? -40.0,
     objectif2026Pct: raw.objectif_2026_pct ?? -25.0,
     annees: raw.annees ?? [],
     reelMwh: raw.reel_mwh ?? [],

--- a/frontend/src/models/dashboardEssentials.js
+++ b/frontend/src/models/dashboardEssentials.js
@@ -561,7 +561,13 @@ export function buildExecutiveKpis(kpis, sites = []) {
       messageCtx: {},
       subShort: `${sitesWithData}/${total} site${total !== 1 ? 's' : ''} couvert${sitesWithData !== 1 ? 's' : ''}`,
       sub: `${sitesWithData}/${total} site${total !== 1 ? 's' : ''} avec données de consommation`,
-      status: couvertureDonnees < COVERAGE_THRESHOLDS.warn ? 'warn' : 'ok',
+      // I5 FIX: crit si couverture nulle ou très basse
+      status:
+        couvertureDonnees == null || couvertureDonnees <= 0
+          ? 'crit'
+          : couvertureDonnees < COVERAGE_THRESHOLDS.warn
+            ? 'warn'
+            : 'ok',
       path: '/consommations/import',
     },
   ];

--- a/frontend/src/pages/BillIntelPage.jsx
+++ b/frontend/src/pages/BillIntelPage.jsx
@@ -345,7 +345,17 @@ export default function BillIntelPage() {
     try {
       const result = await importInvoicesCsv(file);
       track('billing_csv_import', { filename: file.name });
-      toast(`Import CSV réussi : ${result?.imported ?? '?'} facture(s) importée(s)`, 'success');
+      const imported = result?.imported ?? result?.rows_inserted ?? 0;
+      const skipped = result?.skipped ?? result?.rows_skipped ?? 0;
+      if (skipped > 0 && imported === 0) {
+        toast(`${skipped} facture(s) déjà importée(s) — aucun doublon créé.`, 'info');
+      } else if (skipped > 0) {
+        toast(`${imported} facture(s) importée(s), ${skipped} doublon(s) ignoré(s).`, 'success');
+      } else if (imported > 0) {
+        toast(`Import CSV réussi : ${imported} facture(s) importée(s)`, 'success');
+      } else {
+        toast('Import CSV terminé — aucune facture à importer.', 'info');
+      }
       await fetchData();
     } catch {
       toast("Erreur lors de l'import CSV", 'error');
@@ -838,19 +848,27 @@ export default function BillIntelPage() {
               <Explain term="anomalie">Anomalies</Explain> détectées ({insights.length})
             </h3>
             <div className="flex items-center gap-1">
-              {INSIGHT_FILTER_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  onClick={() => setInsightFilter(opt.value)}
-                  className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
-                    insightFilter === opt.value
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                  }`}
-                >
-                  {opt.label}
-                </button>
-              ))}
+              {INSIGHT_FILTER_OPTIONS.map((opt) => {
+                const count =
+                  opt.value === 'all'
+                    ? allInsights.length
+                    : allInsights.filter((i) => (i.insight_status || i.status) === opt.value)
+                        .length;
+                return (
+                  <button
+                    key={opt.value}
+                    onClick={() => setInsightFilter(opt.value)}
+                    className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
+                      insightFilter === opt.value
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    }`}
+                  >
+                    {opt.label}
+                    <span className="ml-1 opacity-70">{count}</span>
+                  </button>
+                );
+              })}
             </div>
           </div>
           <div className="space-y-2">
@@ -905,6 +923,9 @@ export default function BillIntelPage() {
                         <Badge status={SEVERITY_BADGE[insight.severity] || 'neutral'}>
                           {SEVERITY_LABELS[insight.severity] || insight.severity}
                         </Badge>
+                        {insight.supplier && (
+                          <span className="text-xs text-zinc-500">{insight.supplier}</span>
+                        )}
                         {isExpert && (
                           <span className="text-[10px] font-mono text-gray-400">#{insight.id}</span>
                         )}

--- a/frontend/src/pages/Cockpit.jsx
+++ b/frontend/src/pages/Cockpit.jsx
@@ -67,6 +67,7 @@ import {
 } from '../ui/evidence.fixtures';
 import { useComplianceMeta } from '../hooks/useComplianceMeta';
 import { useCockpitData } from '../hooks/useCockpitData';
+import useActivationData from '../hooks/useActivationData';
 import CockpitHero from './cockpit/CockpitHero';
 import TrajectorySection from './cockpit/TrajectorySection';
 import ActionsImpact from './cockpit/ActionsImpact';
@@ -108,8 +109,7 @@ const Cockpit = () => {
   const [complianceApi, setComplianceApi] = useState(null);
   const [nextDeadline, setNextDeadline] = useState(null);
   const [_totalPenaltyExposure, setTotalPenaltyExposure] = useState(null);
-  // A.1: Consumption source tracking
-  const [consoSource, setConsoSource] = useState(null);
+  // A.1: consoSource — now from useCockpitData (I3 FIX: no double fetch)
   // Step 24: Market context compact
   const [marketContext, setMarketContext] = useState(null);
   // Step 33: Compliance score trend (6 months)
@@ -123,6 +123,9 @@ const Cockpit = () => {
     billing,
     loading: cockpitLoading,
   } = useCockpitData();
+
+  // I4 FIX: un seul appel useActivationData, passé en props aux sous-composants
+  const activationData = useActivationData(scopedSites.length);
 
   // Fetch real alert count from notifications summary (same source as CommandCenter)
   useEffect(() => {
@@ -178,20 +181,8 @@ const Cockpit = () => {
       .catch(() => setScoreTrend(null));
   }, [org?.id]);
 
-  // A.1: Fetch consumption source from cockpit API (conso_confidence)
-  useEffect(() => {
-    if (!org?.id) return;
-    fetch(`/api/cockpit`, {
-      headers: { 'X-Org-Id': String(org.id) },
-    })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        const src = data?.stats?.conso_source;
-        if (src && src !== 'none') setConsoSource(src);
-        else setConsoSource(null);
-      })
-      .catch(() => setConsoSource(null));
-  }, [org?.id]);
+  // I3 FIX: consoSource maintenant extrait de useCockpitData (plus de double fetch)
+  const consoSource = cockpitKpis?.consoSource ?? null;
 
   const kpis = useMemo(() => {
     const sites = scopedSites;
@@ -205,8 +196,15 @@ const Cockpit = () => {
     const couvertureDonnees =
       total > 0 ? Math.round((sites.filter((s) => s.conso_kwh_an > 0).length / total) * 100) : 0;
 
-    // Score conformité : source unique = RegAssessment backend (P0, pas de calcul front)
-    const suiviConformite = cockpitKpis?.conformiteScore ?? 0;
+    // I2 FIX: même cascade que compliance_score et buildExecutiveKpis
+    const complianceScoreUnified = cockpitKpis?.conformiteScore ?? complianceApi?.avg_score ?? null;
+    const suiviConformite = complianceScoreUnified ?? 0;
+    const pctConf =
+      complianceScoreUnified != null
+        ? Math.round(complianceScoreUnified)
+        : total > 0
+          ? Math.round((conformes / total) * 100)
+          : 0;
 
     const actionsActives =
       total > 0 ? Math.round((conformes / total) * 60 + ((total - nonConformes) / total) * 40) : 80;
@@ -214,7 +212,7 @@ const Cockpit = () => {
       total > 0
         ? Math.round(
             couvertureDonnees * READINESS_WEIGHTS.data +
-              suiviConformite * READINESS_WEIGHTS.conformity +
+              pctConf * READINESS_WEIGHTS.conformity +
               actionsActives * READINESS_WEIGHTS.actions
           )
         : 0;
@@ -233,8 +231,8 @@ const Cockpit = () => {
       actionsActives,
       compStatus,
       risqueStatus,
-      // Source unique : RegAssessment via useCockpitData (P0)
-      compliance_score: cockpitKpis?.conformiteScore ?? complianceApi?.avg_score ?? null,
+      // I2 FIX: source unique — même valeur que pctConf/suiviConformite
+      compliance_score: complianceScoreUnified,
       compliance_confidence: cockpitKpis?.conformiteSource
         ? 'high'
         : complianceApi?.high_confidence_count > total * 0.6
@@ -607,6 +605,7 @@ const Cockpit = () => {
         loading={cockpitLoading}
         error={!cockpitLoading && !cockpitKpis ? 'Données KPIs indisponibles' : null}
         orgNom={cockpitKpis?.orgNom}
+        sitesARisque={(kpis.nonConformes ?? 0) + (kpis.aRisque ?? 0)}
         onEvidence={setEvidenceOpen}
       />
 
@@ -657,24 +656,13 @@ const Cockpit = () => {
 
       {/* ── Performance sites + Vecteur énergétique (2 colonnes) ── */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <PerformanceSitesCard />
+        <PerformanceSitesCard fallbackSites={scopedSites} />
         <VecteurEnergetiqueCard />
       </div>
 
       <ActionsImpact actions={cockpitActions} loading={cockpitLoading} />
 
-      {/* ═══════════ ZONE 2 : KPI DÉCIDEUR (expert only — remplacé par CockpitHero) ═══════════ */}
-      {isExpert && (
-        <div data-tour="step-1">
-          <ExecutiveKpiRow
-            kpis={executiveKpis}
-            onNavigate={navigate}
-            onEvidence={setEvidenceOpen}
-            isExpert={isExpert}
-            scoreTrend={scoreTrend}
-          />
-        </div>
-      )}
+      {/* ═══════════ ZONE 2 : KPI DÉCIDEUR — déplacé dans ZONE 4 (détail) ═══════════ */}
 
       {/* Single-site compact row (expert only — absent des maquettes exec) */}
       {isExpert && isSingleSite && singleSite && (
@@ -729,233 +717,237 @@ const Cockpit = () => {
         </div>
       )}
 
-      {/* ═══════════ ZONE 4 : ANALYSE DÉTAILLÉE (expert only) ═══════════ */}
-      {isExpert && (
-        <>
-          <div className="flex justify-center pt-2">
-            <button
-              onClick={() => setShowDetail((v) => !v)}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded-lg transition"
-            >
-              {showDetail ? 'Masquer le détail' : 'Plus de détails'}
-              <svg
-                className={`w-4 h-4 transition-transform ${showDetail ? 'rotate-180' : ''}`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
-            </button>
+      {/* ═══════════ ZONE 4 : ANALYSE DÉTAILLÉE (I9: visible pour tous) ═══════════ */}
+      <div className="flex justify-center pt-2">
+        <button
+          onClick={() => setShowDetail((v) => !v)}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded-lg transition"
+        >
+          {showDetail ? 'Masquer le détail' : 'Plus de détails'}
+          <svg
+            className={`w-4 h-4 transition-transform ${showDetail ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      </div>
+
+      {showDetail && (
+        <div className="space-y-4">
+          {/* KPI Décideur — visible pour tous */}
+          <div data-tour="step-1">
+            <ExecutiveKpiRow
+              kpis={executiveKpis}
+              onNavigate={navigate}
+              onEvidence={setEvidenceOpen}
+              isExpert={isExpert}
+              scoreTrend={scoreTrend}
+            />
           </div>
 
-          {showDetail && (
-            <div className="space-y-4">
-              {/* Impact & Décision */}
-              <ImpactDecisionPanel kpis={kpis} />
+          {/* Impact & Décision — visible pour tous */}
+          <ImpactDecisionPanel kpis={kpis} activationData={activationData} />
 
-              {/* Market Intelligence Widget */}
-              <MarketWidget profile="C4" />
+          {/* Expert only — sections techniques */}
+          {isExpert && <MarketWidget profile="C4" />}
+          {isExpert && <MarketContextCompact marketContext={marketContext} onNavigate={navigate} />}
 
-              {/* Market context */}
-              <MarketContextCompact marketContext={marketContext} onNavigate={navigate} />
+          {/* Top Sites (multi-site only) */}
+          {!isSingleSite && <TopSitesCard topSites={topSites} onNavigate={navigate} />}
 
-              {/* Top Sites (multi-site only) */}
-              {!isSingleSite && <TopSitesCard topSites={topSites} onNavigate={navigate} />}
+          {/* Module Launchers (replié) */}
+          <ModuleLaunchers kpis={kpis} isExpert={isExpert} onNavigate={navigate} />
 
-              {/* Module Launchers (replié) */}
-              <ModuleLaunchers kpis={kpis} isExpert={isExpert} onNavigate={navigate} />
-
-              {/* Données & connexions */}
-              <EssentialsRow
-                kpis={kpis}
-                sites={scopedSites}
-                onOpenMaturite={() => setShowMaturiteModal(true)}
-                onNavigate={navigate}
-                consoSource={consoSource}
-              />
-
-              {/* Data Activation — masqué si tout activé */}
-              {kpis.couvertureDonnees < 100 && <DataActivationPanel kpis={kpis} />}
-
-              {/* Expert only */}
-              {isExpert && opportunities.length > 0 && (
-                <OpportunitiesCard opportunities={opportunities} onNavigate={navigate} />
-              )}
-              {isExpert && <DataQualityWidget />}
-              {isExpert && !consistency.ok && <ConsistencyBanner issues={consistency.issues} />}
-            </div>
-          )}
-
-          {/* Portfolio tabs + Sites Table — inside detail zone */}
-          {showDetail && !portefeuille && !isSingleSite && ptfWithCounts.length > 1 && (
-            <Tabs
-              tabs={ptfTabs}
-              active={activePtf}
-              onChange={(id) => {
-                setActivePtf(id);
-                setSitePage(1);
-                setSiteSearch('');
-              }}
+          {/* Données & connexions — expert only */}
+          {isExpert && (
+            <EssentialsRow
+              kpis={kpis}
+              sites={scopedSites}
+              onOpenMaturite={() => setShowMaturiteModal(true)}
+              onNavigate={navigate}
+              consoSource={consoSource}
             />
           )}
 
-          {showDetail && !isSingleSite && (
-            <Card>
-              <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between gap-4">
-                <h3 className="text-lg font-semibold text-gray-800">
-                  <Explain term="distribution_sites">Sites</Explain> ({filteredSites.length})
-                </h3>
-                <div className="relative w-64">
-                  <Search
-                    size={14}
-                    className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-                  />
-                  <input
-                    type="text"
-                    placeholder="Rechercher un site…"
-                    value={siteSearch}
-                    onChange={(e) => {
-                      setSiteSearch(e.target.value);
-                      setSitePage(1);
-                    }}
-                    className="w-full pl-9 pr-3 py-1.5 border border-gray-300 rounded-lg text-sm placeholder:text-gray-400
-                  focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
-              </div>
-
-              {filteredSites.length === 0 ? (
-                <div className="py-12">
-                  <EmptyState
-                    icon={Search}
-                    title="Aucun site trouvé"
-                    text={
-                      siteSearch
-                        ? 'Essayez un autre terme de recherche.'
-                        : 'Aucun site dans ce périmètre.'
-                    }
-                    ctaLabel={siteSearch ? 'Effacer' : undefined}
-                    onCta={siteSearch ? () => setSiteSearch('') : undefined}
-                  />
-                </div>
-              ) : (
-                <>
-                  <Table>
-                    <Thead>
-                      <tr>
-                        <Th
-                          sortable
-                          sorted={siteSort.col === 'nom' ? siteSort.dir : ''}
-                          onSort={() => handleSiteSort('nom')}
-                        >
-                          Site
-                        </Th>
-                        <Th
-                          sortable
-                          sorted={siteSort.col === 'ville' ? siteSort.dir : ''}
-                          onSort={() => handleSiteSort('ville')}
-                        >
-                          Ville
-                        </Th>
-                        <Th
-                          sortable
-                          sorted={siteSort.col === 'surface_m2' ? siteSort.dir : ''}
-                          onSort={() => handleSiteSort('surface_m2')}
-                        >
-                          Surface
-                        </Th>
-                        <Th
-                          sortable
-                          sorted={siteSort.col === 'statut_conformite' ? siteSort.dir : ''}
-                          onSort={() => handleSiteSort('statut_conformite')}
-                        >
-                          <Explain term="statut_conformite">Conformité</Explain>
-                        </Th>
-                        <Th
-                          sortable
-                          sorted={siteSort.col === 'risque_eur' ? siteSort.dir : ''}
-                          onSort={() => handleSiteSort('risque_eur')}
-                          className="text-right"
-                        >
-                          Risque
-                        </Th>
-                        {isExpert && (
-                          <Th
-                            sortable
-                            sorted={siteSort.col === 'conso_kwh_an' ? siteSort.dir : ''}
-                            onSort={() => handleSiteSort('conso_kwh_an')}
-                            className="text-right"
-                          >
-                            Conso kWh/an
-                          </Th>
-                        )}
-                        <Th className="w-10" />
-                      </tr>
-                    </Thead>
-                    <Tbody>
-                      {sitesPageData.map((site) => {
-                        const si = getStatusInfo(site.statut_conformite);
-                        return (
-                          <Tr
-                            key={site.id}
-                            onClick={() => navigate(`/sites/${site.id}`)}
-                            className="group cursor-pointer hover:bg-blue-50/40"
-                          >
-                            <Td>
-                              <div className="font-medium text-gray-900">{site.nom}</div>
-                              <div className="text-xs text-gray-400">{site.usage}</div>
-                            </Td>
-                            <Td>{site.ville}</Td>
-                            <Td>
-                              {site.surface_m2?.toLocaleString('fr-FR')}
-                              {'\u00A0'}m²
-                            </Td>
-                            <Td>
-                              <div className="flex items-center gap-1.5">
-                                <StatusDot status={si.dot} />
-                                <span className="text-xs text-gray-600">{si.label}</span>
-                              </div>
-                            </Td>
-                            <Td className="text-right text-sm font-medium">
-                              <RiskBadge riskEur={site.risque_eur} size="sm" />
-                            </Td>
-                            {isExpert && (
-                              <Td className="text-right text-gray-600">
-                                {site.conso_kwh_an > 0
-                                  ? site.conso_kwh_an.toLocaleString('fr-FR')
-                                  : '-'}
-                              </Td>
-                            )}
-                            <Td className="text-right">
-                              <ArrowRight
-                                size={14}
-                                className="text-gray-300 group-hover:text-gray-500 transition"
-                              />
-                            </Td>
-                          </Tr>
-                        );
-                      })}
-                    </Tbody>
-                  </Table>
-                  <div className="flex items-center justify-end px-4 py-2 border-t border-gray-100">
-                    <Pagination
-                      page={sitePage}
-                      pageSize={sitePageSize}
-                      total={filteredSites.length}
-                      onChange={setSitePage}
-                    />
-                  </div>
-                </>
-              )}
-            </Card>
+          {/* Data Activation — masqué si tout activé, expert only */}
+          {isExpert && kpis.couvertureDonnees < 100 && (
+            <DataActivationPanel kpis={kpis} activationData={activationData} />
           )}
-        </>
+
+          {/* Expert only */}
+          {isExpert && opportunities.length > 0 && (
+            <OpportunitiesCard opportunities={opportunities} onNavigate={navigate} />
+          )}
+          {isExpert && <DataQualityWidget />}
+          {isExpert && !consistency.ok && <ConsistencyBanner issues={consistency.issues} />}
+        </div>
+      )}
+
+      {/* Portfolio tabs + Sites Table — inside detail zone, expert only */}
+      {isExpert && showDetail && !portefeuille && !isSingleSite && ptfWithCounts.length > 1 && (
+        <Tabs
+          tabs={ptfTabs}
+          active={activePtf}
+          onChange={(id) => {
+            setActivePtf(id);
+            setSitePage(1);
+            setSiteSearch('');
+          }}
+        />
+      )}
+
+      {isExpert && showDetail && !isSingleSite && (
+        <Card>
+          <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between gap-4">
+            <h3 className="text-lg font-semibold text-gray-800">
+              <Explain term="distribution_sites">Sites</Explain> ({filteredSites.length})
+            </h3>
+            <div className="relative w-64">
+              <Search
+                size={14}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+              />
+              <input
+                type="text"
+                placeholder="Rechercher un site…"
+                value={siteSearch}
+                onChange={(e) => {
+                  setSiteSearch(e.target.value);
+                  setSitePage(1);
+                }}
+                className="w-full pl-9 pr-3 py-1.5 border border-gray-300 rounded-lg text-sm placeholder:text-gray-400
+                  focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          {filteredSites.length === 0 ? (
+            <div className="py-12">
+              <EmptyState
+                icon={Search}
+                title="Aucun site trouvé"
+                text={
+                  siteSearch
+                    ? 'Essayez un autre terme de recherche.'
+                    : 'Aucun site dans ce périmètre.'
+                }
+                ctaLabel={siteSearch ? 'Effacer' : undefined}
+                onCta={siteSearch ? () => setSiteSearch('') : undefined}
+              />
+            </div>
+          ) : (
+            <>
+              <Table>
+                <Thead>
+                  <tr>
+                    <Th
+                      sortable
+                      sorted={siteSort.col === 'nom' ? siteSort.dir : ''}
+                      onSort={() => handleSiteSort('nom')}
+                    >
+                      Site
+                    </Th>
+                    <Th
+                      sortable
+                      sorted={siteSort.col === 'ville' ? siteSort.dir : ''}
+                      onSort={() => handleSiteSort('ville')}
+                    >
+                      Ville
+                    </Th>
+                    <Th
+                      sortable
+                      sorted={siteSort.col === 'surface_m2' ? siteSort.dir : ''}
+                      onSort={() => handleSiteSort('surface_m2')}
+                    >
+                      Surface
+                    </Th>
+                    <Th
+                      sortable
+                      sorted={siteSort.col === 'statut_conformite' ? siteSort.dir : ''}
+                      onSort={() => handleSiteSort('statut_conformite')}
+                    >
+                      <Explain term="statut_conformite">Conformité</Explain>
+                    </Th>
+                    <Th
+                      sortable
+                      sorted={siteSort.col === 'risque_eur' ? siteSort.dir : ''}
+                      onSort={() => handleSiteSort('risque_eur')}
+                      className="text-right"
+                    >
+                      Risque
+                    </Th>
+                    {isExpert && (
+                      <Th
+                        sortable
+                        sorted={siteSort.col === 'conso_kwh_an' ? siteSort.dir : ''}
+                        onSort={() => handleSiteSort('conso_kwh_an')}
+                        className="text-right"
+                      >
+                        Conso kWh/an
+                      </Th>
+                    )}
+                    <Th className="w-10" />
+                  </tr>
+                </Thead>
+                <Tbody>
+                  {sitesPageData.map((site) => {
+                    const si = getStatusInfo(site.statut_conformite);
+                    return (
+                      <Tr
+                        key={site.id}
+                        onClick={() => navigate(`/sites/${site.id}`)}
+                        className="group cursor-pointer hover:bg-blue-50/40"
+                      >
+                        <Td>
+                          <div className="font-medium text-gray-900">{site.nom}</div>
+                          <div className="text-xs text-gray-400">{site.usage}</div>
+                        </Td>
+                        <Td>{site.ville}</Td>
+                        <Td>
+                          {site.surface_m2?.toLocaleString('fr-FR')}
+                          {'\u00A0'}m²
+                        </Td>
+                        <Td>
+                          <div className="flex items-center gap-1.5">
+                            <StatusDot status={si.dot} />
+                            <span className="text-xs text-gray-600">{si.label}</span>
+                          </div>
+                        </Td>
+                        <Td className="text-right text-sm font-medium">
+                          <RiskBadge riskEur={site.risque_eur} size="sm" />
+                        </Td>
+                        {isExpert && (
+                          <Td className="text-right text-gray-600">
+                            {site.conso_kwh_an > 0
+                              ? site.conso_kwh_an.toLocaleString('fr-FR')
+                              : '-'}
+                          </Td>
+                        )}
+                        <Td className="text-right">
+                          <ArrowRight
+                            size={14}
+                            className="text-gray-300 group-hover:text-gray-500 transition"
+                          />
+                        </Td>
+                      </Tr>
+                    );
+                  })}
+                </Tbody>
+              </Table>
+              <div className="flex items-center justify-end px-4 py-2 border-t border-gray-100">
+                <Pagination
+                  page={sitePage}
+                  pageSize={sitePageSize}
+                  total={filteredSites.length}
+                  onChange={setSitePage}
+                />
+              </div>
+            </>
+          )}
+        </Card>
       )}
 
       {/* Maturité de pilotage — détail modal */}

--- a/frontend/src/pages/Site360.jsx
+++ b/frontend/src/pages/Site360.jsx
@@ -29,6 +29,7 @@ import {
   X,
   ChevronRight,
   Briefcase,
+  BarChart3,
 } from 'lucide-react';
 import {
   Card,
@@ -71,6 +72,8 @@ import SiteBillingMini from '../components/SiteBillingMini';
 import SiteContractsSummary from '../components/SiteContractsSummary';
 import SegmentationWidget from '../components/SegmentationWidget';
 import SegmentationQuestionnaireModal from '../components/SegmentationQuestionnaireModal';
+import TabConsoSite from '../components/TabConsoSite';
+import TabActionsSite from '../components/TabActionsSite';
 import { fmtNum, fmtEurFull, fmtArea } from '../utils/format';
 import DataQualityBadge from '../components/DataQualityBadge';
 import FreshnessIndicator from '../components/FreshnessIndicator';
@@ -982,14 +985,6 @@ function TabReconciliation({ site }) {
   );
 }
 
-function TabStub({ title, text }) {
-  return (
-    <div className="pt-6">
-      <EmptyState title={title} text={text} ctaLabel="Bientôt disponible" />
-    </div>
-  );
-}
-
 const KB_SEV_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
 
 function TabConformite({ site }) {
@@ -1567,6 +1562,16 @@ export default function Site360() {
           value={`${site.anomalies_count ?? 0}`}
           color="text-amber-600"
         />
+        <MiniKpi
+          icon={BarChart3}
+          label="Intensité"
+          value={
+            site.surface_m2 > 0
+              ? `${Math.round((site.conso_kwh_an || 0) / site.surface_m2)} kWh/m²`
+              : '—'
+          }
+          color="text-indigo-600"
+        />
       </div>
 
       {/* Tabs */}
@@ -1576,9 +1581,7 @@ export default function Site360() {
       {activeTab === 'resume' && (
         <TabResume site={site} onSegmentationClick={() => setShowSegModal(true)} />
       )}
-      {activeTab === 'conso' && (
-        <TabStub title="Consommation" text="Courbes de charge, historique et benchmark à venir." />
-      )}
+      {activeTab === 'conso' && <TabConsoSite siteId={site.id} siteName={site.nom} />}
       {activeTab === 'factures' && (
         <div className="space-y-4 pt-6">
           <SiteContractsSummary siteId={site.id} />
@@ -1602,9 +1605,7 @@ export default function Site360() {
       )}
       {activeTab === 'reconciliation' && <TabReconciliation site={site} />}
       {activeTab === 'conformite' && <TabConformite site={site} />}
-      {activeTab === 'actions' && (
-        <TabStub title="Actions" text="Plan d'action et suivi des recommandations à venir." />
-      )}
+      {activeTab === 'actions' && <TabActionsSite siteId={site.id} />}
 
       {/* BACS Wizard modal */}
       {showBacs && <BacsWizard siteId={site.id} onClose={() => setShowBacs(false)} />}

--- a/frontend/src/pages/Site360.jsx
+++ b/frontend/src/pages/Site360.jsx
@@ -1581,7 +1581,7 @@ export default function Site360() {
       {activeTab === 'resume' && (
         <TabResume site={site} onSegmentationClick={() => setShowSegModal(true)} />
       )}
-      {activeTab === 'conso' && <TabConsoSite siteId={site.id} siteName={site.nom} />}
+      {activeTab === 'conso' && <TabConsoSite siteId={site.id} />}
       {activeTab === 'factures' && (
         <div className="space-y-4 pt-6">
           <SiteContractsSummary siteId={site.id} />

--- a/frontend/src/pages/__tests__/ImpactDecisionPanel.test.js
+++ b/frontend/src/pages/__tests__/ImpactDecisionPanel.test.js
@@ -152,10 +152,9 @@ describe('GUARD: Impact panel uses scoped data only', () => {
   const panelSrc = readSrc('pages/cockpit/ImpactDecisionPanel.jsx');
   const modelSrc = readSrc('models/impactDecisionModel.js');
 
-  it('panel reçoit kpis en prop (pas de fetch direct de sites)', () => {
-    // Le composant prend kpis en prop — il ne fait pas de useScope() direct pour les sites
+  it('panel reçoit kpis et activationData en props (I4: plus de hook local)', () => {
     expect(panelSrc).toMatch(
-      /export\s+default\s+function\s+ImpactDecisionPanel\(\s*\{\s*kpis\s*\}/
+      /export\s+default\s+function\s+ImpactDecisionPanel\(\s*\{\s*kpis\s*,\s*activationData\s*\}/
     );
   });
 
@@ -320,9 +319,9 @@ describe('V32: Compteurs contextuels', () => {
     expect(panelSrc).toContain('available && subLabel');
   });
 
-  it('uses useActivationData hook instead of direct API calls (V32)', () => {
-    expect(panelSrc).toContain('useActivationData');
-    // No direct API import — all fetches delegated to shared hook
+  it('receives activationData as prop (I4: hoisted to Cockpit.jsx)', () => {
+    expect(panelSrc).toContain('activationData');
+    // No direct API import — all fetches delegated to parent via props
     const apiCalls = panelSrc.match(/from '\.\.\/\.\.\/services\/api'/g) || [];
     expect(apiCalls).toHaveLength(0);
   });
@@ -382,8 +381,8 @@ describe('V33: Leviers activables', () => {
     expect(modelSrc).not.toContain('computeActionableLevers');
   });
 
-  it('no direct API imports — uses shared hook (contrainte V33)', () => {
-    expect(panelSrc).toContain('useActivationData');
+  it('no direct API imports — receives activationData as prop (I4)', () => {
+    expect(panelSrc).toContain('activationData');
     const apiImports = panelSrc.match(/from '\.\.\/\.\.\/services\/api'/g) || [];
     expect(apiImports).toHaveLength(0);
   });

--- a/frontend/src/pages/__tests__/contractsV36.test.js
+++ b/frontend/src/pages/__tests__/contractsV36.test.js
@@ -371,8 +371,8 @@ describe("V36: ImpactDecisionPanel — achats d'energie", () => {
     expect(panelSrc).toContain('ShoppingCart');
   });
 
-  it('uses useActivationData hook for purchase signals', () => {
-    expect(panelSrc).toContain('useActivationData');
+  it('receives activationData as prop (I4: hoisted to Cockpit.jsx)', () => {
+    expect(panelSrc).toContain('activationData');
     expect(panelSrc).toContain('purchaseSignals');
   });
 

--- a/frontend/src/pages/__tests__/dataActivationV37.test.js
+++ b/frontend/src/pages/__tests__/dataActivationV37.test.js
@@ -348,8 +348,8 @@ describe('DataActivationPanel — V37 guards', () => {
     expect(src).toContain('dataActivationModel');
   });
 
-  it('uses useActivationData hook (shared fetch)', () => {
-    expect(src).toContain('useActivationData');
+  it('receives activationData as prop (I4: hoisted to Cockpit.jsx)', () => {
+    expect(src).toContain('activationData');
     expect(src).toContain('billingSummary');
     expect(src).toContain('purchaseSignals');
     expect(src).toContain('loading');
@@ -373,8 +373,8 @@ describe('DataActivationPanel — V37 guards', () => {
     expect(src).toContain('/activation');
   });
 
-  it('activation data fetched via shared hook', () => {
-    expect(src).toContain('useActivationData');
+  it('activation data received via prop (I4: hoisted to Cockpit.jsx)', () => {
+    expect(src).toContain('activationData');
   });
 
   it('affiche activatedCount/totalDimensions', () => {

--- a/frontend/src/pages/cockpit/ActionsImpact.jsx
+++ b/frontend/src/pages/cockpit/ActionsImpact.jsx
@@ -12,6 +12,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 import { getActionsList } from '../../services/api';
+import { useScope } from '../../contexts/ScopeContext';
 import { fmtEur } from '../../utils/format';
 
 // ── PriorityBadge ────────────────────────────────────────────────────
@@ -114,20 +115,34 @@ function ActionRow({ action, totalGainEur }) {
 
 export default function ActionsImpact({ actions, loading }) {
   const navigate = useNavigate();
+  const { org } = useScope();
   const [actionsList, setActionsList] = useState([]);
   const [listLoading, setListLoading] = useState(true);
   const [listError, setListError] = useState(null);
 
   useEffect(() => {
+    if (!org?.id) return;
+    setActionsList([]);
     setListLoading(true);
-    getActionsList({ status: 'open,in_progress', limit: 6 })
+    setListError(null);
+    getActionsList({ status: 'open,in_progress', limit: 12 })
       .then((data) => {
         const items = data?.actions ?? data?.items ?? data ?? [];
-        setActionsList(Array.isArray(items) ? items : []);
+        const list = Array.isArray(items) ? items : [];
+        // C6 FIX: exclure les alertes P0/critical déjà montrées dans AlertesPrioritaires
+        const filtered = list.filter(
+          (a) =>
+            !(
+              a.priority != null &&
+              a.priority <= 2 &&
+              (a.severity === 'critical' || a.severity === 'high')
+            )
+        );
+        setActionsList(filtered.slice(0, 6));
       })
       .catch((err) => setListError(err.message))
       .finally(() => setListLoading(false));
-  }, []);
+  }, [org?.id]);
 
   const isLoading = loading || listLoading;
   // Total gain pour la barre de proportion (présentation, pas un KPI)
@@ -175,11 +190,11 @@ export default function ActionsImpact({ actions, loading }) {
       {/* Footer — toujours visible (maquette) */}
       <div className="mt-3 pt-3 border-t border-gray-100 flex items-center justify-between">
         <span className="text-xs text-gray-500">
-          {actions?.potentielEur > 0 ? (
+          {actions?.potentielEur > 0 || totalGainEur > 0 ? (
             <>
               Actions planifiées · Économie potentielle :
-              <span className="text-green-700 font-medium ml-1">
-                {fmtEur(actions.potentielEur)}/an
+              <span className="text-emerald-700 font-semibold ml-1">
+                {fmtEur(actions?.potentielEur || totalGainEur)}/an
               </span>
             </>
           ) : (

--- a/frontend/src/pages/cockpit/AlertesPrioritaires.jsx
+++ b/frontend/src/pages/cockpit/AlertesPrioritaires.jsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FileText, Receipt, ShoppingCart, AlertTriangle } from 'lucide-react';
 import { getActionsList } from '../../services/api';
+import { useScope } from '../../contexts/ScopeContext';
 import { fmtEur } from '../../utils/format';
 import { Skeleton } from '../../ui';
 
@@ -25,18 +26,31 @@ function daysUntil(dateStr) {
 
 export default function AlertesPrioritaires() {
   const navigate = useNavigate();
+  const { org } = useScope();
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    getActionsList({ status: 'open,in_progress', limit: 3 })
+    if (!org?.id) return;
+    setItems([]);
+    setLoading(true);
+    getActionsList({ status: 'open,in_progress', limit: 10 })
       .then((data) => {
         const actions = data?.actions ?? data?.items ?? data ?? [];
-        setItems(Array.isArray(actions) ? actions.slice(0, 3) : []);
+        const list = Array.isArray(actions) ? actions : [];
+        // C6 FIX: ne garder que les alertes urgentes (P0/P1, severity critical/high)
+        // pour éviter le doublon avec ActionsImpact qui affiche toutes les actions
+        const urgent = list.filter(
+          (a) =>
+            (a.priority != null && a.priority <= 2) ||
+            a.severity === 'critical' ||
+            a.severity === 'high'
+        );
+        setItems(urgent.slice(0, 3));
       })
       .catch(() => setItems([]))
       .finally(() => setLoading(false));
-  }, []);
+  }, [org?.id]);
 
   return (
     <div
@@ -87,15 +101,17 @@ export default function AlertesPrioritaires() {
                   )}
                   {days != null && (
                     <span
-                      className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
-                        days <= 7
-                          ? 'bg-red-50 text-red-700'
+                      className={`text-[10px] font-bold px-2 py-0.5 rounded border ${
+                        days <= 0
+                          ? 'bg-red-50 text-red-700 border-red-200'
                           : days <= 30
-                            ? 'bg-amber-50 text-amber-700'
-                            : 'bg-gray-100 text-gray-600'
+                            ? 'bg-red-50 text-red-700 border-red-200'
+                            : days <= 90
+                              ? 'bg-amber-50 text-amber-700 border-amber-200'
+                              : 'bg-blue-50 text-blue-700 border-blue-200'
                       }`}
                     >
-                      {days <= 0 ? 'Échu' : `${days} j`}
+                      {days <= 0 ? 'Dépassé' : `J-${days}`}
                     </span>
                   )}
                 </div>

--- a/frontend/src/pages/cockpit/CockpitHero.jsx
+++ b/frontend/src/pages/cockpit/CockpitHero.jsx
@@ -41,6 +41,7 @@ export default function CockpitHero({
   loading,
   error,
   orgNom,
+  sitesARisque,
   onEvidence,
 }) {
   const navigate = useNavigate();
@@ -104,37 +105,57 @@ export default function CockpitHero({
             </button>
           )}
         </div>
-        <div className="flex items-center gap-3">
-          {/* Jauge SVG conservée */}
-          <svg viewBox="0 0 120 70" width={48} height={28} className="shrink-0">
+        <div className="flex items-center gap-2">
+          {/* V1: Gauge SVG agrandie avec score intégré */}
+          <svg viewBox="0 0 120 76" width={72} height={46} className="shrink-0">
+            {/* Track */}
             <path
-              d="M 15 60 A 45 45 0 0 1 105 60"
+              d="M 12 64 A 48 48 0 0 1 108 64"
               fill="none"
               stroke="#e5e7eb"
-              strokeWidth={10}
+              strokeWidth={9}
               strokeLinecap="round"
             />
+            {/* Value arc */}
             <path
-              d="M 15 60 A 45 45 0 0 1 105 60"
+              d="M 12 64 A 48 48 0 0 1 108 64"
               fill="none"
               stroke={color}
-              strokeWidth={10}
+              strokeWidth={9}
               strokeLinecap="round"
               strokeDasharray={CIRCUMFERENCE}
               strokeDashoffset={dashOffset}
-              className="transition-all duration-700"
+              className="transition-all duration-1000 ease-out"
             />
+            {/* Score number inside arc */}
+            <text
+              x="60"
+              y="56"
+              textAnchor="middle"
+              className="fill-gray-900"
+              style={{ fontSize: '22px', fontWeight: 700 }}
+            >
+              {score != null ? Math.round(score) : '—'}
+            </text>
+            <text
+              x="60"
+              y="72"
+              textAnchor="middle"
+              className="fill-gray-400"
+              style={{ fontSize: '9px' }}
+            >
+              /100
+            </text>
           </svg>
-          <div className="flex items-center gap-1.5">
-            <span className="text-xl font-bold text-gray-900">{score ?? '—'} / 100</span>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm font-semibold text-gray-900">{label}</span>
             <span
-              className={`w-2 h-2 rounded-full shrink-0 ${score >= 80 ? 'bg-green-500' : score >= 60 ? 'bg-amber-500' : 'bg-red-500'}`}
+              className={`w-2 h-2 rounded-full shrink-0 ${score == null ? 'bg-gray-300' : score >= 80 ? 'bg-green-500' : score >= 60 ? 'bg-amber-500' : 'bg-red-500'}`}
             />
           </div>
         </div>
         <p className="text-xs text-gray-500">
-          DT {kpis?.weightDt ?? 45}% · BACS {kpis?.weightBacs ?? 30}% · APER{' '}
-          {kpis?.weightAper ?? 25}% · {kpis?.totalSites ?? 0} sites
+          Pondération standard : DT 45% · BACS 30% · APER 25% · {kpis?.totalSites ?? 0} sites
         </p>
         <p className="text-[10px] text-gray-400">
           Source :{' '}
@@ -177,12 +198,11 @@ export default function CockpitHero({
           />
         </div>
         <p className="text-xs text-gray-500">
-          {kpis?.totalSites ?? 0} sites concernés (périmètre sélectionné)
+          {sitesARisque ?? 0} site{(sitesARisque ?? 0) > 1 ? 's' : ''} concerné
+          {(sitesARisque ?? 0) > 1 ? 's' : ''} (périmètre sélectionné)
         </p>
         {(kpis?.risqueTotal ?? 0) > 0 && (
-          <p className="text-[10px] text-red-600">
-            Risque total {fmtEur(kpis?.risqueTotal)}. Actions correctives urgentes.
-          </p>
+          <p className="text-[10px] text-red-600">Actions correctives urgentes.</p>
         )}
         <p className="text-[10px] text-gray-400">
           Source :{' '}

--- a/frontend/src/pages/cockpit/DataActivationPanel.jsx
+++ b/frontend/src/pages/cockpit/DataActivationPanel.jsx
@@ -11,11 +11,11 @@ import { Database, CheckCircle2, Circle, ArrowRight, Loader2 } from 'lucide-reac
 import { Card, CardBody, InfoTip, Button, Progress } from '../../ui';
 import { TOOLTIPS } from '../../ui/tooltips';
 import { buildActivationChecklist } from '../../models/dataActivationModel';
-import useActivationData from '../../hooks/useActivationData';
 
-export default function DataActivationPanel({ kpis }) {
+export default function DataActivationPanel({ kpis, activationData }) {
   const navigate = useNavigate();
-  const { billingSummary, purchaseSignals, loading } = useActivationData(kpis?.total);
+  // I4 FIX: activationData passé en prop depuis Cockpit.jsx (plus de double hook)
+  const { billingSummary, purchaseSignals, loading } = activationData ?? {};
 
   const activation = useMemo(
     () =>

--- a/frontend/src/pages/cockpit/EvenementsRecents.jsx
+++ b/frontend/src/pages/cockpit/EvenementsRecents.jsx
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect } from 'react';
 import { getNotificationsList } from '../../services/api';
+import { useScope } from '../../contexts/ScopeContext';
 import { Skeleton } from '../../ui';
 
 const SEVERITY_DOTS = {
@@ -40,10 +41,14 @@ function relativeDate(dateStr) {
 }
 
 export default function EvenementsRecents() {
+  const { org } = useScope();
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!org?.id) return;
+    setEvents([]);
+    setLoading(true);
     getNotificationsList({ limit: 4 })
       .then((data) => {
         const items = data?.notifications ?? data?.items ?? data ?? [];
@@ -51,7 +56,7 @@ export default function EvenementsRecents() {
       })
       .catch(() => setEvents([]))
       .finally(() => setLoading(false));
-  }, []);
+  }, [org?.id]);
 
   return (
     <div

--- a/frontend/src/pages/cockpit/ImpactDecisionPanel.jsx
+++ b/frontend/src/pages/cockpit/ImpactDecisionPanel.jsx
@@ -29,7 +29,6 @@ import { buildLeverDeepLink } from '../../models/leverActionModel';
 import { hasProofData, buildProofLink, getProofLabel } from '../../models/proofLinkModel';
 import { isPurchaseAvailable } from '../../models/purchaseSignalsContract';
 import { toPurchase } from '../../services/routes';
-import useActivationData from '../../hooks/useActivationData';
 
 // ── KPI tile (inline — small enough) ─────────────────────────────────────────
 
@@ -88,9 +87,10 @@ function ImpactKpiTile({
 
 // ── Main Panel ───────────────────────────────────────────────────────────────
 
-export default function ImpactDecisionPanel({ kpis }) {
+export default function ImpactDecisionPanel({ kpis, activationData }) {
   const navigate = useNavigate();
-  const { billingSummary, purchaseSignals, loading } = useActivationData(kpis?.total);
+  // I4 FIX: activationData passé en prop depuis Cockpit.jsx (plus de double hook)
+  const { billingSummary, purchaseSignals, loading } = activationData ?? {};
 
   const impact = useMemo(
     () => computeImpactKpis(kpis, billingSummary || {}),

--- a/frontend/src/pages/cockpit/PerformanceSitesCard.jsx
+++ b/frontend/src/pages/cockpit/PerformanceSitesCard.jsx
@@ -1,27 +1,44 @@
 /**
- * PerformanceSitesCard — Performance par site en kWh/m² vs benchmark ADEME.
+ * PerformanceSitesCard — Performance par site en kWh/m² vs benchmark OID.
  *
- * RÈGLE : zéro calcul métier. Les données viennent de GET /api/cockpit/benchmark.
- * Le composant affiche — ne calcule pas.
+ * Source primaire : GET /api/cockpit/benchmark (backend)
+ * Fallback V2 : calcul depuis scopedSites (surface_m2 + conso_kwh_an)
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { getCockpitBenchmark } from '../../services/api';
+import { useScope } from '../../contexts/ScopeContext';
 import { Skeleton } from '../../ui';
+
+// Benchmarks OID par usage (kWh/m²/an)
+const OID_BENCHMARKS = {
+  bureaux: 146,
+  hotel: 170,
+  ecole: 110,
+  entrepot: 80,
+  commerce: 200,
+  industrie: 180,
+  logistique: 90,
+  default: 146,
+};
+
+function getBenchmarkForUsage(usageType) {
+  if (!usageType) return OID_BENCHMARKS.default;
+  const key = usageType.toLowerCase().replace(/[^a-z]/g, '');
+  return OID_BENCHMARKS[key] ?? OID_BENCHMARKS.default;
+}
 
 // Couleur sémantique selon écart à la référence
 function getBarColor(ipe, objectif) {
   if (ipe == null || objectif == null) return { bar: 'bg-gray-300', text: 'text-gray-500' };
   const ratio = ipe / objectif;
-  if (ratio <= 1) return { bar: 'bg-green-500', text: 'text-green-700' };
+  if (ratio <= 1) return { bar: 'bg-emerald-500', text: 'text-emerald-700' };
   if (ratio <= 1.2) return { bar: 'bg-amber-500', text: 'text-amber-700' };
   return { bar: 'bg-red-500', text: 'text-red-600' };
 }
 
-function SitePerformanceBar({ site }) {
-  const { site_nom, ipe_kwh_m2_an, benchmark } = site;
-  const objectif = benchmark?.median ?? benchmark?.bon ?? 120;
+function SitePerformanceBar({ site, maxVal }) {
+  const { site_nom, ipe_kwh_m2_an, objectif } = site;
   const color = getBarColor(ipe_kwh_m2_an, objectif);
-  const maxVal = Math.max(ipe_kwh_m2_an ?? 0, objectif, 1);
   const fillPct =
     ipe_kwh_m2_an != null ? Math.min(100, Math.round((ipe_kwh_m2_an / maxVal) * 100)) : 0;
   const targetPct = Math.min(100, Math.round((objectif / maxVal) * 100));
@@ -29,33 +46,67 @@ function SitePerformanceBar({ site }) {
   return (
     <div className="mb-3">
       <div className="flex justify-between text-xs mb-1">
-        <span className="font-medium text-gray-700">{site_nom}</span>
-        <span className={`font-medium ${color.text}`}>
+        <span className="font-medium text-gray-700 truncate">{site_nom}</span>
+        <span className={`font-medium shrink-0 ml-2 ${color.text}`}>
           {ipe_kwh_m2_an ?? '—'} kWh/m² · réf. {objectif}
         </span>
       </div>
-      <div className="relative h-2 bg-gray-100 rounded-full overflow-visible">
-        <div className={`h-full rounded-full ${color.bar}`} style={{ width: `${fillPct}%` }} />
+      <div className="relative h-2.5 bg-gray-100 rounded-full overflow-visible">
         <div
-          className="absolute top-[-2px] w-0.5 h-3 bg-blue-800 rounded"
+          className={`h-full rounded-full transition-all duration-500 ${color.bar}`}
+          style={{ width: `${fillPct}%` }}
+        />
+        <div
+          className="absolute top-[-2px] w-0.5 h-3.5 bg-blue-800 rounded"
           style={{ left: `${targetPct}%` }}
-          title={`Objectif : ${objectif} kWh/m²`}
+          title={`Cible OID : ${objectif} kWh/m²`}
         />
       </div>
     </div>
   );
 }
 
-export default function PerformanceSitesCard() {
-  const [sites, setSites] = useState([]);
+export default function PerformanceSitesCard({ fallbackSites }) {
+  const { org } = useScope();
+  const [apiSites, setApiSites] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!org?.id) return;
+    setApiSites([]);
+    setLoading(true);
     getCockpitBenchmark()
-      .then((data) => setSites(data?.sites ?? []))
-      .catch(() => setSites([]))
+      .then((data) => setApiSites(data?.sites ?? []))
+      .catch(() => setApiSites([]))
       .finally(() => setLoading(false));
-  }, []);
+  }, [org?.id]);
+
+  // V2: fallback — calculer IPE depuis scopedSites si l'API ne retourne rien
+  const sites = useMemo(() => {
+    if (apiSites.length > 0) {
+      return apiSites.map((s) => ({
+        site_id: s.site_id,
+        site_nom: s.site_nom,
+        ipe_kwh_m2_an: s.ipe_kwh_m2_an,
+        objectif: s.benchmark?.median ?? s.benchmark?.bon ?? getBenchmarkForUsage(s.usage_type),
+      }));
+    }
+    if (!fallbackSites?.length) return [];
+    return fallbackSites
+      .filter((s) => s.surface_m2 > 0 && s.conso_kwh_an > 0)
+      .map((s) => ({
+        site_id: s.id,
+        site_nom: s.nom || s.name || `Site #${s.id}`,
+        ipe_kwh_m2_an: Math.round(s.conso_kwh_an / s.surface_m2),
+        objectif: getBenchmarkForUsage(s.usage_type ?? s.activite),
+      }))
+      .sort((a, b) => b.ipe_kwh_m2_an - a.ipe_kwh_m2_an);
+  }, [apiSites, fallbackSites]);
+
+  const maxVal = useMemo(
+    () => Math.max(...sites.map((s) => s.ipe_kwh_m2_an ?? 0), ...sites.map((s) => s.objectif), 1),
+    [sites]
+  );
 
   return (
     <div className="bg-white border border-gray-200 rounded-xl p-4" data-testid="performance-sites">
@@ -63,16 +114,26 @@ export default function PerformanceSitesCard() {
         Performance par site — kWh/m²
       </div>
 
-      {loading ? (
+      {loading && apiSites.length === 0 && !fallbackSites?.length ? (
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
             <Skeleton key={i} className="h-8 rounded" />
           ))}
         </div>
       ) : sites.length === 0 ? (
-        <p className="text-xs text-gray-400 text-center py-4">Données benchmark non disponibles.</p>
+        <p className="text-xs text-gray-400 text-center py-4">
+          Surface ou consommation manquante pour le calcul kWh/m².
+        </p>
       ) : (
-        sites.slice(0, 5).map((site) => <SitePerformanceBar key={site.site_id} site={site} />)
+        <>
+          {sites.slice(0, 5).map((site) => (
+            <SitePerformanceBar key={site.site_id} site={site} maxVal={maxVal} />
+          ))}
+          <p className="text-[10px] text-gray-400 mt-2">
+            <span className="inline-block w-0.5 h-2.5 bg-blue-800 rounded mr-1 align-middle" />
+            Cible OID par usage · Vert = sous la cible · Ambre = au-dessus
+          </p>
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/cockpit/VecteurEnergetiqueCard.jsx
+++ b/frontend/src/pages/cockpit/VecteurEnergetiqueCard.jsx
@@ -8,6 +8,45 @@ import { useState, useEffect } from 'react';
 import { getCockpitCo2 } from '../../services/api';
 import { Skeleton } from '../../ui';
 
+/**
+ * DeltaLine — Affiche la valeur N-1 et l'écart en % sous un KPI CO₂.
+ * Vert ▼ = amélioration (baisse émissions), Rouge ▲ = dégradation (hausse).
+ * « — » si données N-1 indisponibles. Zéro calcul : deltaPct vient du backend.
+ */
+function DeltaLine({ prevValue, deltaPct, co2Factors }) {
+  if (prevValue == null || deltaPct == null) {
+    return (
+      <div className="mt-1.5 pt-1.5 border-t border-gray-100">
+        <span className="text-[11px] text-gray-400">—</span>
+      </div>
+    );
+  }
+
+  const isImprovement = deltaPct < 0;
+  const colorClass = isImprovement ? 'text-green-600' : 'text-red-500';
+  const arrow = isImprovement ? '▼' : '▲';
+  const sign = deltaPct > 0 ? '+' : '';
+
+  return (
+    <div className="flex items-center gap-1 mt-1.5 pt-1.5 border-t border-gray-100">
+      <span className="text-[11px] text-gray-500">
+        {prevValue.toLocaleString('fr-FR', { maximumFractionDigits: 1 })} N-1
+      </span>
+      <span
+        className={`text-[11px] font-medium ${colorClass}`}
+        title={
+          co2Factors
+            ? `Comparaison même période calendaire. Facteurs ADEME : élec ${co2Factors.elec_kgco2_per_kwh}, gaz ${co2Factors.gaz_kgco2_per_kwh} kgCO₂/kWh`
+            : undefined
+        }
+      >
+        {arrow} {sign}
+        {deltaPct.toLocaleString('fr-FR', { maximumFractionDigits: 1 })}%
+      </span>
+    </div>
+  );
+}
+
 const VECTOR_CONFIG = {
   elec: { label: 'Électricité', color: 'bg-blue-500', scopeLabel: 'Scope 2 (élec)' },
   gaz: { label: 'Gaz naturel', color: 'bg-amber-500', scopeLabel: 'Scope 1 (gaz)' },
@@ -120,28 +159,55 @@ export default function VecteurEnergetiqueCard() {
         ))}
       </div>
 
-      {/* CO₂ totaux */}
+      {/* CO₂ totaux + comparaison N-1 — données 100% backend */}
       <div className="border-t border-gray-100 pt-3">
         <div className="text-[10px] font-medium text-gray-500 uppercase tracking-wider mb-2">
-          Émissions CO₂ cumulées {data.annee_ref ?? new Date().getFullYear()}
+          Émissions CO₂ cumulées {data.year ?? data.annee_ref ?? new Date().getFullYear()}
         </div>
-        <div className="flex items-baseline gap-4">
-          <div>
+        <div className="flex items-baseline gap-4 flex-wrap">
+          <div className="min-w-[100px]">
             <span className="text-lg font-bold text-gray-900">{totalTco2}</span>
             <span className="text-xs text-gray-500 ml-1">tCO₂eq</span>
             <div className="text-[10px] text-gray-400">Total</div>
+            <DeltaLine
+              prevValue={data.prev_total_tco2}
+              deltaPct={data.delta_total_pct}
+              co2Factors={data.co2_factors}
+            />
           </div>
-          <div>
+          <div className="min-w-[100px]">
             <span className="text-base font-semibold text-blue-600">{scope2Tco2}</span>
             <span className="text-xs text-gray-500 ml-1">tCO₂eq</span>
             <div className="text-[10px] text-gray-400">Scope 2 (élec)</div>
+            <DeltaLine
+              prevValue={data.prev_scope2_tco2}
+              deltaPct={data.delta_scope2_pct}
+              co2Factors={data.co2_factors}
+            />
           </div>
-          <div>
+          <div className="min-w-[100px]">
             <span className="text-base font-semibold text-amber-600">{scope1Tco2}</span>
             <span className="text-xs text-gray-500 ml-1">tCO₂eq</span>
             <div className="text-[10px] text-gray-400">Scope 1 (gaz)</div>
+            <DeltaLine
+              prevValue={data.prev_scope1_tco2}
+              deltaPct={data.delta_scope1_pct}
+              co2Factors={data.co2_factors}
+            />
           </div>
         </div>
+        {data.period_label && data.prev_period_label && (
+          <div className="text-[10px] text-gray-400 mt-2 leading-relaxed">
+            Comparaison {data.period_label} vs {data.prev_period_label}
+            {data.co2_factors && (
+              <>
+                {' '}
+                · Facteurs ADEME : élec {data.co2_factors.elec_kgco2_per_kwh} · gaz{' '}
+                {data.co2_factors.gaz_kgco2_per_kwh} kgCO₂/kWh
+              </>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/cockpit/VecteurEnergetiqueCard.jsx
+++ b/frontend/src/pages/cockpit/VecteurEnergetiqueCard.jsx
@@ -6,7 +6,8 @@
  */
 import { useState, useEffect } from 'react';
 import { getCockpitCo2 } from '../../services/api';
-import { Skeleton } from '../../ui';
+import { useScope } from '../../contexts/ScopeContext';
+import { Skeleton, InfoTip } from '../../ui';
 
 /**
  * DeltaLine — Affiche la valeur N-1 et l'écart en % sous un KPI CO₂.
@@ -55,15 +56,19 @@ const VECTOR_CONFIG = {
 };
 
 export default function VecteurEnergetiqueCard() {
+  const { org } = useScope();
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!org?.id) return;
+    setData(null);
+    setLoading(true);
     getCockpitCo2()
       .then((d) => setData(d))
       .catch(() => setData(null))
       .finally(() => setLoading(false));
-  }, []);
+  }, [org?.id]);
 
   if (loading) {
     return (
@@ -161,8 +166,9 @@ export default function VecteurEnergetiqueCard() {
 
       {/* CO₂ totaux + comparaison N-1 — données 100% backend */}
       <div className="border-t border-gray-100 pt-3">
-        <div className="text-[10px] font-medium text-gray-500 uppercase tracking-wider mb-2">
+        <div className="flex items-center gap-1 text-[10px] font-medium text-gray-500 uppercase tracking-wider mb-2">
           Émissions CO₂ cumulées {data.year ?? data.annee_ref ?? new Date().getFullYear()}
+          <InfoTip content="Facteurs ADEME Base Empreinte V23.6 : élec 0,052 kgCO₂/kWh · gaz 0,227 kgCO₂/kWh. Comparaison même période calendaire N vs N-1." />
         </div>
         <div className="flex items-baseline gap-4 flex-wrap">
           <div className="min-w-[100px]">

--- a/frontend/src/services/api/core.js
+++ b/frontend/src/services/api/core.js
@@ -21,9 +21,11 @@ const _getCache = new Map();
 const GET_CACHE_TTL_MS = 60_000; // 60 seconds — historical consumption data changes rarely
 
 function _cacheKey(url, params) {
-  if (!params || Object.keys(params).length === 0) return url;
+  // C1 FIX: inclure orgId dans la clé pour éviter le cross-tenant
+  const scopePrefix = _apiScope.orgId != null ? `org:${_apiScope.orgId}|` : '';
+  if (!params || Object.keys(params).length === 0) return `${scopePrefix}${url}`;
   const sorted = JSON.stringify(params, Object.keys(params).sort());
-  return `${url}|${sorted}`;
+  return `${scopePrefix}${url}|${sorted}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **P0-A** : Onglet Consommation Site360 — AreaChart Recharts 30j via `/api/ems/timeseries`, KPI strip (total kWh, pic journalier), CTA "Explorer en détail →"
- **P0-B** : Onglet Actions Site360 — liste actions du site via `/api/actions/list`, tri priorité/statut, badges P1-P5, countdown J-X, CTAs créer + plan complet
- **P2-A** : 4e MiniKpi "Intensité kWh/m²" dans le header Site360 (cohérence cockpit → site)
- Suppression complète de `TabStub` (zéro "à venir" restant dans Site360)
- Corrections cockpit (hero, alertes, performance sites, vecteur énergétique, BillIntel, seed billing)
- E2E `sprint-cockpit-complet.spec.js` : 28 tests couvrant 8 parcours critiques

## Parcours démo débloqués
- Cockpit → "189 kWh/m² Nice" → Site360 → Tab Conso → **graphique 30j** (plus de stub)
- Cockpit → "5 en cours" → Site360 → Tab Actions → **liste avec priorité/statut/impact** (plus de stub)
- Le DG retrouve le kWh/m² dans le header Site360 (cohérence cross-page)

## Test plan
- [x] `npm run build` clean (23s)
- [x] `npx vitest run` — 3610 tests passed, 0 fail
- [x] `npx playwright test sprint-cockpit-complet.spec.js` — 28/28 passed
- [ ] Vérification visuelle cockpit → Site360 → onglets Conso/Actions
- [ ] Vérification parcours BillIntel accessible en mode simple

🤖 Generated with [Claude Code](https://claude.com/claude-code)