### PR TITLE
feat(nav): world-class — transitions, smart palette, contextual actions

### DIFF
--- a/frontend/src/layout/Breadcrumb.jsx
+++ b/frontend/src/layout/Breadcrumb.jsx
@@ -163,7 +163,10 @@ export default function Breadcrumb() {
 
 function BreadcrumbNav({ crumbs, tintText }) {
   return (
-    <nav className="flex items-center gap-1 text-sm text-gray-500">
+    <nav
+      key={crumbs.map((c) => c.to).join('/')}
+      className="flex items-center gap-1 text-sm text-gray-500 animate-[fadeIn_0.2s_ease-out]"
+    >
       {crumbs.map((c, i) => (
         <span key={`${c.to}-${i}`} className="flex items-center gap-1">
           {i > 0 && <ChevronRight size={14} className="text-gray-300" />}

--- a/frontend/src/layout/NavPanel.jsx
+++ b/frontend/src/layout/NavPanel.jsx
@@ -325,9 +325,10 @@ export default function NavPanel({ activeModule, pins, onTogglePin, badges }) {
       role="navigation"
       aria-label={`Module ${mod.label}`}
     >
-      {/* Module header — tinted gradient */}
+      {/* Module header — tinted gradient, animated on module change */}
       <div
-        className={`px-3 pt-3 pb-2 border-b border-slate-200/50 bg-gradient-to-b ${t.panelHeader}`}
+        key={`header-${activeModule}`}
+        className={`px-3 pt-3 pb-2 border-b border-slate-200/50 bg-gradient-to-b ${t.panelHeader} animate-[fadeIn_0.2s_ease-out]`}
       >
         <div className="flex items-center gap-2">
           <mod.icon size={16} className={t.icon} />
@@ -367,9 +368,10 @@ export default function NavPanel({ activeModule, pins, onTogglePin, badges }) {
         </div>
       )}
 
-      {/* Scrollable content — keyboard nav (Arrow up/down moves focus between links) */}
+      {/* Scrollable content — animated on module change + keyboard nav */}
       <nav
-        className="flex-1 overflow-y-auto py-2 px-2"
+        key={`nav-${activeModule}`}
+        className="flex-1 overflow-y-auto py-2 px-2 animate-[fadeIn_0.15s_ease-out]"
         aria-label={`Navigation ${mod.label}`}
         onKeyDown={(e) => {
           if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
@@ -513,35 +515,57 @@ export default function NavPanel({ activeModule, pins, onTogglePin, badges }) {
                     )}
                     {/* Item contextuel : site actif (entre Registre et Conformité) */}
                     {idx === 0 && section.key === 'patrimoine' && activeSiteCtx && (
-                      <div
-                        className={`group flex items-center gap-2 px-3.5 py-1.5 mx-1 rounded-md cursor-pointer text-[12px] transition-all ${
-                          isOnSite360
-                            ? 'bg-emerald-50 text-emerald-700 font-medium border-l-2 border-emerald-600'
-                            : 'text-slate-400 hover:bg-slate-50 hover:text-slate-600'
-                        }`}
-                        onClick={() => _navigate(`/sites/${activeSiteCtx.id}`)}
-                      >
-                        <span
-                          className="w-1.5 h-1.5 rounded-full shrink-0"
-                          style={{
-                            backgroundColor: STATUT_DOT_COLOR[activeSiteCtx.statut] || '#888',
-                          }}
-                        />
-                        <span className="truncate flex-1">{activeSiteCtx.nom}</span>
-                        <button
-                          type="button"
-                          aria-label="Fermer la fiche site"
-                          className="opacity-0 group-hover:opacity-100 hover:bg-slate-200 rounded p-0.5 transition-opacity"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            clearActiveSite();
-                            setActiveSiteCtx(null);
-                            if (isOnSite360) _navigate('/patrimoine');
-                          }}
-                          title="Fermer la fiche site"
+                      <div className="mx-1 mb-1">
+                        <div
+                          className={`group flex items-center gap-2 px-3.5 py-1.5 rounded-md cursor-pointer text-[12px] transition-all ${
+                            isOnSite360
+                              ? 'bg-emerald-50 text-emerald-700 font-medium border-l-2 border-emerald-600'
+                              : 'text-slate-400 hover:bg-slate-50 hover:text-slate-600'
+                          }`}
+                          onClick={() => _navigate(`/sites/${activeSiteCtx.id}`)}
                         >
-                          <X size={12} />
-                        </button>
+                          <span
+                            className="w-1.5 h-1.5 rounded-full shrink-0"
+                            style={{
+                              backgroundColor: STATUT_DOT_COLOR[activeSiteCtx.statut] || '#888',
+                            }}
+                          />
+                          <span className="truncate flex-1">{activeSiteCtx.nom}</span>
+                          <button
+                            type="button"
+                            aria-label="Fermer la fiche site"
+                            className="opacity-0 group-hover:opacity-100 hover:bg-slate-200 rounded p-0.5 transition-opacity"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              clearActiveSite();
+                              setActiveSiteCtx(null);
+                              if (isOnSite360) _navigate('/patrimoine');
+                            }}
+                            title="Fermer la fiche site"
+                          >
+                            <X size={12} />
+                          </button>
+                        </div>
+                        {/* Contextual quick actions for active site */}
+                        {isOnSite360 && (
+                          <div className="flex flex-wrap gap-1 px-3 mt-1">
+                            {[
+                              { label: 'Conso', tab: 'conso' },
+                              { label: 'Factures', tab: 'factures' },
+                              { label: 'Conformité', tab: 'conformite' },
+                              { label: 'Actions', tab: 'actions' },
+                            ].map((a) => (
+                              <button
+                                key={a.tab}
+                                type="button"
+                                onClick={() => _navigate(`/sites/${activeSiteCtx.id}?tab=${a.tab}`)}
+                                className="px-1.5 py-0.5 text-[10px] text-emerald-600 bg-emerald-50 rounded hover:bg-emerald-100 transition"
+                              >
+                                {a.label}
+                              </button>
+                            ))}
+                          </div>
+                        )}
                       </div>
                     )}
                   </Fragment>

--- a/frontend/src/layout/NavRail.jsx
+++ b/frontend/src/layout/NavRail.jsx
@@ -27,7 +27,7 @@ function RailIcon({ mod, isActive, onClick, badgeCount }) {
           ${
             isActive
               ? `${t.railActiveBg} ring-1 ${t.railActiveRing} ${t.railActiveText}`
-              : 'text-slate-400 hover:bg-slate-100/60 hover:text-slate-600'
+              : 'text-slate-400 hover:bg-slate-100 hover:text-slate-600'
           }`}
         aria-label={mod.label}
         aria-current={isActive ? 'true' : undefined}

--- a/frontend/src/ui/CommandPalette.jsx
+++ b/frontend/src/ui/CommandPalette.jsx
@@ -15,15 +15,37 @@ import {
 } from '../layout/NavRegistry';
 import { useScope } from '../contexts/ScopeContext';
 
+const HITS_KEY = 'promeos_cmd_hits';
+
+function loadHits() {
+  try {
+    return JSON.parse(localStorage.getItem(HITS_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function recordHit(path) {
+  const hits = loadHits();
+  hits[path] = (hits[path] || 0) + 1;
+  try {
+    localStorage.setItem(HITS_KEY, JSON.stringify(hits));
+  } catch {
+    /* noop */
+  }
+}
+
 export default function CommandPalette({ open, onClose, onToggleExpert }) {
   const { orgSites: scopedSites = [] } = useScope();
   const [query, setQuery] = useState('');
   const [selectedIdx, setSelectedIdx] = useState(0);
   const inputRef = useRef(null);
   const navigate = useNavigate();
+  const hitsRef = useRef(loadHits());
 
   useEffect(() => {
     if (open) {
+      hitsRef.current = loadHits();
       setQuery('');
       setSelectedIdx(0);
       requestAnimationFrame(() => inputRef.current?.focus());
@@ -32,9 +54,16 @@ export default function CommandPalette({ open, onClose, onToggleExpert }) {
 
   const results = useMemo(() => {
     const q = query.toLowerCase().trim();
+    const hits = hitsRef.current;
     if (!q) {
-      // Default: pages grouped by section + shortcuts
-      const pages = ALL_MAIN_ITEMS.slice(0, 8).map((item) => ({ type: 'page', ...item }));
+      // Default: pages ranked by frequency, then shortcuts
+      const pages = ALL_MAIN_ITEMS.map((item) => ({
+        type: 'page',
+        ...item,
+        _score: hits[item.to] || 0,
+      }))
+        .sort((a, b) => b._score - a._score)
+        .slice(0, 8);
       const shortcuts = COMMAND_SHORTCUTS.map((a) => ({ type: 'shortcut', ...a }));
       return [...pages, ...shortcuts];
     }
@@ -88,7 +117,11 @@ export default function CommandPalette({ open, onClose, onToggleExpert }) {
         subtitle: [s.ville, s.usage].filter(Boolean).join(' · '),
       }));
 
-    return [...siteResults, ...pages, ...legacyPages, ...actions, ...shortcuts];
+    // Boost pages by frequency (frequent pages float to top)
+    const allPages = [...pages, ...legacyPages].sort(
+      (a, b) => (hits[b.to] || 0) - (hits[a.to] || 0)
+    );
+    return [...siteResults, ...allPages, ...actions, ...shortcuts];
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
@@ -102,6 +135,7 @@ export default function CommandPalette({ open, onClose, onToggleExpert }) {
       onClose();
       return;
     }
+    recordHit(item.to);
     navigate(item.to);
     onClose();
   };


### PR DESCRIPTION
## Summary
3 HIGH + 2 MEDIUM improvements for world-class nav:

- **Module switch animation**: NavPanel header + content fade in smoothly when switching modules on the rail
- **CommandPalette smart ranking**: tracks selection frequency in localStorage, most-used pages float to top in default results and search
- **Site360 contextual actions**: 4 tab shortcuts (Conso, Factures, Conformite, Actions) as pills in NavPanel when on a site page
- **NavRail hover opacity**: normalized from 60% to 100%
- **Breadcrumb fade**: smooth transition on route change

## Test plan
- [x] 165/165 test files, 3851 tests pass
- [x] Prettier clean
- [ ] Manual: switch modules on rail (animation), Ctrl+K after visiting pages (ranking), navigate to /sites/1 (contextual pills)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)