### PR TITLE
feat(contrats-v2): ContratCadre model + billing resolve_pricing() cascade

### DIFF
--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -98,6 +98,10 @@ def run_migrations(engine):
     _add_evidence_coverage_pct_column(engine)
     # Sprint F — ConnectorToken (OAuth2 tokens for Enedis/GRDF)
     _create_connector_tokens_table(engine)
+    # Phase 1 V2 — ContratCadre table + NUMERIC columns on contract_annexes
+    _migrate_phase1_contrats_cadre(engine)
+    # Phase 5 V2 — energy_invoices.annexe_site_id for cadre-aware shadow billing
+    _migrate_phase5_invoice_annexe_site(engine)
 
 
 def _add_soft_delete_columns(engine):
@@ -2119,3 +2123,60 @@ def _create_connector_tokens_table(engine):
         )
         conn.execute(text("CREATE INDEX IF NOT EXISTS ix_connector_tokens_prm ON connector_tokens(prm)"))
     logger.info("migration: created connector_tokens table (Sprint F)")
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — ContratCadre entity-level model
+# ---------------------------------------------------------------------------
+
+
+def _migrate_phase1_contrats_cadre(engine):
+    """Run the Phase 1 migration script (idempotent). Wire for startup auto-apply."""
+    import sqlite3
+    from pathlib import Path
+    from urllib.parse import urlparse
+
+    # Extract the SQLite path from the engine URL
+    url = str(engine.url)
+    if not url.startswith("sqlite"):
+        logger.warning("migration phase1: only SQLite is supported, skipping")
+        return
+    db_path = url.split("///", 1)[-1] if "///" in url else None
+    if not db_path or db_path == ":memory:":
+        return
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return
+
+    try:
+        from migrations.add_contrats_cadre_phase1 import migrate as phase1_migrate
+        phase1_migrate(str(db_path))
+    except Exception as e:
+        logger.warning("migration phase1: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Invoice annexe_site_id column
+# ---------------------------------------------------------------------------
+
+
+def _migrate_phase5_invoice_annexe_site(engine):
+    """Run the Phase 5 migration script (idempotent). Wire for startup auto-apply."""
+    from pathlib import Path
+
+    url = str(engine.url)
+    if not url.startswith("sqlite"):
+        logger.warning("migration phase5: only SQLite is supported, skipping")
+        return
+    db_path = url.split("///", 1)[-1] if "///" in url else None
+    if not db_path or db_path == ":memory:":
+        return
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return
+
+    try:
+        from migrations.add_invoice_annexe_site_phase5 import migrate as phase5_migrate
+        phase5_migrate(str(db_path))
+    except Exception as e:
+        logger.warning("migration phase5: %s", e)

--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -2150,6 +2150,7 @@ def _migrate_phase1_contrats_cadre(engine):
 
     try:
         from migrations.add_contrats_cadre_phase1 import migrate as phase1_migrate
+
         phase1_migrate(str(db_path))
     except Exception as e:
         logger.warning("migration phase1: %s", e)
@@ -2177,6 +2178,7 @@ def _migrate_phase5_invoice_annexe_site(engine):
 
     try:
         from migrations.add_invoice_annexe_site_phase5 import migrate as phase5_migrate
+
         phase5_migrate(str(db_path))
     except Exception as e:
         logger.warning("migration phase5: %s", e)

--- a/backend/migrations/add_contrats_cadre_phase1.py
+++ b/backend/migrations/add_contrats_cadre_phase1.py
@@ -1,0 +1,133 @@
+"""
+Migration: Contrats V2 Phase 1 — ContratCadre + AnnexeSite enrichi.
+
+New table: contrats_cadre (entity-level contract model).
+New columns on contract_annexes: cadre_id, prm, pce, prix overrides, volume_engage_kwh.
+
+Safe to re-run: uses IF NOT EXISTS / checks column existence.
+Backward-compatible: does NOT alter existing FKs on energy_contracts or energy_invoices.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent.parent / "data" / "promeos.db"
+
+
+def table_exists(cursor, table: str) -> bool:
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,))
+    return cursor.fetchone() is not None
+
+
+def column_exists(cursor, table: str, column: str) -> bool:
+    cursor.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def add_column_if_missing(cursor, table: str, column: str, col_type: str, default=None):
+    if column_exists(cursor, table, column):
+        return False
+    stmt = f"ALTER TABLE {table} ADD COLUMN {column} {col_type}"
+    if default is not None:
+        stmt += f" DEFAULT {default}"
+    cursor.execute(stmt)
+    return True
+
+
+CREATE_CONTRATS_CADRE = """
+CREATE TABLE IF NOT EXISTS contrats_cadre (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    org_id INTEGER NOT NULL REFERENCES organisations(id),
+    entite_juridique_id INTEGER REFERENCES entites_juridiques(id),
+    reference VARCHAR(100) NOT NULL,
+    reference_fournisseur VARCHAR(100),
+    fournisseur VARCHAR(200) NOT NULL,
+    energie VARCHAR(10) NOT NULL,
+    date_signature DATE,
+    date_debut DATE NOT NULL,
+    date_fin DATE NOT NULL,
+    date_preavis DATE,
+    notice_period_months INTEGER,
+    auto_renew BOOLEAN DEFAULT 0,
+    type_prix VARCHAR(30) NOT NULL,
+    prix_hp_eur_kwh REAL,
+    prix_hc_eur_kwh REAL,
+    prix_base_eur_kwh REAL,
+    poids_hp REAL DEFAULT 62.0,
+    poids_hc REAL DEFAULT 38.0,
+    cee_inclus BOOLEAN DEFAULT 0,
+    cee_eur_mwh REAL,
+    capacite_incluse BOOLEAN DEFAULT 0,
+    capacite_eur_mwh REAL,
+    indexation_reference VARCHAR(100),
+    indexation_spread_eur_mwh REAL,
+    prix_plancher_eur_mwh REAL,
+    prix_plafond_eur_mwh REAL,
+    statut VARCHAR(20) NOT NULL DEFAULT 'draft',
+    is_green BOOLEAN DEFAULT 0,
+    green_percentage REAL,
+    notes TEXT,
+    conditions_particulieres TEXT,
+    document_url VARCHAR(500),
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    deleted_at DATETIME,
+    deleted_by VARCHAR(200),
+    delete_reason VARCHAR(500)
+);
+"""
+
+CREATE_IDX_CADRE_ORG = "CREATE INDEX IF NOT EXISTS ix_contrats_cadre_org_id ON contrats_cadre(org_id);"
+CREATE_IDX_CADRE_EJ = (
+    "CREATE INDEX IF NOT EXISTS ix_contrats_cadre_entite_juridique_id ON contrats_cadre(entite_juridique_id);"
+)
+
+
+def migrate(db_path: str = None):
+    path = db_path or str(DB_PATH)
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+    actions = []
+
+    # ── Create contrats_cadre table ──────────────────────────────────────
+    if not table_exists(cursor, "contrats_cadre"):
+        cursor.execute(CREATE_CONTRATS_CADRE)
+        cursor.execute(CREATE_IDX_CADRE_ORG)
+        cursor.execute(CREATE_IDX_CADRE_EJ)
+        actions.append("CREATE TABLE contrats_cadre")
+
+    # ── Add new columns to contract_annexes ──────────────────────────────
+    if table_exists(cursor, "contract_annexes"):
+        annexe_cols = [
+            ("cadre_id", "INTEGER REFERENCES contrats_cadre(id)", None),
+            ("prm", "VARCHAR(14)", None),
+            ("pce", "VARCHAR(14)", None),
+            ("prix_hp_override", "REAL", None),
+            ("prix_hc_override", "REAL", None),
+            ("prix_base_override", "REAL", None),
+            ("volume_engage_kwh", "REAL", None),
+        ]
+        for col, ctype, default in annexe_cols:
+            if add_column_if_missing(cursor, "contract_annexes", col, ctype, default):
+                actions.append(f"contract_annexes.{col}")
+
+        # Index on cadre_id
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='ix_contract_annexes_cadre_id'")
+        if not cursor.fetchone() and column_exists(cursor, "contract_annexes", "cadre_id"):
+            cursor.execute("CREATE INDEX ix_contract_annexes_cadre_id ON contract_annexes(cadre_id);")
+            actions.append("INDEX ix_contract_annexes_cadre_id")
+
+    conn.commit()
+    conn.close()
+
+    if actions:
+        print(f"Migration Phase 1 OK — {len(actions)} actions: {', '.join(actions)}")
+    else:
+        print("Migration Phase 1 OK — tout existe deja, rien a faire.")
+    return actions
+
+
+if __name__ == "__main__":
+    db = sys.argv[1] if len(sys.argv) > 1 else None
+    migrate(db)

--- a/backend/migrations/add_contrats_cadre_phase1.py
+++ b/backend/migrations/add_contrats_cadre_phase1.py
@@ -51,19 +51,19 @@ CREATE TABLE IF NOT EXISTS contrats_cadre (
     notice_period_months INTEGER,
     auto_renew BOOLEAN DEFAULT 0,
     type_prix VARCHAR(30) NOT NULL,
-    prix_hp_eur_kwh REAL,
-    prix_hc_eur_kwh REAL,
-    prix_base_eur_kwh REAL,
+    prix_hp_eur_kwh NUMERIC(18,6),
+    prix_hc_eur_kwh NUMERIC(18,6),
+    prix_base_eur_kwh NUMERIC(18,6),
     poids_hp REAL DEFAULT 62.0,
     poids_hc REAL DEFAULT 38.0,
     cee_inclus BOOLEAN DEFAULT 0,
-    cee_eur_mwh REAL,
+    cee_eur_mwh NUMERIC(18,6),
     capacite_incluse BOOLEAN DEFAULT 0,
-    capacite_eur_mwh REAL,
+    capacite_eur_mwh NUMERIC(18,6),
     indexation_reference VARCHAR(100),
-    indexation_spread_eur_mwh REAL,
-    prix_plancher_eur_mwh REAL,
-    prix_plafond_eur_mwh REAL,
+    indexation_spread_eur_mwh NUMERIC(18,6),
+    prix_plancher_eur_mwh NUMERIC(18,6),
+    prix_plafond_eur_mwh NUMERIC(18,6),
     statut VARCHAR(20) NOT NULL DEFAULT 'draft',
     is_green BOOLEAN DEFAULT 0,
     green_percentage REAL,
@@ -90,36 +90,45 @@ def migrate(db_path: str = None):
     cursor = conn.cursor()
     actions = []
 
-    # ── Create contrats_cadre table ──────────────────────────────────────
-    if not table_exists(cursor, "contrats_cadre"):
-        cursor.execute(CREATE_CONTRATS_CADRE)
-        cursor.execute(CREATE_IDX_CADRE_ORG)
-        cursor.execute(CREATE_IDX_CADRE_EJ)
-        actions.append("CREATE TABLE contrats_cadre")
+    try:
+        # ── Create contrats_cadre table ──────────────────────────────────
+        if not table_exists(cursor, "contrats_cadre"):
+            cursor.execute(CREATE_CONTRATS_CADRE)
+            cursor.execute(CREATE_IDX_CADRE_ORG)
+            cursor.execute(CREATE_IDX_CADRE_EJ)
+            actions.append("CREATE TABLE contrats_cadre")
 
-    # ── Add new columns to contract_annexes ──────────────────────────────
-    if table_exists(cursor, "contract_annexes"):
-        annexe_cols = [
-            ("cadre_id", "INTEGER REFERENCES contrats_cadre(id)", None),
-            ("prm", "VARCHAR(14)", None),
-            ("pce", "VARCHAR(14)", None),
-            ("prix_hp_override", "REAL", None),
-            ("prix_hc_override", "REAL", None),
-            ("prix_base_override", "REAL", None),
-            ("volume_engage_kwh", "REAL", None),
-        ]
-        for col, ctype, default in annexe_cols:
-            if add_column_if_missing(cursor, "contract_annexes", col, ctype, default):
-                actions.append(f"contract_annexes.{col}")
+        # ── Add new columns to contract_annexes ──────────────────────────
+        # NUMERIC column affinity: SQLite stores Decimal-like values faithfully;
+        # the SQLAlchemy model declares Numeric(18,6) for the same columns.
+        if table_exists(cursor, "contract_annexes"):
+            annexe_cols = [
+                ("cadre_id", "INTEGER REFERENCES contrats_cadre(id)", None),
+                ("prm", "VARCHAR(14)", None),
+                ("pce", "VARCHAR(14)", None),
+                ("prix_hp_override", "NUMERIC(18,6)", None),
+                ("prix_hc_override", "NUMERIC(18,6)", None),
+                ("prix_base_override", "NUMERIC(18,6)", None),
+                ("volume_engage_kwh", "NUMERIC(20,3)", None),
+            ]
+            for col, ctype, default in annexe_cols:
+                if add_column_if_missing(cursor, "contract_annexes", col, ctype, default):
+                    actions.append(f"contract_annexes.{col}")
 
-        # Index on cadre_id
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='ix_contract_annexes_cadre_id'")
-        if not cursor.fetchone() and column_exists(cursor, "contract_annexes", "cadre_id"):
-            cursor.execute("CREATE INDEX ix_contract_annexes_cadre_id ON contract_annexes(cadre_id);")
-            actions.append("INDEX ix_contract_annexes_cadre_id")
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='ix_contract_annexes_cadre_id'")
+            if not cursor.fetchone() and column_exists(cursor, "contract_annexes", "cadre_id"):
+                cursor.execute("CREATE INDEX ix_contract_annexes_cadre_id ON contract_annexes(cadre_id);")
+                actions.append("INDEX ix_contract_annexes_cadre_id")
 
-    conn.commit()
-    conn.close()
+        conn.commit()
+    except Exception as e:
+        # Keep the DB consistent if any step fails: rollback uncommitted DDL
+        # and surface the error so the next run can't silently skip.
+        conn.rollback()
+        print(f"Migration Phase 1 FAILED after {len(actions)} actions: {actions}. Rolled back. Error: {e}")
+        raise
+    finally:
+        conn.close()
 
     if actions:
         print(f"Migration Phase 1 OK — {len(actions)} actions: {', '.join(actions)}")

--- a/backend/migrations/add_invoice_annexe_site_phase5.py
+++ b/backend/migrations/add_invoice_annexe_site_phase5.py
@@ -1,0 +1,50 @@
+"""
+Migration: Contrats V2 Phase 5 — Wire billing → resolve_pricing.
+
+New column on energy_invoices: annexe_site_id (FK → contract_annexes.id).
+Safe to re-run: checks column existence before ALTER.
+Backward-compatible: nullable column, no existing data changed.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent.parent / "data" / "promeos.db"
+
+
+def column_exists(cursor, table: str, column: str) -> bool:
+    cursor.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def migrate(db_path: str = None):
+    path = db_path or str(DB_PATH)
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+    actions = []
+
+    # Add annexe_site_id to energy_invoices
+    if not column_exists(cursor, "energy_invoices", "annexe_site_id"):
+        cursor.execute("ALTER TABLE energy_invoices ADD COLUMN annexe_site_id INTEGER REFERENCES contract_annexes(id)")
+        actions.append("energy_invoices.annexe_site_id")
+
+    # Index for annexe_site_id
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='ix_energy_invoices_annexe_site_id'")
+    if not cursor.fetchone() and column_exists(cursor, "energy_invoices", "annexe_site_id"):
+        cursor.execute("CREATE INDEX ix_energy_invoices_annexe_site_id ON energy_invoices(annexe_site_id);")
+        actions.append("INDEX ix_energy_invoices_annexe_site_id")
+
+    conn.commit()
+    conn.close()
+
+    if actions:
+        print(f"Migration Phase 5 OK — {len(actions)} actions: {', '.join(actions)}")
+    else:
+        print("Migration Phase 5 OK — tout existe deja, rien a faire.")
+    return actions
+
+
+if __name__ == "__main__":
+    db = sys.argv[1] if len(sys.argv) > 1 else None
+    migrate(db)

--- a/backend/models/billing_models.py
+++ b/backend/models/billing_models.py
@@ -343,6 +343,15 @@ class EnergyInvoice(Base, TimestampMixin):
     )
     raw_json = Column(Text, nullable=True, comment="Donnees brutes (JSON)")
 
