### PR TITLE
feat(nav): push to 100/100 — expertOnly, a11y, badges, onboarding, labels

### DIFF
--- a/frontend/src/__tests__/nav_v7_parity.test.js
+++ b/frontend/src/__tests__/nav_v7_parity.test.js
@@ -94,10 +94,10 @@ describe('Nav V7 — Structure', () => {
     expect(expertModules[0].key).toBe('admin');
   });
 
-  it('13 items visible in normal mode across main modules', () => {
+  it('15 items visible in normal mode across main modules', () => {
     const mainSections = NAV_SECTIONS.filter((s) => !s.expertOnly);
     const items = mainSections.flatMap((s) => getVisibleItems(s.items, false));
-    expect(items).toHaveLength(13);
+    expect(items).toHaveLength(15);
   });
 
   it('17 items visible in expert mode across main modules', () => {
@@ -106,11 +106,11 @@ describe('Nav V7 — Structure', () => {
     expect(items).toHaveLength(17);
   });
 
-  it('4 expertOnly items total (diagnostics, facturation, audit-sme, simulateur)', () => {
+  it('2 expertOnly items total (audit-sme, simulateur)', () => {
     const expertItems = NAV_SECTIONS.filter((s) => !s.expertOnly).flatMap((s) =>
       s.items.filter((i) => i.expertOnly)
     );
-    expect(expertItems).toHaveLength(4);
+    expect(expertItems).toHaveLength(2);
   });
 });
 

--- a/frontend/src/__tests__/step24b_nav_clean.test.js
+++ b/frontend/src/__tests__/step24b_nav_clean.test.js
@@ -25,12 +25,12 @@ describe('Step 24b — Navigation clean', () => {
     expect(sections.length).toBeGreaterThanOrEqual(5);
   });
 
-  it('has max 14 main menu items in NAV_MAIN_SECTIONS', () => {
+  it('has max 17 main menu items in NAV_MAIN_SECTIONS', () => {
     const src = fs.readFileSync(navFile, 'utf8');
     // Extract NAV_MAIN_SECTIONS block and count path entries
     const mainBlock = src.split('NAV_MAIN_SECTIONS')[1]?.split('NAV_ADMIN')[0] || '';
     const paths = mainBlock.match(/to:\s*['"]\/[^'"]+['"]/g) || [];
-    expect(paths.length).toBeLessThanOrEqual(14);
+    expect(paths.length).toBeLessThanOrEqual(17);
   });
 
   it('no jargon in NAV_MAIN_SECTIONS menu labels', () => {

--- a/frontend/src/components/OnboardingOverlay.jsx
+++ b/frontend/src/components/OnboardingOverlay.jsx
@@ -1,0 +1,100 @@
+import { useState, useEffect } from 'react';
+import { X, ChevronRight } from 'lucide-react';
+
+const ONBOARDING_KEY = 'promeos_onboarding_done';
+
+const STEPS = [
+  {
+    title: 'Navigation par module',
+    text: 'Le rail regroupe 5 modules : Accueil, Conformite, Energie, Patrimoine, Achat. Cliquez sur une icone pour basculer.',
+  },
+  {
+    title: 'Panneau contextuel',
+    text: 'Chaque module affiche ses pages. Epinglez vos favoris, retrouvez vos recents.',
+  },
+  {
+    title: 'Recherche rapide (Ctrl+K)',
+    text: 'Cherchez pages, sites ou actions instantanement.',
+  },
+  {
+    title: 'Mode Expert',
+    text: 'Toggle Expert en haut a droite pour Audit SME, Simulateur achat et plus.',
+  },
+];
+
+export default function OnboardingOverlay() {
+  const [step, setStep] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(ONBOARDING_KEY)) setVisible(true);
+    } catch {
+      /* noop */
+    }
+  }, []);
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(ONBOARDING_KEY, 'true');
+    } catch {
+      /* noop */
+    }
+  };
+
+  const next = () => {
+    if (step < STEPS.length - 1) setStep(step + 1);
+    else dismiss();
+  };
+
+  if (!visible) return null;
+
+  const s = STEPS[step];
+
+  return (
+    <div className="fixed inset-0 z-[280] flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50 animate-[fadeIn_0.3s_ease-out]"
+        onClick={dismiss}
+      />
+      <div className="relative bg-white rounded-2xl shadow-2xl max-w-md w-full mx-4 p-6 animate-[slideInUp_0.3s_ease-out]">
+        <button
+          onClick={dismiss}
+          className="absolute top-3 right-3 p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition"
+          aria-label="Fermer"
+        >
+          <X size={16} />
+        </button>
+
+        <div className="flex gap-1.5 mb-4">
+          {STEPS.map((_, i) => (
+            <div
+              key={i}
+              className={`h-1 flex-1 rounded-full transition-colors ${i <= step ? 'bg-blue-500' : 'bg-gray-200'}`}
+            />
+          ))}
+        </div>
+
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">{s.title}</h3>
+        <p className="text-sm text-gray-600 leading-relaxed mb-6">{s.text}</p>
+
+        <div className="flex items-center justify-between">
+          <button
+            onClick={dismiss}
+            className="text-sm text-gray-400 hover:text-gray-600 transition"
+          >
+            Passer le tour
+          </button>
+          <button
+            onClick={next}
+            className="inline-flex items-center gap-1.5 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition"
+          >
+            {step < STEPS.length - 1 ? 'Suivant' : 'Commencer'}
+            <ChevronRight size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layout/AppShell.jsx
+++ b/frontend/src/layout/AppShell.jsx
@@ -13,6 +13,7 @@ import Breadcrumb from './Breadcrumb';
 import ScopeSwitcher from './ScopeSwitcher';
 import DataReadinessBadge from '../components/DataReadinessBadge';
 import DevPanel from './DevPanel';
+import OnboardingOverlay from '../components/OnboardingOverlay';
 import CommandPalette from '../ui/CommandPalette';
 import ActionCenterSlideOver, {
   computeActionCenterBadge,
@@ -255,6 +256,14 @@ export default function AppShell() {
 
   return (
     <div className="flex h-screen overflow-hidden bg-gradient-to-b from-slate-50 via-white to-slate-50/80">
+      {/* Skip link (a11y) */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[300] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-lg focus:text-sm focus:font-medium"
+      >
+        Aller au contenu
+      </a>
+
       {/* Sidebar: persistent on desktop, in drawer on mobile */}
       {isDesktop ? (
         <Sidebar />
@@ -350,7 +359,7 @@ export default function AppShell() {
         />
 
         {/* Content */}
-        <main className="flex-1 overflow-y-auto">
+        <main id="main-content" className="flex-1 overflow-y-auto">
           <ToastProvider>
             <ActionDrawerProvider>
               <Outlet />
@@ -375,6 +384,9 @@ export default function AppShell() {
 
       {/* Dev Panel — dev-only, visible when ?debug */}
       <DevPanel />
+
+      {/* Onboarding tour (first login only) */}
+      <OnboardingOverlay />
     </div>
   );
 }

--- a/frontend/src/layout/NavPanel.jsx
+++ b/frontend/src/layout/NavPanel.jsx
@@ -61,12 +61,14 @@ function PanelLink({
     ? BADGE_STYLES[badgeKey] || BADGE_STYLES._default
     : BADGE_STYLES._default;
   const tipText = longLabel || label;
+  const descId = desc ? `nav-desc-${to.replace(/[^a-z0-9]/gi, '-')}` : undefined;
 
   return (
     <NavLink
       to={to}
       end={to === '/'}
       aria-label={tipText}
+      aria-describedby={descId}
       title={desc || undefined}
       className={({ isActive }) =>
         `group/link flex items-center gap-1.5 h-7 rounded-lg text-[12.5px] leading-5 transition-all duration-150 relative py-0.5 px-2${indent ? ' ml-3' : ''}
@@ -85,6 +87,11 @@ function PanelLink({
             className={`shrink-0 transition-colors duration-150 ${isActive ? t.icon : 'text-slate-400'}`}
           />
           <span className="flex-1 truncate">{label}</span>
+          {descId && (
+            <span id={descId} className="sr-only">
+              {desc}
+            </span>
+          )}
           {badge > 0 && (
             <span
               className={`ml-auto px-1 py-px text-[9px] font-semibold rounded-full min-w-[16px] text-center ${badgeStyle}`}

--- a/frontend/src/layout/NavRail.jsx
+++ b/frontend/src/layout/NavRail.jsx
@@ -7,8 +7,14 @@ import { TooltipPortal } from '../ui';
 import { NAV_MODULES, TINT_PALETTE } from './NavRegistry';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 
+/* ── Module → badge key mapping ── */
+const MODULE_BADGE_KEY = {
+  conformite: 'alerts',
+  energie: 'monitoring',
+};
+
 /* ── Rail icon button for one module ── */
-function RailIcon({ mod, isActive, onClick }) {
+function RailIcon({ mod, isActive, onClick, badgeCount }) {
   const t = TINT_PALETTE[mod.tint] || TINT_PALETTE.slate;
   const Icon = mod.icon;
 
@@ -27,6 +33,11 @@ function RailIcon({ mod, isActive, onClick }) {
         aria-current={isActive ? 'true' : undefined}
       >
         <Icon size={20} />
+        {badgeCount > 0 && (
+          <span className="absolute top-1 right-1 w-4 h-4 flex items-center justify-center text-[8px] font-bold bg-red-500 text-white rounded-full leading-none">
+            {badgeCount > 9 ? '9+' : badgeCount}
+          </span>
+        )}
         <span className="text-[10px] mt-0.5 leading-tight opacity-80">{mod.label}</span>
       </button>
     </TooltipPortal>
@@ -34,7 +45,7 @@ function RailIcon({ mod, isActive, onClick }) {
 }
 
 /* ── Main Rail ── */
-export default function NavRail({ activeModule, onSelectModule }) {
+export default function NavRail({ activeModule, onSelectModule, badges = {} }) {
   const { isExpert } = useExpertMode();
 
   const visibleModules = isExpert ? NAV_MODULES : NAV_MODULES.filter((m) => !m.expertOnly);
@@ -58,6 +69,7 @@ export default function NavRail({ activeModule, onSelectModule }) {
             mod={mod}
             isActive={activeModule === mod.key}
             onClick={onSelectModule}
+            badgeCount={badges[MODULE_BADGE_KEY[mod.key]] || 0}
           />
         ))}
       </div>

--- a/frontend/src/layout/NavRegistry.js
+++ b/frontend/src/layout/NavRegistry.js
@@ -569,7 +569,6 @@ export const NAV_SECTIONS = [
         icon: SearchCheck,
         label: 'Diagnostics',
         desc: 'Détection anomalies & gisements',
-        expertOnly: true,
         keywords: ['diagnostic', 'anomalies', 'analyse'],
       },
     ],
@@ -603,7 +602,6 @@ export const NAV_SECTIONS = [
         icon: Receipt,
         label: 'Facturation',
         desc: 'Anomalies factures, shadow billing',
-        expertOnly: true,
         keywords: [
           'factures',
           'billing',

--- a/frontend/src/layout/Sidebar.jsx
+++ b/frontend/src/layout/Sidebar.jsx
@@ -136,7 +136,7 @@ export default function Sidebar() {
       className="flex h-full z-30 shrink-0 overflow-y-auto relative"
       aria-label="Navigation principale"
     >
-      <NavRail activeModule={displayModule} onSelectModule={handleSelectModule} />
+      <NavRail activeModule={displayModule} onSelectModule={handleSelectModule} badges={badges} />
       {!collapsed && (
         <NavPanel
           activeModule={displayModule}

--- a/frontend/src/layout/__tests__/NavRegistry.test.js
+++ b/frontend/src/layout/__tests__/NavRegistry.test.js
@@ -192,9 +192,7 @@ describe('Expert filtering V7', () => {
       s.items.filter((i) => i.expertOnly)
     );
     const labels = expertItems.map((i) => i.label).sort();
-    expect(labels).toEqual(
-      ['Audit SMÉ', "Simulateur d'achat"].sort()
-    );
+    expect(labels).toEqual(['Audit SMÉ', "Simulateur d'achat"].sort());
   });
 
   it('getVisibleItems returns all items in expert mode', () => {

--- a/frontend/src/layout/__tests__/NavRegistry.test.js
+++ b/frontend/src/layout/__tests__/NavRegistry.test.js
@@ -146,10 +146,11 @@ describe('NAV_SECTIONS V7', () => {
     expect(energie.items.find((i) => i.label === 'Facturation')).toBeUndefined();
   });
 
-  it('facturation is expertOnly', () => {
+  it('facturation is visible in normal mode (promoted from expertOnly)', () => {
     const patrimoine = NAV_SECTIONS.find((s) => s.module === 'patrimoine');
     const facturation = patrimoine.items.find((i) => i.label === 'Facturation');
-    expect(facturation.expertOnly).toBe(true);
+    expect(facturation).toBeDefined();
+    expect(facturation.expertOnly).toBeFalsy();
   });
 
   it('usages is visible in normal mode (not expertOnly)', () => {
@@ -172,27 +173,27 @@ describe('NAV_SECTIONS V7', () => {
 
 /* ── Expert filtering (item level) ── */
 describe('Expert filtering V7', () => {
-  it('normal mode: 13 visible items across all modules', () => {
+  it('normal mode: 15 visible items across all modules', () => {
     const normal = NAV_SECTIONS.filter((s) => !s.expertOnly).flatMap((s) =>
       getVisibleItems(s.items, false)
     );
-    expect(normal).toHaveLength(13);
+    expect(normal).toHaveLength(15);
   });
 
-  it('expert mode: 17 visible items (+4 : audit-sme, diagnostics, facturation, simulateur)', () => {
+  it('expert mode: 17 visible items (+2 : audit-sme, simulateur)', () => {
     const expert = NAV_SECTIONS.filter((s) => !s.expertOnly).flatMap((s) =>
       getVisibleItems(s.items, true)
     );
     expect(expert).toHaveLength(17);
   });
 
-  it('the 4 expert-only items are: audit-sme, diagnostics, facturation, simulateur', () => {
+  it('the 2 expert-only items are: audit-sme, simulateur', () => {
     const expertItems = NAV_SECTIONS.filter((s) => !s.expertOnly).flatMap((s) =>
       s.items.filter((i) => i.expertOnly)
     );
     const labels = expertItems.map((i) => i.label).sort();
     expect(labels).toEqual(
-      ['Audit SMÉ', 'Diagnostics', 'Facturation', "Simulateur d'achat"].sort()
+      ['Audit SMÉ', "Simulateur d'achat"].sort()
     );
   });
 

--- a/frontend/src/pages/ConsumptionDiagPage.jsx
+++ b/frontend/src/pages/ConsumptionDiagPage.jsx
@@ -40,7 +40,7 @@ import { track } from '../services/tracker';
 import { useActionDrawer } from '../contexts/ActionDrawerContext';
 import { fmtEur, fmtKwh, fmtCo2, fmtDateFR } from '../utils/format';
 import { deepLinkWithContext } from '../services/deepLink';
-import { toConsoExplorer, toMonitoring, toUsages } from '../services/routes';
+import { toConsoExplorer, toMonitoring, toUsages, toBillIntel } from '../services/routes';
 import usePeriodParams from '../hooks/usePeriodParams';
 import { SEVERITY_TINT } from '../ui/colorTokens';
 import { CO2E_FACTOR_KG_PER_KWH } from './consumption/constants';
@@ -1173,6 +1173,16 @@ export default function ConsumptionDiagPage() {
         onOpenExplorer={handleOpenExplorer}
         onViewInvoice={handleViewInvoice}
       />
+
+      {/* Cross-module exit: facturation */}
+      <div className="flex items-center gap-4 pt-4 mt-4 border-t border-gray-100">
+        <Link
+          to={toBillIntel()}
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-amber-600 hover:text-amber-700 hover:underline transition"
+        >
+          Voir la facturation & anomalies
+        </Link>
+      </div>
 
       {/* Action creation handled by ActionDrawerContext */}
     </PageShell>

--- a/frontend/src/pages/ContractRadarPage.jsx
+++ b/frontend/src/pages/ContractRadarPage.jsx
@@ -403,7 +403,7 @@ export default function ContractRadarPage() {
   return (
     <PageShell
       icon={CalendarRange}
-      title="Renouvellements contrats"
+      title="Échéances"
       subtitle="Radar des échéances et scénarios d'achat"
     >
       <div className="flex items-center gap-3 mb-1">

--- a/frontend/src/pages/Patrimoine.jsx
+++ b/frontend/src/pages/Patrimoine.jsx
@@ -705,7 +705,7 @@ export default function Patrimoine() {
   return (
     <PageShell
       icon={Building2}
-      title="Registre patrimonial & contractuel"
+      title="Sites & bâtiments"
       subtitle={subtitle}
       actions={
         <>

--- a/frontend/src/pages/PurchasePage.jsx
+++ b/frontend/src/pages/PurchasePage.jsx
@@ -548,7 +548,7 @@ export default function PurchasePage() {
     <PurchaseErrorBoundary>
       <PageShell
         icon={ShoppingCart}
-        title="Achats énergie"
+        title="Scénarios d'achat"
         subtitle={
           <span className="flex items-center gap-2">
             Simuler &amp; arbitrer vos stratégies d'achat

--- a/frontend/src/services/routes.js
+++ b/frontend/src/services/routes.js
@@ -275,3 +275,16 @@ export function toMonitoring(opts = {}) {
   const qs = p.toString();
   return `/monitoring${qs ? '?' + qs : ''}`;
 }
+
+/**
+ * Site 360 — fiche site avec tab deep-linkable.
+ * @param {number|string} siteId
+ * @param {object} [opts]
+ * @param {string} [opts.tab] — resume, conso, factures, conformite, actions, puissance, usages
+ */
+export function toSite360(siteId, opts = {}) {
+  const p = new URLSearchParams();
+  if (opts.tab) p.set('tab', opts.tab);
+  const qs = p.toString();
+  return `/sites/${siteId}${qs ? '?' + qs : ''}`;
+}


### PR DESCRIPTION
## Summary
9 improvements to close the gap from 89/100 to ~97/100 on the nav audit score:

- **#5** Facturation + Diagnostics promoted to normal mode (15 items visible, was 13)
- **#11** Page titles aligned with nav labels (Patrimoine, Echéances, Scénarios d'achat)
- **#8** Return link Diagnostic → Facturation via `toBillIntel()`
- **#1** Skip link "Aller au contenu" (a11y, sr-only)
- **#2** `aria-describedby` on NavPanel items (screen reader descriptions)
- **#9** Badge counts on NavRail module icons (alerts on Conformité, monitoring on Énergie)
- **#6** OnboardingOverlay — 4-step first-login tour (localStorage one-shot)
- **#7** `toSite360(id, {tab})` route helper for deep-linkable inbound navigation
- **#10** Legacy pages kept (zero runtime impact, redirect-only)

## Test plan
- [x] 164/164 test files, 3835 tests pass
- [x] Prettier clean
- [x] Nav parity + expert filtering tests updated
- [ ] Playwright visual audit
- [ ] Manual: first login onboarding tour, badge counts, skip link Tab

🤖 Generated with [Claude Code](https://claude.ai/claude-code)