### PR TITLE
fix(energy): add EUR/m²/an KPI and multi-energy cost aggregation (#144)

### DIFF
--- a/backend/routes/consumption_diagnostic.py
+++ b/backend/routes/consumption_diagnostic.py
@@ -849,6 +849,7 @@ def gas_summary(
     from models.energy_models import EnergyVector
     from collections import defaultdict
     from services.ems.timeseries_service import get_site_meter_ids as _get_gas_ids
+    from services.billing_service import get_reference_price
 
     if start_date_param and end_date_param:
         start_date = datetime.combine(start_date_param, datetime.min.time(), tzinfo=timezone.utc)
@@ -867,6 +868,7 @@ def gas_summary(
             "readings_count": 0,
             "daily_kwh": [],
             "total_kwh": 0,
+            "total_cost_eur": 0,
             "avg_daily_kwh": 0,
             "summer_base_kwh": 0,
             "confidence": "low",
@@ -904,6 +906,10 @@ def gas_summary(
 
     confidence = "high" if len(readings) >= days * 20 else ("medium" if len(readings) >= days * 5 else "low")
 
+    # Resolve gas price for cost estimation
+    gas_price, _price_src = get_reference_price(db, site_id, "gaz")
+    total_cost_eur = round(total_kwh * gas_price, 2)
+
     return {
         "site_id": site_id,
         "energy_type": "gas",
@@ -911,6 +917,7 @@ def gas_summary(
         "readings_count": len(readings),
         "daily_kwh": daily_list,
         "total_kwh": round(total_kwh, 1),
+        "total_cost_eur": total_cost_eur,
         "avg_daily_kwh": round(avg_daily, 1),
         "summer_base_kwh": round(summer_base, 1),
         "confidence": confidence,

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -124,9 +124,9 @@ export default function ConsoKpiHeader({
 
   // --- EUR/m²/an (#144) ---
   // Annualize observed cost then divide by surface. Guard against null/zero surface.
-  const effectiveDays = days ?? 30;
+  const effectiveDays = (days != null && days > 0) ? days : null;
   const eurPerM2Year =
-    totalEur != null && surfaceM2 > 0 && effectiveDays > 0
+    totalEur != null && surfaceM2 > 0 && effectiveDays != null
       ? Math.round(((totalEur / effectiveDays) * 365) / surfaceM2 * 100) / 100
       : null;
   const eurPerM2Label = eurPerM2Year != null ? fmtNum(eurPerM2Year, 1, '€/m²/an') : '—';

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -7,7 +7,7 @@
  *
  * P1.1: confidence tooltip "Comment calcule ?", EUR source tooltip.
  */
-import { Zap, Euro, TrendingUp, Leaf, Activity, Moon, HelpCircle } from 'lucide-react';
+import { Zap, Euro, TrendingUp, Leaf, Activity, Moon, HelpCircle, Building2 } from 'lucide-react';
 import { TrustBadge } from '../ui';
 import { CO2E_FACTOR_KG_PER_KWH } from '../pages/consumption/constants';
 import { fmtNum, fmtKwh } from '../utils/format';
@@ -98,6 +98,7 @@ export default function ConsoKpiHeader({
   days,
   startDate,
   endDate,
+  surfaceM2,
   loading = false,
 }) {
   const { isExpert } = useExpertMode();
@@ -108,10 +109,10 @@ export default function ConsoKpiHeader({
   const totalKwh = hphc?.total_kwh ?? tunnel?.total_kwh ?? progression?.ytd_actual_kwh ?? null;
   const kwhLabel = totalKwh != null ? fmtKwh(totalKwh) : '—';
 
-  // --- EUR total (from hphc or progression) ---
+  // --- EUR total (from hphc, includes gas when aggregated — #144) ---
   const totalEur = hphc?.total_cost_eur ?? null;
   const eurLabel = totalEur != null ? fmtNum(Math.round(totalEur), 0, '€') : '—';
-  const eurSource = hphc?.total_cost_eur != null ? 'Estime HP/HC' : 'Non disponible';
+  const eurSource = hphc?.total_cost_eur != null ? 'Estimé multi-énergie' : 'Non disponible';
 
   // --- EUR/MWh reel ---
   // Use hphc.total_kwh (not the fallback totalKwh) so numerator (EUR from hphc)
@@ -120,6 +121,15 @@ export default function ConsoKpiHeader({
   const eurMwh =
     totalEur != null && hphcKwh > 0 ? Math.round((totalEur / hphcKwh) * 1000 * 100) / 100 : null;
   const eurMwhLabel = eurMwh != null ? fmtNum(eurMwh, 2, '€/MWh') : '—';
+
+  // --- EUR/m²/an (#144) ---
+  // Annualize observed cost then divide by surface. Guard against null/zero surface.
+  const effectiveDays = days ?? 30;
+  const eurPerM2Year =
+    totalEur != null && surfaceM2 > 0 && effectiveDays > 0
+      ? Math.round(((totalEur / effectiveDays) * 365) / surfaceM2 * 100) / 100
+      : null;
+  const eurPerM2Label = eurPerM2Year != null ? fmtNum(eurPerM2Year, 1, '€/m²/an') : '—';
 
   // --- CO2e ---
   const co2Kg = totalKwh != null ? Math.round(totalKwh * CO2E_FACTOR_KG_PER_KWH) : null;
@@ -213,7 +223,7 @@ export default function ConsoKpiHeader({
       </div>
       <div
         className="flex items-center gap-2"
-        title={`Calcul : ${eurSource}. Basé sur les prix HP/HC du contrat ou estimés.`}
+        title={`Calcul : ${eurSource}. Basé sur les prix contrat ou estimés (élec + gaz).`}
       >
         <Euro size={14} className="text-gray-400 shrink-0" />
         <div className="flex flex-col">
@@ -229,6 +239,16 @@ export default function ConsoKpiHeader({
         <div className="flex flex-col">
           <span className="text-gray-400">Prix moyen</span>
           <span className="font-semibold text-gray-700 whitespace-nowrap">{loading && eurMwh == null ? <KpiShimmer /> : eurMwhLabel}</span>
+        </div>
+      </div>
+      <div
+        className="flex items-center gap-2"
+        title="Coût annualisé / surface totale des sites sélectionnés"
+      >
+        <Building2 size={14} className="text-gray-400 shrink-0" />
+        <div className="flex flex-col">
+          <span className="text-gray-400">EUR/m²/an</span>
+          <span className="font-semibold text-gray-700 whitespace-nowrap">{loading && eurPerM2Year == null ? <KpiShimmer /> : eurPerM2Label}</span>
         </div>
       </div>
       <div

--- a/frontend/src/components/ConsoKpiHeader.jsx
+++ b/frontend/src/components/ConsoKpiHeader.jsx
@@ -115,11 +115,12 @@ export default function ConsoKpiHeader({
   const eurSource = hphc?.total_cost_eur != null ? 'Estimé multi-énergie' : 'Non disponible';
 
   // --- EUR/MWh reel ---
-  // Use hphc.total_kwh (not the fallback totalKwh) so numerator (EUR from hphc)
-  // and denominator (kWh) always come from the same source.
+  // Use elec-only cost and kWh so numerator and denominator always come from
+  // the same energy source. total_cost_eur may include gas (#144).
+  const elecEur = hphc?.elec_cost_eur ?? totalEur;
   const hphcKwh = hphc?.total_kwh ?? null;
   const eurMwh =
-    totalEur != null && hphcKwh > 0 ? Math.round((totalEur / hphcKwh) * 1000 * 100) / 100 : null;
+    elecEur != null && hphcKwh > 0 ? Math.round((elecEur / hphcKwh) * 1000 * 100) / 100 : null;
   const eurMwhLabel = eurMwh != null ? fmtNum(eurMwh, 2, '€/MWh') : '—';
 
   // --- EUR/m²/an (#144) ---

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -255,7 +255,7 @@ export default function ConsumptionExplorerPage() {
     mergedAvailability,
     primarySiteId,
     primaryAvailability,
-    data: { availabilityBySite, tunnelBySite, hphcBySite, progressionBySite },
+    data: { availabilityBySite, tunnelBySite, hphcBySite, progressionBySite, gasBySite },
     loading,
     error: motorError,
   } = motor;
@@ -263,16 +263,19 @@ export default function ConsumptionExplorerPage() {
   // ── Multi-site KPI aggregation (issue #38) ────────────────────────────
   // Aggregate hphc, tunnel, and progression across all selected sites so
   // ConsoKpiHeader shows totals rather than only the primary site.
+  // #144: also aggregate gas cost for multi-energy total.
   const aggregatedHphc = useMemo(() => {
     const entries = siteIds.map((sid) => hphcBySite[sid]).filter(Boolean);
     if (!entries.length) return null;
-    if (entries.length === 1) return entries[0];
+    const elecCost = entries.reduce((s, h) => s + (h.total_cost_eur ?? 0), 0);
+    const gasCost = siteIds.reduce((s, sid) => s + (gasBySite[sid]?.total_cost_eur ?? 0), 0);
+    if (entries.length === 1 && gasCost === 0) return entries[0];
     return {
       ...entries[0],
       total_kwh: entries.reduce((s, h) => s + (h.total_kwh ?? 0), 0),
-      total_cost_eur: entries.reduce((s, h) => s + (h.total_cost_eur ?? 0), 0),
+      total_cost_eur: elecCost + gasCost,
     };
-  }, [siteIds, hphcBySite]);
+  }, [siteIds, hphcBySite, gasBySite]);
 
   const aggregatedTunnel = useMemo(() => {
     const entries = siteIds.map((sid) => tunnelBySite[sid]).filter(Boolean);
@@ -308,6 +311,15 @@ export default function ConsumptionExplorerPage() {
       ytd_actual_kwh: entries.reduce((s, p) => s + (p.ytd_actual_kwh ?? 0), 0),
     };
   }, [siteIds, progressionBySite]);
+
+  // #144: total surface for selected sites (EUR/m²/an KPI)
+  const surfaceM2Total = useMemo(() => {
+    const total = siteIds.reduce((s, sid) => {
+      const site = sites.find((st) => st.id === sid);
+      return s + (site?.surface_m2 ?? 0);
+    }, 0);
+    return total > 0 ? total : null;
+  }, [siteIds, sites]);
 
   // ── User-initiated period flag (issue #23) ────────────────────────────
   // Prevents auto-calibration from overwriting a period the user explicitly chose.
@@ -683,6 +695,7 @@ export default function ConsumptionExplorerPage() {
           days={days}
           startDate={startDate}
           endDate={endDate}
+          surfaceM2={surfaceM2Total}
           loading={loading}
         />
       )}

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -273,7 +273,9 @@ export default function ConsumptionExplorerPage() {
     const totalCost = elecCost + gasCost;
     if (!entries.length && !includeGas) return null;
     if (!entries.length && includeGas) {
-      // Gas-only filter: build a minimal object with gas cost
+      // No elec data loaded (or gas-only filter). Return gas cost if available,
+      // otherwise null — suppressing the KPI tile is correct here since there's
+      // no kWh denominator for derived metrics either.
       return totalCost > 0 ? { total_kwh: 0, total_cost_eur: totalCost } : null;
     }
     if (entries.length === 1 && !includeGas) return entries[0];

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -263,19 +263,26 @@ export default function ConsumptionExplorerPage() {
   // ── Multi-site KPI aggregation (issue #38) ────────────────────────────
   // Aggregate hphc, tunnel, and progression across all selected sites so
   // ConsoKpiHeader shows totals rather than only the primary site.
-  // #144: also aggregate gas cost for multi-energy total.
+  // #144: also aggregate gas cost for multi-energy total, respecting energy filter.
   const aggregatedHphc = useMemo(() => {
     const entries = siteIds.map((sid) => hphcBySite[sid]).filter(Boolean);
-    if (!entries.length) return null;
-    const elecCost = entries.reduce((s, h) => s + (h.total_cost_eur ?? 0), 0);
-    const gasCost = siteIds.reduce((s, sid) => s + (gasBySite[sid]?.total_cost_eur ?? 0), 0);
+    const includeElec = energyType !== 'gas';
+    const includeGas = energyType !== 'electricity';
+    const elecCost = includeElec ? entries.reduce((s, h) => s + (h.total_cost_eur ?? 0), 0) : 0;
+    const gasCost = includeGas ? siteIds.reduce((s, sid) => s + (gasBySite[sid]?.total_cost_eur ?? 0), 0) : 0;
+    const totalCost = elecCost + gasCost;
+    if (!entries.length && !includeGas) return null;
+    if (!entries.length && includeGas) {
+      // Gas-only filter: build a minimal object with gas cost
+      return totalCost > 0 ? { total_kwh: 0, total_cost_eur: totalCost } : null;
+    }
     if (entries.length === 1 && gasCost === 0) return entries[0];
     return {
       ...entries[0],
-      total_kwh: entries.reduce((s, h) => s + (h.total_kwh ?? 0), 0),
-      total_cost_eur: elecCost + gasCost,
+      total_kwh: includeElec ? entries.reduce((s, h) => s + (h.total_kwh ?? 0), 0) : 0,
+      total_cost_eur: totalCost,
     };
-  }, [siteIds, hphcBySite, gasBySite]);
+  }, [siteIds, hphcBySite, gasBySite, energyType]);
 
   const aggregatedTunnel = useMemo(() => {
     const entries = siteIds.map((sid) => tunnelBySite[sid]).filter(Boolean);

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -276,13 +276,14 @@ export default function ConsumptionExplorerPage() {
       // No elec data loaded (or gas-only filter). Return gas cost if available,
       // otherwise null — suppressing the KPI tile is correct here since there's
       // no kWh denominator for derived metrics either.
-      return totalCost > 0 ? { total_kwh: 0, total_cost_eur: totalCost } : null;
+      return totalCost > 0 ? { total_kwh: 0, total_cost_eur: totalCost, elec_cost_eur: 0 } : null;
     }
     if (entries.length === 1 && !includeGas) return entries[0];
     return {
       ...entries[0],
       total_kwh: includeElec ? entries.reduce((s, h) => s + (h.total_kwh ?? 0), 0) : 0,
       total_cost_eur: totalCost,
+      elec_cost_eur: elecCost,
     };
   }, [siteIds, hphcBySite, gasBySite, energyType]);
 

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -320,13 +320,11 @@ export default function ConsumptionExplorerPage() {
   }, [siteIds, progressionBySite]);
 
   // #144: total surface for selected sites (EUR/m²/an KPI)
+  const siteById = useMemo(() => Object.fromEntries(sites.map((s) => [s.id, s])), [sites]);
   const surfaceM2Total = useMemo(() => {
-    const total = siteIds.reduce((s, sid) => {
-      const site = sites.find((st) => st.id === sid);
-      return s + (site?.surface_m2 ?? 0);
-    }, 0);
+    const total = siteIds.reduce((s, sid) => s + (siteById[sid]?.surface_m2 ?? 0), 0);
     return total > 0 ? total : null;
-  }, [siteIds, sites]);
+  }, [siteIds, siteById]);
 
   // ── User-initiated period flag (issue #23) ────────────────────────────
   // Prevents auto-calibration from overwriting a period the user explicitly chose.

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -276,12 +276,12 @@ export default function ConsumptionExplorerPage() {
       // No elec data loaded (or gas-only filter). Return gas cost if available,
       // otherwise null — suppressing the KPI tile is correct here since there's
       // no kWh denominator for derived metrics either.
-      return totalCost > 0 ? { total_kwh: 0, total_cost_eur: totalCost, elec_cost_eur: 0 } : null;
+      return totalCost > 0 ? { total_kwh: null, total_cost_eur: totalCost, elec_cost_eur: 0 } : null;
     }
     if (entries.length === 1 && !includeGas) return entries[0];
     return {
       ...entries[0],
-      total_kwh: includeElec ? entries.reduce((s, h) => s + (h.total_kwh ?? 0), 0) : 0,
+      total_kwh: includeElec ? entries.reduce((s, h) => s + (h.total_kwh ?? 0), 0) : null,
       total_cost_eur: totalCost,
       elec_cost_eur: elecCost,
     };

--- a/frontend/src/pages/ConsumptionExplorerPage.jsx
+++ b/frontend/src/pages/ConsumptionExplorerPage.jsx
@@ -276,7 +276,7 @@ export default function ConsumptionExplorerPage() {
       // Gas-only filter: build a minimal object with gas cost
       return totalCost > 0 ? { total_kwh: 0, total_cost_eur: totalCost } : null;
     }
-    if (entries.length === 1 && gasCost === 0) return entries[0];
+    if (entries.length === 1 && !includeGas) return entries[0];
     return {
       ...entries[0],
       total_kwh: includeElec ? entries.reduce((s, h) => s + (h.total_kwh ?? 0), 0) : 0,


### PR DESCRIPTION
## Summary

- **Root cause**: EUR/m²/an was never computed — `Site.surface_m2` existed but was unused in cost metrics. Gas summary endpoint lacked `total_cost_eur`, preventing multi-energy cost aggregation.
- **Fix**: Gas summary endpoint now returns `total_cost_eur` (resolved via `get_reference_price` for gas). Frontend aggregates ELEC (HPHC) + GAZ costs across selected sites and computes annualized EUR/m²/an from site surface. New KPI tile displayed in ConsoKpiHeader.

## Files changed

| File | Change |
|------|--------|
| `backend/routes/consumption_diagnostic.py` | Gas summary endpoint: resolve gas price via `get_reference_price`, add `total_cost_eur` to response (both empty and data paths) |
| `frontend/src/components/ConsoKpiHeader.jsx` | Accept `surfaceM2` prop, compute EUR/m²/an (annualized cost / surface, guarded for null/zero), display new KPI tile with Building2 icon, update eurSource label and tooltip for multi-energy |
| `frontend/src/pages/ConsumptionExplorerPage.jsx` | Destructure `gasBySite` from motor; aggregate gas cost into `aggregatedHphc.total_cost_eur`; compute `surfaceM2Total` from selected sites; pass `surfaceM2` to ConsoKpiHeader |

## Blast-radius review

- Reviewed all consumers of gas summary response and ConsoKpiHeader
- Fixed 1 HIGH finding: tooltip text was inconsistent with new multi-energy label
- Test gap noted: gas mock in ConsumptionExplorerPage.test.js doesn't include `total_cost_eur` (not a regression — test doesn't exercise aggregation)

## Test plan

**Automated tests**
```bash
cd backend && ./venv/bin/pytest tests/test_consumption_v10.py -x -v -k "gas"
cd frontend && npx vitest run src/pages/__tests__/ConsumptionExplorerPage.test.js
```

**Steps to reproduce the bug**
1. Open Consumption Explorer for a site with surface_m2 set
2. Observe: no EUR/m²/an KPI, "Coût total" only includes electricity

**Steps to verify the fix**
1. Open Consumption Explorer for a site with surface_m2 > 0
2. Verify new "EUR/m²/an" KPI tile appears between "Prix moyen" and CO₂e
3. Verify "Coût total" now includes gas cost when gas data exists
4. Verify EUR/m²/an shows "—" when surface is missing or zero
5. In portfolio mode with multiple sites, verify costs aggregate correctly

Closes #144