+    # V2 Phase 5 — Lien annexe cadre
+    annexe_site_id = Column(
+        Integer,
+        ForeignKey("contract_annexes.id"),
+        nullable=True,
+        index=True,
+        comment="Annexe cadre V2 rattachee (nullable, backward-compat)",
+    )
+
     # V2 Engine — champs reconstitution
     invoice_type = Column(
         Enum(InvoiceTypeEnum),
@@ -370,6 +379,7 @@ class EnergyInvoice(Base, TimestampMixin):
     # Relations
     site = relationship("Site", backref="energy_invoices")
     contract = relationship("EnergyContract", back_populates="invoices")
+    annexe_site = relationship("ContractAnnexe", foreign_keys=[annexe_site_id])
     lines = relationship(
         "EnergyInvoiceLine",
         back_populates="invoice",

--- a/backend/models/contract_v2_models.py
+++ b/backend/models/contract_v2_models.py
@@ -1,6 +1,11 @@
 """
 PROMEOS — Contrats V2 : Cadre + Annexes Site
-Tables : contract_annexes, contract_pricing, volume_commitments, contract_events.
+Tables : contrats_cadre, contract_annexes, contract_pricing,
+         volume_commitments, contract_events.
+
+Phase 1 (PRO-43): ContratCadre entity-level + AnnexeSite enrichi.
+Backward-compatible: EnergyInvoice.contract_id FK preserved,
+ContractAnnexe.contrat_cadre_id → energy_contracts preserved.
 """
 
 from sqlalchemy import (
@@ -19,23 +24,210 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from .base import Base, TimestampMixin, SoftDeleteMixin
-from .enums import ContractStatus, TariffOptionEnum
+from .enums import ContractIndexation, ContractStatus, TariffOptionEnum, BillingEnergyType
+
+
+# ---------------------------------------------------------------------------
+# ContratCadre — contrat cadre entity-level (multi-sites)
+# ---------------------------------------------------------------------------
+
+
+class ContratCadre(Base, TimestampMixin, SoftDeleteMixin):
+    """Contrat cadre au niveau entite juridique / organisation.
+
+    Un ContratCadre couvre N sites via ses AnnexeSites.
+    Prix par defaut HP/HC/base + poids + CEE + capacite.
+    """
+
+    __tablename__ = "contrats_cadre"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # Rattachement hierarchique
+    org_id = Column(
+        Integer,
+        ForeignKey("organisations.id"),
+        nullable=False,
+        index=True,
+        comment="Organisation signataire",
+    )
+    entite_juridique_id = Column(
+        Integer,
+        ForeignKey("entites_juridiques.id"),
+        nullable=True,
+        index=True,
+        comment="Entite juridique signataire (si multi-entites)",
+    )
+
+    # Identification
+    reference = Column(
+        String(100),
+        nullable=False,
+        comment="Reference interne du contrat cadre (ex: CC-2025-001)",
+    )
+    reference_fournisseur = Column(
+        String(100),
+        nullable=True,
+        comment="Reference chez le fournisseur",
+    )
+    fournisseur = Column(
+        String(200),
+        nullable=False,
+        comment="Nom du fournisseur (EDF, Engie, TotalEnergies...)",
+    )
+    energie = Column(
+        Enum(BillingEnergyType),
+        nullable=False,
+        comment="Type d'energie: elec / gaz",
+    )
+
+    # Dates
+    date_signature = Column(Date, nullable=True, comment="Date de signature")
+    date_debut = Column(Date, nullable=False, comment="Date debut de fourniture")
+    date_fin = Column(Date, nullable=False, comment="Date fin de fourniture")
+    date_preavis = Column(Date, nullable=True, comment="Date limite de preavis resiliation")
+    notice_period_months = Column(Integer, nullable=True, comment="Preavis en mois")
+    auto_renew = Column(Boolean, default=False, comment="Reconduction tacite")
+
+    # Type de prix
+    type_prix = Column(
+        Enum(ContractIndexation),
+        nullable=False,
+        comment="Modele de prix: fixe/indexe/spot/tunnel/clic",
+    )
+
+    # Prix de reference (EUR HT/kWh) — defaut cadre, overridable par annexe
+    prix_hp_eur_kwh = Column(Float, nullable=True, comment="Prix HP EUR HT/kWh")
+    prix_hc_eur_kwh = Column(Float, nullable=True, comment="Prix HC EUR HT/kWh")
+    prix_base_eur_kwh = Column(Float, nullable=True, comment="Prix Base EUR HT/kWh (tarif unique)")
+
+    # Poids HP/HC (repartition forfaitaire)
+    poids_hp = Column(
+        Float,
+        nullable=True,
+        default=62.0,
+        comment="Poids HP en % (defaut 62% convention marche)",
+    )
+    poids_hc = Column(
+        Float,
+        nullable=True,
+        default=38.0,
+        comment="Poids HC en % (defaut 38% convention marche)",
+    )
+
+    # CEE (Certificats d'Economies d'Energie)
+    cee_inclus = Column(
+        Boolean,
+        default=False,
+        comment="True si CEE inclus dans le prix fourniture",
+    )
+    cee_eur_mwh = Column(
+        Float,
+        nullable=True,
+        comment="Prix CEE EUR/MWh (si facture separement)",
+    )
+
+    # Capacite (mecanisme de capacite)
+    capacite_incluse = Column(
+        Boolean,
+        default=False,
+        comment="True si capacite incluse dans le prix fourniture",
+    )
+    capacite_eur_mwh = Column(
+        Float,
+        nullable=True,
+        comment="Prix capacite EUR/MWh (si facture separement)",
+    )
+
+    # Indexation details (pour type tunnel/clic)
+    indexation_reference = Column(
+        String(100),
+        nullable=True,
+        comment="Index de reference (TRVE, EPEX_SPOT_FR, PEG_DA)",
+    )
+    indexation_spread_eur_mwh = Column(
+        Float,
+        nullable=True,
+        comment="Spread EUR/MWh par rapport a l'index",
+    )
+    prix_plancher_eur_mwh = Column(
+        Float,
+        nullable=True,
+        comment="Plancher prix EUR/MWh (tunnel)",
+    )
+    prix_plafond_eur_mwh = Column(
+        Float,
+        nullable=True,
+        comment="Plafond prix EUR/MWh (tunnel/cap)",
+    )
+
+    # Statut lifecycle
+    statut = Column(
+        Enum(ContractStatus),
+        nullable=False,
+        default=ContractStatus.DRAFT,
+        comment="Statut lifecycle: draft/active/expiring/expired/terminated",
+    )
+
+    # Offre verte
+    is_green = Column(Boolean, default=False, comment="Offre verte (GO)")
+    green_percentage = Column(Float, nullable=True, comment="% couverture GO (0-100)")
+
+    # Notes / metadata
+    notes = Column(Text, nullable=True, comment="Notes libres")
+    conditions_particulieres = Column(Text, nullable=True, comment="Conditions particulieres / derogations")
+    document_url = Column(String(500), nullable=True, comment="Lien vers le PDF signe")
+
+    # Relations
+    organisation = relationship("Organisation")
+    entite_juridique = relationship("EntiteJuridique")
+    annexes = relationship(
+        "ContractAnnexe",
+        back_populates="cadre",
+        cascade="all, delete-orphan",
+        foreign_keys="ContractAnnexe.cadre_id",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ContractAnnexe — annexe site d'un contrat cadre
+# ---------------------------------------------------------------------------
 
 
 class ContractAnnexe(Base, TimestampMixin, SoftDeleteMixin):
-    """Annexe site = conditions specifiques par site/PDL rattachees a un contrat cadre."""
+    """Annexe site = conditions specifiques par site/PDL rattachees a un contrat cadre.
+
+    Supporte deux FK parent:
+    - cadre_id → contrats_cadre (nouveau, Phase 1)
+    - contrat_cadre_id → energy_contracts (legacy, backward-compatible)
+    """
 
     __tablename__ = "contract_annexes"
-    __table_args__ = (UniqueConstraint("contrat_cadre_id", "site_id", name="uq_annexe_cadre_site"),)
+    __table_args__ = (
+        UniqueConstraint("contrat_cadre_id", "site_id", name="uq_annexe_cadre_site"),
+        UniqueConstraint("cadre_id", "site_id", name="uq_annexe_cadre_v2_site"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # FK vers ContratCadre (nouveau)
+    cadre_id = Column(
+        Integer,
+        ForeignKey("contrats_cadre.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+        comment="Contrat cadre parent (Phase 1)",
+    )
+
+    # FK legacy vers EnergyContract (backward-compatible, a deprecier)
     contrat_cadre_id = Column(
         Integer,
         ForeignKey("energy_contracts.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
-        comment="Contrat cadre parent",
+        comment="Contrat cadre parent legacy (EnergyContract)",
     )
+
     site_id = Column(
         Integer,
         ForeignKey("sites.id"),
@@ -51,6 +243,10 @@ class ContractAnnexe(Base, TimestampMixin, SoftDeleteMixin):
     )
     annexe_ref = Column(String(100), nullable=True, comment="Reference annexe (ex: ANX-Paris-001)")
 
+    # Identifiants reseau (PRM / PCE)
+    prm = Column(String(14), nullable=True, comment="PRM elec (14 chiffres)")
+    pce = Column(String(14), nullable=True, comment="PCE gaz (14 chiffres)")
+
     # Donnees specifiques site (peuvent differer du cadre)
     tariff_option = Column(
         Enum(TariffOptionEnum),
@@ -64,9 +260,17 @@ class ContractAnnexe(Base, TimestampMixin, SoftDeleteMixin):
     has_price_override = Column(Boolean, default=False, comment="True si prix differents du cadre")
     override_pricing_model = Column(String(30), nullable=True, comment="Modele prix override (null = herite)")
 
+    # Prix override (si has_price_override=True)
+    prix_hp_override = Column(Float, nullable=True, comment="Prix HP override EUR HT/kWh")
+    prix_hc_override = Column(Float, nullable=True, comment="Prix HC override EUR HT/kWh")
+    prix_base_override = Column(Float, nullable=True, comment="Prix Base override EUR HT/kWh")
+
     # Dates specifiques (null = herite du cadre)
     start_date_override = Column(Date, nullable=True, comment="Date debut override")
     end_date_override = Column(Date, nullable=True, comment="Date fin override")
+
+    # Volume engage (au niveau annexe)
+    volume_engage_kwh = Column(Float, nullable=True, comment="Volume annuel engage kWh")
 
     # Status annexe
     status = Column(
@@ -77,7 +281,16 @@ class ContractAnnexe(Base, TimestampMixin, SoftDeleteMixin):
     )
 
     # Relations
-    contrat_cadre = relationship("EnergyContract", back_populates="annexes")
+    cadre = relationship(
+        "ContratCadre",
+        back_populates="annexes",
+        foreign_keys=[cadre_id],
+    )
+    contrat_cadre = relationship(
+        "EnergyContract",
+        back_populates="annexes",
+        foreign_keys=[contrat_cadre_id],
+    )
     site = relationship("Site")
     delivery_point = relationship("DeliveryPoint")
     volume_commitment = relationship(
@@ -92,6 +305,11 @@ class ContractAnnexe(Base, TimestampMixin, SoftDeleteMixin):
         cascade="all, delete-orphan",
         foreign_keys="ContractPricing.annexe_id",
     )
+
+
+# ---------------------------------------------------------------------------
+# ContractPricing — grille tarifaire structuree
+# ---------------------------------------------------------------------------
 
 
 class ContractPricing(Base, TimestampMixin):
@@ -145,6 +363,11 @@ class ContractPricing(Base, TimestampMixin):
     )
 
 
+# ---------------------------------------------------------------------------
+# VolumeCommitment — engagement de volume par annexe
+# ---------------------------------------------------------------------------
+
+
 class VolumeCommitment(Base, TimestampMixin):
     """Engagement de volume par annexe site."""
 
@@ -168,6 +391,11 @@ class VolumeCommitment(Base, TimestampMixin):
 
     # Relations
     annexe = relationship("ContractAnnexe", back_populates="volume_commitment")
+
+
+# ---------------------------------------------------------------------------
+# ContractEvent — evenement lifecycle
+# ---------------------------------------------------------------------------
 
 
 class ContractEvent(Base, TimestampMixin):

--- a/backend/models/contract_v2_models.py
+++ b/backend/models/contract_v2_models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Integer,
     String,
     Float,
+    Numeric,
     Text,
     Boolean,
     ForeignKey,
@@ -97,9 +98,10 @@ class ContratCadre(Base, TimestampMixin, SoftDeleteMixin):
     )
 
     # Prix de reference (EUR HT/kWh) — defaut cadre, overridable par annexe
-    prix_hp_eur_kwh = Column(Float, nullable=True, comment="Prix HP EUR HT/kWh")
-    prix_hc_eur_kwh = Column(Float, nullable=True, comment="Prix HC EUR HT/kWh")
-    prix_base_eur_kwh = Column(Float, nullable=True, comment="Prix Base EUR HT/kWh (tarif unique)")
+    # Numeric pour precision billing (eviter erreurs flottantes cumulees sur milliers kWh)
+    prix_hp_eur_kwh = Column(Numeric(18, 6), nullable=True, comment="Prix HP EUR HT/kWh")
+    prix_hc_eur_kwh = Column(Numeric(18, 6), nullable=True, comment="Prix HC EUR HT/kWh")
+    prix_base_eur_kwh = Column(Numeric(18, 6), nullable=True, comment="Prix Base EUR HT/kWh (tarif unique)")
 
     # Poids HP/HC (repartition forfaitaire)
     poids_hp = Column(
@@ -122,7 +124,7 @@ class ContratCadre(Base, TimestampMixin, SoftDeleteMixin):
         comment="True si CEE inclus dans le prix fourniture",
     )
     cee_eur_mwh = Column(
-        Float,
+        Numeric(18, 6),
         nullable=True,
         comment="Prix CEE EUR/MWh (si facture separement)",
     )
@@ -134,7 +136,7 @@ class ContratCadre(Base, TimestampMixin, SoftDeleteMixin):
         comment="True si capacite incluse dans le prix fourniture",
     )
     capacite_eur_mwh = Column(
-        Float,
+        Numeric(18, 6),
         nullable=True,
         comment="Prix capacite EUR/MWh (si facture separement)",
     )
@@ -146,17 +148,17 @@ class ContratCadre(Base, TimestampMixin, SoftDeleteMixin):
         comment="Index de reference (TRVE, EPEX_SPOT_FR, PEG_DA)",
     )
     indexation_spread_eur_mwh = Column(
-        Float,
+        Numeric(18, 6),
         nullable=True,
         comment="Spread EUR/MWh par rapport a l'index",
     )
     prix_plancher_eur_mwh = Column(
-        Float,
+        Numeric(18, 6),
         nullable=True,
         comment="Plancher prix EUR/MWh (tunnel)",
     )
     prix_plafond_eur_mwh = Column(
-        Float,
+        Numeric(18, 6),
         nullable=True,
         comment="Plafond prix EUR/MWh (tunnel/cap)",
     )
@@ -260,23 +262,23 @@ class ContractAnnexe(Base, TimestampMixin, SoftDeleteMixin):
     has_price_override = Column(Boolean, default=False, comment="True si prix differents du cadre")
     override_pricing_model = Column(String(30), nullable=True, comment="Modele prix override (null = herite)")
 
-    # Prix override (si has_price_override=True)
-    prix_hp_override = Column(Float, nullable=True, comment="Prix HP override EUR HT/kWh")
-    prix_hc_override = Column(Float, nullable=True, comment="Prix HC override EUR HT/kWh")
-    prix_base_override = Column(Float, nullable=True, comment="Prix Base override EUR HT/kWh")
+    # Prix override (si has_price_override=True) — Numeric pour precision billing
+    prix_hp_override = Column(Numeric(18, 6), nullable=True, comment="Prix HP override EUR HT/kWh")
+    prix_hc_override = Column(Numeric(18, 6), nullable=True, comment="Prix HC override EUR HT/kWh")
+    prix_base_override = Column(Numeric(18, 6), nullable=True, comment="Prix Base override EUR HT/kWh")
 
     # Dates specifiques (null = herite du cadre)
     start_date_override = Column(Date, nullable=True, comment="Date debut override")
     end_date_override = Column(Date, nullable=True, comment="Date fin override")
 
     # Volume engage (au niveau annexe)
-    volume_engage_kwh = Column(Float, nullable=True, comment="Volume annuel engage kWh")
+    volume_engage_kwh = Column(Numeric(20, 3), nullable=True, comment="Volume annuel engage kWh")
 
     # Status annexe
     status = Column(
         Enum(ContractStatus),
         nullable=True,
-        default="active",
+        default=ContractStatus.ACTIVE,
         comment="Statut lifecycle annexe",
     )
 
@@ -345,8 +347,8 @@ class ContractPricing(Base, TimestampMixin):
         comment="BASE/HP/HC/HPH/HCH/HPB/HCB/POINTE",
     )
     season = Column(String(10), default="ANNUEL", comment="ANNUEL/HIVER/ETE")
-    unit_price_eur_kwh = Column(Float, nullable=True, comment="Prix unitaire EUR HT/kWh")
-    subscription_eur_month = Column(Float, nullable=True, comment="Abonnement EUR HT/mois")
+    unit_price_eur_kwh = Column(Numeric(18, 6), nullable=True, comment="Prix unitaire EUR HT/kWh")
+    subscription_eur_month = Column(Numeric(14, 2), nullable=True, comment="Abonnement EUR HT/mois")
     effective_from = Column(Date, nullable=True, comment="Date debut validite")
     effective_to = Column(Date, nullable=True, comment="Date fin validite")
 
@@ -383,11 +385,11 @@ class VolumeCommitment(Base, TimestampMixin):
         comment="Annexe concernee",
     )
 
-    annual_kwh = Column(Float, nullable=False, comment="Volume engage MWh/an (en kWh)")
+    annual_kwh = Column(Numeric(20, 3), nullable=False, comment="Volume engage MWh/an (en kWh)")
     tolerance_pct_up = Column(Float, default=10.0, comment="Tolerance haute %")
     tolerance_pct_down = Column(Float, default=10.0, comment="Tolerance basse %")
-    penalty_eur_kwh_above = Column(Float, nullable=True, comment="Penalite depassement EUR/kWh")
-    penalty_eur_kwh_below = Column(Float, nullable=True, comment="Penalite sous-conso EUR/kWh")
+    penalty_eur_kwh_above = Column(Numeric(18, 6), nullable=True, comment="Penalite depassement EUR/kWh")
+    penalty_eur_kwh_below = Column(Numeric(18, 6), nullable=True, comment="Penalite sous-conso EUR/kWh")
 
     # Relations
     annexe = relationship("ContractAnnexe", back_populates="volume_commitment")

--- a/backend/schemas/contract_v2_schemas.py
+++ b/backend/schemas/contract_v2_schemas.py
@@ -368,6 +368,7 @@ class CadreResponse(BaseModel):
     """Reponse cadre serialisee (detail + annexes)."""
 
     id: Optional[int] = None
+    source: Optional[str] = None  # 'v2' or 'legacy' — cadre data source
     supplier_name: Optional[str] = None
     energy_type: Optional[str] = None
     contract_ref: Optional[str] = None
@@ -375,13 +376,22 @@ class CadreResponse(BaseModel):
     pricing_model: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
+    status: Optional[str] = None
+    days_to_expiry: Optional[int] = None
     tacit_renewal: Optional[bool] = None
     notice_period_months: Optional[int] = None
     is_green: Optional[bool] = None
     green_percentage: Optional[float] = None
     segment_enedis: Optional[str] = None
+    indexation_formula: Optional[str] = None
+    indexation_reference: Optional[str] = None
+    price_revision_clause: Optional[str] = None
     annual_consumption_kwh: Optional[float] = None
+    entite_juridique_id: Optional[int] = None
     nb_annexes: Optional[int] = None
+    total_volume_mwh: Optional[float] = None
+    avg_price_eur_mwh: Optional[float] = None
+    budget_eur: Optional[float] = None
     annexes: Optional[list] = None
     pricing: Optional[list] = None
     kpis: Optional[dict] = None
@@ -389,7 +399,7 @@ class CadreResponse(BaseModel):
     events: Optional[list] = None
     notes: Optional[str] = None
 
-    model_config = {"from_attributes": True}
+    model_config = {"from_attributes": True, "extra": "ignore"}
 
 
 class SuppliersResponse(BaseModel):

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -31,8 +31,10 @@ from models import (
     ActionItem,
     Portefeuille,
     EntiteJuridique,
+    ContractAnnexe,
 )
-from models.enums import ActionSourceType, ActionStatus
+from models.contract_v2_models import ContratCadre
+from models.enums import ActionSourceType, ActionStatus, ContractStatus
 from config.default_prices import (
     DEFAULT_PRICE_ELEC_EUR_KWH,
     DEFAULT_PRICE_GAZ_EUR_KWH,
@@ -41,9 +43,104 @@ from config.default_prices import (
 
 
 # ========================================
-# Price reference resolution (V1.1)
+# Price reference resolution (V1.1 + V2 Phase 5)
 # Source unique : config/default_prices.py
 # ========================================
+
+
+def find_active_annexe(
+    db: Session,
+    site_id: int,
+    energy_type: str = "elec",
+    ref_date: Optional[date] = None,
+) -> Optional[ContractAnnexe]:
+    """Find the active ContractAnnexe for a site+energy+date via ContratCadre.
+
+    Lookup chain:
+      1. ContractAnnexe.site_id == site_id
+      2. ContractAnnexe.cadre_id is not null (V2 cadre, not legacy)
+      3. ContratCadre.energie matches energy_type
+      4. ContratCadre.statut is active
+      5. ref_date within [date_debut, date_fin] (if provided)
+      6. Soft-deleted annexes excluded
+
+    Returns the first matching annexe or None.
+    """
+    try:
+        energy_enum = BillingEnergyType(energy_type)
+    except ValueError:
+        return None
+
+    q = (
+        db.query(ContractAnnexe)
+        .join(ContratCadre, ContratCadre.id == ContractAnnexe.cadre_id)
+        .filter(
+            ContractAnnexe.site_id == site_id,
+            ContractAnnexe.cadre_id.isnot(None),
+            ContractAnnexe.deleted_at.is_(None),
+            ContratCadre.energie == energy_enum,
+            ContratCadre.statut == ContractStatus.ACTIVE,
+            ContratCadre.deleted_at.is_(None),
+        )
+    )
+
+    if ref_date:
+        q = q.filter(
+            ContratCadre.date_debut <= ref_date,
+            ContratCadre.date_fin >= ref_date,
+        )
+
+    return q.first()
+
+
+def _resolve_cadre_weighted_price(
+    db: Optional[Session],
+    annexe: ContractAnnexe,
+) -> Optional[Tuple[float, str]]:
+    """Resolve a single weighted price from a V2 cadre annexe using resolve_pricing().
+
+    Cascade: override annexe > cadre structured > cadre flat columns.
+    For HP/HC contracts: prix_moyen = poids_hp * prix_hp + poids_hc * prix_hc.
+    For BASE contracts: prix_base directly.
+
+    Returns (price_eur_per_kwh, source_label) or None if no pricing found.
+    """
+    from services.contrat_coherence import resolve_pricing
+
+    pricing_lines = resolve_pricing(db, annexe)
+    if not pricing_lines:
+        return None
+
+    # Build price map: period_code → unit_price_eur_kwh
+    price_map = {}
+    for line in pricing_lines:
+        pc = line.get("period_code", "")
+        price = line.get("unit_price_eur_kwh")
+        if price is not None and pc:
+            price_map[pc] = price
+
+    # Case 1: BASE price available → direct
+    if "BASE" in price_map:
+        source = f"cadre_annexe:{annexe.id}"
+        return (price_map["BASE"], source)
+
+    # Case 2: HP/HC → weighted average
+    hp_price = price_map.get("HP")
+    hc_price = price_map.get("HC")
+    if hp_price is not None and hc_price is not None:
+        cadre = annexe.cadre
+        poids_hp = (cadre.poids_hp if cadre and cadre.poids_hp else 62.0) / 100.0
+        poids_hc = (cadre.poids_hc if cadre and cadre.poids_hc else 38.0) / 100.0
+        weighted = round(hp_price * poids_hp + hc_price * poids_hc, 6)
+        source = f"cadre_annexe:{annexe.id}"
+        return (weighted, source)
+
+    # Case 3: any single price available
+    if price_map:
+        first_price = next(iter(price_map.values()))
+        return (first_price, f"cadre_annexe:{annexe.id}")
+
+    return None
 
 
 def get_reference_price(
@@ -55,13 +152,22 @@ def get_reference_price(
 ) -> Tuple[float, str]:
     """
     Resolve the reference price for a site, with clear priority:
+      0. Active V2 ContratCadre annexe → resolve_pricing() cascade
       1. Active EnergyContract covering the invoice period
       2. MarketPrice moyenne 30 jours (EPEX Spot FR)
       3. SiteTariffProfile for the site
       4. Config fallback (0.068 elec, 0.045 gaz)
     Returns: (price_eur_per_kwh, source_label)
     """
-    # Priority 1: Active contract
+    # Priority 0: V2 ContratCadre annexe (Phase 5)
+    ref_date = period_start or period_end or date.today()
+    annexe = find_active_annexe(db, site_id, energy_type, ref_date)
+    if annexe:
+        result = _resolve_cadre_weighted_price(db, annexe)
+        if result:
+            return result
+
+    # Priority 1: Active contract (legacy)
     q = db.query(EnergyContract).filter(
         EnergyContract.site_id == site_id,
         EnergyContract.price_ref_eur_per_kwh.isnot(None),
@@ -122,6 +228,93 @@ def get_reference_price(
 # ========================================
 
 
+def _shadow_billing_cadre_hphc(
+    invoice: EnergyInvoice,
+    annexe: ContractAnnexe,
+    db: Session,
+) -> Optional[Dict[str, Any]]:
+    """Shadow billing with HP/HC decomposition using cadre annexe pricing.
+
+    Uses period_resolver to estimate HP/HC split, then applies the resolved
+    pricing grid from the cadre/annexe for a more accurate shadow total.
+
+    Returns shadow result dict or None if pricing grid lacks HP/HC prices.
+    """
+    from services.contrat_coherence import resolve_pricing
+
+    pricing_lines = resolve_pricing(db, annexe)
+    if not pricing_lines:
+        return None
+
+    price_map = {}
+    for line in pricing_lines:
+        pc = line.get("period_code", "")
+        price = line.get("unit_price_eur_kwh")
+        if price is not None and pc:
+            price_map[pc] = price
+
+    hp_price = price_map.get("HP")
+    hc_price = price_map.get("HC")
+
+    # Only use HP/HC decomposition if both prices are available
+    if hp_price is None or hc_price is None:
+        return None
+
+    # Get HP/HC weights from cadre or defaults
+    cadre = annexe.cadre
+    poids_hp = (cadre.poids_hp if cadre and cadre.poids_hp else 62.0) / 100.0
+    poids_hc = (cadre.poids_hc if cadre and cadre.poids_hc else 38.0) / 100.0
+
+    kwh = invoice.energy_kwh
+    kwh_hp = round(kwh * poids_hp, 1)
+    kwh_hc = round(kwh * poids_hc, 1)
+
+    shadow_hp = round(kwh_hp * hp_price, 2)
+    shadow_hc = round(kwh_hc * hc_price, 2)
+    shadow_total = round(shadow_hp + shadow_hc, 2)
+
+    # Compare against energy line total when available
+    actual_total = invoice.total_eur or 0
+    energy_line_total = (
+        db.query(func.sum(EnergyInvoiceLine.amount_eur))
+        .filter(
+            EnergyInvoiceLine.invoice_id == invoice.id,
+            EnergyInvoiceLine.line_type == InvoiceLineType.ENERGY,
+        )
+        .scalar()
+    )
+    if energy_line_total and energy_line_total > 0:
+        actual_total = float(energy_line_total)
+
+    delta = round(actual_total - shadow_total, 2)
+    delta_pct = round(delta / shadow_total * 100, 2) if shadow_total > 0 else None
+
+    weighted_price = round(hp_price * poids_hp + hc_price * poids_hc, 6)
+
+    return {
+        "shadow_total_eur": shadow_total,
+        "actual_total_eur": actual_total,
+        "delta_eur": delta,
+        "delta_pct": delta_pct,
+        "price_ref_eur_kwh": weighted_price,
+        "ref_price_source": f"cadre_annexe:{annexe.id}",
+        "energy_kwh": kwh,
+        "method": "cadre_hphc",
+        "cadre_detail": {
+            "annexe_id": annexe.id,
+            "cadre_id": annexe.cadre_id,
+            "hp_price": hp_price,
+            "hc_price": hc_price,
+            "poids_hp_pct": round(poids_hp * 100, 1),
+            "poids_hc_pct": round(poids_hc * 100, 1),
+            "kwh_hp": kwh_hp,
+            "kwh_hc": kwh_hc,
+            "shadow_hp_eur": shadow_hp,
+            "shadow_hc_eur": shadow_hc,
+        },
+    }
+
+
 def shadow_billing_simple(
     invoice: EnergyInvoice,
     contract: Optional[EnergyContract] = None,
@@ -130,6 +323,7 @@ def shadow_billing_simple(
     """
     Shadow billing simplifie: energy_kwh * price_ref.
     V1.1: uses get_reference_price when db is provided.
+    V2 Phase 5: tries cadre HP/HC decomposition first when annexe available.
     """
     if not invoice.energy_kwh or invoice.energy_kwh <= 0:
         return {
@@ -140,6 +334,17 @@ def shadow_billing_simple(
             "reason": "energy_kwh manquant ou <= 0",
         }
 
+    # Phase 5: Try cadre HP/HC shadow billing first
+    if db:
+        energy_type_str = _energy_type(invoice, contract)
+        ref_date = invoice.period_start or invoice.period_end or date.today()
+        annexe = find_active_annexe(db, invoice.site_id, energy_type_str, ref_date)
+        if annexe:
+            cadre_result = _shadow_billing_cadre_hphc(invoice, annexe, db)
+            if cadre_result:
+                return cadre_result
+
+    # Fallback: simple weighted shadow billing
     # Resolve price reference
     price_ref = None
     ref_source = "fallback"

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -40,6 +40,7 @@ from config.default_prices import (
     DEFAULT_PRICE_GAZ_EUR_KWH,
     get_default_price,
 )
+from services.contrat_coherence import DEFAULT_POIDS_HP, DEFAULT_POIDS_HC
 
 
 # ========================================
@@ -48,22 +49,20 @@ from config.default_prices import (
 # ========================================
 
 
-_DEFAULT_POIDS_HP = 62.0
-_DEFAULT_POIDS_HC = 38.0
-
-
 def _normalized_hp_hc_weights(cadre) -> Tuple[float, float]:
     """Return normalized (poids_hp, poids_hc) as fractions summing to 1.0.
 
-    Guards against operator typos (e.g. 70 + 40 = 110%) that would otherwise
-    inflate the weighted price silently. Falls back to market default (62/38)
-    when either weight is missing.
+    Guards against operator typos (e.g. 70 + 40 = 110%). Uses is-not-None
+    checks so an explicit 0 is honored, not silently replaced by the default.
+    Default constants come from contrat_coherence (single source of truth).
     """
-    hp = float(cadre.poids_hp) if cadre and cadre.poids_hp else _DEFAULT_POIDS_HP
-    hc = float(cadre.poids_hc) if cadre and cadre.poids_hc else _DEFAULT_POIDS_HC
+    if cadre is None or (cadre.poids_hp is None and cadre.poids_hc is None):
+        return (DEFAULT_POIDS_HP / 100.0, DEFAULT_POIDS_HC / 100.0)
+    hp = float(cadre.poids_hp) if cadre.poids_hp is not None else DEFAULT_POIDS_HP
+    hc = float(cadre.poids_hc) if cadre.poids_hc is not None else DEFAULT_POIDS_HC
     total = hp + hc
     if total <= 0:
-        return (_DEFAULT_POIDS_HP / 100.0, _DEFAULT_POIDS_HC / 100.0)
+        return (DEFAULT_POIDS_HP / 100.0, DEFAULT_POIDS_HC / 100.0)
     return (hp / total, hc / total)
 
 
@@ -162,18 +161,6 @@ def _resolve_cadre_weighted_price(
     return None
 
 
-def _site_org_id(db: Session, site_id: int) -> Optional[int]:
-    """Resolve org_id from a site via portefeuille > entite_juridique chain."""
-    row = (
-        db.query(EntiteJuridique.organisation_id)
-        .join(Portefeuille, Portefeuille.entite_juridique_id == EntiteJuridique.id)
-        .join(Site, Site.portefeuille_id == Portefeuille.id)
-        .filter(Site.id == site_id)
-        .first()
-    )
-    return row[0] if row else None
-
-
 def get_reference_price(
     db: Session,
     site_id: int,
@@ -192,7 +179,8 @@ def get_reference_price(
     """
     # Priority 0: V2 ContratCadre annexe (Phase 5) — scoped by org
     ref_date = period_start or period_end or date.today()
-    site_org_id = _site_org_id(db, site_id)
+    from services.scope_utils import resolve_org_id_from_site as _resolve_org_id
+    site_org_id = _resolve_org_id(db, site_id)
     annexe = find_active_annexe(db, site_id, energy_type, ref_date, org_id=site_org_id)
     if annexe:
         result = _resolve_cadre_weighted_price(db, annexe)
@@ -368,7 +356,8 @@ def shadow_billing_simple(
     if db:
         energy_type_str = _energy_type(invoice, contract)
         ref_date = invoice.period_start or invoice.period_end or date.today()
-        invoice_org_id = _site_org_id(db, invoice.site_id)
+        from services.scope_utils import resolve_org_id_from_site as _resolve_org_id
+        invoice_org_id = _resolve_org_id(db, invoice.site_id)
         annexe = find_active_annexe(db, invoice.site_id, energy_type_str, ref_date, org_id=invoice_org_id)
         if annexe:
             cadre_result = _shadow_billing_cadre_hphc(invoice, annexe, db)

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -180,6 +180,7 @@ def get_reference_price(
     # Priority 0: V2 ContratCadre annexe (Phase 5) — scoped by org
     ref_date = period_start or period_end or date.today()
     from services.scope_utils import resolve_org_id_from_site as _resolve_org_id
+
     site_org_id = _resolve_org_id(db, site_id)
     annexe = find_active_annexe(db, site_id, energy_type, ref_date, org_id=site_org_id)
     if annexe:
@@ -357,6 +358,7 @@ def shadow_billing_simple(
         energy_type_str = _energy_type(invoice, contract)
         ref_date = invoice.period_start or invoice.period_end or date.today()
         from services.scope_utils import resolve_org_id_from_site as _resolve_org_id
+
         invoice_org_id = _resolve_org_id(db, invoice.site_id)
         annexe = find_active_annexe(db, invoice.site_id, energy_type_str, ref_date, org_id=invoice_org_id)
         if annexe:

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -48,11 +48,31 @@ from config.default_prices import (
 # ========================================
 
 
+_DEFAULT_POIDS_HP = 62.0
+_DEFAULT_POIDS_HC = 38.0
+
+
+def _normalized_hp_hc_weights(cadre) -> Tuple[float, float]:
+    """Return normalized (poids_hp, poids_hc) as fractions summing to 1.0.
+
+    Guards against operator typos (e.g. 70 + 40 = 110%) that would otherwise
+    inflate the weighted price silently. Falls back to market default (62/38)
+    when either weight is missing.
+    """
+    hp = float(cadre.poids_hp) if cadre and cadre.poids_hp else _DEFAULT_POIDS_HP
+    hc = float(cadre.poids_hc) if cadre and cadre.poids_hc else _DEFAULT_POIDS_HC
+    total = hp + hc
+    if total <= 0:
+        return (_DEFAULT_POIDS_HP / 100.0, _DEFAULT_POIDS_HC / 100.0)
+    return (hp / total, hc / total)
+
+
 def find_active_annexe(
     db: Session,
     site_id: int,
     energy_type: str = "elec",
     ref_date: Optional[date] = None,
+    org_id: Optional[int] = None,
 ) -> Optional[ContractAnnexe]:
     """Find the active ContractAnnexe for a site+energy+date via ContratCadre.
 
@@ -63,8 +83,9 @@ def find_active_annexe(
       4. ContratCadre.statut is active
       5. ref_date within [date_debut, date_fin] (if provided)
       6. Soft-deleted annexes excluded
-
-    Returns the first matching annexe or None.
+      7. Multi-tenant: if org_id is provided, ContratCadre.org_id must match.
+         Callers that resolve org_id from the site itself (preferred) get
+         defense-in-depth against site_id collisions across tenants.
     """
     try:
         energy_enum = BillingEnergyType(energy_type)
@@ -84,6 +105,9 @@ def find_active_annexe(
         )
     )
 
+    if org_id is not None:
+        q = q.filter(ContratCadre.org_id == org_id)
+
     if ref_date:
         q = q.filter(
             ContratCadre.date_debut <= ref_date,
@@ -100,10 +124,13 @@ def _resolve_cadre_weighted_price(
     """Resolve a single weighted price from a V2 cadre annexe using resolve_pricing().
 
     Cascade: override annexe > cadre structured > cadre flat columns.
-    For HP/HC contracts: prix_moyen = poids_hp * prix_hp + poids_hc * prix_hc.
+    For HP/HC contracts: prix_moyen = poids_hp_norm * prix_hp + poids_hc_norm * prix_hc,
+    where poids_hp_norm + poids_hc_norm == 1.0 (normalized to guard operator typos).
     For BASE contracts: prix_base directly.
 
-    Returns (price_eur_per_kwh, source_label) or None if no pricing found.
+    Incomplete grids (only HP or only HC, or exotic period codes like pointe)
+    return None so that get_reference_price() can fall through to a lower
+    priority source rather than silently reporting a wrong average.
     """
     from services.contrat_coherence import resolve_pricing
 
@@ -111,7 +138,6 @@ def _resolve_cadre_weighted_price(
     if not pricing_lines:
         return None
 
-    # Build price map: period_code → unit_price_eur_kwh
     price_map = {}
     for line in pricing_lines:
         pc = line.get("period_code", "")
@@ -119,28 +145,33 @@ def _resolve_cadre_weighted_price(
         if price is not None and pc:
             price_map[pc] = price
 
-    # Case 1: BASE price available → direct
-    if "BASE" in price_map:
-        source = f"cadre_annexe:{annexe.id}"
-        return (price_map["BASE"], source)
+    source = f"cadre_annexe:{annexe.id}"
 
-    # Case 2: HP/HC → weighted average
+    if "BASE" in price_map:
+        return (float(price_map["BASE"]), source)
+
     hp_price = price_map.get("HP")
     hc_price = price_map.get("HC")
     if hp_price is not None and hc_price is not None:
-        cadre = annexe.cadre
-        poids_hp = (cadre.poids_hp if cadre and cadre.poids_hp else 62.0) / 100.0
-        poids_hc = (cadre.poids_hc if cadre and cadre.poids_hc else 38.0) / 100.0
-        weighted = round(hp_price * poids_hp + hc_price * poids_hc, 6)
-        source = f"cadre_annexe:{annexe.id}"
+        poids_hp, poids_hc = _normalized_hp_hc_weights(annexe.cadre)
+        weighted = round(float(hp_price) * poids_hp + float(hc_price) * poids_hc, 6)
         return (weighted, source)
 
-    # Case 3: any single price available
-    if price_map:
-        first_price = next(iter(price_map.values()))
-        return (first_price, f"cadre_annexe:{annexe.id}")
-
+    # Incomplete grid: let caller fall through to next priority instead of
+    # returning an arbitrary price (e.g. pointe) as if it were a flat reference.
     return None
+
+
+def _site_org_id(db: Session, site_id: int) -> Optional[int]:
+    """Resolve org_id from a site via portefeuille > entite_juridique chain."""
+    row = (
+        db.query(EntiteJuridique.organisation_id)
+        .join(Portefeuille, Portefeuille.entite_juridique_id == EntiteJuridique.id)
+        .join(Site, Site.portefeuille_id == Portefeuille.id)
+        .filter(Site.id == site_id)
+        .first()
+    )
+    return row[0] if row else None
 
 
 def get_reference_price(
@@ -159,9 +190,10 @@ def get_reference_price(
       4. Config fallback (0.068 elec, 0.045 gaz)
     Returns: (price_eur_per_kwh, source_label)
     """
-    # Priority 0: V2 ContratCadre annexe (Phase 5)
+    # Priority 0: V2 ContratCadre annexe (Phase 5) — scoped by org
     ref_date = period_start or period_end or date.today()
-    annexe = find_active_annexe(db, site_id, energy_type, ref_date)
+    site_org_id = _site_org_id(db, site_id)
+    annexe = find_active_annexe(db, site_id, energy_type, ref_date, org_id=site_org_id)
     if annexe:
         result = _resolve_cadre_weighted_price(db, annexe)
         if result:
@@ -260,17 +292,15 @@ def _shadow_billing_cadre_hphc(
     if hp_price is None or hc_price is None:
         return None
 
-    # Get HP/HC weights from cadre or defaults
-    cadre = annexe.cadre
-    poids_hp = (cadre.poids_hp if cadre and cadre.poids_hp else 62.0) / 100.0
-    poids_hc = (cadre.poids_hc if cadre and cadre.poids_hc else 38.0) / 100.0
+    # Normalized HP/HC weights — guards against operator typos (e.g. 70+40)
+    poids_hp, poids_hc = _normalized_hp_hc_weights(annexe.cadre)
 
-    kwh = invoice.energy_kwh
+    kwh = invoice.energy_kwh or 0
     kwh_hp = round(kwh * poids_hp, 1)
     kwh_hc = round(kwh * poids_hc, 1)
 
-    shadow_hp = round(kwh_hp * hp_price, 2)
-    shadow_hc = round(kwh_hc * hc_price, 2)
+    shadow_hp = round(kwh_hp * float(hp_price), 2)
+    shadow_hc = round(kwh_hc * float(hc_price), 2)
     shadow_total = round(shadow_hp + shadow_hc, 2)
 
     # Compare against energy line total when available
@@ -289,7 +319,7 @@ def _shadow_billing_cadre_hphc(
     delta = round(actual_total - shadow_total, 2)
     delta_pct = round(delta / shadow_total * 100, 2) if shadow_total > 0 else None
 
-    weighted_price = round(hp_price * poids_hp + hc_price * poids_hc, 6)
+    weighted_price = round(float(hp_price) * poids_hp + float(hc_price) * poids_hc, 6)
 
     return {
         "shadow_total_eur": shadow_total,
@@ -303,8 +333,8 @@ def _shadow_billing_cadre_hphc(
         "cadre_detail": {
             "annexe_id": annexe.id,
             "cadre_id": annexe.cadre_id,
-            "hp_price": hp_price,
-            "hc_price": hc_price,
+            "hp_price": float(hp_price),
+            "hc_price": float(hc_price),
             "poids_hp_pct": round(poids_hp * 100, 1),
             "poids_hc_pct": round(poids_hc * 100, 1),
             "kwh_hp": kwh_hp,
@@ -334,11 +364,12 @@ def shadow_billing_simple(
             "reason": "energy_kwh manquant ou <= 0",
         }
 
-    # Phase 5: Try cadre HP/HC shadow billing first
+    # Phase 5: Try cadre HP/HC shadow billing first (scoped by org)
     if db:
         energy_type_str = _energy_type(invoice, contract)
         ref_date = invoice.period_start or invoice.period_end or date.today()
-        annexe = find_active_annexe(db, invoice.site_id, energy_type_str, ref_date)
+        invoice_org_id = _site_org_id(db, invoice.site_id)
+        annexe = find_active_annexe(db, invoice.site_id, energy_type_str, ref_date, org_id=invoice_org_id)
         if annexe:
             cadre_result = _shadow_billing_cadre_hphc(invoice, annexe, db)
             if cadre_result:

--- a/backend/services/contract_v2_service.py
+++ b/backend/services/contract_v2_service.py
@@ -140,8 +140,39 @@ def list_cadres(
     return results
 
 
-def get_cadre(db: Session, cadre_id: int) -> Optional[Dict[str, Any]]:
-    """Cadre complet + annexes + pricing + events."""
+def get_cadre(
+    db: Session,
+    cadre_id: int,
+    *,
+    source: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Cadre complet + annexes + pricing + events.
+
+    Tries V2 ContratCadre first (Phase 1), falls back to legacy EnergyContract.
+    Pass source="v2" or source="legacy" to force a specific table when IDs
+    collide between the two tables.
+    """
+    # ── V2 ContratCadre (nouveau data model, Phase 1) ────────────────
+    if source in (None, "v2"):
+        v2 = (
+            db.query(ContratCadre)
+            .options(
+                joinedload(ContratCadre.annexes).joinedload(ContractAnnexe.site),
+                joinedload(ContratCadre.annexes).joinedload(ContractAnnexe.volume_commitment),
+                joinedload(ContratCadre.annexes).joinedload(ContractAnnexe.pricing_overrides),
+            )
+            .filter(ContratCadre.id == cadre_id, ContratCadre.deleted_at.is_(None))
+            .first()
+        )
+        if v2:
+            result = _serialize_v2_cadre(v2)
+            result["events"] = []  # V2 ContratCadre has no events relationship yet
+            result["coherence"] = []  # coherence_check expects legacy EnergyContract
+            return result
+        if source == "v2":
+            return None
+
+    # ── Legacy EnergyContract.is_cadre=True ──────────────────────────
     c = (
         db.query(EnergyContract)
         .options(

--- a/backend/services/contract_v2_service.py
+++ b/backend/services/contract_v2_service.py
@@ -114,12 +114,7 @@ def list_cadres(
         )
         .filter(EnergyContract.is_cadre == True)  # noqa: E712
     )
-    ej_ids = [
-        ej.id
-        for ej in db.query(EntiteJuridique.id)
-        .filter(EntiteJuridique.organisation_id == org_id)
-        .all()
-    ]
+    ej_ids = [ej.id for ej in db.query(EntiteJuridique.id).filter(EntiteJuridique.organisation_id == org_id).all()]
     if ej_ids:
         legacy_q = legacy_q.filter(EnergyContract.entite_juridique_id.in_(ej_ids))
     if status:
@@ -944,8 +939,7 @@ def _serialize_v2_cadre(c: ContratCadre) -> Dict[str, Any]:
     """
     annexes = [a for a in c.annexes if a.deleted_at is None]
     total_vol_kwh = sum(
-        float(a.volume_engage_kwh or 0)
-        + (float(a.volume_commitment.annual_kwh) if a.volume_commitment else 0)
+        float(a.volume_engage_kwh or 0) + (float(a.volume_commitment.annual_kwh) if a.volume_commitment else 0)
         for a in annexes
     )
     total_vol_mwh = round(total_vol_kwh / 1000, 2)
@@ -969,11 +963,17 @@ def _serialize_v2_cadre(c: ContratCadre) -> Dict[str, Any]:
 
     pricing: List[Dict[str, Any]] = []
     if prix_base is not None:
-        pricing.append({"period_code": "BASE", "season": "ANNUEL", "unit_price_eur_kwh": prix_base, "subscription_eur_month": None})
+        pricing.append(
+            {"period_code": "BASE", "season": "ANNUEL", "unit_price_eur_kwh": prix_base, "subscription_eur_month": None}
+        )
     if prix_hp is not None:
-        pricing.append({"period_code": "HP", "season": "ANNUEL", "unit_price_eur_kwh": prix_hp, "subscription_eur_month": None})
+        pricing.append(
+            {"period_code": "HP", "season": "ANNUEL", "unit_price_eur_kwh": prix_hp, "subscription_eur_month": None}
+        )
     if prix_hc is not None:
-        pricing.append({"period_code": "HC", "season": "ANNUEL", "unit_price_eur_kwh": prix_hc, "subscription_eur_month": None})
+        pricing.append(
+            {"period_code": "HC", "season": "ANNUEL", "unit_price_eur_kwh": prix_hc, "subscription_eur_month": None}
+        )
 
     return {
         "id": c.id,

--- a/backend/services/contract_v2_service.py
+++ b/backend/services/contract_v2_service.py
@@ -526,15 +526,16 @@ def refresh_all_statuses(db: Session, org_id: int) -> int:
 def compute_cadre_kpis(db: Session, cadre: EnergyContract) -> Dict[str, Any]:
     """KPIs pour un cadre avec prix moyen pondere par volume."""
     annexes = [a for a in cadre.annexes if a.deleted_at is None]
-    total_vol = sum((a.volume_commitment.annual_kwh if a.volume_commitment else 0) for a in annexes)
+    total_vol = sum((float(a.volume_commitment.annual_kwh) if a.volume_commitment else 0) for a in annexes)
 
     # Prix moyen pondere : chaque ligne pricing contribue proportionnellement
+    # Cast Decimal → float for arithmetic with PERIOD_WEIGHTS (floats)
     weighted_sum = 0.0
     weight_total = 0.0
     for p in cadre.pricing_lines:
         if p.unit_price_eur_kwh:
             w = PERIOD_WEIGHTS.get(p.period_code, 0.25)
-            weighted_sum += p.unit_price_eur_kwh * w
+            weighted_sum += float(p.unit_price_eur_kwh) * w
             weight_total += w
     avg_price = (weighted_sum / weight_total) if weight_total else 0
 
@@ -626,7 +627,7 @@ def compute_shadow_gap(db: Session, annexe_id: int) -> Dict[str, Any]:
                     pc = p.get("period_code", "")
                     if line.qty and p.get("unit_price_eur_kwh"):
                         if not pc or pc == (getattr(line, "period_code", None) or ""):
-                            shadow_supply += line.qty * p["unit_price_eur_kwh"]
+                            shadow_supply += float(line.qty) * float(p["unit_price_eur_kwh"])
                             break
             elif lt in NETWORK_TYPES:
                 inv_network += amount
@@ -872,12 +873,13 @@ def _serialize_cadre(c: EnergyContract) -> Dict[str, Any]:
     total_vol = sum((a.volume_commitment.annual_kwh / 1000 if a.volume_commitment else 0) for a in annexes)
 
     # Prix moyen pondere (meme formule que compute_cadre_kpis)
+    # Cast Decimal → float: unit_price_eur_kwh is Numeric(18,6), PERIOD_WEIGHTS floats
     weighted_sum = 0.0
     weight_total = 0.0
     for p in c.pricing_lines:
         if p.unit_price_eur_kwh:
             w = PERIOD_WEIGHTS.get(p.period_code, 0.25)
-            weighted_sum += p.unit_price_eur_kwh * w
+            weighted_sum += float(p.unit_price_eur_kwh) * w
             weight_total += w
     avg_price = (weighted_sum / weight_total) if weight_total else 0
     avg_price_mwh = round(avg_price * 1000, 2)
@@ -918,8 +920,10 @@ def _serialize_cadre(c: EnergyContract) -> Dict[str, Any]:
             {
                 "period_code": p.period_code,
                 "season": p.season,
-                "unit_price_eur_kwh": p.unit_price_eur_kwh,
-                "subscription_eur_month": p.subscription_eur_month,
+                "unit_price_eur_kwh": float(p.unit_price_eur_kwh) if p.unit_price_eur_kwh is not None else None,
+                "subscription_eur_month": float(p.subscription_eur_month)
+                if p.subscription_eur_month is not None
+                else None,
             }
             for p in c.pricing_lines
         ],
@@ -942,7 +946,7 @@ def _serialize_annexe_summary(a: ContractAnnexe) -> Dict[str, Any]:
         "status": a.status.value if a.status else "active",
         "start_date": str(dates["start_date"]) if dates["start_date"] else None,
         "end_date": str(dates["end_date"]) if dates["end_date"] else None,
-        "volume_mwh": round(a.volume_commitment.annual_kwh / 1000, 2) if a.volume_commitment else None,
+        "volume_mwh": round(float(a.volume_commitment.annual_kwh) / 1000, 2) if a.volume_commitment else None,
     }
 
 

--- a/backend/services/contract_v2_service.py
+++ b/backend/services/contract_v2_service.py
@@ -16,6 +16,7 @@ from models.contract_v2_models import (
     ContractAnnexe,
     ContractEvent,
     ContractPricing,
+    ContratCadre,
     VolumeCommitment,
 )
 from models.enums import BillingEnergyType, ContractStatus
@@ -66,11 +67,45 @@ def list_cadres(
     supplier: Optional[str] = None,
     search: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Liste contrats cadre + annexes avec KPIs. Filtre par org via EJ ou site."""
-    from models import Site, Portefeuille, EntiteJuridique
+    """Liste contrats cadre + annexes avec KPIs, union V2 ContratCadre + legacy EnergyContract."""
+    from models import EntiteJuridique
 
-    # Build base query: cadre contracts
-    q = (
+    results: List[Dict[str, Any]] = []
+
+    # ── V2: ContratCadre (nouveau data model, Phase 1) ──────────────
+    v2_q = (
+        db.query(ContratCadre)
+        .options(
+            joinedload(ContratCadre.annexes).joinedload(ContractAnnexe.site),
+            joinedload(ContratCadre.annexes).joinedload(ContractAnnexe.volume_commitment),
+        )
+        .filter(ContratCadre.org_id == org_id)
+        .filter(ContratCadre.deleted_at.is_(None))
+    )
+    if status:
+        try:
+            v2_q = v2_q.filter(ContratCadre.statut == ContractStatus(status.upper()))
+        except ValueError:
+            pass
+    if energy_type:
+        try:
+            v2_q = v2_q.filter(ContratCadre.energie == BillingEnergyType(energy_type))
+        except ValueError:
+            pass
+    if supplier:
+        v2_q = v2_q.filter(ContratCadre.fournisseur.ilike(f"%{supplier}%"))
+    if search:
+        pattern = f"%{search}%"
+        v2_q = v2_q.filter(
+            ContratCadre.fournisseur.ilike(pattern)
+            | ContratCadre.reference_fournisseur.ilike(pattern)
+            | ContratCadre.reference.ilike(pattern)
+            | ContratCadre.notes.ilike(pattern)
+        )
+    results.extend(_serialize_v2_cadre(c) for c in v2_q.all())
+
+    # ── Legacy: EnergyContract.is_cadre (backward compat) ───────────
+    legacy_q = (
         db.query(EnergyContract)
         .options(
             joinedload(EnergyContract.annexes).joinedload(ContractAnnexe.site),
@@ -79,29 +114,30 @@ def list_cadres(
         )
         .filter(EnergyContract.is_cadre == True)  # noqa: E712
     )
-
-    # Org scoping via entite_juridique_id
-    ej_ids = [ej.id for ej in db.query(EntiteJuridique.id).filter(EntiteJuridique.organisation_id == org_id).all()]
+    ej_ids = [
+        ej.id
+        for ej in db.query(EntiteJuridique.id)
+        .filter(EntiteJuridique.organisation_id == org_id)
+        .all()
+    ]
     if ej_ids:
-        q = q.filter(EnergyContract.entite_juridique_id.in_(ej_ids))
-
-    # Filters
+        legacy_q = legacy_q.filter(EnergyContract.entite_juridique_id.in_(ej_ids))
     if status:
-        q = q.filter(EnergyContract.contract_status == status)
+        legacy_q = legacy_q.filter(EnergyContract.contract_status == status)
     if energy_type:
-        q = q.filter(EnergyContract.energy_type == energy_type)
+        legacy_q = legacy_q.filter(EnergyContract.energy_type == energy_type)
     if supplier:
-        q = q.filter(EnergyContract.supplier_name.ilike(f"%{supplier}%"))
+        legacy_q = legacy_q.filter(EnergyContract.supplier_name.ilike(f"%{supplier}%"))
     if search:
         pattern = f"%{search}%"
-        q = q.filter(
+        legacy_q = legacy_q.filter(
             EnergyContract.supplier_name.ilike(pattern)
             | EnergyContract.reference_fournisseur.ilike(pattern)
             | EnergyContract.notes.ilike(pattern)
         )
+    results.extend(_serialize_cadre(c) for c in legacy_q.all())
 
-    cadres = q.all()
-    return [_serialize_cadre(c) for c in cadres]
+    return results
 
 
 def get_cadre(db: Session, cadre_id: int) -> Optional[Dict[str, Any]]:
@@ -865,6 +901,78 @@ def get_cadre_for_org(db: Session, cadre_id: int, org_id: int) -> Optional[Dict[
     ]
     result["coherence"] = coherence_check(db, cadre_id)
     return result
+
+
+def _serialize_v2_cadre(c: ContratCadre) -> Dict[str, Any]:
+    """Serialize a V2 ContratCadre into the same envelope as legacy _serialize_cadre.
+
+    V2 cadres have flat price columns (prix_hp_eur_kwh, prix_hc_eur_kwh,
+    prix_base_eur_kwh) and a denormalized poids_hp / poids_hc split. The
+    weighted-average price is computed from these flat columns so the UI can
+    display a single EUR/MWh figure consistent with legacy cadres.
+    """
+    annexes = [a for a in c.annexes if a.deleted_at is None]
+    total_vol_kwh = sum(
+        float(a.volume_engage_kwh or 0)
+        + (float(a.volume_commitment.annual_kwh) if a.volume_commitment else 0)
+        for a in annexes
+    )
+    total_vol_mwh = round(total_vol_kwh / 1000, 2)
+
+    # Weighted average from flat V2 columns
+    prix_base = float(c.prix_base_eur_kwh) if c.prix_base_eur_kwh is not None else None
+    prix_hp = float(c.prix_hp_eur_kwh) if c.prix_hp_eur_kwh is not None else None
+    prix_hc = float(c.prix_hc_eur_kwh) if c.prix_hc_eur_kwh is not None else None
+    if prix_base is not None:
+        avg_price = prix_base
+    elif prix_hp is not None and prix_hc is not None:
+        hp_w = float(c.poids_hp or 62.0) / 100.0
+        hc_w = float(c.poids_hc or 38.0) / 100.0
+        avg_price = prix_hp * hp_w + prix_hc * hc_w
+    else:
+        avg_price = 0
+    avg_price_mwh = round(avg_price * 1000, 2)
+
+    days_to_expiry = (c.date_fin - date.today()).days if c.date_fin else None
+    statut_val = c.statut.value if c.statut else None
+
+    pricing: List[Dict[str, Any]] = []
+    if prix_base is not None:
+        pricing.append({"period_code": "BASE", "season": "ANNUEL", "unit_price_eur_kwh": prix_base, "subscription_eur_month": None})
+    if prix_hp is not None:
+        pricing.append({"period_code": "HP", "season": "ANNUEL", "unit_price_eur_kwh": prix_hp, "subscription_eur_month": None})
+    if prix_hc is not None:
+        pricing.append({"period_code": "HC", "season": "ANNUEL", "unit_price_eur_kwh": prix_hc, "subscription_eur_month": None})
+
+    return {
+        "id": c.id,
+        "source": "v2",
+        "supplier_name": c.fournisseur,
+        "contract_ref": c.reference_fournisseur or c.reference,
+        "energy_type": c.energie.value if c.energie else None,
+        "contract_type": "CADRE",
+        "pricing_model": c.type_prix.value if c.type_prix else None,
+        "start_date": str(c.date_debut) if c.date_debut else None,
+        "end_date": str(c.date_fin) if c.date_fin else None,
+        "status": statut_val,
+        "days_to_expiry": days_to_expiry,
+        "tacit_renewal": c.auto_renew,
+        "notice_period_months": c.notice_period_months,
+        "is_green": c.is_green,
+        "green_percentage": c.green_percentage,
+        "segment_enedis": None,
+        "indexation_formula": None,
+        "indexation_reference": c.indexation_reference,
+        "price_revision_clause": None,
+        "notes": c.notes,
+        "entite_juridique_id": c.entite_juridique_id,
+        "nb_annexes": len(annexes),
+        "total_volume_mwh": total_vol_mwh,
+        "avg_price_eur_mwh": avg_price_mwh,
+        "budget_eur": round(avg_price * total_vol_kwh, 0) if avg_price and total_vol_kwh else 0,
+        "pricing": pricing,
+        "annexes": [_serialize_annexe_summary(a) for a in annexes],
+    }
 
 
 def _serialize_cadre(c: EnergyContract) -> Dict[str, Any]:

--- a/backend/services/contrat_coherence.py
+++ b/backend/services/contrat_coherence.py
@@ -510,26 +510,32 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
     if v2_cadre:
         v2_lines = []
         if v2_cadre.prix_base_eur_kwh is not None:
-            v2_lines.append({
-                "period_code": "BASE",
-                "season": "ANNUEL",
-                "unit_price_eur_kwh": _as_float(v2_cadre.prix_base_eur_kwh),
-                "source": "cadre",
-            })
+            v2_lines.append(
+                {
+                    "period_code": "BASE",
+                    "season": "ANNUEL",
+                    "unit_price_eur_kwh": _as_float(v2_cadre.prix_base_eur_kwh),
+                    "source": "cadre",
+                }
+            )
         if v2_cadre.prix_hp_eur_kwh is not None:
-            v2_lines.append({
-                "period_code": "HP",
-                "season": "ANNUEL",
-                "unit_price_eur_kwh": _as_float(v2_cadre.prix_hp_eur_kwh),
-                "source": "cadre",
-            })
+            v2_lines.append(
+                {
+                    "period_code": "HP",
+                    "season": "ANNUEL",
+                    "unit_price_eur_kwh": _as_float(v2_cadre.prix_hp_eur_kwh),
+                    "source": "cadre",
+                }
+            )
         if v2_cadre.prix_hc_eur_kwh is not None:
-            v2_lines.append({
-                "period_code": "HC",
-                "season": "ANNUEL",
-                "unit_price_eur_kwh": _as_float(v2_cadre.prix_hc_eur_kwh),
-                "source": "cadre",
-            })
+            v2_lines.append(
+                {
+                    "period_code": "HC",
+                    "season": "ANNUEL",
+                    "unit_price_eur_kwh": _as_float(v2_cadre.prix_hc_eur_kwh),
+                    "source": "cadre",
+                }
+            )
         if v2_lines:
             return v2_lines
 

--- a/backend/services/contrat_coherence.py
+++ b/backend/services/contrat_coherence.py
@@ -503,7 +503,37 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
             for p in annexe.pricing_overrides
         ]
 
-    # 2. Heritage cadre (grille structuree)
+    # 2. Heritage V2 ContratCadre (colonnes flat prix_*_eur_kwh).
+    # V2 annexes reference ContratCadre via `annexe.cadre` (cadre_id FK).
+    # V2 ContratCadre has no pricing_lines relationship — only flat columns.
+    v2_cadre = annexe.cadre
+    if v2_cadre:
+        v2_lines = []
+        if v2_cadre.prix_base_eur_kwh is not None:
+            v2_lines.append({
+                "period_code": "BASE",
+                "season": "ANNUEL",
+                "unit_price_eur_kwh": _as_float(v2_cadre.prix_base_eur_kwh),
+                "source": "cadre",
+            })
+        if v2_cadre.prix_hp_eur_kwh is not None:
+            v2_lines.append({
+                "period_code": "HP",
+                "season": "ANNUEL",
+                "unit_price_eur_kwh": _as_float(v2_cadre.prix_hp_eur_kwh),
+                "source": "cadre",
+            })
+        if v2_cadre.prix_hc_eur_kwh is not None:
+            v2_lines.append({
+                "period_code": "HC",
+                "season": "ANNUEL",
+                "unit_price_eur_kwh": _as_float(v2_cadre.prix_hc_eur_kwh),
+                "source": "cadre",
+            })
+        if v2_lines:
+            return v2_lines
+
+    # 3. Legacy EnergyContract cadre (grille structuree pricing_lines)
     cadre = annexe.contrat_cadre
     if cadre and cadre.pricing_lines:
         return [
@@ -517,7 +547,7 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
             for p in cadre.pricing_lines
         ]
 
-    # 3. Fallback: colonnes plates sur EnergyContract
+    # 4. Legacy EnergyContract fallback (colonnes plates)
     if cadre:
         lines = []
         if cadre.price_base_eur_kwh:
@@ -525,7 +555,7 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
                 {
                     "period_code": "BASE",
                     "season": "ANNUEL",
-                    "unit_price_eur_kwh": cadre.price_base_eur_kwh,
+                    "unit_price_eur_kwh": _as_float(cadre.price_base_eur_kwh),
                     "source": "cadre",
                 }
             )
@@ -534,7 +564,7 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
                 {
                     "period_code": "HP",
                     "season": "ANNUEL",
-                    "unit_price_eur_kwh": cadre.price_hp_eur_kwh,
+                    "unit_price_eur_kwh": _as_float(cadre.price_hp_eur_kwh),
                     "source": "cadre",
                 }
             )
@@ -543,7 +573,7 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
                 {
                     "period_code": "HC",
                     "season": "ANNUEL",
-                    "unit_price_eur_kwh": cadre.price_hc_eur_kwh,
+                    "unit_price_eur_kwh": _as_float(cadre.price_hc_eur_kwh),
                     "source": "cadre",
                 }
             )
@@ -552,7 +582,7 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
                 {
                     "period_code": "BASE",
                     "season": "ANNUEL",
-                    "subscription_eur_month": cadre.fixed_fee_eur_per_month,
+                    "subscription_eur_month": _as_float(cadre.fixed_fee_eur_per_month),
                     "source": "cadre",
                 }
             )

--- a/backend/services/contrat_coherence.py
+++ b/backend/services/contrat_coherence.py
@@ -480,6 +480,11 @@ def validate_contrat(db: Session, cadre_id: int) -> List[Dict[str, str]]:
     return results
 
 
+def _as_float(v):
+    """Cast Decimal (from Numeric columns) to float for API output. Passes None through."""
+    return float(v) if v is not None else None
+
+
 def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[str, Any]]:
     """Retourne pricing effectif avec cascade: override annexe > cadre > fallback colonnes plates.
 
@@ -491,8 +496,8 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
             {
                 "period_code": p.period_code,
                 "season": p.season,
-                "unit_price_eur_kwh": p.unit_price_eur_kwh,
-                "subscription_eur_month": p.subscription_eur_month,
+                "unit_price_eur_kwh": _as_float(p.unit_price_eur_kwh),
+                "subscription_eur_month": _as_float(p.subscription_eur_month),
                 "source": "override",
             }
             for p in annexe.pricing_overrides
@@ -505,8 +510,8 @@ def resolve_pricing(db: Optional[Session], annexe: ContractAnnexe) -> List[Dict[
             {
                 "period_code": p.period_code,
                 "season": p.season,
-                "unit_price_eur_kwh": p.unit_price_eur_kwh,
-                "subscription_eur_month": p.subscription_eur_month,
+                "unit_price_eur_kwh": _as_float(p.unit_price_eur_kwh),
+                "subscription_eur_month": _as_float(p.subscription_eur_month),
                 "source": "cadre",
             }
             for p in cadre.pricing_lines

--- a/backend/services/demo_seed/gen_billing.py
+++ b/backend/services/demo_seed/gen_billing.py
@@ -234,9 +234,22 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
             tva = round((energy_eur + network_eur + tax_eur) * 0.20 + abo_eur * 0.055, 2)
             total = round(ht + tva, 2)
 
+        # V2 Phase 5: resolve annexe_site_id from cadre if available
+        _annexe_site_id = None
+        try:
+            from services.billing_service import find_active_annexe
+
+            energy_str = "gaz" if is_gaz else "elec"
+            _annexe = find_active_annexe(db, site.id, energy_str, period_start)
+            if _annexe:
+                _annexe_site_id = _annexe.id
+        except Exception:
+            pass  # cadre tables may not exist yet
+
         invoice = EnergyInvoice(
             site_id=site.id,
             contract_id=contract.id,
+            annexe_site_id=_annexe_site_id,
             invoice_number=inv_number,
             period_start=period_start,
             period_end=period_end,
@@ -393,10 +406,31 @@ def generate_billing(db, org, sites: list, invoices_count: int, rng: random.Rand
 # ──────────────────────────────────────────────────────────────
 
 
+def _cadre_exists(db, ref_fournisseur: str) -> bool:
+    """Idempotency guard: skip if a ContratCadre with this reference_fournisseur exists."""
+    from models.contract_v2_models import ContratCadre
+
+    return db.query(ContratCadre.id).filter(ContratCadre.reference_fournisseur == ref_fournisseur).first() is not None
+
+
 def generate_cadre_contracts(db, org, sites: list, rng=None) -> dict:
-    """Generate V2 cadre contracts with annexes, pricing, volumes, events.
-    Additive — does not break existing seed."""
-    from models.contract_v2_models import ContractAnnexe, ContractPricing, VolumeCommitment, ContractEvent
+    """Generate V2 cadre contracts (ContratCadre) with annexes, pricing, volumes.
+
+    4 cadres HELIOS — idempotent via reference_fournisseur:
+      1. EDF FIXE elec — Paris + Lyon (2 sites)
+      2. ENGIE gaz INDEXE PEG — Toulouse (1 site)
+      3. TotalEnergies FIXE elec — Nice + Marseille (2 sites)
+      4. Ekwateur SPOT EPEX elec — Nice (1 site)
+
+    Uses ContratCadre model (contrats_cadre table), NOT legacy EnergyContract.
+    Additive — does not break existing seed.
+    """
+    from models.contract_v2_models import (
+        ContratCadre,
+        ContractAnnexe,
+        ContractPricing,
+        VolumeCommitment,
+    )
     from models import EntiteJuridique, ContractStatus
 
     if len(sites) < 3:
@@ -409,354 +443,286 @@ def generate_cadre_contracts(db, org, sites: list, rng=None) -> dict:
     cadres_created = 0
     annexes_created = 0
 
-    # ── Cadre 1: EDF Elec multi-site (3 annexes) ──
-    cadre1 = EnergyContract(
-        site_id=sites[0].id,
-        energy_type=BillingEnergyType.ELEC,
-        supplier_name="EDF Entreprises",
-        start_date=date(2024, 1, 1),
-        end_date=date(2026, 6, 15),
-        reference_fournisseur="CADRE-2024-001",
-        auto_renew=False,
-        notice_period_days=90,
-        offer_indexation=ContractIndexation.FIXE,
-        contract_status=ContractStatus.EXPIRING,
-        is_cadre=True,
-        contract_type="CADRE",
-        entite_juridique_id=ej_id,
-        notice_period_months=3,
-        is_green=False,
-        segment_enedis="C4",
-        annual_consumption_kwh=2_100_000.0,
-        indexation_formula="TRVE-5%",
-        indexation_reference="TRVE",
-        indexation_spread_eur_mwh=-5.0,
-        price_revision_clause="ANNUAL_REVIEW",
-        notes="Contrat cadre EDF 3 sites — demo HELIOS",
-    )
-    db.add(cadre1)
-    db.flush()
-    cadres_created += 1
+    # ── Cadre 1: EDF Entreprises — FIXE elec — Paris + Lyon ──
+    ref1 = "EDF-CADRE-2024-001"
+    if not _cadre_exists(db, ref1):
+        cadre1 = ContratCadre(
+            org_id=org.id,
+            entite_juridique_id=ej_id,
+            reference="CC-2024-001",
+            reference_fournisseur=ref1,
+            fournisseur="EDF Entreprises",
+            energie=BillingEnergyType.ELEC,
+            date_signature=date(2024, 1, 10),
+            date_debut=date(2024, 2, 1),
+            date_fin=date(2026, 12, 31),
+            date_preavis=date(2026, 9, 30),
+            notice_period_months=3,
+            auto_renew=False,
+            type_prix=ContractIndexation.FIXE,
+            prix_hp_eur_kwh=0.1580,
+            prix_hc_eur_kwh=0.1180,
+            prix_base_eur_kwh=0.1420,
+            poids_hp=62.0,
+            poids_hc=38.0,
+            cee_inclus=True,
+            cee_eur_mwh=4.50,
+            capacite_incluse=False,
+            capacite_eur_mwh=12.80,
+            statut=ContractStatus.ACTIVE,
+            is_green=False,
+            notes="Contrat cadre EDF 2 sites bureaux — demo HELIOS",
+        )
+        db.add(cadre1)
+        db.flush()
+        cadres_created += 1
 
-    # Pricing cadre EDF: horosaisonnier
-    for pc, season, price in [
-        ("HP", "HIVER", 0.1680),
-        ("HC", "HIVER", 0.1220),
-        ("HP", "ETE", 0.1425),
-        ("HC", "ETE", 0.0985),
-    ]:
+        # Annexe 1a: Paris — herite prix cadre
+        a1a = ContractAnnexe(
+            cadre_id=cadre1.id,
+            site_id=sites[0].id,
+            annexe_ref="ANX-EDF-Paris-001",
+            tariff_option=TariffOptionEnum.LU,
+            subscribed_power_kva=200,
+            segment_enedis="C4",
+            has_price_override=False,
+            status=ContractStatus.ACTIVE,
+            volume_engage_kwh=595_000,
+        )
+        db.add(a1a)
+        db.flush()
         db.add(
-            ContractPricing(
-                contract_id=cadre1.id,
-                period_code=pc,
-                season=season,
-                unit_price_eur_kwh=price,
+            VolumeCommitment(
+                annexe_id=a1a.id,
+                annual_kwh=595_000,
+                tolerance_pct_up=10,
+                tolerance_pct_down=10,
+                penalty_eur_kwh_above=0.015,
+                penalty_eur_kwh_below=0.010,
             )
         )
-    db.add(
-        ContractPricing(
-            contract_id=cadre1.id,
-            period_code="BASE",
-            season="ANNUEL",
-            subscription_eur_month=145.80,
-        )
-    )
+        annexes_created += 1
 
-    # Annexe 1: Paris (herite)
-    a1 = ContractAnnexe(
-        contrat_cadre_id=cadre1.id,
-        site_id=sites[0].id,
-        annexe_ref="ANX-Paris-001",
-        tariff_option=TariffOptionEnum.LU,
-        subscribed_power_kva=108,
-        segment_enedis="C4",
-        has_price_override=False,
-        status=ContractStatus.ACTIVE,
-    )
-    db.add(a1)
-    db.flush()
-    db.add(
-        VolumeCommitment(
-            annexe_id=a1.id,
-            annual_kwh=850000,
-            tolerance_pct_up=10,
-            tolerance_pct_down=10,
-            penalty_eur_kwh_above=0.015,
-            penalty_eur_kwh_below=0.010,
+        # Annexe 1b: Lyon — override prix (bureau plus petit, prix negocie)
+        a1b = ContractAnnexe(
+            cadre_id=cadre1.id,
+            site_id=sites[1].id,
+            annexe_ref="ANX-EDF-Lyon-002",
+            tariff_option=TariffOptionEnum.HP_HC,
+            subscribed_power_kva=80,
+            segment_enedis="C5",
+            has_price_override=True,
+            override_pricing_model="FIXE",
+            prix_base_override=0.1380,
+            status=ContractStatus.ACTIVE,
+            volume_engage_kwh=204_000,
         )
-    )
-    annexes_created += 1
+        db.add(a1b)
+        db.flush()
+        db.add(
+            ContractPricing(
+                annexe_id=a1b.id,
+                period_code="BASE",
+                season="ANNUEL",
+                unit_price_eur_kwh=0.1380,
+            )
+        )
+        db.add(
+            VolumeCommitment(
+                annexe_id=a1b.id,
+                annual_kwh=204_000,
+                tolerance_pct_up=10,
+                tolerance_pct_down=10,
+            )
+        )
+        annexes_created += 1
 
-    # Annexe 2: Lyon (override prix fixe 138)
-    a2 = ContractAnnexe(
-        contrat_cadre_id=cadre1.id,
-        site_id=sites[1].id,
-        annexe_ref="ANX-Lyon-002",
-        tariff_option=TariffOptionEnum.MU4,
-        subscribed_power_kva=60,
-        segment_enedis="C4",
-        has_price_override=True,
-        override_pricing_model="FIXE",
-        end_date_override=date(2026, 6, 28),
-        status=ContractStatus.EXPIRING,
-    )
-    db.add(a2)
-    db.flush()
-    db.add(
-        ContractPricing(
-            annexe_id=a2.id,
-            period_code="BASE",
-            season="ANNUEL",
-            unit_price_eur_kwh=0.138,
-        )
-    )
-    db.add(
-        VolumeCommitment(
-            annexe_id=a2.id,
-            annual_kwh=420000,
-            tolerance_pct_up=10,
-            tolerance_pct_down=10,
-        )
-    )
-    annexes_created += 1
-
-    # Annexe 3: Toulouse (herite)
-    a3 = ContractAnnexe(
-        contrat_cadre_id=cadre1.id,
-        site_id=sites[2].id if len(sites) > 2 else sites[0].id,
-        annexe_ref="ANX-Toulouse-003",
-        tariff_option=TariffOptionEnum.CU4,
-        subscribed_power_kva=72,
-        segment_enedis="C4",
-        has_price_override=False,
-        status=ContractStatus.ACTIVE,
-    )
-    db.add(a3)
-    db.flush()
-    db.add(
-        VolumeCommitment(
-            annexe_id=a3.id,
-            annual_kwh=380000,
-            tolerance_pct_up=10,
-            tolerance_pct_down=10,
-        )
-    )
-    annexes_created += 1
-
-    # Events cadre 1
-    db.add(
-        ContractEvent(
-            contract_id=cadre1.id,
-            event_type="CREATION",
-            event_date=date(2024, 1, 1),
-            description="Signature cadre 3 sites",
-        )
-    )
-    db.add(
-        ContractEvent(
-            contract_id=cadre1.id,
-            event_type="AVENANT",
-            event_date=date(2024, 6, 15),
-            description="Ajout Toulouse + PS Paris 96→108 kVA",
-        )
-    )
-
-    # ── Cadre 2: ENGIE Gaz mono-site ──
-    if len(sites) > 3:
-        cadre2 = EnergyContract(
-            site_id=sites[3].id,
-            energy_type=BillingEnergyType.GAZ,
-            supplier_name="ENGIE Pro",
-            start_date=date(2025, 9, 1),
-            end_date=date(2027, 12, 31),
-            reference_fournisseur="GP-2025-114",
-            auto_renew=True,
-            notice_period_days=90,
-            offer_indexation=ContractIndexation.INDEXE,
-            contract_status=ContractStatus.ACTIVE,
-            is_cadre=True,
-            contract_type="UNIQUE",
+    # ── Cadre 2: ENGIE Pro — INDEXE PEG gaz — Toulouse ──
+    ref2 = "ENGIE-GP-2025-042"
+    if not _cadre_exists(db, ref2):
+        cadre2 = ContratCadre(
+            org_id=org.id,
             entite_juridique_id=ej_id,
+            reference="CC-2025-002",
+            reference_fournisseur=ref2,
+            fournisseur="ENGIE Pro",
+            energie=BillingEnergyType.GAZ,
+            date_signature=date(2025, 1, 15),
+            date_debut=date(2025, 3, 1),
+            date_fin=date(2027, 2, 28),
+            date_preavis=date(2026, 11, 30),
             notice_period_months=3,
-            annual_consumption_kwh=320_000.0,
-            indexation_formula="PEG_DA+3",
+            auto_renew=True,
+            type_prix=ContractIndexation.INDEXE,
+            prix_base_eur_kwh=0.0528,
             indexation_reference="PEG_DA",
             indexation_spread_eur_mwh=3.0,
-            price_revision_clause="ANNUAL_REVIEW",
+            statut=ContractStatus.ACTIVE,
+            is_green=False,
+            notes="Contrat gaz indexe PEG entrepot Toulouse — demo HELIOS",
         )
         db.add(cadre2)
         db.flush()
         cadres_created += 1
 
-        db.add(
-            ContractPricing(
-                contract_id=cadre2.id,
-                period_code="BASE",
-                season="ANNUEL",
-                unit_price_eur_kwh=0.0528,
-            )
-        )
-        a4 = ContractAnnexe(
-            contrat_cadre_id=cadre2.id,
-            site_id=sites[3].id,
-            annexe_ref="ANX-Marseille-001",
-            subscribed_power_kva=45,
+        # Annexe 2a: Toulouse entrepot (gaz)
+        a2a = ContractAnnexe(
+            cadre_id=cadre2.id,
+            site_id=sites[2].id,
+            annexe_ref="ANX-ENGIE-Toulouse-001",
             segment_enedis=None,
             has_price_override=False,
             status=ContractStatus.ACTIVE,
+            volume_engage_kwh=720_000,
         )
-        db.add(a4)
+        db.add(a2a)
         db.flush()
         db.add(
             VolumeCommitment(
-                annexe_id=a4.id,
-                annual_kwh=320000,
+                annexe_id=a2a.id,
+                annual_kwh=720_000,
+                tolerance_pct_up=15,
+                tolerance_pct_down=10,
             )
         )
         annexes_created += 1
 
-        db.add(
-            ContractEvent(
-                contract_id=cadre2.id,
-                event_type="CREATION",
-                event_date=date(2025, 9, 1),
-                description="Signature ENGIE gaz Marseille",
-            )
-        )
-
-    # ── Cadre 3: TotalEnergies Elec mono-site ──
-    if len(sites) > 4:
-        cadre3 = EnergyContract(
-            site_id=sites[4].id,
-            energy_type=BillingEnergyType.ELEC,
-            supplier_name="TotalEnergies",
-            start_date=date(2025, 1, 1),
-            end_date=date(2027, 9, 30),
-            reference_fournisseur="TE-B2B-2025-087",
-            auto_renew=False,
-            notice_period_days=90,
-            # D.2: pricing SPOT + TUNNEL (cap+floor) pour Nice
-            offer_indexation=ContractIndexation.SPOT,
-            price_granularity="horaire",
-            contract_status=ContractStatus.ACTIVE,
-            is_cadre=True,
-            contract_type="UNIQUE",
+    # ── Cadre 3: TotalEnergies — FIXE elec — Nice + Marseille ──
+    ref3 = "TE-B2B-2025-087"
+    if not _cadre_exists(db, ref3) and len(sites) > 4:
+        cadre3 = ContratCadre(
+            org_id=org.id,
             entite_juridique_id=ej_id,
-            notice_period_months=3,
-            segment_enedis="C3",
-            annual_consumption_kwh=720_000.0,
-            # Clause TUNNEL : cap + floor
-            price_revision_clause="TUNNEL",
-            price_cap_eur_mwh=180.0,
-            price_floor_eur_mwh=80.0,
-            indexation_reference="EPEX_SPOT_FR",
-            indexation_spread_eur_mwh=5.0,
-            indexation_formula="SPOT+5",
+            reference="CC-2025-003",
+            reference_fournisseur=ref3,
+            fournisseur="TotalEnergies",
+            energie=BillingEnergyType.ELEC,
+            date_signature=date(2025, 2, 1),
+            date_debut=date(2025, 4, 1),
+            date_fin=date(2027, 3, 31),
+            date_preavis=date(2027, 1, 31),
+            notice_period_months=2,
+            auto_renew=False,
+            type_prix=ContractIndexation.FIXE,
+            prix_hp_eur_kwh=0.1650,
+            prix_hc_eur_kwh=0.1250,
+            prix_base_eur_kwh=0.1490,
+            poids_hp=62.0,
+            poids_hc=38.0,
+            cee_inclus=False,
+            capacite_incluse=True,
+            capacite_eur_mwh=11.50,
+            statut=ContractStatus.ACTIVE,
+            is_green=True,
+            green_percentage=100.0,
+            notes="Contrat cadre TotalEnergies 2 sites tertiaire — offre verte GO — demo HELIOS",
         )
         db.add(cadre3)
         db.flush()
         cadres_created += 1
 
-        for pc, season, price in [
-            ("HP", "HIVER", 0.1780),
-            ("HC", "HIVER", 0.1340),
-            ("HP", "ETE", 0.1520),
-            ("HC", "ETE", 0.1080),
-        ]:
-            db.add(
-                ContractPricing(
-                    contract_id=cadre3.id,
-                    period_code=pc,
-                    season=season,
-                    unit_price_eur_kwh=price,
-                )
-            )
-        a5 = ContractAnnexe(
-            contrat_cadre_id=cadre3.id,
-            site_id=sites[4].id,
-            annexe_ref="ANX-Nice-001",
+        # Annexe 3a: Nice hotel — herite prix cadre
+        a3a = ContractAnnexe(
+            cadre_id=cadre3.id,
+            site_id=sites[3].id,
+            annexe_ref="ANX-TE-Nice-001",
             tariff_option=TariffOptionEnum.HP_HC,
-            subscribed_power_kva=120,
+            subscribed_power_kva=250,
             segment_enedis="C4",
             has_price_override=False,
             status=ContractStatus.ACTIVE,
+            volume_engage_kwh=1_120_000,
         )
-        db.add(a5)
+        db.add(a3a)
         db.flush()
         db.add(
             VolumeCommitment(
-                annexe_id=a5.id,
-                annual_kwh=720000,
+                annexe_id=a3a.id,
+                annual_kwh=1_120_000,
+                tolerance_pct_up=10,
+                tolerance_pct_down=10,
+                penalty_eur_kwh_above=0.012,
+                penalty_eur_kwh_below=0.008,
             )
         )
         annexes_created += 1
 
+        # Annexe 3b: Marseille ecole — herite prix cadre
+        a3b = ContractAnnexe(
+            cadre_id=cadre3.id,
+            site_id=sites[4].id,
+            annexe_ref="ANX-TE-Marseille-002",
+            tariff_option=TariffOptionEnum.HP_HC,
+            subscribed_power_kva=150,
+            segment_enedis="C4",
+            has_price_override=False,
+            status=ContractStatus.ACTIVE,
+            volume_engage_kwh=308_000,
+        )
+        db.add(a3b)
+        db.flush()
         db.add(
-            ContractEvent(
-                contract_id=cadre3.id,
-                event_type="CREATION",
-                event_date=date(2025, 1, 1),
-                description="Signature TotalEnergies Nice",
+            VolumeCommitment(
+                annexe_id=a3b.id,
+                annual_kwh=308_000,
+                tolerance_pct_up=10,
+                tolerance_pct_down=10,
             )
         )
+        annexes_created += 1
 
-    # ── Cadre 4: ENGIE Gaz expire ──
-    cadre4 = EnergyContract(
-        site_id=sites[0].id,
-        energy_type=BillingEnergyType.GAZ,
-        supplier_name="ENGIE Pro",
-        start_date=date(2023, 1, 1),
-        end_date=date(2025, 12, 31),
-        reference_fournisseur="GP-2023-089",
-        auto_renew=False,
-        notice_period_days=90,
-        offer_indexation=ContractIndexation.FIXE,
-        contract_status=ContractStatus.EXPIRED,
-        is_cadre=True,
-        contract_type="UNIQUE",
-        entite_juridique_id=ej_id,
-        notice_period_months=3,
-        annual_consumption_kwh=150_000.0,
-        indexation_formula="FIXE",
-        price_revision_clause="NONE",
-    )
-    db.add(cadre4)
-    db.flush()
-    cadres_created += 1
+    # ── Cadre 4: Ekwateur — SPOT EPEX elec — Nice ──
+    ref4 = "EKW-SPOT-2025-019"
+    if not _cadre_exists(db, ref4) and len(sites) > 3:
+        cadre4 = ContratCadre(
+            org_id=org.id,
+            entite_juridique_id=ej_id,
+            reference="CC-2025-004",
+            reference_fournisseur=ref4,
+            fournisseur="Ekwateur",
+            energie=BillingEnergyType.ELEC,
+            date_signature=date(2025, 3, 1),
+            date_debut=date(2025, 6, 1),
+            date_fin=date(2026, 5, 31),
+            notice_period_months=2,
+            auto_renew=True,
+            type_prix=ContractIndexation.SPOT,
+            indexation_reference="EPEX_SPOT_FR",
+            indexation_spread_eur_mwh=5.0,
+            prix_plafond_eur_mwh=200.0,
+            prix_plancher_eur_mwh=60.0,
+            statut=ContractStatus.ACTIVE,
+            is_green=True,
+            green_percentage=100.0,
+            notes="Contrat spot EPEX hotel Nice — demo HELIOS",
+        )
+        db.add(cadre4)
+        db.flush()
+        cadres_created += 1
 
-    db.add(
-        ContractPricing(
-            contract_id=cadre4.id,
-            period_code="BASE",
-            season="ANNUEL",
-            unit_price_eur_kwh=0.0486,
+        # Annexe 4a: Nice hotel — spot
+        a4a = ContractAnnexe(
+            cadre_id=cadre4.id,
+            site_id=sites[3].id,
+            annexe_ref="ANX-EKW-Nice-001",
+            tariff_option=TariffOptionEnum.BASE,
+            subscribed_power_kva=250,
+            segment_enedis="C4",
+            has_price_override=False,
+            status=ContractStatus.ACTIVE,
+            volume_engage_kwh=1_120_000,
         )
-    )
-    a6 = ContractAnnexe(
-        contrat_cadre_id=cadre4.id,
-        site_id=sites[0].id,
-        annexe_ref="ANX-Paris-Gaz-001",
-        has_price_override=False,
-        status=ContractStatus.EXPIRED,
-    )
-    db.add(a6)
-    db.flush()
-    db.add(
-        VolumeCommitment(
-            annexe_id=a6.id,
-            annual_kwh=150000,
+        db.add(a4a)
+        db.flush()
+        db.add(
+            VolumeCommitment(
+                annexe_id=a4a.id,
+                annual_kwh=1_120_000,
+                tolerance_pct_up=20,
+                tolerance_pct_down=15,
+            )
         )
-    )
-    annexes_created += 1
-
-    db.add(
-        ContractEvent(
-            contract_id=cadre4.id,
-            event_type="CREATION",
-            event_date=date(2023, 1, 1),
-            description="Signature ENGIE gaz Paris",
-        )
-    )
+        annexes_created += 1
 
     db.flush()
 

--- a/backend/tests/test_billing_cadre_resolution.py
+++ b/backend/tests/test_billing_cadre_resolution.py
@@ -297,3 +297,31 @@ class TestV2CadreInheritance:
         expected = 0.170 * 0.62 + 0.110 * 0.38
         assert price == pytest.approx(expected, abs=1e-5)
 
+
+# ── 5. get_cadre V2 fallback (service-level) ─────────────────────
+
+
+class TestGetCadreV2:
+    """Guard-rail: contract_v2_service.get_cadre must find V2 ContratCadre,
+    not only legacy EnergyContract.is_cadre=True. Regression: PR #190 Playwright
+    audit showed the detail endpoint returned None for V2 cadres."""
+
+    def test_get_cadre_returns_v2_cadre(self, db):
+        """get_cadre(id) returns a V2 ContratCadre when it exists."""
+        from services.contract_v2_service import get_cadre as svc_get_cadre
+        org, site = _make_site(db, "OrgGet", "600000006", "SiteGet")
+        cadre = _make_cadre(db, org.id, 1, prix_base_eur_kwh=0.15)
+        annexe = _make_annexe(db, cadre.id, site.id, with_base_pricing=True)
+
+        result = svc_get_cadre(db, cadre.id)
+        assert result is not None, "V2 cadre not found by get_cadre"
+        assert result["source"] == "v2"
+        assert result["supplier_name"] == "EDF Entreprises"
+        assert result["status"] == "active"
+
+    def test_get_cadre_returns_none_for_unknown_id(self, db):
+        """get_cadre(unknown) returns None, not an error."""
+        from services.contract_v2_service import get_cadre as svc_get_cadre
+        result = svc_get_cadre(db, 99999)
+        assert result is None
+

--- a/backend/tests/test_billing_cadre_resolution.py
+++ b/backend/tests/test_billing_cadre_resolution.py
@@ -266,8 +266,7 @@ class TestV2CadreInheritance:
 
         result = _resolve_cadre_weighted_price(db, annexe)
         assert result is not None, (
-            "V2 cadre inheritance broken: annexe without override should resolve "
-            "from cadre.prix_base_eur_kwh"
+            "V2 cadre inheritance broken: annexe without override should resolve from cadre.prix_base_eur_kwh"
         )
         price, source = result
         assert price == pytest.approx(0.145)
@@ -277,7 +276,9 @@ class TestV2CadreInheritance:
         """Non-override annexe inherits prix_hp/hc from the V2 cadre with weighted avg."""
         org, site = _make_site(db, "OrgHpHcInh", "500000005", "SiteHpHcInh")
         cadre = _make_cadre(
-            db, org.id, 1,
+            db,
+            org.id,
+            1,
             prix_hp_eur_kwh=0.170,
             prix_hc_eur_kwh=0.110,
         )
@@ -309,6 +310,7 @@ class TestGetCadreV2:
     def test_get_cadre_returns_v2_cadre(self, db):
         """get_cadre(id) returns a V2 ContratCadre when it exists."""
         from services.contract_v2_service import get_cadre as svc_get_cadre
+
         org, site = _make_site(db, "OrgGet", "600000006", "SiteGet")
         cadre = _make_cadre(db, org.id, 1, prix_base_eur_kwh=0.15)
         annexe = _make_annexe(db, cadre.id, site.id, with_base_pricing=True)
@@ -322,6 +324,6 @@ class TestGetCadreV2:
     def test_get_cadre_returns_none_for_unknown_id(self, db):
         """get_cadre(unknown) returns None, not an error."""
         from services.contract_v2_service import get_cadre as svc_get_cadre
+
         result = svc_get_cadre(db, 99999)
         assert result is None
-

--- a/backend/tests/test_billing_cadre_resolution.py
+++ b/backend/tests/test_billing_cadre_resolution.py
@@ -1,0 +1,241 @@
+"""
+PROMEOS — Phase 5 billing cascade + org scope tests.
+
+Fixes from PR #190 audit :
+  - `find_active_annexe` multi-tenant scope (org_id filter)
+  - `_normalized_hp_hc_weights` guards operator typos (70+40 ≠ 100)
+  - `_resolve_cadre_weighted_price` returns None on incomplete grids
+    instead of silently picking the first price (pointe falsely used as base)
+  - `get_reference_price` Priority 0 cascade (cadre annexe > legacy contract)
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import date
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import (
+    Base,
+    Organisation,
+    EntiteJuridique,
+    Portefeuille,
+    Site,
+    BillingEnergyType,
+    ContractIndexation,
+    TariffOptionEnum,
+)
+from models.enums import TypeSite, ContractStatus
+from models.contract_v2_models import ContratCadre, ContractAnnexe, ContractPricing
+from services.billing_service import (
+    _normalized_hp_hc_weights,
+    _resolve_cadre_weighted_price,
+    find_active_annexe,
+    get_reference_price,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+def _make_site(db, org_name, siren, site_name):
+    org = Organisation(nom=org_name, siren=siren, actif=True)
+    db.add(org)
+    db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom=f"EJ {org_name}", siren=siren)
+    db.add(ej)
+    db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom=f"PF {org_name}")
+    db.add(pf)
+    db.flush()
+    site = Site(portefeuille_id=pf.id, nom=site_name, type=TypeSite.BUREAU, actif=True)
+    db.add(site)
+    db.flush()
+    return org, site
+
+
+def _make_cadre(db, org_id, ej_id, **overrides):
+    defaults = dict(
+        org_id=org_id,
+        entite_juridique_id=ej_id,
+        reference=f"CADRE-{org_id}-INT",
+        fournisseur="EDF Entreprises",
+        reference_fournisseur=f"REF-{org_id}",
+        energie=BillingEnergyType.ELEC,
+        date_debut=date(2025, 1, 1),
+        date_fin=date(2025, 12, 31),
+        type_prix=ContractIndexation.FIXE,
+        statut=ContractStatus.ACTIVE,
+        poids_hp=62.0,
+        poids_hc=38.0,
+    )
+    defaults.update(overrides)
+    cadre = ContratCadre(**defaults)
+    db.add(cadre)
+    db.flush()
+    return cadre
+
+
+def _make_annexe(db, cadre_id, site_id, with_hp_hc_pricing=True, with_base_pricing=False):
+    annexe = ContractAnnexe(
+        cadre_id=cadre_id,
+        site_id=site_id,
+        annexe_ref=f"ANX-{cadre_id}-{site_id}",
+        tariff_option=TariffOptionEnum.HP_HC if with_hp_hc_pricing else TariffOptionEnum.BASE,
+        has_price_override=True,
+        status=ContractStatus.ACTIVE,
+    )
+    db.add(annexe)
+    db.flush()
+    if with_hp_hc_pricing:
+        db.add(ContractPricing(annexe_id=annexe.id, period_code="HP", season="ANNUEL", unit_price_eur_kwh=0.160))
+        db.add(ContractPricing(annexe_id=annexe.id, period_code="HC", season="ANNUEL", unit_price_eur_kwh=0.120))
+    if with_base_pricing:
+        db.add(ContractPricing(annexe_id=annexe.id, period_code="BASE", season="ANNUEL", unit_price_eur_kwh=0.140))
+    db.commit()
+    return annexe
+
+
+# ── 1. HP/HC weights normalization ────────────────────────────────
+
+
+class TestNormalizedWeights:
+    def test_default_market_weights_62_38(self):
+        class _Cadre:
+            poids_hp = None
+            poids_hc = None
+
+        hp, hc = _normalized_hp_hc_weights(_Cadre())
+        assert hp == pytest.approx(0.62)
+        assert hc == pytest.approx(0.38)
+        assert hp + hc == pytest.approx(1.0)
+
+    def test_normalizes_operator_typo_70_plus_40(self):
+        """Operator typo : 70+40=110 must normalize to 0.636/0.364, not inflate by 10%."""
+
+        class _Cadre:
+            poids_hp = 70.0
+            poids_hc = 40.0
+
+        hp, hc = _normalized_hp_hc_weights(_Cadre())
+        assert hp + hc == pytest.approx(1.0)
+        assert hp == pytest.approx(70.0 / 110.0)
+        assert hc == pytest.approx(40.0 / 110.0)
+
+    def test_handles_none_cadre(self):
+        hp, hc = _normalized_hp_hc_weights(None)
+        assert hp == pytest.approx(0.62)
+        assert hc == pytest.approx(0.38)
+
+    def test_zero_total_falls_back_to_default(self):
+        class _Cadre:
+            poids_hp = 0
+            poids_hc = 0
+
+        hp, hc = _normalized_hp_hc_weights(_Cadre())
+        assert hp == pytest.approx(0.62)
+        assert hc == pytest.approx(0.38)
+
+
+# ── 2. _resolve_cadre_weighted_price ──────────────────────────────
+
+
+class TestResolveCadreWeightedPrice:
+    def test_base_price_returned_as_is(self, db):
+        org, site = _make_site(db, "Org1", "111111111", "Site1")
+        cadre = _make_cadre(db, org.id, 1)
+        annexe = _make_annexe(db, cadre.id, site.id, with_hp_hc_pricing=False, with_base_pricing=True)
+
+        result = _resolve_cadre_weighted_price(db, annexe)
+        assert result is not None
+        price, source = result
+        assert price == pytest.approx(0.140)
+        assert source == f"cadre_annexe:{annexe.id}"
+
+    def test_hp_hc_weighted_average(self, db):
+        """0.160 HP * 0.62 + 0.120 HC * 0.38 = 0.1448."""
+        org, site = _make_site(db, "Org2", "222222222", "Site2")
+        cadre = _make_cadre(db, org.id, 1)
+        annexe = _make_annexe(db, cadre.id, site.id, with_hp_hc_pricing=True)
+
+        result = _resolve_cadre_weighted_price(db, annexe)
+        assert result is not None
+        price, source = result
+        expected = 0.160 * 0.62 + 0.120 * 0.38
+        assert price == pytest.approx(expected, abs=1e-5)
+
+    def test_incomplete_grid_returns_none(self, db):
+        """Only HP available (no HC, no BASE) must return None, not an arbitrary price."""
+        org, site = _make_site(db, "Org3", "333333333", "Site3")
+        cadre = _make_cadre(db, org.id, 1)
+        annexe = ContractAnnexe(
+            cadre_id=cadre.id,
+            site_id=site.id,
+            annexe_ref="ANX-partial",
+            has_price_override=True,
+            status=ContractStatus.ACTIVE,
+        )
+        db.add(annexe)
+        db.flush()
+        db.add(ContractPricing(annexe_id=annexe.id, period_code="HP", season="ANNUEL", unit_price_eur_kwh=0.16))
+        db.add(ContractPricing(annexe_id=annexe.id, period_code="P", season="ANNUEL", unit_price_eur_kwh=0.25))
+        db.commit()
+
+        result = _resolve_cadre_weighted_price(db, annexe)
+        assert result is None, (
+            "Incomplete grid must fall through to next priority source, "
+            "not silently pick a pointe price as the reference."
+        )
+
+
+# ── 3. Multi-tenant org scope ─────────────────────────────────────
+
+
+class TestOrgScopeIsolation:
+    def test_find_active_annexe_respects_org_id(self, db):
+        """Two cadres on the same site_id (different orgs) must not leak cross-tenant."""
+        org_a, site_a = _make_site(db, "OrgA", "100000001", "SiteA")
+        org_b, site_b = _make_site(db, "OrgB", "200000002", "SiteB")
+
+        cadre_a = _make_cadre(db, org_a.id, 1, reference_fournisseur="REF-A")
+        cadre_b = _make_cadre(db, org_b.id, 2, reference_fournisseur="REF-B")
+        annexe_a = _make_annexe(db, cadre_a.id, site_a.id, with_base_pricing=True)
+        annexe_b = _make_annexe(db, cadre_b.id, site_b.id, with_base_pricing=True)
+
+        # Query with org_a scope must NOT return annexe_b
+        found_for_a = find_active_annexe(db, site_a.id, "elec", date(2025, 6, 1), org_id=org_a.id)
+        assert found_for_a is not None
+        assert found_for_a.id == annexe_a.id
+
+        # Query with org_b scope on site_a must return None (org_a owns that site)
+        found_wrong_org = find_active_annexe(db, site_a.id, "elec", date(2025, 6, 1), org_id=org_b.id)
+        assert found_wrong_org is None, "Annexe leaked across orgs — multi-tenant isolation broken"
+
+    def test_get_reference_price_auto_resolves_org_id_from_site(self, db):
+        """get_reference_price() derives org_id from the site without caller passing it."""
+        org_a, site_a = _make_site(db, "OrgCheck", "300000003", "SiteCheck")
+        cadre = _make_cadre(db, org_a.id, 1)
+        _make_annexe(db, cadre.id, site_a.id, with_base_pricing=True)
+
+        price, source = get_reference_price(db, site_a.id, "elec", date(2025, 6, 1), date(2025, 6, 30))
+        assert price == pytest.approx(0.140)
+        assert source.startswith("cadre_annexe:")

--- a/backend/tests/test_billing_cadre_resolution.py
+++ b/backend/tests/test_billing_cadre_resolution.py
@@ -239,3 +239,61 @@ class TestOrgScopeIsolation:
         price, source = get_reference_price(db, site_a.id, "elec", date(2025, 6, 1), date(2025, 6, 30))
         assert price == pytest.approx(0.140)
         assert source.startswith("cadre_annexe:")
+
+
+# ── 4. V2 cadre inheritance path (non-override) ──────────────────
+
+
+class TestV2CadreInheritance:
+    """Guard-rail: resolve_pricing must traverse annexe.cadre (V2) for non-override
+    annexes, not only annexe.contrat_cadre (legacy). Regression: the flat V2 columns
+    prix_base_eur_kwh / prix_hp_eur_kwh / prix_hc_eur_kwh were silently ignored."""
+
+    def test_inheritance_base_from_v2_cadre(self, db):
+        """Non-override annexe inherits prix_base_eur_kwh from the V2 ContratCadre."""
+        org, site = _make_site(db, "OrgBaseInh", "400000004", "SiteBaseInh")
+        cadre = _make_cadre(db, org.id, 1, prix_base_eur_kwh=0.145)
+        # has_price_override=False — falls through to cadre inheritance
+        annexe = ContractAnnexe(
+            cadre_id=cadre.id,
+            site_id=site.id,
+            annexe_ref="ANX-inherit-base",
+            has_price_override=False,
+            status=ContractStatus.ACTIVE,
+        )
+        db.add(annexe)
+        db.commit()
+
+        result = _resolve_cadre_weighted_price(db, annexe)
+        assert result is not None, (
+            "V2 cadre inheritance broken: annexe without override should resolve "
+            "from cadre.prix_base_eur_kwh"
+        )
+        price, source = result
+        assert price == pytest.approx(0.145)
+        assert source == f"cadre_annexe:{annexe.id}"
+
+    def test_inheritance_hp_hc_from_v2_cadre(self, db):
+        """Non-override annexe inherits prix_hp/hc from the V2 cadre with weighted avg."""
+        org, site = _make_site(db, "OrgHpHcInh", "500000005", "SiteHpHcInh")
+        cadre = _make_cadre(
+            db, org.id, 1,
+            prix_hp_eur_kwh=0.170,
+            prix_hc_eur_kwh=0.110,
+        )
+        annexe = ContractAnnexe(
+            cadre_id=cadre.id,
+            site_id=site.id,
+            annexe_ref="ANX-inherit-hphc",
+            has_price_override=False,
+            status=ContractStatus.ACTIVE,
+        )
+        db.add(annexe)
+        db.commit()
+
+        result = _resolve_cadre_weighted_price(db, annexe)
+        assert result is not None
+        price, _ = result
+        expected = 0.170 * 0.62 + 0.110 * 0.38
+        assert price == pytest.approx(expected, abs=1e-5)
+

--- a/backend/tests/test_contrat_api.py
+++ b/backend/tests/test_contrat_api.py
@@ -1,0 +1,291 @@
+"""
+PROMEOS — Tests API Contrats V2 : CRUD + validate + expiring.
+Phase 6 CONTRATS-V2 QA — couvre endpoints via TestClient.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import date, timedelta
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from main import app
+from models import (
+    Base,
+    Organisation,
+    EntiteJuridique,
+    Portefeuille,
+    Site,
+    EnergyContract,
+    BillingEnergyType,
+    ContractStatus,
+    ContractIndexation,
+    TariffOptionEnum,
+)
+from models.contract_v2_models import ContractAnnexe, ContractPricing, VolumeCommitment
+from database import get_db
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def org_hierarchy(db):
+    from models.enums import TypeSite
+
+    org = Organisation(nom="TestOrg", siren="123456789", actif=True)
+    db.add(org)
+    db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom="TestEJ", siren="987654321")
+    db.add(ej)
+    db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom="TestPF")
+    db.add(pf)
+    db.flush()
+    sites = []
+    for name in ["Site A", "Site B", "Site C"]:
+        s = Site(portefeuille_id=pf.id, nom=name, type=TypeSite.BUREAU, actif=True)
+        db.add(s)
+        db.flush()
+        sites.append(s)
+    db.commit()
+    return {"org": org, "ej": ej, "sites": sites}
+
+
+@pytest.fixture
+def client(db, org_hierarchy):
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _base_payload(site_id, **overrides):
+    payload = {
+        "supplier_name": "EDF Entreprises",
+        "energy_type": "elec",
+        "start_date": "2026-01-01",
+        "end_date": "2028-12-31",
+        "annexes": [{"site_id": site_id}],
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ============================================================
+# CRUD — Create cadre
+# ============================================================
+
+
+class TestCreateCadre:
+    def test_create_cadre_basic_201(self, client, org_hierarchy):
+        """POST /cadres → 201 avec cadre + 1 annexe."""
+        payload = _base_payload(org_hierarchy["sites"][0].id)
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        assert r.status_code == 201
+        data = r.json()
+        assert data["supplier_name"] == "EDF Entreprises"
+        assert data["energy_type"] == "elec"
+        assert data["nb_annexes"] >= 1
+
+    def test_create_cadre_with_pricing(self, client, org_hierarchy):
+        """POST /cadres avec grille tarifaire HP+HC."""
+        payload = _base_payload(
+            org_hierarchy["sites"][0].id,
+            pricing=[
+                {"period_code": "HP", "season": "ANNUEL", "unit_price_eur_kwh": 0.168},
+                {"period_code": "HC", "season": "ANNUEL", "unit_price_eur_kwh": 0.122},
+            ],
+        )
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        assert r.status_code == 201
+        data = r.json()
+        assert len(data.get("pricing", [])) == 2
+
+    def test_create_cadre_multi_annexes(self, client, org_hierarchy):
+        """POST /cadres avec 2 annexes (2 sites differents)."""
+        sites = org_hierarchy["sites"]
+        payload = _base_payload(
+            sites[0].id,
+            annexes=[
+                {"site_id": sites[0].id, "annexe_ref": "ANX-001"},
+                {"site_id": sites[1].id, "annexe_ref": "ANX-002"},
+            ],
+        )
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        assert r.status_code == 201
+        data = r.json()
+        assert data["nb_annexes"] == 2
+
+
+# ============================================================
+# CRUD — Read / Update / Delete
+# ============================================================
+
+
+class TestCRUDCycle:
+    def _create(self, client, site_id):
+        payload = _base_payload(site_id)
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        return r.json()["id"]
+
+    def test_get_cadre_200(self, client, org_hierarchy):
+        """GET /cadres/{id} retourne detail complet."""
+        cadre_id = self._create(client, org_hierarchy["sites"][0].id)
+        r = client.get(f"/api/contracts/v2/cadres/{cadre_id}")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["id"] == cadre_id
+        assert "annexes" in data
+        assert "coherence" in data
+
+    def test_patch_cadre_notes(self, client, org_hierarchy):
+        """PATCH /cadres/{id} met a jour les notes."""
+        cadre_id = self._create(client, org_hierarchy["sites"][0].id)
+        r = client.patch(
+            f"/api/contracts/v2/cadres/{cadre_id}",
+            json={"notes": "Updated by QA test"},
+        )
+        assert r.status_code == 200
+        assert r.json()["notes"] == "Updated by QA test"
+
+    def test_delete_cadre_soft(self, client, org_hierarchy):
+        """DELETE /cadres/{id} → soft-delete (status=terminated)."""
+        cadre_id = self._create(client, org_hierarchy["sites"][0].id)
+        r = client.delete(f"/api/contracts/v2/cadres/{cadre_id}")
+        assert r.status_code == 200
+        assert r.json()["status"] == "deleted"
+
+        # cadre still accessible but terminated
+        r2 = client.get(f"/api/contracts/v2/cadres/{cadre_id}")
+        # May return 404 or the terminated cadre depending on implementation
+        assert r2.status_code in (200, 404)
+
+
+# ============================================================
+# Validation — dates inversees
+# ============================================================
+
+
+class TestValidation:
+    def test_create_reversed_dates_422(self, client, org_hierarchy):
+        """POST /cadres avec start > end → 422."""
+        payload = _base_payload(
+            org_hierarchy["sites"][0].id,
+            start_date="2028-12-31",
+            end_date="2026-01-01",
+        )
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        assert r.status_code == 422
+
+    def test_create_missing_annexes_422(self, client, org_hierarchy):
+        """POST /cadres sans annexes → 422 (validation Pydantic)."""
+        payload = {
+            "supplier_name": "EDF",
+            "energy_type": "elec",
+            "start_date": "2026-01-01",
+            "end_date": "2028-12-31",
+            "annexes": [],
+        }
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        # Empty annexes list may fail validation
+        assert r.status_code in (422, 201)  # Depends on schema min_length
+
+
+# ============================================================
+# Coherence endpoint
+# ============================================================
+
+
+class TestCoherenceEndpoint:
+    def test_coherence_check_returns_rules(self, client, org_hierarchy):
+        """GET /cadres/{id}/coherence retourne liste de regles."""
+        site_id = org_hierarchy["sites"][0].id
+        payload = _base_payload(site_id)
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        cadre_id = r.json()["id"]
+
+        r2 = client.get(f"/api/contracts/v2/cadres/{cadre_id}/coherence")
+        assert r2.status_code == 200
+        data = r2.json()
+        assert "rules" in data
+        assert "total" in data
+        assert isinstance(data["rules"], list)
+
+
+# ============================================================
+# Expiring endpoint
+# ============================================================
+
+
+class TestExpiringEndpoint:
+    def test_expiring_90_days(self, client, db, org_hierarchy):
+        """GET /cadres/expiring?days=90 retourne cadres expirant."""
+        # Create a cadre that expires in 60 days (within 90 day window)
+        # Must include entite_juridique_id for org-scoped expiring query
+        sites = org_hierarchy["sites"]
+        ej_id = org_hierarchy["ej"].id
+        start = (date.today() - timedelta(days=300)).isoformat()
+        end = (date.today() + timedelta(days=60)).isoformat()
+        payload = _base_payload(
+            sites[0].id,
+            start_date=start,
+            end_date=end,
+            entite_juridique_id=ej_id,
+        )
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        assert r.status_code == 201
+
+        r2 = client.get("/api/contracts/v2/cadres/expiring?days=90")
+        assert r2.status_code == 200
+        data = r2.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+
+    def test_expiring_does_not_include_distant(self, client, db, org_hierarchy):
+        """Cadre expirant dans 400j n'apparait pas dans expiring?days=90."""
+        sites = org_hierarchy["sites"]
+        ej_id = org_hierarchy["ej"].id
+        start = (date.today() - timedelta(days=30)).isoformat()
+        end = (date.today() + timedelta(days=400)).isoformat()
+        payload = _base_payload(
+            sites[0].id,
+            start_date=start,
+            end_date=end,
+            entite_juridique_id=ej_id,
+        )
+        r = client.post("/api/contracts/v2/cadres", json=payload)
+        assert r.status_code == 201
+
+        r2 = client.get("/api/contracts/v2/cadres/expiring?days=90")
+        assert r2.status_code == 200
+        data = r2.json()
+        # The distant cadre should NOT appear
+        cadre_id = r.json()["id"]
+        ids_in_expiring = [c["id"] for c in data]
+        assert cadre_id not in ids_in_expiring

--- a/backend/tests/test_resolve_pricing.py
+++ b/backend/tests/test_resolve_pricing.py
@@ -1,0 +1,216 @@
+"""
+PROMEOS — Tests resolve_pricing() cascade — 7 tests.
+Couvre les 3 niveaux: override annexe > cadre structured > fallback flat.
+Phase 6 CONTRATS-V2 QA.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import date, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import (
+    Base,
+    Organisation,
+    EntiteJuridique,
+    Portefeuille,
+    Site,
+    EnergyContract,
+    BillingEnergyType,
+    ContractStatus,
+    ContractIndexation,
+    TariffOptionEnum,
+)
+from models.contract_v2_models import ContractAnnexe, ContractPricing, VolumeCommitment
+from services.contrat_coherence import resolve_pricing
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def setup(db):
+    from models.enums import TypeSite
+
+    org = Organisation(nom="TestOrg", siren="111222333", actif=True)
+    db.add(org)
+    db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom="TestEJ", siren="999888777")
+    db.add(ej)
+    db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom="PF1")
+    db.add(pf)
+    db.flush()
+    s = Site(portefeuille_id=pf.id, nom="Site A", type=TypeSite.BUREAU, actif=True)
+    db.add(s)
+    db.flush()
+    db.commit()
+    return {"org": org, "ej": ej, "site": s}
+
+
+def _make_cadre(db, setup, **overrides):
+    defaults = dict(
+        site_id=setup["site"].id,
+        energy_type=BillingEnergyType.ELEC,
+        supplier_name="EDF Entreprises",
+        start_date=date.today() - timedelta(days=30),
+        end_date=date.today() + timedelta(days=335),
+        notice_period_days=90,
+        is_cadre=True,
+        contract_type="CADRE",
+        entite_juridique_id=setup["ej"].id,
+    )
+    defaults.update(overrides)
+    cadre = EnergyContract(**defaults)
+    db.add(cadre)
+    db.flush()
+    return cadre
+
+
+def _make_annexe(db, cadre_id, site_id, **overrides):
+    defaults = dict(
+        contrat_cadre_id=cadre_id,
+        site_id=site_id,
+        annexe_ref=f"ANX-{site_id}",
+        status=ContractStatus.ACTIVE,
+    )
+    defaults.update(overrides)
+    a = ContractAnnexe(**defaults)
+    db.add(a)
+    db.flush()
+    return a
+
+
+# ============================================================
+# Cascade Level 1 — Override annexe
+# ============================================================
+
+
+class TestOverridePricing:
+    def test_override_returns_annexe_pricing(self, db, setup):
+        """has_price_override=True + pricing_overrides → source='override'."""
+        c = _make_cadre(db, setup)
+        a = _make_annexe(db, c.id, setup["site"].id, has_price_override=True)
+        db.add(ContractPricing(annexe_id=a.id, period_code="BASE", season="ANNUEL", unit_price_eur_kwh=0.14))
+        db.commit()
+        result = resolve_pricing(db, a)
+        assert len(result) == 1
+        assert result[0]["source"] == "override"
+        assert result[0]["unit_price_eur_kwh"] == 0.14
+        assert result[0]["period_code"] == "BASE"
+
+    def test_override_multi_period(self, db, setup):
+        """Override avec HP+HC retourne 2 lignes source='override'."""
+        c = _make_cadre(db, setup)
+        a = _make_annexe(db, c.id, setup["site"].id, has_price_override=True)
+        db.add(ContractPricing(annexe_id=a.id, period_code="HP", season="ANNUEL", unit_price_eur_kwh=0.16))
+        db.add(ContractPricing(annexe_id=a.id, period_code="HC", season="ANNUEL", unit_price_eur_kwh=0.12))
+        db.commit()
+        result = resolve_pricing(db, a)
+        assert len(result) == 2
+        assert all(p["source"] == "override" for p in result)
+        codes = {p["period_code"] for p in result}
+        assert codes == {"HP", "HC"}
+
+
+# ============================================================
+# Cascade Level 2 — Heritage cadre (grille structuree)
+# ============================================================
+
+
+class TestCadrePricingInheritance:
+    def test_cadre_structured_grid(self, db, setup):
+        """Annexe sans override → herite grille ContractPricing du cadre, source='cadre'."""
+        c = _make_cadre(db, setup)
+        db.add(ContractPricing(contract_id=c.id, period_code="HP", season="ANNUEL", unit_price_eur_kwh=0.168))
+        db.add(ContractPricing(contract_id=c.id, period_code="HC", season="ANNUEL", unit_price_eur_kwh=0.122))
+        a = _make_annexe(db, c.id, setup["site"].id, has_price_override=False)
+        db.commit()
+        result = resolve_pricing(db, a)
+        assert len(result) == 2
+        assert all(p["source"] == "cadre" for p in result)
+        hp = next(p for p in result if p["period_code"] == "HP")
+        assert hp["unit_price_eur_kwh"] == 0.168
+
+    def test_override_beats_cadre_grid(self, db, setup):
+        """Override prend priorite meme si cadre a une grille structuree."""
+        c = _make_cadre(db, setup)
+        db.add(ContractPricing(contract_id=c.id, period_code="HP", season="ANNUEL", unit_price_eur_kwh=0.168))
+        db.add(ContractPricing(contract_id=c.id, period_code="HC", season="ANNUEL", unit_price_eur_kwh=0.122))
+        a = _make_annexe(db, c.id, setup["site"].id, has_price_override=True)
+        db.add(ContractPricing(annexe_id=a.id, period_code="BASE", season="ANNUEL", unit_price_eur_kwh=0.14))
+        db.commit()
+        result = resolve_pricing(db, a)
+        assert len(result) == 1
+        assert result[0]["source"] == "override"
+        assert result[0]["period_code"] == "BASE"
+
+
+# ============================================================
+# Cascade Level 3 — Fallback colonnes plates
+# ============================================================
+
+
+class TestFallbackFlat:
+    def test_fallback_flat_columns(self, db, setup):
+        """Pas de ContractPricing → fallback sur colonnes plates du cadre (price_base/hp/hc)."""
+        c = _make_cadre(
+            db,
+            setup,
+            price_base_eur_kwh=0.142,
+            price_hp_eur_kwh=0.158,
+            price_hc_eur_kwh=0.118,
+        )
+        a = _make_annexe(db, c.id, setup["site"].id, has_price_override=False)
+        db.commit()
+        result = resolve_pricing(db, a)
+        assert len(result) >= 2
+        assert all(p["source"] == "cadre" for p in result)
+        codes = {p["period_code"] for p in result}
+        assert "HP" in codes or "BASE" in codes
+
+
+# ============================================================
+# Edge: aucun prix
+# ============================================================
+
+
+class TestNoPricing:
+    def test_empty_when_no_pricing_anywhere(self, db, setup):
+        """Ni override ni cadre ni colonnes plates → liste vide."""
+        c = _make_cadre(db, setup)
+        a = _make_annexe(db, c.id, setup["site"].id, has_price_override=False)
+        db.commit()
+        result = resolve_pricing(db, a)
+        assert result == []
+
+    def test_override_flag_true_but_no_lines(self, db, setup):
+        """has_price_override=True mais aucune ligne → fallback sur cadre."""
+        c = _make_cadre(db, setup)
+        db.add(ContractPricing(contract_id=c.id, period_code="HP", season="ANNUEL", unit_price_eur_kwh=0.168))
+        a = _make_annexe(db, c.id, setup["site"].id, has_price_override=True)
+        db.commit()
+        result = resolve_pricing(db, a)
+        # Override flag is True but no override lines → falls through to cadre
+        assert len(result) >= 1
+        assert all(p["source"] == "cadre" for p in result)

--- a/backend/tests/test_seed_contrats.py
+++ b/backend/tests/test_seed_contrats.py
@@ -168,8 +168,8 @@ class TestHeliosCadres:
         assert cadre is not None
         assert cadre.fournisseur == "EDF Entreprises"
         assert cadre.energie == BillingEnergyType.ELEC
-        assert cadre.prix_hp_eur_kwh == 0.1580
-        assert cadre.prix_hc_eur_kwh == 0.1180
+        assert float(cadre.prix_hp_eur_kwh) == 0.1580
+        assert float(cadre.prix_hc_eur_kwh) == 0.1180
         assert cadre.poids_hp == 62.0
         assert cadre.poids_hc == 38.0
         assert cadre.cee_inclus is True
@@ -187,7 +187,7 @@ class TestHeliosCadres:
         assert cadre.fournisseur == "ENGIE Pro"
         assert cadre.energie == BillingEnergyType.GAZ
         assert cadre.indexation_reference == "PEG_DA"
-        assert cadre.indexation_spread_eur_mwh == 3.0
+        assert float(cadre.indexation_spread_eur_mwh) == 3.0
 
         annexes = db.query(ContractAnnexe).filter(ContractAnnexe.cadre_id == cadre.id).all()
         assert len(annexes) == 1
@@ -215,9 +215,9 @@ class TestHeliosCadres:
         assert cadre is not None
         assert cadre.fournisseur == "Ekwateur"
         assert cadre.indexation_reference == "EPEX_SPOT_FR"
-        assert cadre.indexation_spread_eur_mwh == 5.0
-        assert cadre.prix_plafond_eur_mwh == 200.0
-        assert cadre.prix_plancher_eur_mwh == 60.0
+        assert float(cadre.indexation_spread_eur_mwh) == 5.0
+        assert float(cadre.prix_plafond_eur_mwh) == 200.0
+        assert float(cadre.prix_plancher_eur_mwh) == 60.0
 
         annexes = db.query(ContractAnnexe).filter(ContractAnnexe.cadre_id == cadre.id).all()
         assert len(annexes) == 1
@@ -251,7 +251,7 @@ class TestVolumeCommitments:
 
         pricing = db.query(ContractPricing).filter(ContractPricing.annexe_id == lyon_annexe.id).all()
         assert len(pricing) >= 1
-        assert pricing[0].unit_price_eur_kwh == 0.1380
+        assert float(pricing[0].unit_price_eur_kwh) == 0.1380
 
 
 # ============================================================

--- a/backend/tests/test_seed_contrats.py
+++ b/backend/tests/test_seed_contrats.py
@@ -1,0 +1,268 @@
+"""
+PROMEOS — Tests seed contrats cadre V2 (generate_cadre_contracts).
+Idempotence + 4 cadres HELIOS + annexes + volumes.
+Phase 6 CONTRATS-V2 QA.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import date
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import (
+    Base,
+    Organisation,
+    EntiteJuridique,
+    Portefeuille,
+    Site,
+    BillingEnergyType,
+    ContractStatus,
+)
+from models.contract_v2_models import (
+    ContratCadre,
+    ContractAnnexe,
+    ContractPricing,
+    VolumeCommitment,
+)
+from services.demo_seed.gen_billing import generate_cadre_contracts
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def helios_setup(db):
+    """Simulate HELIOS org with 5 sites (minimum for all 4 cadres)."""
+    from models.enums import TypeSite
+
+    org = Organisation(nom="HELIOS", siren="123456789", actif=True)
+    db.add(org)
+    db.flush()
+
+    ej = EntiteJuridique(organisation_id=org.id, nom="HELIOS SAS", siren="987654321")
+    db.add(ej)
+    db.flush()
+
+    pf = Portefeuille(entite_juridique_id=ej.id, nom="Portefeuille HELIOS")
+    db.add(pf)
+    db.flush()
+
+    site_names = ["Paris Bureaux", "Lyon Bureaux", "Toulouse Entrepot", "Nice Hotel", "Marseille Ecole"]
+    sites = []
+    for name in site_names:
+        s = Site(portefeuille_id=pf.id, nom=name, type=TypeSite.BUREAU, actif=True)
+        db.add(s)
+        db.flush()
+        sites.append(s)
+
+    db.commit()
+    return {"org": org, "ej": ej, "sites": sites}
+
+
+@pytest.fixture
+def small_setup(db):
+    """Org with only 2 sites (below threshold for full cadre generation)."""
+    from models.enums import TypeSite
+
+    org = Organisation(nom="SmallOrg", siren="222333444", actif=True)
+    db.add(org)
+    db.flush()
+
+    ej = EntiteJuridique(organisation_id=org.id, nom="SmallEJ", siren="444333222")
+    db.add(ej)
+    db.flush()
+
+    pf = Portefeuille(entite_juridique_id=ej.id, nom="PF-Small")
+    db.add(pf)
+    db.flush()
+
+    sites = []
+    for name in ["Site A", "Site B"]:
+        s = Site(portefeuille_id=pf.id, nom=name, type=TypeSite.BUREAU, actif=True)
+        db.add(s)
+        db.flush()
+        sites.append(s)
+
+    db.commit()
+    return {"org": org, "ej": ej, "sites": sites}
+
+
+# ============================================================
+# Idempotence
+# ============================================================
+
+
+class TestIdempotence:
+    def test_double_run_no_duplicates(self, db, helios_setup):
+        """Running generate_cadre_contracts twice → same number of cadres, no duplicates."""
+        org = helios_setup["org"]
+        sites = helios_setup["sites"]
+
+        result1 = generate_cadre_contracts(db, org, sites)
+        db.commit()
+        count_after_first = db.query(ContratCadre).count()
+
+        result2 = generate_cadre_contracts(db, org, sites)
+        db.commit()
+        count_after_second = db.query(ContratCadre).count()
+
+        assert count_after_first == count_after_second
+        assert result2["cadres"] == 0  # No new cadres on second run
+
+    def test_idempotency_guard_checks_ref_fournisseur(self, db, helios_setup):
+        """Each cadre is guarded by reference_fournisseur uniqueness."""
+        org = helios_setup["org"]
+        sites = helios_setup["sites"]
+
+        generate_cadre_contracts(db, org, sites)
+        db.commit()
+
+        refs = [c.reference_fournisseur for c in db.query(ContratCadre).all()]
+        assert len(refs) == len(set(refs))  # All unique
+
+
+# ============================================================
+# 4 cadres HELIOS
+# ============================================================
+
+
+class TestHeliosCadres:
+    def test_creates_4_cadres_with_5_sites(self, db, helios_setup):
+        """5 sites → 4 cadres created (EDF, ENGIE, TotalEnergies, Ekwateur)."""
+        org = helios_setup["org"]
+        sites = helios_setup["sites"]
+
+        result = generate_cadre_contracts(db, org, sites)
+        db.commit()
+
+        assert result["cadres"] == 4
+        cadres = db.query(ContratCadre).all()
+        assert len(cadres) == 4
+
+    def test_cadre1_edf_fixe_elec(self, db, helios_setup):
+        """Cadre 1: EDF Entreprises — FIXE elec — 2 annexes (Paris + Lyon)."""
+        generate_cadre_contracts(db, helios_setup["org"], helios_setup["sites"])
+        db.commit()
+
+        cadre = db.query(ContratCadre).filter(ContratCadre.reference_fournisseur == "EDF-CADRE-2024-001").first()
+        assert cadre is not None
+        assert cadre.fournisseur == "EDF Entreprises"
+        assert cadre.energie == BillingEnergyType.ELEC
+        assert cadre.prix_hp_eur_kwh == 0.1580
+        assert cadre.prix_hc_eur_kwh == 0.1180
+        assert cadre.poids_hp == 62.0
+        assert cadre.poids_hc == 38.0
+        assert cadre.cee_inclus is True
+
+        annexes = db.query(ContractAnnexe).filter(ContractAnnexe.cadre_id == cadre.id).all()
+        assert len(annexes) == 2
+
+    def test_cadre2_engie_indexe_gaz(self, db, helios_setup):
+        """Cadre 2: ENGIE Pro — INDEXE PEG gaz — 1 annexe (Toulouse)."""
+        generate_cadre_contracts(db, helios_setup["org"], helios_setup["sites"])
+        db.commit()
+
+        cadre = db.query(ContratCadre).filter(ContratCadre.reference_fournisseur == "ENGIE-GP-2025-042").first()
+        assert cadre is not None
+        assert cadre.fournisseur == "ENGIE Pro"
+        assert cadre.energie == BillingEnergyType.GAZ
+        assert cadre.indexation_reference == "PEG_DA"
+        assert cadre.indexation_spread_eur_mwh == 3.0
+
+        annexes = db.query(ContractAnnexe).filter(ContractAnnexe.cadre_id == cadre.id).all()
+        assert len(annexes) == 1
+
+    def test_cadre3_total_fixe_vert(self, db, helios_setup):
+        """Cadre 3: TotalEnergies — FIXE elec vert — 2 annexes (Nice + Marseille)."""
+        generate_cadre_contracts(db, helios_setup["org"], helios_setup["sites"])
+        db.commit()
+
+        cadre = db.query(ContratCadre).filter(ContratCadre.reference_fournisseur == "TE-B2B-2025-087").first()
+        assert cadre is not None
+        assert cadre.fournisseur == "TotalEnergies"
+        assert cadre.is_green is True
+        assert cadre.green_percentage == 100.0
+
+        annexes = db.query(ContractAnnexe).filter(ContractAnnexe.cadre_id == cadre.id).all()
+        assert len(annexes) == 2
+
+    def test_cadre4_ekwateur_spot(self, db, helios_setup):
+        """Cadre 4: Ekwateur — SPOT EPEX elec — 1 annexe (Nice)."""
+        generate_cadre_contracts(db, helios_setup["org"], helios_setup["sites"])
+        db.commit()
+
+        cadre = db.query(ContratCadre).filter(ContratCadre.reference_fournisseur == "EKW-SPOT-2025-019").first()
+        assert cadre is not None
+        assert cadre.fournisseur == "Ekwateur"
+        assert cadre.indexation_reference == "EPEX_SPOT_FR"
+        assert cadre.indexation_spread_eur_mwh == 5.0
+        assert cadre.prix_plafond_eur_mwh == 200.0
+        assert cadre.prix_plancher_eur_mwh == 60.0
+
+        annexes = db.query(ContractAnnexe).filter(ContractAnnexe.cadre_id == cadre.id).all()
+        assert len(annexes) == 1
+
+
+# ============================================================
+# Volume commitments
+# ============================================================
+
+
+class TestVolumeCommitments:
+    def test_annexes_have_volumes(self, db, helios_setup):
+        """All annexes have a VolumeCommitment attached."""
+        generate_cadre_contracts(db, helios_setup["org"], helios_setup["sites"])
+        db.commit()
+
+        annexes = db.query(ContractAnnexe).all()
+        for a in annexes:
+            vc = db.query(VolumeCommitment).filter(VolumeCommitment.annexe_id == a.id).first()
+            assert vc is not None, f"Annexe {a.annexe_ref} missing VolumeCommitment"
+            assert vc.annual_kwh > 0
+
+    def test_edf_lyon_override_pricing(self, db, helios_setup):
+        """Annexe Lyon (EDF) has price override + ContractPricing line."""
+        generate_cadre_contracts(db, helios_setup["org"], helios_setup["sites"])
+        db.commit()
+
+        lyon_annexe = db.query(ContractAnnexe).filter(ContractAnnexe.annexe_ref == "ANX-EDF-Lyon-002").first()
+        assert lyon_annexe is not None
+        assert lyon_annexe.has_price_override is True
+
+        pricing = db.query(ContractPricing).filter(ContractPricing.annexe_id == lyon_annexe.id).all()
+        assert len(pricing) >= 1
+        assert pricing[0].unit_price_eur_kwh == 0.1380
+
+
+# ============================================================
+# Edge: insufficient sites
+# ============================================================
+
+
+class TestEdgeCases:
+    def test_less_than_3_sites_returns_zero(self, db, small_setup):
+        """With < 3 sites, generate_cadre_contracts returns 0 cadres."""
+        result = generate_cadre_contracts(db, small_setup["org"], small_setup["sites"])
+        assert result["cadres"] == 0
+        assert result["annexes"] == 0
+        assert db.query(ContratCadre).count() == 0


### PR DESCRIPTION
## Summary

Chantier **Contrats V2** — data model `ContratCadre` + cascade billing `resolve_pricing()` V2.

**4 commits :**
1. `20cb09c8` feat: Phase 5 — wire billing → resolve_pricing() cascade (Paperclip)
2. `b8be4277` feat: Phase 1 — ContratCadre entity-level model + migration + tests (Paperclip)
3. `fb1adfac` fix: 6 critical blockers raised by PR #190 audit (Claude Code)
4. `b0318a3f` fix: resolve_pricing V2 cadre path + simplify reuse (Claude Code, 2nd pass)

## Objectif fonctionnel

Modèle V2 **contrat-cadre multi-sites** :
1. Un **Contrat Cadre** signé au niveau org (fournisseur, type de prix, période)
2. N **Annexes** (une par site/PRM) avec prix overrides optionnels
3. Cascade billing : **annexe override > cadre V2 flat > legacy contract > marché > fallback**
4. Shadow billing HP/HC pondéré : `prix_hp × poids_hp + prix_hc × poids_hc` (poids normalisés)

## Parcours de review (2 passes d'audit)

### Pass 1 — 13 findings confidence ≥80 (commit `fb1adfac`)

**6 bloquants critiques fixés :**
1. ✅ **Multi-tenant scope** — `find_active_annexe` accepte `org_id`, dérivé via `_site_org_id()` puis `scope_utils.resolve_org_id_from_site()`. Plus de fuite cross-org dans shadow billing.
2. ✅ **Enum default** — `ContractAnnexe.status` utilise `ContractStatus.ACTIVE` (membre enum) au lieu de la string `"active"`.
3. ✅ **Precision billing** — `Float` → `Numeric(18,6)` pour prix EUR/kWh et EUR/MWh, `Numeric(20,3)` pour volumes kWh, `Numeric(14,2)` pour abonnement. Modèle + migration + serializers avec casts `Decimal → float` pour JSON.
4. ✅ **HP/HC weights normalisés** — nouveau `_normalized_hp_hc_weights()` : un typo opérateur `poids_hp=70 + poids_hc=40` (=110%) ne gonfle plus silencieusement le prix de 10%.
5. ✅ **Fallback dangereux supprimé** — `_resolve_cadre_weighted_price` retourne `None` pour grilles incomplètes au lieu de `next(iter(price_map.values()))` (qui pouvait retourner un prix pointe comme référence).
6. ✅ **Migration rollback** — `add_contrats_cadre_phase1.py` wrappé `try/except + conn.rollback() + raise + log`.

### Pass 2 — 1 bug caché + 3 cleanups reuse (commit `b0318a3f`)

**Bug critique non détecté en pass 1 :**
- ✅ **`resolve_pricing()` V2 FK** — la fonction traversait uniquement `annexe.contrat_cadre` (legacy FK). Toute annexe V2 non-override retournait silencieusement `[]` et fallback sur legacy contract. Fixed : nouvelle Priority 2 "V2 cadre flat columns" via `annexe.cadre.prix_*_eur_kwh` avant le legacy path. **2 tests de régression ajoutés** (`TestV2CadreInheritance`).

**Simplify reuse :**
- ✅ `_site_org_id` supprimé → `scope_utils.resolve_org_id_from_site` (single source of truth)
- ✅ `_DEFAULT_POIDS_HP/HC` supprimés → import depuis `contrat_coherence` (62/38 single source)
- ✅ `_normalized_hp_hc_weights` : `is not None` au lieu de check truthy pour honorer `poids_hp=0` (contrat tout-HC)

## Test plan

### ✅ Complété
- [x] `cd backend && python -m pytest tests/test_billing_cadre_resolution.py tests/test_contrat_api.py tests/test_resolve_pricing.py tests/test_seed_contrats.py tests/test_billing.py` → **78 passed, 0 regression**
- [x] `test_billing_cadre_resolution.py` (11 tests) : normalized weights, resolve_pricing cases, multi-org isolation, V2 cadre inheritance
- [x] 2 passes d'audit automatisé (code-review + simplify sub-agents)

### ⚠️ À faire avant merge prod
- [ ] **1 review humain** sur la cascade V2 (cohérence métier)
- [ ] **Smoke test staging** : seed HELIOS → shadow billing → comparer montants vs legacy
- [ ] **Migration test** sur DB de staging existante (Phase 1 + Phase 5)
- [ ] Non-régression `gen_billing.py` sur seed existant

### Non-bloquants (V2.1)
- [ ] #7 Table `contract_pricing` dans migration Phase 1 (actuellement créée par `Base.metadata.create_all` en tests seulement)
- [ ] #8 Denormaliser `ContractAnnexe.org_id` (defense-in-depth)
- [ ] #9 Cache `find_active_annexe` au niveau batch billing (2 calls → 1)
- [ ] #10 `gen_billing.py` re-seed refresh `annexe_site_id` sur factures existantes
- [ ] #11 Auto-wire migration Phase 5 au startup (`create_tables()` lifespan)

## Migrations

- `backend/migrations/add_contrats_cadre_phase1.py` — CREATE `contrats_cadre` + ALTER `contract_annexes` (idempotent IF NOT EXISTS, rollback try/except, NUMERIC affinity)
- `backend/migrations/add_invoice_annexe_site_phase5.py` — ALTER `energy_invoices` ADD `annexe_site_id` (idempotent)

⚠️ **Migrations à exécuter manuellement** jusqu'à résolution du #11 :
```bash
cd backend && python migrations/add_contrats_cadre_phase1.py
cd backend && python migrations/add_invoice_annexe_site_phase5.py
```

## Contexte split PR

Cette PR est issue du split de l'ancienne PR #188 (fermée) qui mélangeait nav-v7 + contrats-v2. Voir aussi :
- **PR #189** (nav-v7) : https://github.com/promeosenergies-svg/promeos-poc/pull/189

## Notes pour le reviewer

- Les 2 commits Phase 1 / Phase 5 proviennent de l'agent **Paperclip** et n'ont pas eu de revue humaine avant le split. Les 2 commits de fix Claude Code adressent les findings d'audit sur ces commits originaux.
- Le worktree `promeos-contrats-v2-fix` a été créé temporairement durant les fixes pour isoler le travail — supprimé après push.
- Aucun changement frontend dans cette PR (backend uniquement).

🤖 Generated with [Claude Code](https://claude.ai/code)