### PR TITLE
feat(energy): intensité énergétique kWh/m²/an (#146)

### DIFF
--- a/backend/routes/energy.py
+++ b/backend/routes/energy.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from database import get_db
 from middleware.auth import get_optional_auth, AuthContext
 from services.iam_scope import check_site_access
+from routes.patrimoine._helpers import _check_portfolio_belongs_to_org
 from models import (
     Site,
     Meter,
@@ -727,4 +728,6 @@ def get_energy_intensity(
         check_site_access(auth, site_id)
         return get_site_intensity(db, site_id, year)
 
+    if auth is not None:
+        _check_portfolio_belongs_to_org(db, portfolio_id, auth.org_id)
     return get_portfolio_intensity(db, portfolio_id, year)

--- a/backend/routes/energy.py
+++ b/backend/routes/energy.py
@@ -693,3 +693,38 @@ def _parse_timestamp(ts_str: str) -> datetime:
             continue
 
     return None
+
+
+# --- Energy Intensity endpoints (#146) ---
+
+
+@router.get("/intensity")
+def get_energy_intensity(
+    site_id: Optional[int] = None,
+    portfolio_id: Optional[int] = None,
+    year: Optional[int] = None,
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """
+    Intensité énergétique (kWh/m²/an) — finale et primaire.
+
+    - site_id : intensité d'un site unique
+    - portfolio_id : intensité agrégée portefeuille (moyenne pondérée par surface)
+    - year : année de référence (défaut = année en cours, calcul sur année N-1)
+
+    Retourne kWh_m2_final, kWh_m2_primary, détail EP par vecteur, couverture.
+    """
+    from services.energy_intensity_service import get_site_intensity, get_portfolio_intensity
+
+    if not site_id and not portfolio_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Paramètre site_id ou portfolio_id requis",
+        )
+
+    if site_id:
+        check_site_access(auth, site_id)
+        return get_site_intensity(db, site_id, year)
+
+    return get_portfolio_intensity(db, portfolio_id, year)

--- a/backend/services/energy_intensity_service.py
+++ b/backend/services/energy_intensity_service.py
@@ -96,8 +96,8 @@ def get_site_intensity(
         kwh = summary.get("value_kwh", 0) or 0
         if kwh <= 0:
             continue
-        # Skip estimated fallback — it uses total site kWh, not per-vector
-        if summary.get("source_used") == "estimated":
+        # Skip billed/estimated — they use total site kWh, not per-vector
+        if summary.get("source_used") in ("billed", "estimated"):
             continue
 
         coeff = EP_COEFFICIENTS.get(vector, 1.0)

--- a/backend/services/energy_intensity_service.py
+++ b/backend/services/energy_intensity_service.py
@@ -1,0 +1,271 @@
+"""
+PROMEOS — Energy Intensity Service (kWh/m²/an)
+Calcul d'intensité énergétique finale et primaire par site et portefeuille.
+
+Intensité finale  = kWh_final / surface_m2
+Intensité primaire = kWh_final × coeff_EP / surface_m2
+
+Coefficients EP (énergie primaire) depuis janvier 2026 — RE2020 :
+  - Électricité : 1.9 (anciennement 2.3)
+  - Gaz : 1.0
+  - Chaleur réseau : 1.0 (valeur par défaut — dépend du mix local)
+"""
+
+import logging
+from datetime import date, timedelta
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from models import Site, Portefeuille
+from models.energy_models import EnergyVector
+from services.consumption_unified_service import get_consumption_summary
+
+logger = logging.getLogger("promeos.energy_intensity")
+
+# ── EP coefficients (énergie primaire) ──────────────────────────────
+# Source: RE2020 — applicable depuis le 1er janvier 2026
+EP_COEFFICIENTS = {
+    EnergyVector.ELECTRICITY: 1.9,
+    EnergyVector.GAS: 1.0,
+    EnergyVector.HEAT: 1.0,
+    EnergyVector.WATER: 0.0,  # pas de conversion EP pour l'eau
+    EnergyVector.OTHER: 1.0,
+}
+
+
+def get_site_intensity(
+    db: Session,
+    site_id: int,
+    year: Optional[int] = None,
+) -> dict:
+    """
+    Intensité énergétique d'un site (finale + primaire).
+
+    Returns:
+        {
+            site_id, site_nom, surface_m2, year,
+            kWh_final, kWh_m2_final, kWh_m2_primary,
+            ep_detail: { electricity: {kwh, coeff_ep, kwh_ep}, gas: {...}, ... },
+            data_source, confidence,
+            warnings: [str]
+        }
+    """
+    site = db.query(Site).filter(Site.id == site_id, Site.actif == True).first()
+    if not site:
+        return {"error": "site_not_found", "site_id": site_id}
+
+    warnings = []
+    surface = site.surface_m2
+
+    # Surface validation
+    if not surface or surface <= 0:
+        warnings.append("surface_m2 absente ou nulle — intensité non calculable")
+        return {
+            "site_id": site_id,
+            "site_nom": site.nom,
+            "surface_m2": None,
+            "year": year or date.today().year,
+            "kWh_final": None,
+            "kWh_m2_final": None,
+            "kWh_m2_primary": None,
+            "ep_detail": {},
+            "data_source": None,
+            "confidence": "none",
+            "warnings": warnings,
+        }
+
+    # Period
+    if year is None:
+        year = date.today().year
+    period_start = date(year - 1, 1, 1)
+    period_end = date(year - 1, 12, 31)
+
+    # Consumption per energy vector
+    ep_detail = {}
+    total_kwh_final = 0.0
+    total_kwh_ep = 0.0
+    best_source = "none"
+    best_confidence = "none"
+    confidence_order = {"high": 3, "medium": 2, "low": 1, "none": 0}
+
+    for vector in [EnergyVector.ELECTRICITY, EnergyVector.GAS, EnergyVector.HEAT]:
+        summary = get_consumption_summary(
+            db, site_id, period_start, period_end, energy_vector=vector
+        )
+        kwh = summary.get("value_kwh", 0) or 0
+        if kwh <= 0:
+            continue
+        # Skip estimated fallback — it uses total site kWh, not per-vector
+        if summary.get("source_used") == "estimated":
+            continue
+
+        coeff = EP_COEFFICIENTS.get(vector, 1.0)
+        kwh_ep = kwh * coeff
+
+        ep_detail[vector.value] = {
+            "kwh": round(kwh, 2),
+            "coeff_ep": coeff,
+            "kwh_ep": round(kwh_ep, 2),
+        }
+        total_kwh_final += kwh
+        total_kwh_ep += kwh_ep
+
+        # Track best confidence across vectors
+        src = summary.get("source_used", "none")
+        conf = summary.get("confidence", "none")
+        if confidence_order.get(conf, 0) > confidence_order.get(best_confidence, 0):
+            best_confidence = conf
+            best_source = src
+
+    # If no per-vector data, fallback to unified (all vectors combined)
+    if total_kwh_final == 0:
+        summary = get_consumption_summary(db, site_id, period_start, period_end)
+        kwh = summary.get("value_kwh", 0) or 0
+        if kwh > 0:
+            # Assume electricity if vector breakdown unavailable
+            coeff = EP_COEFFICIENTS[EnergyVector.ELECTRICITY]
+            ep_detail["electricity"] = {
+                "kwh": round(kwh, 2),
+                "coeff_ep": coeff,
+                "kwh_ep": round(kwh * coeff, 2),
+            }
+            total_kwh_final = kwh
+            total_kwh_ep = kwh * coeff
+            best_source = summary.get("source_used", "estimated")
+            best_confidence = summary.get("confidence", "low")
+            warnings.append(
+                "ventilation par vecteur indisponible — "
+                "coefficient EP électricité appliqué par défaut"
+            )
+
+    # Compute intensities
+    kwh_m2_final = round(total_kwh_final / surface, 2) if total_kwh_final > 0 else 0.0
+    kwh_m2_primary = round(total_kwh_ep / surface, 2) if total_kwh_ep > 0 else 0.0
+
+    if total_kwh_final == 0:
+        warnings.append("aucune donnée de consommation pour la période")
+        best_confidence = "none"
+
+    return {
+        "site_id": site_id,
+        "site_nom": site.nom,
+        "surface_m2": surface,
+        "year": year,
+        "kWh_final": round(total_kwh_final, 2),
+        "kWh_m2_final": kwh_m2_final,
+        "kWh_m2_primary": kwh_m2_primary,
+        "ep_detail": ep_detail,
+        "data_source": best_source,
+        "confidence": best_confidence,
+        "warnings": warnings,
+    }
+
+
+def get_portfolio_intensity(
+    db: Session,
+    portfolio_id: int,
+    year: Optional[int] = None,
+) -> dict:
+    """
+    Intensité énergétique agrégée d'un portefeuille.
+
+    Moyenne pondérée par surface : Σ(kWh_sites) / Σ(surface_sites)
+    pour les sites ayant une surface renseignée.
+
+    Returns:
+        {
+            portfolio_id, portfolio_nom, year,
+            kWh_m2_final, kWh_m2_primary,
+            total_kwh_final, total_kwh_primary, total_surface_m2,
+            coverage: { sites_total, sites_with_surface, sites_with_data, ratio },
+            sites: [ site_intensity_result, ... ],
+            warnings: [str]
+        }
+    """
+    portfolio = db.query(Portefeuille).filter(Portefeuille.id == portfolio_id).first()
+    if not portfolio:
+        return {"error": "portfolio_not_found", "portfolio_id": portfolio_id}
+
+    sites = (
+        db.query(Site)
+        .filter(Site.portefeuille_id == portfolio_id, Site.actif == True)
+        .all()
+    )
+
+    if not sites:
+        return {
+            "portfolio_id": portfolio_id,
+            "portfolio_nom": portfolio.nom,
+            "year": year or date.today().year,
+            "kWh_m2_final": None,
+            "kWh_m2_primary": None,
+            "total_kwh_final": 0,
+            "total_kwh_primary": 0,
+            "total_surface_m2": 0,
+            "coverage": {"sites_total": 0, "sites_with_surface": 0, "sites_with_data": 0, "ratio": 0},
+            "sites": [],
+            "warnings": ["aucun site actif dans ce portefeuille"],
+        }
+
+    warnings = []
+    site_results = []
+    total_kwh_final = 0.0
+    total_kwh_primary = 0.0
+    total_surface = 0.0
+    sites_with_surface = 0
+    sites_with_data = 0
+
+    for site in sites:
+        result = get_site_intensity(db, site.id, year)
+        site_results.append(result)
+
+        surface = result.get("surface_m2")
+        kwh_final = result.get("kWh_final")
+
+        if surface and surface > 0:
+            sites_with_surface += 1
+            total_surface += surface
+
+            if kwh_final and kwh_final > 0:
+                sites_with_data += 1
+                total_kwh_final += kwh_final
+                # Sum EP kWh from ep_detail
+                for vec_data in result.get("ep_detail", {}).values():
+                    total_kwh_primary += vec_data.get("kwh_ep", 0)
+
+    # Weighted average intensity
+    if total_surface > 0 and total_kwh_final > 0:
+        kwh_m2_final = round(total_kwh_final / total_surface, 2)
+        kwh_m2_primary = round(total_kwh_primary / total_surface, 2)
+    else:
+        kwh_m2_final = None
+        kwh_m2_primary = None
+
+    sites_total = len(sites)
+    coverage_ratio = round(sites_with_surface / sites_total, 2) if sites_total > 0 else 0
+
+    if sites_with_surface < sites_total:
+        n_missing = sites_total - sites_with_surface
+        warnings.append(
+            f"{n_missing} site(s) exclu(s) du calcul — surface manquante"
+        )
+
+    return {
+        "portfolio_id": portfolio_id,
+        "portfolio_nom": portfolio.nom,
+        "year": year or date.today().year,
+        "kWh_m2_final": kwh_m2_final,
+        "kWh_m2_primary": kwh_m2_primary,
+        "total_kwh_final": round(total_kwh_final, 2),
+        "total_kwh_primary": round(total_kwh_primary, 2),
+        "total_surface_m2": round(total_surface, 2),
+        "coverage": {
+            "sites_total": sites_total,
+            "sites_with_surface": sites_with_surface,
+            "sites_with_data": sites_with_data,
+            "ratio": coverage_ratio,
+        },
+        "sites": site_results,
+        "warnings": warnings,
+    }

--- a/backend/services/energy_intensity_service.py
+++ b/backend/services/energy_intensity_service.py
@@ -225,10 +225,10 @@ def get_portfolio_intensity(
 
         if surface and surface > 0:
             sites_with_surface += 1
-            total_surface += surface
 
             if kwh_final and kwh_final > 0:
                 sites_with_data += 1
+                total_surface += surface
                 total_kwh_final += kwh_final
                 # Sum EP kWh from ep_detail
                 for vec_data in result.get("ep_detail", {}).values():

--- a/backend/tests/test_energy_intensity.py
+++ b/backend/tests/test_energy_intensity.py
@@ -1,0 +1,317 @@
+"""
+Tests — #146: Energy intensity service (kWh/m²/an).
+Covers: get_site_intensity, get_portfolio_intensity, EP coefficients, API endpoint.
+"""
+
+import pytest
+from datetime import date, datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+pytestmark = pytest.mark.fast
+
+from models.base import Base
+from models import (
+    Organisation,
+    EntiteJuridique,
+    Portefeuille,
+    Site,
+)
+from models.enums import TypeSite
+from models.energy_models import Meter, MeterReading, EnergyVector, FrequencyType
+from services.energy_intensity_service import (
+    get_site_intensity,
+    get_portfolio_intensity,
+    EP_COEFFICIENTS,
+)
+
+
+@pytest.fixture()
+def db():
+    """In-memory SQLite with seed data for intensity tests."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    org = Organisation(id=1, nom="Test Org", siren="123456789", type_client="tertiaire")
+    session.add(org)
+    session.flush()
+
+    ej = EntiteJuridique(id=1, nom="Test EJ", siren="123456789", organisation_id=1)
+    session.add(ej)
+    session.flush()
+
+    ptf = Portefeuille(id=1, nom="Test Portfolio", entite_juridique_id=1)
+    session.add(ptf)
+    session.flush()
+
+    # Site with surface + consumption
+    site1 = Site(
+        id=1,
+        nom="Bureau Paris",
+        type=TypeSite.BUREAU,
+        actif=True,
+        portefeuille_id=1,
+        surface_m2=500.0,
+        annual_kwh_total=100000,
+    )
+    # Site with surface but no consumption data
+    site2 = Site(
+        id=2,
+        nom="Bureau Lyon",
+        type=TypeSite.BUREAU,
+        actif=True,
+        portefeuille_id=1,
+        surface_m2=300.0,
+        annual_kwh_total=60000,
+    )
+    # Site without surface
+    site3 = Site(
+        id=3,
+        nom="Site No Surface",
+        type=TypeSite.BUREAU,
+        actif=True,
+        portefeuille_id=1,
+        surface_m2=None,
+        annual_kwh_total=50000,
+    )
+    # Site with surface = 0
+    site4 = Site(
+        id=4,
+        nom="Site Zero Surface",
+        type=TypeSite.BUREAU,
+        actif=True,
+        portefeuille_id=1,
+        surface_m2=0.0,
+        annual_kwh_total=40000,
+    )
+    session.add_all([site1, site2, site3, site4])
+    session.flush()
+
+    # Electricity meter for site1
+    meter_elec = Meter(
+        id=1,
+        meter_id="PRM-ELEC-001",
+        name="Compteur elec",
+        energy_vector=EnergyVector.ELECTRICITY,
+        site_id=1,
+        is_active=True,
+    )
+    # Gas meter for site1
+    meter_gas = Meter(
+        id=2,
+        meter_id="PCE-GAZ-001",
+        name="Compteur gaz",
+        energy_vector=EnergyVector.GAS,
+        site_id=1,
+        is_active=True,
+    )
+    session.add_all([meter_elec, meter_gas])
+    session.flush()
+
+    # Electricity readings: 365 days of daily readings, 100 kWh/day = 36500 kWh/year
+    for day_offset in range(365):
+        dt = datetime(2025, 1, 1) + __import__("datetime").timedelta(days=day_offset)
+        session.add(
+            MeterReading(
+                meter_id=1,
+                timestamp=dt,
+                frequency=FrequencyType.DAILY,
+                value_kwh=100.0,
+                is_estimated=False,
+            )
+        )
+
+    # Gas readings: 365 days of daily readings, 50 kWh/day = 18250 kWh/year
+    for day_offset in range(365):
+        dt = datetime(2025, 1, 1) + __import__("datetime").timedelta(days=day_offset)
+        session.add(
+            MeterReading(
+                meter_id=2,
+                timestamp=dt,
+                frequency=FrequencyType.DAILY,
+                value_kwh=50.0,
+                is_estimated=False,
+            )
+        )
+
+    session.commit()
+    yield session
+    session.close()
+
+
+# ── EP Coefficients ──
+
+
+class TestEPCoefficients:
+    def test_electricity_coeff_is_1_9(self):
+        assert EP_COEFFICIENTS[EnergyVector.ELECTRICITY] == 1.9
+
+    def test_gas_coeff_is_1_0(self):
+        assert EP_COEFFICIENTS[EnergyVector.GAS] == 1.0
+
+    def test_heat_coeff_is_1_0(self):
+        assert EP_COEFFICIENTS[EnergyVector.HEAT] == 1.0
+
+    def test_water_coeff_is_0(self):
+        assert EP_COEFFICIENTS[EnergyVector.WATER] == 0.0
+
+
+# ── Site Intensity ──
+
+
+class TestSiteIntensity:
+    def test_site_with_metered_data(self, db):
+        """Site 1 has elec (36500 kWh) + gas (18250 kWh), surface=500 m2."""
+        result = get_site_intensity(db, site_id=1, year=2026)
+        # year=2026 means period 2025-01-01 to 2025-12-31
+
+        assert result["site_id"] == 1
+        assert result["site_nom"] == "Bureau Paris"
+        assert result["surface_m2"] == 500.0
+        assert result["year"] == 2026
+
+        # Final energy
+        assert result["kWh_final"] > 0
+        # With 36500 elec + 18250 gas = 54750 kWh / 500 m2 = 109.5
+        expected_final = 54750.0 / 500.0
+        assert abs(result["kWh_m2_final"] - expected_final) < 1.0
+
+        # Primary energy: 36500*1.9 + 18250*1.0 = 69350+18250 = 87600 / 500 = 175.2
+        expected_primary = (36500.0 * 1.9 + 18250.0 * 1.0) / 500.0
+        assert abs(result["kWh_m2_primary"] - expected_primary) < 1.0
+
+        # EP detail
+        assert "electricity" in result["ep_detail"]
+        assert "gas" in result["ep_detail"]
+        assert result["ep_detail"]["electricity"]["coeff_ep"] == 1.9
+        assert result["ep_detail"]["gas"]["coeff_ep"] == 1.0
+
+        assert result["confidence"] != "none"
+        assert result["warnings"] == []
+
+    def test_site_no_surface(self, db):
+        """Site 3 has surface=None — should return warning."""
+        result = get_site_intensity(db, site_id=3, year=2026)
+
+        assert result["kWh_m2_final"] is None
+        assert result["kWh_m2_primary"] is None
+        assert result["surface_m2"] is None
+        assert result["confidence"] == "none"
+        assert any("surface_m2" in w for w in result["warnings"])
+
+    def test_site_zero_surface(self, db):
+        """Site 4 has surface=0 — should return warning."""
+        result = get_site_intensity(db, site_id=4, year=2026)
+
+        assert result["kWh_m2_final"] is None
+        assert result["kWh_m2_primary"] is None
+        assert result["confidence"] == "none"
+        assert any("surface_m2" in w for w in result["warnings"])
+
+    def test_site_not_found(self, db):
+        result = get_site_intensity(db, site_id=999, year=2026)
+        assert result["error"] == "site_not_found"
+
+    def test_site_no_consumption_data(self, db):
+        """Site 2 has surface but no meter readings — fallback to estimated."""
+        result = get_site_intensity(db, site_id=2, year=2026)
+
+        assert result["surface_m2"] == 300.0
+        # Should still compute using estimated fallback from annual_kwh_total
+        # Exact value depends on the unified service behavior
+        assert "warnings" in result
+
+    def test_primary_always_gte_final(self, db):
+        """kWh_m2_primary >= kWh_m2_final (EP coefficients >= 1.0 for energy vectors)."""
+        result = get_site_intensity(db, site_id=1, year=2026)
+        if result["kWh_m2_final"] and result["kWh_m2_primary"]:
+            assert result["kWh_m2_primary"] >= result["kWh_m2_final"]
+
+    def test_default_year_is_current(self, db):
+        """When year is None, defaults to current year."""
+        result = get_site_intensity(db, site_id=1)
+        assert result["year"] == date.today().year
+
+
+# ── Portfolio Intensity ──
+
+
+class TestPortfolioIntensity:
+    def test_portfolio_aggregation(self, db):
+        """Portfolio 1 has 4 sites, 2 with valid surface+data."""
+        result = get_portfolio_intensity(db, portfolio_id=1, year=2026)
+
+        assert result["portfolio_id"] == 1
+        assert result["portfolio_nom"] == "Test Portfolio"
+        assert result["year"] == 2026
+
+        # Coverage
+        assert result["coverage"]["sites_total"] == 4
+        assert result["coverage"]["sites_with_surface"] >= 2  # sites 1 and 2
+
+        # Weighted average should be computed
+        assert result["sites"] is not None
+        assert len(result["sites"]) == 4
+
+    def test_portfolio_coverage_ratio(self, db):
+        result = get_portfolio_intensity(db, portfolio_id=1, year=2026)
+        coverage = result["coverage"]
+        expected_ratio = coverage["sites_with_surface"] / coverage["sites_total"]
+        assert abs(coverage["ratio"] - round(expected_ratio, 2)) < 0.01
+
+    def test_portfolio_not_found(self, db):
+        result = get_portfolio_intensity(db, portfolio_id=999, year=2026)
+        assert result["error"] == "portfolio_not_found"
+
+    def test_portfolio_warns_missing_surface(self, db):
+        """Sites 3 and 4 have no usable surface — should generate a warning."""
+        result = get_portfolio_intensity(db, portfolio_id=1, year=2026)
+        assert any("surface manquante" in w for w in result["warnings"])
+
+    def test_portfolio_weighted_average_not_simple_mean(self, db):
+        """Verify it's Σ(kWh)/Σ(surface), not mean of per-site kWh/m²."""
+        result = get_portfolio_intensity(db, portfolio_id=1, year=2026)
+        if result["kWh_m2_final"] is not None:
+            assert result["total_kwh_final"] > 0
+            assert result["total_surface_m2"] > 0
+            expected = round(result["total_kwh_final"] / result["total_surface_m2"], 2)
+            assert result["kWh_m2_final"] == expected
+
+
+# ── API endpoint ──
+
+
+class TestIntensityEndpoint:
+    """API tests use the demo DB (matches codebase convention)."""
+
+    @pytest.fixture()
+    def client(self):
+        from fastapi.testclient import TestClient
+        from main import app
+
+        return TestClient(app)
+
+    def test_endpoint_requires_param(self, client):
+        resp = client.get("/api/energy/intensity")
+        assert resp.status_code == 400
+
+    def test_endpoint_site(self, client):
+        """Hit a demo site — just verify shape, not exact values."""
+        resp = client.get("/api/energy/intensity?site_id=1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "kWh_m2_final" in data or "error" in data
+
+    def test_endpoint_portfolio(self, client):
+        resp = client.get("/api/energy/intensity?portfolio_id=1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "coverage" in data or "error" in data
+
+    def test_endpoint_site_not_found(self, client):
+        resp = client.get("/api/energy/intensity?site_id=999999")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("error") == "site_not_found"


### PR DESCRIPTION
## Summary

- **Feature**: Dedicated energy intensity service computing final and primary energy intensity (kWh/m²/an)
- **EP coefficients**: RE2020 — electricity 1.9, gas 1.0, heat 1.0
- **Endpoints**: `GET /api/energy/intensity?site_id=X` and `GET /api/energy/intensity?portfolio_id=X`
- **Additive only** — existing cockpit calculations untouched, ready for future migration

## Files changed

| File | Change |
|------|--------|
| `backend/services/energy_intensity_service.py` | New service: `get_site_intensity()` and `get_portfolio_intensity()` with per-vector EP breakdown, weighted portfolio aggregation, coverage ratio |
| `backend/routes/energy.py` | New endpoint `GET /api/energy/intensity` with site_id/portfolio_id/year params |
| `backend/tests/test_energy_intensity.py` | 20 tests: EP coefficients, site intensity, surface=0/NULL, portfolio aggregation, weighted average, coverage, API shape |

## Design decisions

- Per-vector EP calculation (electricity × 1.9, gas × 1.0) with fallback to unified consumption if no vector breakdown available
- Portfolio intensity = `Σ(kWh) / Σ(surface)` (weighted average, not simple mean)
- Sites with missing/zero surface excluded from calculation with explicit warning
- Estimated fallback from `annual_kwh_total` skipped during per-vector iteration (avoids double-counting total site consumption across vectors)

## Test plan

**Automated tests**
```bash
cd promeos-poc && ./backend/venv/bin/pytest backend/tests/test_energy_intensity.py -v
```

**Steps to verify**
1. `GET /api/energy/intensity?site_id=1` — returns `kWh_m2_final`, `kWh_m2_primary`, `ep_detail`
2. `GET /api/energy/intensity?portfolio_id=1` — returns weighted average + `coverage.ratio`
3. `GET /api/energy/intensity` (no params) — returns 400
4. Site with `surface_m2=NULL` — returns warning, `kWh_m2_final=null`

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)