### PR TITLE
fix(energy): raise 404 for not-found in intensity endpoints (#185)

### DIFF
--- a/backend/services/energy_intensity_service.py
+++ b/backend/services/energy_intensity_service.py
@@ -15,6 +15,7 @@ import logging
 from datetime import date, timedelta
 from typing import Optional
 
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from models import Site, Portefeuille
@@ -53,7 +54,7 @@ def get_site_intensity(
     """
     site = db.query(Site).filter(Site.id == site_id, Site.actif == True).first()
     if not site:
-        return {"error": "site_not_found", "site_id": site_id}
+        raise HTTPException(status_code=404, detail=f"Site {site_id} not found")
 
     warnings = []
     surface = site.surface_m2
@@ -185,7 +186,7 @@ def get_portfolio_intensity(
     """
     portfolio = db.query(Portefeuille).filter(Portefeuille.id == portfolio_id).first()
     if not portfolio:
-        return {"error": "portfolio_not_found", "portfolio_id": portfolio_id}
+        raise HTTPException(status_code=404, detail=f"Portfolio {portfolio_id} not found")
 
     sites = (
         db.query(Site)

--- a/backend/tests/test_energy_intensity.py
+++ b/backend/tests/test_energy_intensity.py
@@ -5,6 +5,7 @@ Covers: get_site_intensity, get_portfolio_intensity, EP coefficients, API endpoi
 
 import pytest
 from datetime import date, datetime
+from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -211,8 +212,9 @@ class TestSiteIntensity:
         assert any("surface_m2" in w for w in result["warnings"])
 
     def test_site_not_found(self, db):
-        result = get_site_intensity(db, site_id=999, year=2026)
-        assert result["error"] == "site_not_found"
+        with pytest.raises(HTTPException) as exc_info:
+            get_site_intensity(db, site_id=999, year=2026)
+        assert exc_info.value.status_code == 404
 
     def test_site_no_consumption_data(self, db):
         """Site 2 has surface but no meter readings — fallback to estimated."""
@@ -262,8 +264,9 @@ class TestPortfolioIntensity:
         assert abs(coverage["ratio"] - round(expected_ratio, 2)) < 0.01
 
     def test_portfolio_not_found(self, db):
-        result = get_portfolio_intensity(db, portfolio_id=999, year=2026)
-        assert result["error"] == "portfolio_not_found"
+        with pytest.raises(HTTPException) as exc_info:
+            get_portfolio_intensity(db, portfolio_id=999, year=2026)
+        assert exc_info.value.status_code == 404
 
     def test_portfolio_warns_missing_surface(self, db):
         """Sites 3 and 4 have no usable surface — should generate a warning."""
@@ -312,6 +315,4 @@ class TestIntensityEndpoint:
 
     def test_endpoint_site_not_found(self, client):
         resp = client.get("/api/energy/intensity?site_id=999999")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data.get("error") == "site_not_found"
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- **Root cause**: `get_site_intensity` and `get_portfolio_intensity` returned plain error dicts `{"error": "site_not_found"}` with HTTP 200 instead of raising `HTTPException(404)`
- **Fix**: Replace error dict returns with `raise HTTPException(status_code=404)` matching codebase convention; update tests to assert 404

## Analysis

### Root Cause Investigation

**Issue hypothesis**: Service returns 200 with error dict for not-found entities
**Actual root cause**: Confirmed — lines 56 and 188 of `energy_intensity_service.py` return dicts instead of raising
**Evidence**: `backend/services/energy_intensity_service.py:56`, `backend/services/energy_intensity_service.py:188`
**Match**: YES

### Approach Selection

No meaningful alternatives — single clear fix. Other services (`consumption_context_service.py`, `routes/energy.py`) already use `HTTPException(404)`.

### Complexity Assessment

**Score**: 0/5
**Model**: Sonnet

### Pre-Mortem Analysis

No significant risks identified. The internal call from `get_portfolio_intensity` → `get_site_intensity` (line 221) iterates active DB sites, so the not-found path is unreachable there.

### Blast-Radius Review

Only callers: the route (FastAPI handles HTTPException automatically), tests (updated), and internal portfolio→site call (unreachable path). All SAFE.

### Code Review

No issues found.

## Files Changed

| File | Change |
|------|--------|
| `backend/services/energy_intensity_service.py` | Raise `HTTPException(404)` instead of returning error dicts for site/portfolio not found |
| `backend/tests/test_energy_intensity.py` | Update 3 tests to assert 404 instead of error dict / 200 |

## Test Plan

**Automated tests**
```
pytest backend/tests/test_energy_intensity.py -v → 20 passed
```

**Steps to reproduce the bug**
1. `GET /api/energy/intensity?site_id=999999` → returns 200 with `{"error": "site_not_found"}`

**Steps to verify the fix**
1. `GET /api/energy/intensity?site_id=999999` → returns 404

Closes #185

---
_Auto-generated by `/fix-issue-auto` — all analysis embedded for PR review._