### PR TITLE
feat: nav strategic + Sirene V115 + Sprints 1-8 Enedis pipeline complet

### DIFF
--- a/backend/data_staging/engine.py
+++ b/backend/data_staging/engine.py
@@ -84,8 +84,9 @@ def run_promotion(
     db.refresh(run)
 
     try:
-        # High-water marks
-        hwm_before = _get_high_water_marks(db, flux_types) if mode == "incremental" else {}
+        # High-water marks : lus du DERNIER RUN completed, pas du max(id) actuel
+        # (sinon les rows ajoutées depuis le dernier run seraient ignorées)
+        hwm_before = _load_last_hwm(db, flux_types) if mode == "incremental" else {}
         run.high_water_mark_before = json.dumps(hwm_before)
 
         # Discover : collecter tous les PRM distincts à traiter
@@ -252,27 +253,29 @@ def _upsert_quality_first(
     update_attrs: list[str],
     run_id: int,
 ) -> int:
-    """UPSERT batch avec quality-first overwrite via INSERT ON CONFLICT.
+    """UPSERT batch avec quality-first overwrite.
 
-    Utilise sqlite INSERT OR REPLACE pour les nouvelles rows,
-    et un pre-check batch pour respecter la règle quality-first
-    (ne pas écraser une row de meilleure qualité).
+    Par chunk :
+    1 query SELECT (batch fetch existing)
+    1 query INSERT (bulk_save_objects pour nouveaux)
+    1 query UPDATE (bulk_update_mappings pour existants avec meilleure qualité)
+
+    Total : 3 queries par chunk de 1000 rows (vs 2000+ dans l'ancienne version).
     """
     if not rows:
         return 0
 
     model_cls = type(rows[0])
-    table = model_cls.__table__
     count = 0
+    all_update_attrs = [*update_attrs, "quality_score", "is_estimated", "promotion_run_id"]
 
-    # Batch par chunks pour limiter la mémoire
     for chunk_start in range(0, len(rows), CHUNK_SIZE):
         chunk = rows[chunk_start : chunk_start + CHUNK_SIZE]
-
-        # Pre-fetch les rows existantes pour ce chunk (1 query par chunk, pas par row)
         existing_map = _batch_fetch_existing(db, model_cls, unique_key_attrs, chunk)
 
         to_insert = []
+        to_update_mappings: list[dict] = []
+
         for row in chunk:
             key = tuple(getattr(row, attr) for attr in unique_key_attrs)
             existing = existing_map.get(key)
@@ -280,21 +283,27 @@ def _upsert_quality_first(
             if existing:
                 # Quality-first : update seulement si >= (latest wins on tie)
                 if row.quality_score >= existing.quality_score:
+                    mapping = {"id": existing.id}
                     for attr in update_attrs:
                         new_val = getattr(row, attr)
                         if new_val is not None:
-                            setattr(existing, attr, new_val)
-                    existing.quality_score = row.quality_score
-                    existing.is_estimated = row.is_estimated
-                    existing.promotion_run_id = run_id
+                            mapping[attr] = new_val
+                    mapping["quality_score"] = row.quality_score
+                    mapping["is_estimated"] = row.is_estimated
+                    mapping["promotion_run_id"] = run_id
+                    to_update_mappings.append(mapping)
                     count += 1
             else:
                 to_insert.append(row)
 
-        # Batch insert des nouvelles rows
+        # Batch INSERT (1 query)
         if to_insert:
             db.bulk_save_objects(to_insert)
             count += len(to_insert)
+
+        # Batch UPDATE (1 query)
+        if to_update_mappings:
+            db.bulk_update_mappings(model_cls, to_update_mappings)
 
     return count
 
@@ -415,7 +424,7 @@ def _resolve_backlog(db: Session, prm_code: str, meter_id: int) -> None:
 
 
 def _get_high_water_marks(db: Session, flux_types: list[str]) -> dict[str, int]:
-    """Retourne le max(id) par table staging."""
+    """Retourne le max(id) par table staging (snapshot courant)."""
     hwm = {}
     for flux_key in flux_types:
         if flux_key not in _STAGING_TABLES:
@@ -425,3 +434,19 @@ def _get_high_water_marks(db: Session, flux_types: list[str]) -> dict[str, int]:
         if max_id is not None:
             hwm[flux_key] = max_id
     return hwm
+
+
+def _load_last_hwm(db: Session, flux_types: list[str]) -> dict[str, int]:
+    """Charge le HWM du dernier run COMPLETED (source de vérité pour incrémental).
+
+    Si aucun run précédent : retourne {} (= tout traiter).
+    """
+    last_run = (
+        db.query(PromotionRun).filter(PromotionRun.status == "completed").order_by(PromotionRun.id.desc()).first()
+    )
+    if not last_run or not last_run.high_water_mark_after:
+        return {}
+    try:
+        return json.loads(last_run.high_water_mark_after)
+    except (json.JSONDecodeError, TypeError):
+        return {}

--- a/backend/models/sirene.py
+++ b/backend/models/sirene.py
@@ -62,6 +62,7 @@ class SireneUniteLegale(Base, TimestampMixin):
         Index("ix_sirene_ul_denomination", "denomination"),
         Index("ix_sirene_ul_etat", "etat_administratif"),
         Index("ix_sirene_ul_ddt", "date_dernier_traitement"),
+        Index("ix_sirene_ul_snapshot", "snapshot_date"),
     )
 
 
@@ -122,6 +123,7 @@ class SireneEtablissement(Base, TimestampMixin):
         Index("ix_sirene_etab_commune", "libelle_commune"),
         Index("ix_sirene_etab_etat", "etat_administratif"),
         Index("ix_sirene_etab_ddt", "date_dernier_traitement"),
+        Index("ix_sirene_etab_snapshot", "snapshot_date"),
     )
 
 

--- a/backend/routes/enedis.py
+++ b/backend/routes/enedis.py
@@ -51,6 +51,27 @@ def _require_auth():
         return None
 
 
+# Rate limit : max 1 promotion démarrée par fenêtre de 60s par source
+_PROMOTION_RATE_LIMIT_WINDOW = 60.0
+_last_promotion_trigger: dict[str, float] = {}
+
+
+def _check_promotion_rate_limit(triggered_by: str = "api"):
+    """Rate limit : max 1 run démarré par fenêtre de 60s par source. Anti DoS."""
+    import time
+
+    now = time.monotonic()
+    last = _last_promotion_trigger.get(triggered_by, 0.0)
+    elapsed = now - last
+    if elapsed < _PROMOTION_RATE_LIMIT_WINDOW:
+        wait = int(_PROMOTION_RATE_LIMIT_WINDOW - elapsed)
+        raise HTTPException(
+            status_code=429,
+            detail=f"Rate limit : attendre {wait}s avant prochain run (source={triggered_by})",
+        )
+    _last_promotion_trigger[triggered_by] = now
+
+
 # ========================================
 # Pydantic schemas — Ingestion
 # ========================================
@@ -415,8 +436,15 @@ def trigger_promotion(
     db: Session = Depends(get_db),
     _auth=Depends(_require_auth),
 ):
-    """Déclenche un run de promotion staging → tables fonctionnelles."""
+    """Déclenche un run de promotion staging → tables fonctionnelles.
+
+    Rate limit : 1 run par fenêtre de 60s (anti DoS).
+    Dry-run : exempt du rate limit pour debug.
+    """
     from data_staging.engine import run_promotion
+
+    if not dry_run:
+        _check_promotion_rate_limit("api")
 
     ft = [f.strip().upper() for f in flux_types.split(",")] if flux_types else None
     try:
@@ -498,6 +526,266 @@ def get_promotion_run(run_id: int, db: Session = Depends(get_db)):
         "rows_skipped": run.rows_skipped,
         "rows_flagged": run.rows_flagged,
         "error_message": run.error_message,
+    }
+
+
+@router.get("/promotion/metrics")
+def get_promotion_metrics(db: Session = Depends(get_db)):
+    """Métriques du pipeline de promotion au format Prometheus-compatible.
+
+    Retourne un texte exposition format Prometheus. Scrapable par Prometheus
+    ou par un agent de monitoring sans dépendance externe.
+
+    Usage :
+        curl http://localhost:8001/api/enedis/promotion/metrics
+    """
+    from fastapi.responses import PlainTextResponse
+    from data_staging.models import PromotionRun, UnmatchedPrm, MeterLoadCurve
+    from sqlalchemy import func as sql_func
+
+    # Collecter les métriques
+    total_runs = db.query(PromotionRun).count()
+    completed_runs = db.query(PromotionRun).filter(PromotionRun.status == "completed").count()
+    failed_runs = db.query(PromotionRun).filter(PromotionRun.status == "failed").count()
+    running_runs = db.query(PromotionRun).filter(PromotionRun.status == "running").count()
+
+    last_completed = (
+        db.query(PromotionRun).filter(PromotionRun.status == "completed").order_by(PromotionRun.id.desc()).first()
+    )
+
+    # Backlog
+    backlog_pending = db.query(UnmatchedPrm).filter(UnmatchedPrm.status == "pending").count()
+    backlog_resolved = db.query(UnmatchedPrm).filter(UnmatchedPrm.status == "resolved").count()
+
+    # Volume tables fonctionnelles
+    mlc_total = db.query(MeterLoadCurve).count()
+
+    # Format Prometheus text exposition
+    lines = [
+        "# HELP promeos_promotion_runs_total Total promotion runs by status",
+        "# TYPE promeos_promotion_runs_total counter",
+        f'promeos_promotion_runs_total{{status="completed"}} {completed_runs}',
+        f'promeos_promotion_runs_total{{status="failed"}} {failed_runs}',
+        f'promeos_promotion_runs_total{{status="running"}} {running_runs}',
+        f'promeos_promotion_runs_total{{status="all"}} {total_runs}',
+        "",
+        "# HELP promeos_promotion_backlog_prms Number of unmatched PRMs in backlog",
+        "# TYPE promeos_promotion_backlog_prms gauge",
+        f'promeos_promotion_backlog_prms{{status="pending"}} {backlog_pending}',
+        f'promeos_promotion_backlog_prms{{status="resolved"}} {backlog_resolved}',
+        "",
+        "# HELP promeos_meter_load_curve_rows_total Total rows in meter_load_curve",
+        "# TYPE promeos_meter_load_curve_rows_total gauge",
+        f"promeos_meter_load_curve_rows_total {mlc_total}",
+    ]
+
+    if last_completed:
+        lines.extend(
+            [
+                "",
+                "# HELP promeos_last_promotion_prms_matched PRMs matched in last completed run",
+                "# TYPE promeos_last_promotion_prms_matched gauge",
+                f"promeos_last_promotion_prms_matched {last_completed.prms_matched or 0}",
+                "",
+                "# HELP promeos_last_promotion_prms_unmatched PRMs unmatched in last completed run",
+                "# TYPE promeos_last_promotion_prms_unmatched gauge",
+                f"promeos_last_promotion_prms_unmatched {last_completed.prms_unmatched or 0}",
+                "",
+                "# HELP promeos_last_promotion_rows_promoted Total rows promoted in last run",
+                "# TYPE promeos_last_promotion_rows_promoted gauge",
+                f"promeos_last_promotion_rows_promoted "
+                f"{(last_completed.rows_load_curve or 0) + (last_completed.rows_energy_index or 0) + (last_completed.rows_power_peak or 0)}",
+            ]
+        )
+
+        # Age du dernier run (secondes)
+        if last_completed.finished_at:
+            from datetime import datetime, timezone
+
+            finished = last_completed.finished_at
+            if finished.tzinfo is None:
+                finished = finished.replace(tzinfo=timezone.utc)
+            age_seconds = (datetime.now(timezone.utc) - finished).total_seconds()
+            lines.extend(
+                [
+                    "",
+                    "# HELP promeos_last_promotion_age_seconds Seconds since last completed run",
+                    "# TYPE promeos_last_promotion_age_seconds gauge",
+                    f"promeos_last_promotion_age_seconds {int(age_seconds)}",
+                ]
+            )
+
+    return PlainTextResponse("\n".join(lines) + "\n", media_type="text/plain; version=0.0.4")
+
+
+@router.post("/opendata/refresh")
+def refresh_opendata(
+    date_from: Optional[str] = Query(None, description="YYYY-MM-DD"),
+    date_to: Optional[str] = Query(None, description="YYYY-MM-DD"),
+    dataset: str = Query("sup36", pattern="^(sup36|inf36|all)$"),
+    db: Session = Depends(get_db),
+    _auth=Depends(_require_auth),
+):
+    """Import/refresh des agrégats Enedis Open Data.
+
+    Endpoint à appeler périodiquement (cron hebdomadaire recommandé) pour
+    maintenir les benchmarks NAF à jour. Rate-limité pour éviter surcharge ODS.
+    """
+    _check_promotion_rate_limit("opendata_refresh")
+
+    from connectors.registry import get_connector
+
+    connector = get_connector("enedis_opendata")
+    if not connector:
+        raise HTTPException(status_code=500, detail="Connector enedis_opendata non trouvé")
+
+    try:
+        results = connector.sync(db, object_type=dataset, date_from=date_from, date_to=date_to)
+        return {
+            "status": "completed",
+            "dataset": dataset,
+            "date_from": date_from,
+            "date_to": date_to,
+            "results": results,
+            "total_rows": sum(r.get("rows_imported", 0) for r in results),
+        }
+    except Exception as e:
+        logger.error("ODS refresh failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"ODS refresh failed: {e}")
+
+
+@router.get("/opendata/freshness")
+def get_opendata_freshness(db: Session = Depends(get_db)):
+    """Retourne l'état de fraîcheur des données Open Data.
+
+    Permet aux dashboards de savoir si les benchmarks sont à jour.
+    """
+    from models.enedis_opendata import EnedisConsoSup36, EnedisConsoInf36
+    from sqlalchemy import func as sql_func
+    from datetime import datetime, timezone
+
+    sup36_count = db.query(EnedisConsoSup36).count()
+    inf36_count = db.query(EnedisConsoInf36).count()
+
+    sup36_latest = db.query(sql_func.max(EnedisConsoSup36.created_at)).scalar()
+    inf36_latest = db.query(sql_func.max(EnedisConsoInf36.created_at)).scalar()
+
+    def _age_days(dt):
+        if not dt:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return round((datetime.now(timezone.utc) - dt).total_seconds() / 86400, 1)
+
+    sup36_age = _age_days(sup36_latest)
+    inf36_age = _age_days(inf36_latest)
+
+    status = "empty"
+    alerts = []
+    if sup36_count > 0:
+        if sup36_age is not None and sup36_age > 90:
+            status = "stale"
+            alerts.append(f"Agrégats sup36 vieux de {sup36_age} jours (seuil : 90)")
+        elif sup36_age is not None and sup36_age > 30:
+            status = "aging"
+        else:
+            status = "fresh"
+
+    return {
+        "status": status,
+        "alerts": alerts,
+        "sup36": {
+            "count": sup36_count,
+            "latest_import": sup36_latest.isoformat() if sup36_latest else None,
+            "age_days": sup36_age,
+        },
+        "inf36": {
+            "count": inf36_count,
+            "latest_import": inf36_latest.isoformat() if inf36_latest else None,
+            "age_days": inf36_age,
+        },
+    }
+
+
+@router.get("/promotion/health")
+def get_promotion_health(db: Session = Depends(get_db)):
+    """Health check du pipeline de promotion.
+
+    Retourne : status (healthy/stale/warning/error/never_ran/running),
+    dernier run, volumes, backlog, alertes actives.
+    """
+    from data_staging.models import PromotionRun, UnmatchedPrm, MeterLoadCurve
+    from datetime import datetime, timezone
+
+    last_run = db.query(PromotionRun).order_by(PromotionRun.id.desc()).first()
+    last_completed = (
+        db.query(PromotionRun).filter(PromotionRun.status == "completed").order_by(PromotionRun.id.desc()).first()
+    )
+    running = db.query(PromotionRun).filter(PromotionRun.status == "running").first()
+    pending_backlog = db.query(UnmatchedPrm).filter(UnmatchedPrm.status == "pending").count()
+    resolved_backlog = db.query(UnmatchedPrm).filter(UnmatchedPrm.status == "resolved").count()
+    promoted_rows_total = db.query(MeterLoadCurve).count()
+
+    alerts = []
+    now = datetime.now(timezone.utc)
+
+    if not last_run:
+        status = "never_ran"
+        alerts.append("Aucun run de promotion effectué")
+    elif running:
+        status = "running"
+    elif last_completed:
+        last_finished = last_completed.finished_at
+        if last_finished and last_finished.tzinfo is None:
+            last_finished = last_finished.replace(tzinfo=timezone.utc)
+
+        if last_finished:
+            age_hours = (now - last_finished).total_seconds() / 3600
+            if age_hours > 48:
+                status = "stale"
+                alerts.append(f"Dernier run il y a {int(age_hours)}h (seuil : 48h)")
+            elif age_hours > 24:
+                status = "warning"
+                alerts.append(f"Dernier run il y a {int(age_hours)}h (seuil warning : 24h)")
+            else:
+                status = "healthy"
+        else:
+            status = "unknown"
+    else:
+        status = "error"
+        alerts.append("Aucun run complété avec succès")
+
+    if pending_backlog > 100:
+        alerts.append(f"Backlog élevé : {pending_backlog} PRMs non résolus")
+
+    last_run_info = None
+    if last_run:
+        last_run_info = {
+            "id": last_run.id,
+            "status": last_run.status,
+            "mode": last_run.mode,
+            "triggered_by": last_run.triggered_by,
+            "started_at": last_run.started_at.isoformat() if last_run.started_at else None,
+            "finished_at": last_run.finished_at.isoformat() if last_run.finished_at else None,
+            "prms_total": last_run.prms_total,
+            "prms_matched": last_run.prms_matched,
+            "prms_unmatched": last_run.prms_unmatched,
+            "rows_promoted": (
+                (last_run.rows_load_curve or 0) + (last_run.rows_energy_index or 0) + (last_run.rows_power_peak or 0)
+            ),
+            "error_message": last_run.error_message,
+        }
+
+    return {
+        "status": status,
+        "alerts": alerts,
+        "last_run": last_run_info,
+        "volumes": {
+            "meter_load_curve_total": promoted_rows_total,
+            "backlog_pending": pending_backlog,
+            "backlog_resolved": resolved_backlog,
+        },
+        "checked_at": now.isoformat(),
     }
 
 

--- a/backend/routes/sirene.py
+++ b/backend/routes/sirene.py
@@ -428,6 +428,18 @@ def onboarding_from_sirene(
         correlation_id=correlation_id,
     )
     db.add(trace)
+
+    # Funnel onboarding — best-effort, ne doit pas bloquer la creation.
+    # TODO(V116): extraire _get_or_create/_auto_detect vers services/onboarding_stepper
+    # pour eviter le route-to-route import (leaky abstraction).
+    try:
+        from routes.onboarding_stepper import _get_or_create, _auto_detect
+
+        progress = _get_or_create(db, org.id)
+        _auto_detect(db, org.id, progress)
+    except Exception as e:
+        logger.warning("onboarding_progress wiring failed [%s]: %s", correlation_id, e)
+
     db.commit()
 
     logger.info(

--- a/backend/routes/sirene.py
+++ b/backend/routes/sirene.py
@@ -49,6 +49,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Sirene"])
 
+# NAF 2025 entre en vigueur le 01/01/2027 (transition officielle INSEE).
+# Avant : on garde NAF Rev2. Apres : on bascule sur NAF25.
+_NAF25_EFFECTIVE = datetime(2027, 1, 1, tzinfo=timezone.utc)
+
 
 # ======================================================================
 # Recherche Sirene (referentiel local)
@@ -383,7 +387,7 @@ def onboarding_from_sirene(
         nom=ul.denomination or ul.nom_unite_legale or org_nom,
         siren=req.siren,
         siret=(req.siren + ul.nic_siege) if ul.nic_siege else None,
-        naf_code=ul.activite_principale,
+        naf_code=_resolve_naf(None, ul),
         insee_code=siege.code_commune if siege else None,
     )
     db.add(ej)
@@ -467,6 +471,19 @@ def onboarding_from_sirene(
 # ======================================================================
 
 
+def _resolve_naf(etab, ul) -> Optional[str]:
+    """Resout le code NAF en priorisant NAF25 apres 2027-01-01 (transition INSEE).
+
+    Fallback chain : NAF25 etab -> NAF25 ul -> NAF Rev2 etab -> NAF Rev2 ul.
+    Avant 2027, NAF Rev2 reste la reference officielle.
+    """
+    rev2 = (etab.activite_principale if etab else None) or ul.activite_principale
+    if datetime.now(timezone.utc) < _NAF25_EFFECTIVE:
+        return rev2
+    naf25 = (etab.activite_principale_naf25 if etab else None) or ul.activite_principale_naf25
+    return naf25 or rev2
+
+
 def _create_site_from_etab(db: Session, portefeuille_id: int, etab, ul, org_nom: str) -> tuple:
     """Cree un Site PROMEOS depuis un etablissement Sirene. Ne cree PAS de batiment/compteur."""
     site_nom = (
@@ -474,7 +491,7 @@ def _create_site_from_etab(db: Session, portefeuille_id: int, etab, ul, org_nom:
         or etab.denomination_usuelle
         or f"{org_nom} — {etab.libelle_commune or etab.code_postal or etab.siret}"
     )
-    naf = etab.activite_principale or ul.activite_principale
+    naf = _resolve_naf(etab, ul)
     try:
         type_site = classify_naf(naf) if naf else TypeSite.BUREAU
     except Exception:

--- a/backend/routes/usages.py
+++ b/backend/routes/usages.py
@@ -543,6 +543,95 @@ def api_benchmark(
     return result
 
 
+# ── Estimateur pré-consentement (NAF + puissance → courbe de référence) ─
+
+
+@router.get("/estimate/reference-curve")
+def api_estimate_reference_curve(
+    naf_code: str = Query(..., description="Code NAF (ex: 6201Z)"),
+    power_kva: float = Query(..., gt=0, description="Puissance souscrite en kVA"),
+    months: int = Query(12, ge=3, le=36),
+    db: Session = Depends(get_db),
+):
+    """Génère une courbe de référence pour un NAF + puissance, sans données client.
+
+    Source : agrégats Enedis Open Data (sup36 par NAF × puissance × région).
+    Usage : démonstration pré-vente, dimensionnement PV, estimation annuelle.
+    """
+    from services.naf_estimator import estimate_reference_curve
+
+    result = estimate_reference_curve(db, naf_code, power_kva, months)
+    if result is None or (isinstance(result, dict) and "error" in result):
+        detail = result.get("error", "Estimation impossible") if isinstance(result, dict) else "Estimation impossible"
+        raise HTTPException(404, detail)
+    return result
+
+
+@router.get("/estimate/sector-trend")
+def api_sector_trend(
+    naf_code: str = Query(..., description="Code NAF"),
+    power_kva: float | None = Query(None, description="Puissance souscrite (optionnel)"),
+    db: Session = Depends(get_db),
+):
+    """Tendance mensuelle d'un secteur : évolution, saisonnalité, écart moyen."""
+    from services.naf_estimator import compute_sector_trend
+
+    result = compute_sector_trend(db, naf_code, power_kva)
+    if result is None or "error" in result:
+        raise HTTPException(404, result.get("error", "Pas de tendance disponible") if result else "Pas de tendance")
+    return result
+
+
+@router.post("/recommendations/generate/{site_id}")
+def api_generate_recommendations(
+    site_id: int,
+    request: Request,
+    persist: bool = Query(True, description="Sauvegarde en DB"),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Génère automatiquement les recommandations pour un site.
+
+    Parse tous les KPIs analytics (load profile, signature, benchmark)
+    et applique les règles métier pour produire des Anomaly + Recommendation
+    classées par ICE score.
+    """
+    from services.recommendation_engine import generate_recommendations_for_site
+
+    org_id = resolve_org_id(request, auth, db)
+    _check_site_org(db, site_id, org_id)
+    result = generate_recommendations_for_site(db, site_id, persist=persist)
+    if result is None or (isinstance(result, dict) and "error" in result):
+        detail = result.get("error", "Génération impossible") if isinstance(result, dict) else "Génération impossible"
+        raise HTTPException(404, detail)
+    return result
+
+
+@router.get("/compare/site-vs-sector/{site_id}")
+def api_site_vs_sector(
+    site_id: int,
+    request: Request,
+    months: int = Query(12, ge=3, le=36),
+    persist_alerts: bool = Query(False, description="Créer des Anomaly pour les mois atypiques"),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Compare la consommation d'un site à la moyenne sectorielle mois par mois.
+
+    Détecte automatiquement les mois atypiques (>20% écart vs benchmark).
+    Si persist_alerts=true, crée des Anomaly visibles dans l'inbox cockpit.
+    """
+    from services.naf_estimator import compare_site_vs_sector
+
+    org_id = resolve_org_id(request, auth, db)
+    _check_site_org(db, site_id, org_id)
+    result = compare_site_vs_sector(db, site_id, months, persist_alerts=persist_alerts)
+    if result is None or (isinstance(result, dict) and "error" in result):
+        detail = result.get("error", "Comparaison impossible") if isinstance(result, dict) else "Comparaison impossible"
+        raise HTTPException(404, detail)
+    return result
+
+
 # ── Optimisation puissance souscrite ───────────────────────────────────────
 
 

--- a/backend/services/naf_estimator.py
+++ b/backend/services/naf_estimator.py
@@ -1,0 +1,511 @@
+"""
+Estimateur pré-consentement : génère une courbe de référence pour un NAF + puissance.
+
+Source : agrégats Enedis Open Data (conso-sup36-region, NAF × puissance × région).
+Sans données client — permet de démontrer la valeur produit avant signature.
+
+Cas d'usage :
+- Simulation pré-vente : "voici à quoi ressemble la courbe type d'un site comme le vôtre"
+- Dimensionnement PV : recouvrement PV simulé vs courbe de référence
+- Estimation de consommation annuelle pour un nouveau site sans historique
+- Benchmark pour prospects non consentants
+"""
+
+import logging
+import math
+import time
+from collections import defaultdict
+from datetime import datetime, date, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from models.enedis_opendata import EnedisConsoSup36
+
+logger = logging.getLogger(__name__)
+
+_ESTIMATOR_CACHE: dict[tuple, tuple] = {}
+_CACHE_TTL = 3600  # 1h — les agrégats changent trimestriellement
+
+# Mapping NAF prefix → secteur Enedis (doit matcher enedis_benchmarks.py)
+_NAF_PREFIX_TO_SECTOR = {
+    # Agriculture
+    "01": "S1: Agriculture",
+    "02": "S1: Agriculture",
+    "03": "S1: Agriculture",
+    # Industrie
+    "05": "S2: Industrie",
+    "06": "S2: Industrie",
+    "07": "S2: Industrie",
+    "08": "S2: Industrie",
+    "09": "S2: Industrie",
+    "10": "S2: Industrie",
+    "11": "S2: Industrie",
+    "12": "S2: Industrie",
+    "13": "S2: Industrie",
+    "14": "S2: Industrie",
+    "15": "S2: Industrie",
+    "16": "S2: Industrie",
+    "17": "S2: Industrie",
+    "18": "S2: Industrie",
+    "19": "S2: Industrie",
+    "20": "S2: Industrie",
+    "21": "S2: Industrie",
+    "22": "S2: Industrie",
+    "23": "S2: Industrie",
+    "24": "S2: Industrie",
+    "25": "S2: Industrie",
+    "26": "S2: Industrie",
+    "27": "S2: Industrie",
+    "28": "S2: Industrie",
+    "29": "S2: Industrie",
+    "30": "S2: Industrie",
+    "31": "S2: Industrie",
+    "32": "S2: Industrie",
+    "33": "S2: Industrie",
+    "35": "S2: Industrie",
+    "36": "S2: Industrie",
+    "37": "S2: Industrie",
+    "38": "S2: Industrie",
+    "39": "S2: Industrie",
+    # Tertiaire (commerce, transport, hébergement, services, admin, santé, enseignement)
+}
+
+
+def _naf_to_sector(naf_code: str) -> str:
+    """Convertit un code NAF (ex: 6201Z) en secteur Enedis."""
+    if not naf_code:
+        return "S3: Tertiaire"
+    prefix = naf_code.strip()[:2]
+    return _NAF_PREFIX_TO_SECTOR.get(prefix, "S3: Tertiaire")
+
+
+def _power_to_range(kva: float | None) -> str | None:
+    """Convention Enedis : ]low, high] → low < kva <= high."""
+    if kva is None or kva <= 36:
+        return None
+    for low, high, code in (
+        (36, 120, "P1: ]36-120] kVA"),
+        (120, 250, "P2: ]120-250] kVA"),
+        (250, 1000, "P4: ]250-1000] kVA"),
+        (1000, 2000, "P5: ]1000-2000] kVA"),
+        (2000, float("inf"), "P6: > 2000 kVA"),
+    ):
+        if low < kva <= high:
+            return code
+    return None
+
+
+def estimate_reference_curve(
+    db: Session,
+    naf_code: str,
+    power_kva: float,
+    months: int = 12,
+) -> dict | None:
+    """Génère une courbe de référence pour un NAF + puissance.
+
+    Retourne :
+    - profil horaire type (24 valeurs kWh)
+    - consommation annuelle estimée (kWh)
+    - nombre de points de référence dans l'agrégat
+    - intervalle de confiance (stddev)
+    - dérivés : load factor estimé, part thermosensible, saisonnalité
+    """
+    key = (naf_code, round(power_kva, 0), months)
+    cached = _ESTIMATOR_CACHE.get(key)
+    if cached and time.monotonic() < cached[1]:
+        return cached[0]
+
+    result = _estimate(db, naf_code, power_kva, months)
+    if result and "error" not in result:
+        _ESTIMATOR_CACHE[key] = (result, time.monotonic() + _CACHE_TTL)
+    return result
+
+
+def _estimate(db: Session, naf_code: str, power_kva: float, months: int) -> dict | None:
+    sector = _naf_to_sector(naf_code)
+    power_range = _power_to_range(power_kva)
+
+    if power_range is None:
+        return {
+            "error": "Puissance hors périmètre agrégats Enedis >36 kVA",
+            "power_kva": power_kva,
+            "naf_code": naf_code,
+        }
+
+    end_date = date.today()
+    start_date = end_date - timedelta(days=months * 30)
+    start_dt = datetime(start_date.year, start_date.month, start_date.day)
+
+    # Query agrégats (seulement colonnes nécessaires, pas les ORM)
+    rows = (
+        db.query(
+            EnedisConsoSup36.horodate,
+            EnedisConsoSup36.courbe_moyenne_wh,
+            EnedisConsoSup36.nb_points_soutirage,
+        )
+        .filter(
+            EnedisConsoSup36.horodate >= start_dt,
+            EnedisConsoSup36.secteur_activite == sector,
+            EnedisConsoSup36.plage_puissance == power_range,
+        )
+        .all()
+    )
+
+    if not rows:
+        # Fallback sans filtre puissance
+        rows = (
+            db.query(
+                EnedisConsoSup36.horodate,
+                EnedisConsoSup36.courbe_moyenne_wh,
+                EnedisConsoSup36.nb_points_soutirage,
+            )
+            .filter(
+                EnedisConsoSup36.horodate >= start_dt,
+                EnedisConsoSup36.secteur_activite == sector,
+            )
+            .all()
+        )
+        if not rows:
+            return {
+                "error": "Aucune donnée Open Data pour ce secteur/puissance",
+                "sector": sector,
+                "power_range": power_range,
+                "hint": "Lancez POST /api/connectors/enedis_opendata/sync pour importer les agrégats.",
+            }
+
+    # Profil horaire type (moyenne par heure)
+    hourly_values: dict[int, list[float]] = defaultdict(list)
+    hourly_counts: dict[int, list[int]] = defaultdict(list)
+    monthly_values: dict[int, list[float]] = defaultdict(list)
+    max_points = 0
+
+    for ts, wh, nb_pts in rows:
+        if ts is None or wh is None:
+            continue
+        hourly_values[ts.hour].append(wh)
+        hourly_counts[ts.hour].append(nb_pts or 0)
+        monthly_values[ts.month].append(wh)
+        max_points = max(max_points, nb_pts or 0)
+
+    if not hourly_values:
+        return {"error": "Agrégats vides pour ce segment"}
+
+    hourly_profile = []
+    hourly_stddev = []
+    for h in range(24):
+        vals = hourly_values.get(h, [])
+        if vals:
+            mean = sum(vals) / len(vals)
+            variance = sum((v - mean) ** 2 for v in vals) / len(vals) if len(vals) > 1 else 0
+            std = math.sqrt(variance)
+            # Conversion Wh → kWh pour affichage
+            hourly_profile.append(round(mean / 1000, 2))
+            hourly_stddev.append(round(std / 1000, 2))
+        else:
+            hourly_profile.append(0)
+            hourly_stddev.append(0)
+
+    # Consommation annuelle estimée (moyenne × 365 × 48 pas/jour)
+    daily_energy_kwh = sum(hourly_profile) * 2  # 2 pas 30min par heure
+    annual_kwh_estimate = daily_energy_kwh * 365
+
+    # Load factor estimé
+    p_max = max(hourly_profile) if hourly_profile else 0
+    p_mean = sum(hourly_profile) / len(hourly_profile) if hourly_profile else 0
+    load_factor = p_mean / p_max if p_max > 0 else 0
+
+    # Ratio nuit/jour
+    night_sum = sum(hourly_profile[h] for h in range(24) if h >= 22 or h < 6)
+    day_sum = sum(hourly_profile[h] for h in range(24) if 6 <= h < 22)
+    night_day_ratio = night_sum / day_sum if day_sum > 0 else 0
+
+    # Saisonnalité : écart hiver vs été
+    monthly_mean = {}
+    for month, vals in monthly_values.items():
+        if vals:
+            monthly_mean[month] = sum(vals) / len(vals) / 1000  # kWh
+    winter = [monthly_mean.get(m, 0) for m in (12, 1, 2)]
+    summer = [monthly_mean.get(m, 0) for m in (6, 7, 8)]
+    winter_mean = sum(winter) / len(winter) if any(winter) else 0
+    summer_mean = sum(summer) / len(summer) if any(summer) else 0
+    seasonality_ratio = winter_mean / summer_mean if summer_mean > 0 else 0
+
+    return {
+        "naf_code": naf_code,
+        "power_kva": power_kva,
+        "sector": sector,
+        "power_range": power_range,
+        "period_months": months,
+        "reference": {
+            "hourly_profile_kwh": hourly_profile,
+            "hourly_stddev_kwh": hourly_stddev,
+            "daily_kwh": round(daily_energy_kwh, 1),
+            "annual_kwh_estimate": round(annual_kwh_estimate, 0),
+        },
+        "kpis": {
+            "load_factor": round(load_factor, 3),
+            "night_day_ratio": round(night_day_ratio, 3),
+            "seasonality_winter_summer_ratio": round(seasonality_ratio, 2),
+        },
+        "sample": {
+            "n_points_in_aggregate": max_points,
+            "n_rows_queried": len(rows),
+            "confidence": "high" if max_points > 100 else "medium" if max_points > 20 else "low",
+        },
+        "disclaimer": (
+            f"Courbe de référence basée sur {max_points} points Enedis du segment "
+            f"{sector} × {power_range}. Écart individuel typique : 20-40%. "
+            f"À utiliser comme ordre de grandeur avant consentement client."
+        ),
+    }
+
+
+# ── Tendance mensuelle par secteur ──────────────────────────────────────
+
+
+def compute_sector_trend(db: Session, naf_code: str, power_kva: float | None = None) -> dict | None:
+    """Tendance mensuelle de consommation pour un secteur.
+
+    Retourne l'évolution mois par mois de l'énergie moyenne et du nb de points.
+    Permet de détecter saisonnalité et dérives sectorielles.
+    """
+    sector = _naf_to_sector(naf_code)
+    power_range = _power_to_range(power_kva) if power_kva else None
+
+    query = db.query(
+        EnedisConsoSup36.horodate,
+        EnedisConsoSup36.courbe_moyenne_wh,
+        EnedisConsoSup36.nb_points_soutirage,
+    ).filter(EnedisConsoSup36.secteur_activite == sector)
+    if power_range:
+        query = query.filter(EnedisConsoSup36.plage_puissance == power_range)
+
+    rows = query.all()
+    if not rows:
+        return {"error": "Aucune donnée Open Data", "sector": sector, "power_range": power_range}
+
+    # Agréger par (année, mois)
+    monthly: dict[tuple[int, int], list[float]] = defaultdict(list)
+    monthly_points: dict[tuple[int, int], int] = defaultdict(int)
+    for ts, wh, nb in rows:
+        if ts is None or wh is None:
+            continue
+        key = (ts.year, ts.month)
+        monthly[key].append(wh / 1000)  # Wh → kWh
+        monthly_points[key] = max(monthly_points[key], nb or 0)
+
+    if not monthly:
+        return {"error": "Données vides après agrégation"}
+
+    trend = []
+    for (year, month), vals in sorted(monthly.items()):
+        mean_kwh = sum(vals) / len(vals)
+        variance = sum((v - mean_kwh) ** 2 for v in vals) / len(vals) if len(vals) > 1 else 0
+        trend.append(
+            {
+                "year": year,
+                "month": month,
+                "label": f"{year}-{month:02d}",
+                "mean_kwh": round(mean_kwh, 2),
+                "stddev_kwh": round(math.sqrt(variance), 2),
+                "n_samples": len(vals),
+                "n_points": monthly_points[(year, month)],
+            }
+        )
+
+    # Variation vs moyenne globale
+    all_means = [m["mean_kwh"] for m in trend]
+    overall_mean = sum(all_means) / len(all_means) if all_means else 0
+    for m in trend:
+        m["deviation_pct"] = round((m["mean_kwh"] - overall_mean) / overall_mean * 100, 1) if overall_mean > 0 else 0
+
+    return {
+        "naf_code": naf_code,
+        "sector": sector,
+        "power_range": power_range,
+        "overall_mean_kwh": round(overall_mean, 2),
+        "n_months": len(trend),
+        "trend": trend,
+    }
+
+
+# ── Comparaison site vs secteur (mois par mois) ─────────────────────────
+
+
+def compare_site_vs_sector(db: Session, site_id: int, months: int = 12, persist_alerts: bool = False) -> dict | None:
+    """Compare la consommation d'un site à la moyenne de son secteur, mois par mois.
+
+    Calcule l'écart pct et détecte les mois atypiques (>20% écart).
+    Si persist_alerts=True, crée des Anomaly en DB pour chaque mois atypique.
+    """
+    from models.site import Site
+    from models.energy_models import Meter
+    from data_staging.bridge import get_site_meter_ids, get_daily_kwh
+
+    site = db.query(Site).filter(Site.id == site_id).first()
+    if not site:
+        return None
+
+    # Mapping archetype → NAF prefix inverse (fallback)
+    arch = site.type.value if site.type else "bureau"
+
+    # Récupérer puissance
+    meter = db.query(Meter).filter(Meter.site_id == site_id, Meter.parent_meter_id.is_(None)).first()
+    power_kva = getattr(meter, "subscribed_power_kva", None) if meter else None
+
+    # Construire le NAF du site (si NAF réel dispo, sinon archetype)
+    naf_code = getattr(site, "naf_code", None) or _archetype_to_naf(arch)
+    sector = _naf_to_sector(naf_code)
+    power_range = _power_to_range(power_kva)
+
+    # Charger la consommation du site
+    end_date = date.today()
+    start_date = end_date - timedelta(days=months * 30)
+    start_dt = datetime(start_date.year, start_date.month, start_date.day)
+
+    meter_ids = get_site_meter_ids(db, site_id)
+    if not meter_ids:
+        return {"error": "Aucun compteur principal", "site_id": site_id}
+
+    daily_kwh, data_source = get_daily_kwh(db, meter_ids, start_dt)
+    if not daily_kwh:
+        return {"error": "Aucune donnée site"}
+
+    # Agréger par mois
+    site_monthly: dict[tuple[int, int], float] = defaultdict(float)
+    for day_str, kwh in daily_kwh.items():
+        try:
+            y, m, d = map(int, day_str.split("-")[:3])
+            site_monthly[(y, m)] += kwh
+        except (ValueError, AttributeError):
+            continue
+
+    # Charger le benchmark sectoriel mensuel
+    bench_query = db.query(
+        EnedisConsoSup36.horodate,
+        EnedisConsoSup36.courbe_moyenne_wh,
+    ).filter(
+        EnedisConsoSup36.horodate >= start_dt,
+        EnedisConsoSup36.secteur_activite == sector,
+    )
+    if power_range:
+        bench_query = bench_query.filter(EnedisConsoSup36.plage_puissance == power_range)
+    bench_rows = bench_query.all()
+
+    bench_monthly: dict[tuple[int, int], list[float]] = defaultdict(list)
+    for ts, wh in bench_rows:
+        if ts is None or wh is None:
+            continue
+        key = (ts.year, ts.month)
+        # Convertir courbe moyenne 30min (Wh) en kWh/jour estimé
+        # 1 pas 30min × 48 pas × 30 jours
+        bench_monthly[key].append(wh * 48 * 30 / 1000)
+
+    # Comparer
+    comparison = []
+    alerts = []
+    for (y, m), site_kwh in sorted(site_monthly.items()):
+        bench_vals = bench_monthly.get((y, m), [])
+        if bench_vals:
+            bench_mean = sum(bench_vals) / len(bench_vals)
+            deviation_pct = round((site_kwh - bench_mean) / bench_mean * 100, 1) if bench_mean > 0 else 0
+            atypical = abs(deviation_pct) > 20
+            if atypical:
+                alerts.append(
+                    {
+                        "month": f"{y}-{m:02d}",
+                        "deviation_pct": deviation_pct,
+                        "message": (
+                            f"Site {'au-dessus' if deviation_pct > 0 else 'en-dessous'} "
+                            f"de {abs(deviation_pct)}% vs secteur en {y}-{m:02d}"
+                        ),
+                    }
+                )
+        else:
+            bench_mean = None
+            deviation_pct = None
+            atypical = False
+
+        comparison.append(
+            {
+                "month": f"{y}-{m:02d}",
+                "site_kwh": round(site_kwh, 0),
+                "benchmark_kwh": round(bench_mean, 0) if bench_mean else None,
+                "deviation_pct": deviation_pct,
+                "atypical": atypical,
+            }
+        )
+
+    # Persister les anomalies si demandé
+    persisted_anomaly_ids = []
+    if persist_alerts and alerts:
+        from models.energy_models import Anomaly, AnomalySeverity, Meter
+
+        main_meter = db.query(Meter).filter(Meter.site_id == site_id, Meter.parent_meter_id.is_(None)).first()
+        if main_meter:
+            # Désactiver les anciennes anomalies d'atypie sectorielle
+            db.query(Anomaly).filter(
+                Anomaly.meter_id == main_meter.id,
+                Anomaly.anomaly_code == "ANOM_ATYPIE_MENSUELLE_SECTEUR",
+                Anomaly.is_active.is_(True),
+            ).update({"is_active": False})
+
+            for alert in alerts:
+                dev = alert["deviation_pct"]
+                severity = AnomalySeverity.HIGH if abs(dev) > 40 else AnomalySeverity.MEDIUM
+
+                anom = Anomaly(
+                    meter_id=main_meter.id,
+                    anomaly_code="ANOM_ATYPIE_MENSUELLE_SECTEUR",
+                    title=f"Écart sectoriel atypique — {alert['month']}",
+                    description=alert["message"],
+                    severity=severity,
+                    confidence=0.75,
+                    detected_at=datetime.now(timezone.utc),
+                    measured_value=dev,
+                    threshold_value=20.0,
+                    deviation_pct=dev,
+                    explanation_json={
+                        "month": alert["month"],
+                        "sector": sector,
+                        "deviation_pct": dev,
+                    },
+                    is_active=True,
+                )
+                db.add(anom)
+                db.flush()
+                persisted_anomaly_ids.append(anom.id)
+            db.commit()
+
+    return {
+        "site_id": site_id,
+        "site_name": site.nom,
+        "archetype": arch,
+        "naf_code": naf_code,
+        "sector": sector,
+        "power_range": power_range,
+        "persisted_anomaly_ids": persisted_anomaly_ids,
+        "data_source": data_source,
+        "comparison": comparison,
+        "alerts": alerts,
+        "n_months": len(comparison),
+        "n_alerts": len(alerts),
+    }
+
+
+def _archetype_to_naf(archetype: str) -> str:
+    """Fallback : archetype PROMEOS → code NAF représentatif."""
+    mapping = {
+        "bureau": "6201Z",
+        "hotel": "5510Z",
+        "commerce": "4711D",
+        "magasin": "4711D",
+        "enseignement": "8542Z",
+        "sante": "8610Z",
+        "collectivite": "8411Z",
+        "copropriete": "6832A",
+        "logement_social": "6820A",
+        "usine": "2561Z",
+        "entrepot": "5210A",
+    }
+    return mapping.get(archetype, "6201Z")

--- a/backend/services/recommendation_engine.py
+++ b/backend/services/recommendation_engine.py
@@ -1,0 +1,439 @@
+"""
+Recommendation Engine — transforme les KPIs analytics en actions priorisées.
+
+Parse les résultats de :
+- load_profile_service (baseload, LF, ratios, qualité)
+- energy_signature_service (signature 3P/4P/5P)
+- enedis_benchmarks (score d'atypie)
+- naf_estimator (comparaison site vs secteur)
+
+Génère des objets Anomaly + Recommendation avec ICE scoring dans la DB.
+"""
+
+import logging
+import math
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from config.default_prices import DEFAULT_PRICE_ELEC_EUR_KWH
+from models.energy_models import (
+    Anomaly,
+    Recommendation,
+    Meter,
+    AnomalySeverity,
+    RecommendationStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _ice(impact: int, confidence: int, ease: int) -> float:
+    """ICE score = moyenne géométrique (plus robuste que produit)."""
+    return round((impact * confidence * ease) ** (1 / 3), 2)
+
+
+# ── Rules metier : KPI → (Anomaly, Recommendation) ───────────────────────
+
+
+def _rule_baseload_excessive(load_profile: dict, meter_id: int) -> tuple[dict, dict] | None:
+    """Baseload > 60% du max → serveurs/veilles/éclairage permanent."""
+    baseload = load_profile.get("baseload", {})
+    verdict = baseload.get("verdict")
+    pct = baseload.get("baseload_pct_of_mean", 0)
+    p_moy = load_profile.get("power_stats", {}).get("p_mean_kwh", 0)
+
+    if verdict != "eleve" or pct < 60:
+        return None
+
+    excess_kwh_year = round((pct - 40) / 100 * p_moy * 8760, 0)
+    excess_eur_year = round(excess_kwh_year * DEFAULT_PRICE_ELEC_EUR_KWH, 0)
+
+    anomaly = {
+        "code": "ANOM_BASELOAD_ELEVE",
+        "title": "Baseload excessive (talon de consommation anormal)",
+        "explanation": (
+            f"La consommation minimale nocturne/WE représente {pct}% de la moyenne, "
+            f"indiquant un gaspillage probable (serveurs, éclairage permanent, veilles)."
+        ),
+        "severity": "high",
+        "confidence": 0.85,
+        "measured_value": pct,
+        "threshold_value": 40.0,
+        "deviation_pct": round((pct - 40), 1),
+    }
+
+    reco = {
+        "code": "RECO_REDUIRE_BASELOAD",
+        "title": "Éteindre les équipements hors occupation",
+        "description": (
+            "Identifier les équipements qui tournent la nuit et le week-end "
+            "(serveurs, CVC mal programmé, éclairage, veilles). "
+            "Mettre en place un pilotage horaire ou manuel."
+        ),
+        "impact_score": 9,
+        "confidence_score": 8,
+        "ease_score": 7,
+        "estimated_savings_kwh": excess_kwh_year,
+        "estimated_savings_eur": excess_eur_year,
+        "estimated_savings_pct": round((pct - 40) / pct * 100, 1),
+    }
+    return anomaly, reco
+
+
+def _rule_low_load_factor(load_profile: dict, meter_id: int) -> tuple[dict, dict] | None:
+    """Load factor < 0.15 → puissance souscrite surdimensionnée."""
+    lf = load_profile.get("load_factor", 0)
+    if lf >= 0.15 or lf == 0:
+        return None
+
+    anomaly = {
+        "code": "ANOM_LOAD_FACTOR_FAIBLE",
+        "title": "Puissance souscrite potentiellement surdimensionnée",
+        "explanation": (
+            f"Facteur de charge {lf} très faible : la puissance max appelée est beaucoup "
+            f"plus élevée que la moyenne. L'abonnement peut probablement être réduit."
+        ),
+        "severity": "medium",
+        "confidence": 0.75,
+        "measured_value": lf,
+        "threshold_value": 0.15,
+        "deviation_pct": round((0.15 - lf) / 0.15 * 100, 1),
+    }
+
+    reco = {
+        "code": "RECO_OPTIMISER_PSOUS",
+        "title": "Optimiser la puissance souscrite",
+        "description": (
+            "Analyser la monotone de charge pour déterminer la puissance souscrite "
+            "optimale. Une réduction d'un palier TURPE peut économiser 10-20% sur "
+            "l'abonnement annuel sans risquer les dépassements."
+        ),
+        "impact_score": 7,
+        "confidence_score": 7,
+        "ease_score": 9,  # Changement contractuel simple
+        "estimated_savings_kwh": 0,  # Economie sur abonnement, pas sur conso
+        "estimated_savings_eur": 500,  # Ordre de grandeur
+        "estimated_savings_pct": 15.0,
+    }
+    return anomaly, reco
+
+
+def _rule_night_day_ratio_high(load_profile: dict, meter_id: int) -> tuple[dict, dict] | None:
+    """Ratio nuit/jour > 0.5 pour un tertiaire → activité nocturne anormale."""
+    ratio = load_profile.get("ratios", {}).get("night_day", 0)
+    if ratio < 0.5:
+        return None
+
+    anomaly = {
+        "code": "ANOM_NUIT_JOUR_ELEVE",
+        "title": "Consommation nocturne anormalement élevée",
+        "explanation": (
+            f"Ratio nuit/jour de {ratio} : plus de 50% de la consommation diurne "
+            f"se poursuit la nuit. Pour un site tertiaire, c'est un indicateur fort "
+            f"de gaspillage hors occupation."
+        ),
+        "severity": "high",
+        "confidence": 0.80,
+        "measured_value": ratio,
+        "threshold_value": 0.5,
+        "deviation_pct": round((ratio - 0.5) / 0.5 * 100, 1),
+    }
+
+    reco = {
+        "code": "RECO_PILOTAGE_NOCTURNE",
+        "title": "Programmer l'arrêt CVC/éclairage hors occupation",
+        "description": (
+            "Mettre en place un scénario GTB/horloge pour arrêter CVC, éclairage "
+            "et équipements non critiques de 20h à 7h et les week-ends."
+        ),
+        "impact_score": 8,
+        "confidence_score": 7,
+        "ease_score": 6,  # Nécessite GTB ou horloges
+        "estimated_savings_kwh": 5000,
+        "estimated_savings_eur": 340,
+        "estimated_savings_pct": 10.0,
+    }
+    return anomaly, reco
+
+
+def _rule_thermosensitivity_high(signature: dict, meter_id: int) -> tuple[dict, dict] | None:
+    """Part thermosensible > 40% → potentiel isolation élevé."""
+    thermo = signature.get("thermosensitivity", {})
+    part_pct = thermo.get("part_thermo_pct", 0)
+    if part_pct < 40:
+        return None
+
+    classification = thermo.get("classification", "")
+    if classification not in ("heating_dominant", "mixed"):
+        return None
+
+    anomaly = {
+        "code": "ANOM_THERMOSENSIBILITE_ELEVEE",
+        "title": "Forte dépendance chauffage électrique",
+        "explanation": (
+            f"Part thermosensible de {part_pct}% (hiver vs base). Le bâtiment est très "
+            f"sensible à la météo, indiquant une isolation perfectible ou un chauffage "
+            f"électrique dominant sans régulation."
+        ),
+        "severity": "medium",
+        "confidence": 0.75,
+        "measured_value": part_pct,
+        "threshold_value": 40.0,
+        "deviation_pct": round((part_pct - 40), 1),
+    }
+
+    reco = {
+        "code": "RECO_ISOLATION_THERMIQUE",
+        "title": "Audit énergétique ciblé + plan d'isolation",
+        "description": (
+            "La thermosensibilité élevée indique un potentiel d'économie via isolation "
+            "(toiture, fenêtres, murs) et/ou régulation CVC (sondes, optimisation, PAC). "
+            "Un audit énergétique ciblé permet de prioriser les travaux par ROI."
+        ),
+        "impact_score": 8,
+        "confidence_score": 6,
+        "ease_score": 4,  # Travaux lourds, capex
+        "estimated_savings_kwh": 15000,
+        "estimated_savings_eur": 1020,
+        "estimated_savings_pct": 20.0,
+    }
+    return anomaly, reco
+
+
+def _rule_atypicity_high(benchmark: dict, meter_id: int) -> tuple[dict, dict] | None:
+    """Score d'atypie > 0.50 → profil très éloigné du secteur."""
+    atyp = benchmark.get("atypicity", {})
+    score = atyp.get("score")
+    if score is None or score < 0.50:
+        return None
+
+    sector = benchmark.get("sector_enedis", "")
+    site_stats = benchmark.get("site_stats", {})
+    conso_spec = site_stats.get("conso_kwh_m2_year", 0)
+
+    anomaly = {
+        "code": "ANOM_ATYPIE_SECTEUR",
+        "title": "Profil de charge atypique vs secteur",
+        "explanation": (
+            f"Score d'atypie {score} (très atypique) vs benchmark Enedis {sector}. "
+            f"Consommation spécifique : {conso_spec} kWh/m²/an. "
+            f"Le profil horaire diverge significativement de la moyenne sectorielle."
+        ),
+        "severity": "medium",
+        "confidence": 0.70,
+        "measured_value": score,
+        "threshold_value": 0.30,
+        "deviation_pct": round((score - 0.30) / 0.30 * 100, 1),
+    }
+
+    reco = {
+        "code": "RECO_DIAGNOSTIC_ATYPIE",
+        "title": "Diagnostic énergétique pour identifier la cause d'atypie",
+        "description": (
+            f"Le profil diverge fortement du segment {sector}. Causes possibles : "
+            f"activité mixte sur un seul PDL, équipements spécifiques non-standards, "
+            f"horaires atypiques, ou anomalie réelle. Un audit terrain est recommandé."
+        ),
+        "impact_score": 6,
+        "confidence_score": 5,
+        "ease_score": 7,
+        "estimated_savings_kwh": 3000,
+        "estimated_savings_eur": 205,
+        "estimated_savings_pct": 5.0,
+    }
+    return anomaly, reco
+
+
+def _rule_data_quality_low(load_profile: dict, meter_id: int) -> tuple[dict, dict] | None:
+    """Score qualité < 0.80 → alerter sur fiabilité analyses."""
+    quality = load_profile.get("data_quality", {})
+    score = quality.get("score", 1.0)
+    if score >= 0.80:
+        return None
+
+    details = quality.get("details", {})
+    gaps = details.get("gaps", 0)
+
+    anomaly = {
+        "code": "ANOM_QUALITE_DONNEES",
+        "title": "Qualité de données insuffisante pour analyses fiables",
+        "explanation": (
+            f"Score qualité {score} (seuil : 0.80). "
+            f"{gaps} jours manquants, {details.get('outliers', 0)} valeurs aberrantes. "
+            f"Les analyses ci-dessous sont à interpréter avec prudence."
+        ),
+        "severity": "low",
+        "confidence": 0.95,
+        "measured_value": score,
+        "threshold_value": 0.80,
+        "deviation_pct": round((0.80 - score) / 0.80 * 100, 1),
+    }
+
+    reco = {
+        "code": "RECO_FIABILISER_COLLECTE",
+        "title": "Activer courbes Linky + vérifier acquisition",
+        "description": (
+            "Activer l'enregistrement des courbes de charge Linky (inhibé par défaut), "
+            "vérifier la connexion Data Connect et relancer une collecte complète pour "
+            "disposer de données fiables pour les analyses."
+        ),
+        "impact_score": 3,  # Pas d'économie directe mais débloque les analyses
+        "confidence_score": 10,
+        "ease_score": 9,
+        "estimated_savings_kwh": 0,
+        "estimated_savings_eur": 0,
+        "estimated_savings_pct": 0,
+    }
+    return anomaly, reco
+
+
+# ── Rules orchestration ───────────────────────────────────────────────────
+
+
+_RULES = [
+    ("load_profile", _rule_baseload_excessive),
+    ("load_profile", _rule_low_load_factor),
+    ("load_profile", _rule_night_day_ratio_high),
+    ("load_profile", _rule_data_quality_low),
+    ("signature", _rule_thermosensitivity_high),
+    ("benchmark", _rule_atypicity_high),
+]
+
+
+def generate_recommendations_for_site(db: Session, site_id: int, persist: bool = True) -> dict:
+    """Analyse un site avec tous les services et génère des recommandations.
+
+    Si persist=True, insère les Anomaly + Recommendation en DB.
+    Retourne un dict avec les recommandations classées par ICE score.
+    """
+    from services.load_profile_service import compute_load_profile
+    from services.energy_signature_service import compute_energy_signature_advanced
+    from services.enedis_benchmarks import compute_benchmark
+
+    # Trouver le compteur principal pour FK
+    main_meter = db.query(Meter).filter(Meter.site_id == site_id, Meter.parent_meter_id.is_(None)).first()
+    if not main_meter:
+        return {"error": "Aucun compteur principal", "site_id": site_id}
+
+    meter_id = main_meter.id
+
+    # Collecter les analytics
+    analytics = {}
+    load_profile = compute_load_profile(db, site_id)
+    if load_profile and "error" not in load_profile:
+        analytics["load_profile"] = load_profile
+
+    signature = compute_energy_signature_advanced(db, site_id)
+    if signature and "error" not in signature:
+        analytics["signature"] = signature
+
+    benchmark = compute_benchmark(db, site_id)
+    if benchmark and "error" not in benchmark:
+        analytics["benchmark"] = benchmark
+
+    if not analytics:
+        return {"error": "Aucune analyse disponible", "site_id": site_id}
+
+    # Appliquer les règles
+    generated = []
+    for source_key, rule_fn in _RULES:
+        source_data = analytics.get(source_key)
+        if not source_data:
+            continue
+        result = rule_fn(source_data, meter_id)
+        if result:
+            anomaly_dict, reco_dict = result
+            reco_dict["ice_score"] = _ice(
+                reco_dict["impact_score"],
+                reco_dict["confidence_score"],
+                reco_dict["ease_score"],
+            )
+            generated.append((anomaly_dict, reco_dict))
+
+    # Trier par ICE score décroissant
+    generated.sort(key=lambda x: x[1]["ice_score"], reverse=True)
+
+    # Persister
+    persisted = []
+    if persist and generated:
+        for rank, (anom_dict, reco_dict) in enumerate(generated, 1):
+            # Désactiver les anomalies existantes du même code
+            db.query(Anomaly).filter(
+                Anomaly.meter_id == meter_id,
+                Anomaly.anomaly_code == anom_dict["code"],
+                Anomaly.is_active.is_(True),
+            ).update({"is_active": False})
+
+            anom = Anomaly(
+                meter_id=meter_id,
+                anomaly_code=anom_dict["code"],
+                title=anom_dict["title"],
+                description=anom_dict["explanation"],
+                severity=AnomalySeverity(anom_dict["severity"]),
+                confidence=anom_dict["confidence"],
+                detected_at=datetime.now(timezone.utc),
+                measured_value=anom_dict["measured_value"],
+                threshold_value=anom_dict["threshold_value"],
+                deviation_pct=anom_dict["deviation_pct"],
+                is_active=True,
+            )
+            db.add(anom)
+            db.flush()
+
+            reco = Recommendation(
+                meter_id=meter_id,
+                recommendation_code=reco_dict["code"],
+                title=reco_dict["title"],
+                description=reco_dict["description"],
+                triggered_by_anomaly_id=anom.id,
+                impact_score=reco_dict["impact_score"],
+                confidence_score=reco_dict["confidence_score"],
+                ease_score=reco_dict["ease_score"],
+                ice_score=reco_dict["ice_score"],
+                priority_rank=rank,
+                estimated_savings_kwh_year=reco_dict["estimated_savings_kwh"],
+                estimated_savings_eur_year=reco_dict.get("estimated_savings_eur"),
+                estimated_savings_pct=reco_dict["estimated_savings_pct"],
+                status=RecommendationStatus.PENDING,
+            )
+            db.add(reco)
+            db.flush()
+            persisted.append(
+                {
+                    "anomaly_id": anom.id,
+                    "recommendation_id": reco.id,
+                    "code": reco_dict["code"],
+                    "ice_score": reco_dict["ice_score"],
+                }
+            )
+
+        db.commit()
+
+    return {
+        "site_id": site_id,
+        "meter_id": meter_id,
+        "n_recommendations": len(generated),
+        "recommendations": [
+            {
+                "code": r["code"],
+                "title": r["title"],
+                "description": r["description"],
+                "impact_score": r["impact_score"],
+                "confidence_score": r["confidence_score"],
+                "ease_score": r["ease_score"],
+                "ice_score": r["ice_score"],
+                "priority_rank": i + 1,
+                "estimated_savings_kwh_year": r["estimated_savings_kwh"],
+                "estimated_savings_eur_year": r.get("estimated_savings_eur", 0),
+                "estimated_savings_pct": r["estimated_savings_pct"],
+                "triggered_by": {
+                    "code": a["code"],
+                    "severity": a["severity"],
+                    "explanation": a["explanation"],
+                },
+            }
+            for i, (a, r) in enumerate(generated)
+        ],
+        "persisted": persisted,
+    }

--- a/backend/services/sirene_import.py
+++ b/backend/services/sirene_import.py
@@ -190,6 +190,15 @@ def _import_csv(
                 if not mapped.get(key_field) or len(mapped[key_field]) != key_length:
                     stats["rejected"] += 1
                     continue
+                # RGPD : exclure a l'import les lignes a diffusion restreinte (statut P)
+                if mapped.get("statut_diffusion") == "P":
+                    stats["skipped"] += 1
+                    continue
+                # RGPD : ne pas stocker les prenoms/noms de personnes physiques
+                # (personnes morales ont denomination set, personnes physiques ont nom_unite_legale+prenom)
+                if mapped.get("nom_unite_legale") and not mapped.get("denomination"):
+                    mapped["nom_unite_legale"] = None
+                    mapped["prenom1"] = None
                 mapped["snapshot_date"] = snapshot_date
                 mapped["payload_brut"] = json.dumps(row, ensure_ascii=False)
                 batch.append(mapped)
@@ -321,6 +330,35 @@ def import_doublons(
     db.flush()
     logger.info("import_doublons: %s", stats)
     return stats
+
+
+# ======================================================================
+# RGPD — Purge policy
+# ======================================================================
+
+
+def purge_old_payloads(db: Session, max_age_days: int = 180) -> dict:
+    """RGPD : purge payload_brut des lignes > max_age_days (defaut 6 mois).
+
+    On garde les lignes mais on efface le JSON brut qui contient
+    potentiellement des donnees personnelles (prenoms, noms, adresses).
+    """
+    from datetime import timedelta
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+    ul_purged = (
+        db.query(SireneUniteLegale)
+        .filter(SireneUniteLegale.snapshot_date < cutoff, SireneUniteLegale.payload_brut.isnot(None))
+        .update({SireneUniteLegale.payload_brut: None}, synchronize_session=False)
+    )
+    etab_purged = (
+        db.query(SireneEtablissement)
+        .filter(SireneEtablissement.snapshot_date < cutoff, SireneEtablissement.payload_brut.isnot(None))
+        .update({SireneEtablissement.payload_brut: None}, synchronize_session=False)
+    )
+    db.commit()
+    logger.info("rgpd_purge: ul=%d etab=%d cutoff=%s", ul_purged, etab_purged, cutoff.date())
+    return {"unites_legales_purged": ul_purged, "etablissements_purged": etab_purged, "cutoff": cutoff.isoformat()}
 
 
 # ======================================================================

--- a/backend/tests/test_recommendation_engine.py
+++ b/backend/tests/test_recommendation_engine.py
@@ -1,0 +1,201 @@
+"""Tests du Recommendation Engine — règles métier + pipeline complet."""
+
+from data_staging.models import MeterLoadCurve  # noqa: F401 register table
+
+from services.recommendation_engine import (
+    _ice,
+    _rule_baseload_excessive,
+    _rule_low_load_factor,
+    _rule_night_day_ratio_high,
+    _rule_thermosensitivity_high,
+    _rule_atypicity_high,
+    _rule_data_quality_low,
+)
+
+
+# ── Tests ICE scoring ────────────────────────────────────────────────────
+
+
+class TestIceScoring:
+    def test_perfect_score(self):
+        """10/10/10 → 10."""
+        assert _ice(10, 10, 10) == 10.0
+
+    def test_balanced_medium(self):
+        """7/7/7 → ~7."""
+        assert abs(_ice(7, 7, 7) - 7.0) < 0.01
+
+    def test_penalizes_weak_dimension(self):
+        """Low ease (2) tire le score vers le bas."""
+        score = _ice(10, 10, 2)
+        assert score < 6  # Moyenne géométrique pénalise fortement
+
+    def test_returns_float(self):
+        assert isinstance(_ice(5, 5, 5), float)
+
+
+# ── Tests règles métier individuelles ───────────────────────────────────
+
+
+class TestRuleBaseloadExcessive:
+    def test_triggers_on_high_baseload(self):
+        load_profile = {
+            "baseload": {"verdict": "eleve", "baseload_pct_of_mean": 75},
+            "power_stats": {"p_mean_kwh": 10.0},
+        }
+        result = _rule_baseload_excessive(load_profile, meter_id=1)
+        assert result is not None
+        anomaly, reco = result
+        assert anomaly["code"] == "ANOM_BASELOAD_ELEVE"
+        assert anomaly["severity"] == "high"
+        assert reco["code"] == "RECO_REDUIRE_BASELOAD"
+        assert reco["impact_score"] == 9
+        assert reco["estimated_savings_kwh"] > 0
+
+    def test_no_trigger_on_normal(self):
+        load_profile = {
+            "baseload": {"verdict": "normal", "baseload_pct_of_mean": 25},
+            "power_stats": {"p_mean_kwh": 10.0},
+        }
+        assert _rule_baseload_excessive(load_profile, meter_id=1) is None
+
+    def test_no_trigger_below_60pct(self):
+        load_profile = {
+            "baseload": {"verdict": "eleve", "baseload_pct_of_mean": 55},
+            "power_stats": {"p_mean_kwh": 10.0},
+        }
+        assert _rule_baseload_excessive(load_profile, meter_id=1) is None
+
+
+class TestRuleLowLoadFactor:
+    def test_triggers_on_low_lf(self):
+        result = _rule_low_load_factor({"load_factor": 0.08}, meter_id=1)
+        assert result is not None
+        anomaly, reco = result
+        assert anomaly["code"] == "ANOM_LOAD_FACTOR_FAIBLE"
+        assert reco["code"] == "RECO_OPTIMISER_PSOUS"
+        assert reco["ease_score"] == 9  # Changement contractuel = facile
+
+    def test_no_trigger_on_normal_lf(self):
+        assert _rule_low_load_factor({"load_factor": 0.35}, meter_id=1) is None
+
+    def test_no_trigger_on_zero(self):
+        assert _rule_low_load_factor({"load_factor": 0}, meter_id=1) is None
+
+
+class TestRuleNightDayRatio:
+    def test_triggers_on_high_ratio(self):
+        result = _rule_night_day_ratio_high({"ratios": {"night_day": 0.75}}, meter_id=1)
+        assert result is not None
+        anomaly, reco = result
+        assert anomaly["severity"] == "high"
+        assert reco["code"] == "RECO_PILOTAGE_NOCTURNE"
+
+    def test_no_trigger_low_ratio(self):
+        assert _rule_night_day_ratio_high({"ratios": {"night_day": 0.2}}, meter_id=1) is None
+
+
+class TestRuleThermosensitivity:
+    def test_triggers_heating_dominant(self):
+        signature = {"thermosensitivity": {"part_thermo_pct": 55, "classification": "heating_dominant"}}
+        result = _rule_thermosensitivity_high(signature, meter_id=1)
+        assert result is not None
+        _, reco = result
+        assert reco["code"] == "RECO_ISOLATION_THERMIQUE"
+        assert reco["ease_score"] == 4  # Travaux lourds = difficile
+
+    def test_no_trigger_if_flat(self):
+        signature = {"thermosensitivity": {"part_thermo_pct": 55, "classification": "flat"}}
+        assert _rule_thermosensitivity_high(signature, meter_id=1) is None
+
+    def test_no_trigger_low_thermo(self):
+        signature = {"thermosensitivity": {"part_thermo_pct": 20, "classification": "heating_dominant"}}
+        assert _rule_thermosensitivity_high(signature, meter_id=1) is None
+
+
+class TestRuleAtypicity:
+    def test_triggers_on_high_atypicity(self):
+        benchmark = {
+            "atypicity": {"score": 0.65},
+            "sector_enedis": "S3: Tertiaire",
+            "site_stats": {"conso_kwh_m2_year": 250},
+        }
+        result = _rule_atypicity_high(benchmark, meter_id=1)
+        assert result is not None
+        anomaly, reco = result
+        assert reco["code"] == "RECO_DIAGNOSTIC_ATYPIE"
+
+    def test_no_trigger_on_typical(self):
+        benchmark = {
+            "atypicity": {"score": 0.15},
+            "sector_enedis": "S3: Tertiaire",
+            "site_stats": {},
+        }
+        assert _rule_atypicity_high(benchmark, meter_id=1) is None
+
+    def test_no_trigger_none_score(self):
+        benchmark = {"atypicity": {"score": None}, "site_stats": {}}
+        assert _rule_atypicity_high(benchmark, meter_id=1) is None
+
+
+class TestRuleDataQuality:
+    def test_triggers_on_low_quality(self):
+        load_profile = {
+            "data_quality": {
+                "score": 0.65,
+                "details": {"gaps": 50, "outliers": 10},
+            }
+        }
+        result = _rule_data_quality_low(load_profile, meter_id=1)
+        assert result is not None
+        _, reco = result
+        assert reco["code"] == "RECO_FIABILISER_COLLECTE"
+        assert reco["impact_score"] == 3  # Pas d'économie directe
+
+    def test_no_trigger_on_good_quality(self):
+        load_profile = {"data_quality": {"score": 0.95, "details": {}}}
+        assert _rule_data_quality_low(load_profile, meter_id=1) is None
+
+
+# ── Test pipeline complet ───────────────────────────────────────────────
+
+
+class TestRecommendationPipeline:
+    def test_no_meter_returns_error(self):
+        from unittest.mock import MagicMock
+        from services.recommendation_engine import generate_recommendations_for_site
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        result = generate_recommendations_for_site(db, 99999, persist=False)
+        assert "error" in result
+
+    def test_rules_sorted_by_ice_score(self):
+        """Les règles retournent des recos triées par ICE décroissant."""
+        # Simuler les 6 règles activées
+        results = []
+        for rule_fn, data in [
+            (
+                _rule_baseload_excessive,
+                {
+                    "baseload": {"verdict": "eleve", "baseload_pct_of_mean": 75},
+                    "power_stats": {"p_mean_kwh": 10.0},
+                },
+            ),
+            (_rule_low_load_factor, {"load_factor": 0.08}),
+            (_rule_night_day_ratio_high, {"ratios": {"night_day": 0.75}}),
+        ]:
+            r = rule_fn(data, meter_id=1)
+            if r:
+                _, reco = r
+                reco["ice_score"] = _ice(
+                    reco["impact_score"],
+                    reco["confidence_score"],
+                    reco["ease_score"],
+                )
+                results.append(reco)
+
+        results.sort(key=lambda x: x["ice_score"], reverse=True)
+        scores = [r["ice_score"] for r in results]
+        assert scores == sorted(scores, reverse=True)
+        assert all(0 < s <= 10 for s in scores)

--- a/backend/tests/test_sf5_e2e.py
+++ b/backend/tests/test_sf5_e2e.py
@@ -1,0 +1,289 @@
+"""Tests E2E du pipeline SF5 : staging → promote → bridge → service.
+
+Valide la chaîne complète avec des données seed :
+1. Créer un site + DeliveryPoint + Meter
+2. Insérer des EnedisFluxMesureR4x en staging
+3. Lancer run_promotion()
+4. Vérifier que meter_load_curve contient les données converties
+5. Vérifier que le bridge retourne data_source="promoted"
+6. Vérifier que les services (load_profile) utilisent les données promues
+"""
+
+import pytest
+from datetime import datetime, date, timezone, timedelta
+from sqlalchemy.orm import Session
+
+from database import SessionLocal, engine
+from database.migrations import run_migrations
+from data_ingestion.enedis.models import EnedisFluxFile, EnedisFluxMesureR4x
+from data_staging.models import MeterLoadCurve, PromotionRun, UnmatchedPrm
+from data_staging.engine import run_promotion
+from data_staging.bridge import invalidate_promoted_cache, _is_promoted_available
+
+
+@pytest.fixture
+def e2e_db():
+    """Session DB avec migrations appliquées, isolée par test."""
+    run_migrations(engine)
+    db = SessionLocal()
+    # Nettoyer d'un test précédent
+    db.query(MeterLoadCurve).delete()
+    db.query(EnedisFluxMesureR4x).delete()
+    db.query(EnedisFluxFile).filter(EnedisFluxFile.filename.like("e2e_test_%")).delete()
+    db.query(PromotionRun).filter(PromotionRun.triggered_by == "e2e_test").delete()
+    db.query(UnmatchedPrm).filter(UnmatchedPrm.point_id.like("99999%")).delete()
+    db.commit()
+    invalidate_promoted_cache()
+    yield db
+    # Cleanup
+    db.query(MeterLoadCurve).delete()
+    db.query(EnedisFluxMesureR4x).delete()
+    db.query(EnedisFluxFile).filter(EnedisFluxFile.filename.like("e2e_test_%")).delete()
+    db.query(PromotionRun).filter(PromotionRun.triggered_by == "e2e_test").delete()
+    db.query(UnmatchedPrm).filter(UnmatchedPrm.point_id.like("99999%")).delete()
+    db.commit()
+    db.close()
+    invalidate_promoted_cache()
+
+
+def _seed_meter_with_prm(db: Session, prm_code: str, site_id: int = 1) -> int:
+    """Crée DeliveryPoint + Meter pour un PRM donné. Retourne meter.id."""
+    from models.patrimoine import DeliveryPoint
+    from models.energy_models import Meter
+
+    from models.enums import DeliveryPointEnergyType
+
+    dp = db.query(DeliveryPoint).filter(DeliveryPoint.code == prm_code).first()
+    if not dp:
+        dp = DeliveryPoint(code=prm_code, site_id=site_id, energy_type=DeliveryPointEnergyType.ELEC)
+        db.add(dp)
+        db.flush()
+
+    meter = db.query(Meter).filter(Meter.delivery_point_id == dp.id).first()
+    if not meter:
+        meter = Meter(
+            meter_id=prm_code,
+            name=f"E2E test {prm_code}",
+            energy_vector="ELECTRICITY",
+            site_id=site_id,
+            delivery_point_id=dp.id,
+            is_active=True,
+            subscribed_power_kva=100,
+        )
+        db.add(meter)
+        db.flush()
+
+    return meter.id
+
+
+def _seed_flux_file(db: Session, flux_type: str = "R4H") -> int:
+    """Crée un EnedisFluxFile factice."""
+    ff = EnedisFluxFile(
+        filename=f"e2e_test_{flux_type}_{datetime.now(timezone.utc).strftime('%H%M%S%f')}.zip",
+        file_hash=f"e2e_hash_{flux_type}_{datetime.now(timezone.utc).timestamp()}",
+        flux_type=flux_type,
+        status="parsed",
+        measures_count=0,
+        version=1,
+    )
+    db.add(ff)
+    db.flush()
+    return ff.id
+
+
+def _seed_r4x_measures(db: Session, flux_file_id: int, prm_code: str, count: int = 10, base_power_kw: float = 50.0):
+    """Seed N mesures R4x de 10 min pour un PRM."""
+    base_ts = datetime(2025, 6, 15, 10, 0, 0)
+    for i in range(count):
+        ts = base_ts + timedelta(minutes=10 * i)
+        m = EnedisFluxMesureR4x(
+            flux_file_id=flux_file_id,
+            flux_type="R4H",
+            point_id=prm_code,
+            grandeur_physique="EA",
+            grandeur_metier="CONS",
+            unite_mesure="kW",
+            granularite="10",
+            horodatage=ts.isoformat(),
+            valeur_point=str(base_power_kw + i),
+            statut_point="R",
+        )
+        db.add(m)
+    db.flush()
+
+
+# ── Tests E2E ────────────────────────────────────────────────────────────
+
+
+class TestE2ESF5Pipeline:
+    """Validation complète staging → promotion → bridge."""
+
+    def test_full_chain_unmatched_prm(self, e2e_db):
+        """PRM sans DeliveryPoint → va dans unmatched_prm."""
+        db = e2e_db
+        flux_file_id = _seed_flux_file(db, "R4H")
+        _seed_r4x_measures(db, flux_file_id, "99999999999001", count=5)
+        db.commit()
+
+        run = run_promotion(db, mode="full", triggered_by="e2e_test")
+
+        assert run.status == "completed"
+        assert run.prms_total >= 1
+        assert run.prms_unmatched >= 1
+        assert run.rows_load_curve == 0  # Aucune row promue (PRM bloqué)
+
+        # Vérifier que le PRM est dans le backlog
+        backlog = db.query(UnmatchedPrm).filter(UnmatchedPrm.point_id == "99999999999001").first()
+        assert backlog is not None
+        assert backlog.block_reason == "no_delivery_point"
+
+    def test_full_chain_matched_and_promoted(self, e2e_db):
+        """PRM avec Meter → promotion réussie vers meter_load_curve."""
+        db = e2e_db
+        # Trouver un site existant
+        from models.site import Site
+
+        site = db.query(Site).first()
+        assert site is not None, "Demo seed must provide at least one site"
+
+        prm = "99999999999002"
+        meter_id = _seed_meter_with_prm(db, prm, site_id=site.id)
+
+        flux_file_id = _seed_flux_file(db, "R4H")
+        _seed_r4x_measures(db, flux_file_id, prm, count=12, base_power_kw=75.0)
+        db.commit()
+
+        # Promotion
+        run = run_promotion(db, mode="full", triggered_by="e2e_test")
+
+        assert run.status == "completed"
+        assert run.prms_matched >= 1
+        assert run.rows_load_curve >= 12
+
+        # Vérifier que les données sont dans meter_load_curve
+        promoted_rows = db.query(MeterLoadCurve).filter(MeterLoadCurve.meter_id == meter_id).all()
+        assert len(promoted_rows) == 12
+        # Vérifier qualité (statut_point="R" → quality=1.0)
+        assert all(r.quality_score == 1.0 for r in promoted_rows)
+        assert all(r.is_estimated is False for r in promoted_rows)
+        # Vérifier unité : active_power_kw (pas converti en Wh)
+        assert all(r.active_power_kw is not None for r in promoted_rows)
+        assert any(r.active_power_kw >= 75.0 for r in promoted_rows)
+
+    def test_bridge_switches_to_promoted_after_promotion(self, e2e_db):
+        """Après promotion, le bridge doit retourner data_source='promoted'."""
+        db = e2e_db
+        from models.site import Site
+
+        site = db.query(Site).first()
+
+        prm = "99999999999003"
+        meter_id = _seed_meter_with_prm(db, prm, site_id=site.id)
+
+        flux_file_id = _seed_flux_file(db, "R4H")
+        # Seed 30 jours × 24h × 6 points/h = beaucoup de points
+        # Simplification : 1 point par heure sur 7 jours
+        base_ts = datetime(2025, 1, 1, 0, 0, 0)
+        for day in range(7):
+            for hour in range(24):
+                ts = base_ts + timedelta(days=day, hours=hour)
+                db.add(
+                    EnedisFluxMesureR4x(
+                        flux_file_id=flux_file_id,
+                        flux_type="R4H",
+                        point_id=prm,
+                        grandeur_physique="EA",
+                        grandeur_metier="CONS",
+                        unite_mesure="kW",
+                        granularite="10",
+                        horodatage=ts.isoformat(),
+                        valeur_point="100",
+                        statut_point="R",
+                    )
+                )
+        db.commit()
+
+        run = run_promotion(db, mode="full", triggered_by="e2e_test")
+        assert run.rows_load_curve >= 168  # 7 × 24
+
+        # Test direct du bridge (pas via service, pour isoler)
+        # Période ciblée pour avoir 100% coverage des données seedées
+        from data_staging.bridge import get_readings
+
+        readings, source = get_readings(db, [meter_id], datetime(2025, 1, 1), datetime(2025, 1, 7, 23, 59))
+
+        assert source == "promoted", f"Expected promoted, got {source}"
+        assert len(readings) >= 168
+        # Conversion kW → kWh : 100 kW × (10/60) = 16.67 kWh par pas de 10min
+        assert abs(readings[0].value_kwh - 16.67) < 0.1
+
+    def test_promoted_cache_invalidation_after_run(self, e2e_db):
+        """Le cache _is_promoted_available doit être invalidé après un run."""
+        db = e2e_db
+        invalidate_promoted_cache()
+
+        # Avant : vérifier que _is_promoted_available met en cache
+        from data_staging import bridge as bridge_mod
+
+        bridge_mod._promoted_available = False
+        bridge_mod._promoted_checked_at = 999999999.0  # Far future
+
+        # Seed + run
+        from models.site import Site
+
+        site = db.query(Site).first()
+        prm = "99999999999004"
+        _seed_meter_with_prm(db, prm, site_id=site.id)
+        flux_file_id = _seed_flux_file(db, "R4H")
+        _seed_r4x_measures(db, flux_file_id, prm, count=5)
+        db.commit()
+
+        run_promotion(db, mode="full", triggered_by="e2e_test")
+
+        # Après : le cache doit avoir été invalidé
+        assert bridge_mod._promoted_available is None
+        assert bridge_mod._promoted_checked_at == 0.0
+
+    def test_incremental_mode_respects_high_water_mark(self, e2e_db):
+        """Mode incremental ne retraite pas les rows déjà vues."""
+        db = e2e_db
+        from models.site import Site
+
+        site = db.query(Site).first()
+
+        prm = "99999999999005"
+        _seed_meter_with_prm(db, prm, site_id=site.id)
+
+        # Premier lot
+        flux1 = _seed_flux_file(db, "R4H")
+        _seed_r4x_measures(db, flux1, prm, count=5)
+        db.commit()
+
+        run1 = run_promotion(db, mode="incremental", triggered_by="e2e_test")
+        rows_run1 = run1.rows_load_curve
+
+        # Deuxième run sans nouvelles données → 0 rows promues
+        run2 = run_promotion(db, mode="incremental", triggered_by="e2e_test")
+        assert run2.rows_load_curve == 0
+
+        # Ajouter de nouvelles mesures
+        flux2 = _seed_flux_file(db, "R4H")
+        for i in range(3):
+            ts = datetime(2025, 7, 15, 10, i * 10)
+            db.add(
+                EnedisFluxMesureR4x(
+                    flux_file_id=flux2,
+                    flux_type="R4H",
+                    point_id=prm,
+                    grandeur_physique="EA",
+                    granularite="10",
+                    horodatage=ts.isoformat(),
+                    valeur_point="80",
+                    statut_point="R",
+                )
+            )
+        db.commit()
+
+        # Troisième run → 3 nouvelles rows
+        run3 = run_promotion(db, mode="incremental", triggered_by="e2e_test")
+        assert run3.rows_load_curve == 3

--- a/backend/tests/test_sirene.py
+++ b/backend/tests/test_sirene.py
@@ -832,6 +832,39 @@ class TestRgpdHardening:
         assert ul_recent.payload_brut is not None, "payload_brut recent doit etre conserve"
 
 
+class TestNaf25Resolver:
+    """V115 : time-aware NAF25 resolver (bascule 01/01/2027 INSEE)."""
+
+    def test_resolver_avant_2027_utilise_naf_rev2(self):
+        """Avant 2027-01-01, le resolver retourne activite_principale (NAF Rev2)."""
+        from routes.sirene import _resolve_naf
+        from types import SimpleNamespace
+
+        etab = SimpleNamespace(activite_principale="47.11F", activite_principale_naf25="47.11")
+        ul = SimpleNamespace(activite_principale="47.11F", activite_principale_naf25="47.11")
+        # Date courante (2026) < 2027 → NAF Rev2
+        result = _resolve_naf(etab, ul)
+        assert result == "47.11F", f"Avant 2027 doit retourner NAF Rev2, got {result}"
+
+    def test_resolver_fallback_chain(self):
+        """Si NAF etab absent, fallback sur NAF UL."""
+        from routes.sirene import _resolve_naf
+        from types import SimpleNamespace
+
+        etab = SimpleNamespace(activite_principale=None, activite_principale_naf25=None)
+        ul = SimpleNamespace(activite_principale="35.11Z", activite_principale_naf25=None)
+        assert _resolve_naf(etab, ul) == "35.11Z"
+
+    def test_resolver_retourne_none_si_aucune_source(self):
+        """Aucun NAF disponible → None."""
+        from routes.sirene import _resolve_naf
+        from types import SimpleNamespace
+
+        etab = SimpleNamespace(activite_principale=None, activite_principale_naf25=None)
+        ul = SimpleNamespace(activite_principale=None, activite_principale_naf25=None)
+        assert _resolve_naf(etab, ul) is None
+
+
 class TestSchemaValidation:
     def test_path_traversal_rejected(self):
         """Les chemins avec .. sont rejetes par le schema."""

--- a/backend/tests/test_sirene.py
+++ b/backend/tests/test_sirene.py
@@ -868,15 +868,18 @@ class TestNaf25Resolver:
 class TestSchemaValidation:
     def test_path_traversal_rejected(self):
         """Les chemins avec .. sont rejetes par le schema."""
+        from pydantic import ValidationError
         from schemas.sirene import SireneImportRequest
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError) as exc_info:
             SireneImportRequest(ul_path="../../etc/passwd")
+        assert "traversee" in str(exc_info.value).lower() or "invalide" in str(exc_info.value).lower()
 
     def test_absolute_path_rejected(self):
+        from pydantic import ValidationError
         from schemas.sirene import SireneImportRequest
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             SireneImportRequest(ul_path="/etc/passwd")
 
     def test_relative_path_accepted(self):
@@ -887,19 +890,22 @@ class TestSchemaValidation:
 
     def test_siret_max_50(self):
         """Plus de 50 SIRETs rejetes."""
+        from pydantic import ValidationError
         from schemas.sirene import OnboardingFromSireneRequest
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError) as exc_info:
             OnboardingFromSireneRequest(
                 siren="552032534",
                 etablissement_sirets=[f"5520325340{i:04d}" for i in range(51)],
             )
+        assert "at most 50" in str(exc_info.value).lower() or "too_long" in str(exc_info.value).lower()
 
     def test_type_client_invalid(self):
         """Type client hors liste rejete."""
+        from pydantic import ValidationError
         from schemas.sirene import OnboardingFromSireneRequest
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             OnboardingFromSireneRequest(
                 siren="552032534",
                 etablissement_sirets=["55203253400017"],

--- a/backend/tests/test_sirene.py
+++ b/backend/tests/test_sirene.py
@@ -720,6 +720,118 @@ class TestOnboardingFromSirene:
         assert data["prenom1"] == "JEAN"
 
 
+class TestFunnelIntegration:
+    """V115 : cablage onboarding_from_sirene -> OnboardingProgress."""
+
+    def _seed_sirene(self, db, sample_ul_csv, sample_etab_csv):
+        run = SireneSyncRun(sync_type="full", started_at=datetime.now(timezone.utc), status="running")
+        db.add(run)
+        db.flush()
+        import_full_unites_legales(db, sample_ul_csv, SNAPSHOT, run)
+        import_full_etablissements(db, sample_etab_csv, SNAPSHOT, run)
+
+    def test_onboarding_progress_cree_apres_sirene(self, app_client, sample_ul_csv, sample_etab_csv):
+        """Apres creation Sirene, OnboardingProgress est auto-cree avec step_org_created et step_sites_added."""
+        from models.onboarding_progress import OnboardingProgress
+
+        client, db = app_client
+        self._seed_sirene(db, sample_ul_csv, sample_etab_csv)
+
+        resp = client.post(
+            "/api/onboarding/from-sirene",
+            json={
+                "siren": "552032534",
+                "etablissement_sirets": ["55203253400017", "55203253401234"],
+            },
+        )
+        assert resp.status_code == 200
+        org_id = resp.json()["organisation_id"]
+
+        progress = db.query(OnboardingProgress).filter(OnboardingProgress.org_id == org_id).first()
+        assert progress is not None, "OnboardingProgress doit etre cree"
+        assert progress.step_org_created is True, "step_org_created doit etre True"
+        assert progress.step_sites_added is True, "step_sites_added doit etre True"
+        # Pas de compteur ni facture → ces steps restent False
+        assert progress.step_meters_connected is False
+        assert progress.step_invoices_imported is False
+
+
+class TestRgpdHardening:
+    """V115 : exclusion statut_diffusion=P + purge payload_brut."""
+
+    def test_statut_diffusion_p_exclu_a_import(self, db, tmp_path):
+        """Les lignes avec statut_diffusion=P ne doivent pas etre inserees."""
+        csv_path = tmp_path / "stock_p.csv"
+        import csv as csvmod
+
+        rows = [
+            {
+                "siren": "111111111",
+                "statutDiffusionUniteLegale": "O",  # OK
+                "denominationUniteLegale": "ENTREPRISE OUVERTE",
+                "etatAdministratifUniteLegale": "A",
+                "dateDernierTraitementUniteLegale": "2025-12-01T10:00:00",
+                "activitePrincipaleUniteLegale": "47.11F",
+            },
+            {
+                "siren": "222222222",
+                "statutDiffusionUniteLegale": "P",  # A exclure
+                "denominationUniteLegale": "ENTREPRISE PROTEGEE",
+                "etatAdministratifUniteLegale": "A",
+                "dateDernierTraitementUniteLegale": "2025-12-01T10:00:00",
+                "activitePrincipaleUniteLegale": "47.11F",
+            },
+        ]
+        with open(csv_path, "w", encoding="utf-8-sig", newline="") as f:
+            writer = csvmod.DictWriter(f, fieldnames=rows[0].keys())
+            writer.writeheader()
+            writer.writerows(rows)
+
+        stats = import_full_unites_legales(db, str(csv_path), SNAPSHOT)
+        assert stats["read"] == 2
+        assert stats["inserted"] == 1, "Seule l'entreprise O doit etre inseree"
+        assert stats["skipped"] == 1, "La P doit etre skipped"
+
+        # Verify DB state
+        assert db.query(SireneUniteLegale).filter_by(siren="111111111").first() is not None
+        assert db.query(SireneUniteLegale).filter_by(siren="222222222").first() is None
+
+    def test_purge_old_payloads(self, db):
+        """purge_old_payloads efface payload_brut apres max_age_days."""
+        from services.sirene_import import purge_old_payloads
+        from datetime import timedelta
+
+        old_snapshot = datetime.now(timezone.utc) - timedelta(days=200)
+        recent_snapshot = datetime.now(timezone.utc) - timedelta(days=30)
+
+        ul_old = SireneUniteLegale(
+            siren="333333333",
+            denomination="OLD",
+            etat_administratif="A",
+            statut_diffusion="O",
+            snapshot_date=old_snapshot,
+            payload_brut='{"data":"old"}',
+        )
+        ul_recent = SireneUniteLegale(
+            siren="444444444",
+            denomination="RECENT",
+            etat_administratif="A",
+            statut_diffusion="O",
+            snapshot_date=recent_snapshot,
+            payload_brut='{"data":"recent"}',
+        )
+        db.add_all([ul_old, ul_recent])
+        db.commit()
+
+        result = purge_old_payloads(db, max_age_days=180)
+        assert result["unites_legales_purged"] == 1
+
+        db.refresh(ul_old)
+        db.refresh(ul_recent)
+        assert ul_old.payload_brut is None, "payload_brut vieux doit etre efface"
+        assert ul_recent.payload_brut is not None, "payload_brut recent doit etre conserve"
+
+
 class TestSchemaValidation:
     def test_path_traversal_rejected(self):
         """Les chemins avec .. sont rejetes par le schema."""

--- a/docs/adr/006-enedis-dual-source-bridge.md
+++ b/docs/adr/006-enedis-dual-source-bridge.md
@@ -1,0 +1,107 @@
+# ADR-006: Enedis — Bridge dual-source promoted/legacy
+
+**Date**: 2026-04-12
+**Statut**: Accepted
+**Sprint**: Sprint 4 — SF5 Integration
+
+---
+
+## Contexte
+
+PROMEOS doit exploiter deux sources de donnees de consommation :
+
+1. **Donnees demo/seed** stockees dans `MeterReading` (historique du POC, `value_kwh` deja agrege)
+2. **Donnees Enedis reelles** promues depuis les staging SF1-SF4 vers `meter_load_curve` (SF5), qui stockent de la **puissance instantanee** (`active_power_kw`) et non de l'energie.
+
+Les services analytiques (signature, load profile, benchmark) doivent fonctionner des le jour 1 (demo) **et** basculer sur les donnees reelles des qu'elles sont disponibles, **sans reecriture** et **sans recompilation**.
+
+---
+
+## Probleme
+
+Comment permettre aux services analytiques de consommer transparentement soit les donnees demo, soit les donnees Enedis promues, avec :
+
+- Basculement automatique vers les donnees reelles quand elles existent
+- Fallback transparent si la promotion n'a pas encore eu lieu
+- Visibilite pour l'utilisateur de la source utilisee
+- Zero re-architecture des services existants
+
+---
+
+## Options envisagees
+
+### Option A: Re-ecrire tous les services pour lire `meter_load_curve` directement
+
+- (+) Plus simple, une seule source
+- (-) Casse la demo (plus de donnees seed)
+- (-) Necessite un backfill de `meter_load_curve` avec des donnees factices
+- (-) Perte de la capacite a fonctionner en mode degrade
+
+### Option B: Migration complete des donnees seed vers `meter_load_curve`
+
+- (+) Une seule table queryee
+- (-) Perd la semantique puissance vs energie (MeterReading est energie, MLC est puissance)
+- (-) Operation destructive et irreversible
+- (-) Pas de rollback possible
+
+### Option C: Bridge dual-source avec fallback automatique (choisi)
+
+- Creer un module `data_staging/bridge.py` qui :
+  - Query `meter_load_curve` en premier
+  - Calcule la couverture (days_covered / period_days)
+  - Si >= 50% de couverture, utilise les donnees promues (converties kW -> kWh)
+  - Sinon, fallback vers `MeterReading`
+  - Retourne la source utilisee (`promoted` / `legacy` / `none`)
+
+---
+
+## Decision
+
+**Option C retenue.** Le bridge est l'unique point d'entree pour toutes les lectures de consommation dans les services analytiques.
+
+### Points cles :
+
+1. **Conversion unite a la lecture** : `E(kWh) = P(kW) * (pas_minutes / 60)` pour les donnees promues.
+2. **Seuil de couverture 50%** : evite de basculer prematurement quand seules quelques heures sont disponibles.
+3. **Champ `data_source` dans chaque reponse API** : l'utilisateur voit explicitement si les chiffres sont demo ou reels.
+4. **Hot-path skip** : flag module-level `_promoted_available` avec TTL 5 min pour eviter de queryer `meter_load_curve` a chaque requete quand elle est vide.
+5. **Invalidation cache apres promotion** : `invalidate_promoted_cache()` appele automatiquement par `run_promotion()`.
+
+---
+
+## Consequences
+
+### Positives
+
+- **Zero migration** : la demo continue de fonctionner, les nouveaux clients aussi
+- **Basculement transparent** : des qu'un client consent et que SF5 promeut, les services utilisent les vraies donnees
+- **Debuggable** : le champ `data_source` dans les reponses permet de tracer quelle source a servi
+- **Testable** : les 4 tests `TestBridgeKwhConversion` verifient explicitement la conversion kW/kWh
+
+### Negatives
+
+- **Complexite additionnelle** : 2 chemins de donnees au lieu d'1
+- **Risque d'incoherence** : si un site a 50% de donnees promues et 50% legacy, le bridge bascule a 50% mais la reponse peut etre hybride
+- **Calcul de couverture coute une query supplementaire** (mitigee par le hot-path skip)
+
+---
+
+## Notes d'implementation
+
+Fichier : `backend/data_staging/bridge.py`
+
+- `get_readings(db, meter_ids, start_dt, end_dt)` : retourne `(list[ReadingRow], source)`
+- `_query_promoted()` : convertit kW -> kWh via `pas_minutes / 60`
+- `_is_promoted_available()` : check TTL-cached de l'existence de donnees dans `meter_load_curve`
+- `invalidate_promoted_cache()` : reset du flag apres un run de promotion
+
+Testes par :
+- `tests/test_data_staging.py::TestBridgeKwhConversion` (4 tests unitaires sur la conversion)
+- `tests/test_sf5_e2e.py::TestE2ESF5Pipeline::test_bridge_switches_to_promoted_after_promotion` (1 test E2E)
+
+---
+
+## References
+
+- Spec SF5 : `docs/specs/feature-enedis-sge-5-data-staging.md`
+- Bug corrige par ce pattern : P0 kW->kWh conversion (Sprint 4 audit)

--- a/docs/adr/007-sf5-quality-first-upsert.md
+++ b/docs/adr/007-sf5-quality-first-upsert.md
@@ -1,0 +1,121 @@
+# ADR-007: SF5 — Quality-first UPSERT pour la promotion
+
+**Date**: 2026-04-12
+**Statut**: Accepted
+**Sprint**: Sprint 3 — SF5 Promotion Pipeline
+
+---
+
+## Contexte
+
+Le pipeline SF5 promeut les donnees brutes Enedis (staging `enedis_flux_mesure_r4x`, `r50`, `r171`, `r151`) vers les tables fonctionnelles (`meter_load_curve`, `meter_energy_index`, `meter_power_peak`).
+
+Enedis republie regulierement des donnees pour le meme (PRM, timestamp) :
+- Une mesure initialement estimee (`statut_point=E`, quality=0.60)
+- Ensuite corrigee (`statut_point=C`, quality=0.95)
+- Finalement reelle (`statut_point=R`, quality=1.00)
+
+Chaque run de promotion peut recevoir une republication qui ameliore ou degrade la qualite d'une row deja promue.
+
+---
+
+## Probleme
+
+Quelle regle appliquer quand une row deja promue recoit une mise a jour ?
+
+- Option A: Toujours ecraser (latest wins) -> perd les donnees R ecrasees par E
+- Option B: Ne jamais ecraser (first wins) -> reste bloque sur les estimations initiales
+- Option C: Comparer les qualites et choisir la meilleure
+
+---
+
+## Decision
+
+**Option C avec comparateur `>=` (quality-first, latest wins on tie)**
+
+Regle :
+```
+SI row.quality_score >= existing.quality_score:
+    UPDATE existing avec les champs de row
+SINON:
+    SKIP (garder existing)
+```
+
+Le `>=` (pas `>`) est intentionnel : en cas d'egalite de qualite, la row la plus recente gagne, ce qui permet de propager des corrections mineures sans degrader la qualite moyenne.
+
+### Points cles :
+
+1. **Mapping qualite officiel Enedis** (dans `data_staging/quality.py`):
+   - R (Reel) : 1.00
+   - C (Corrige) : 0.95
+   - S/T/F/G (Coupure) : 0.90
+   - D (Import manuel) : 0.85
+   - H (Reconstitue) : 0.80
+   - K (Derive) : 0.75
+   - P (Reconstitue + coupure) : 0.70
+   - E (Estime) : 0.60
+   - Inconnu : 0.50
+
+2. **Preservation des champs null** : si `row.active_power_kw is None`, on ne l'ecrase PAS (fix du bug P0 `or` vs `is not None`).
+
+3. **Zero preservation** : `0.0 kW` est une valeur legitime (site ferme, dimanche matin) et doit etre preservee. C'est pour cela qu'on teste `is not None` et pas `or` :
+   ```python
+   # FAUX (perd les zeros)
+   existing.active_power_kw = row.active_power_kw or existing.active_power_kw
+   # CORRECT
+   existing.active_power_kw = (
+       row.active_power_kw if row.active_power_kw is not None else existing.active_power_kw
+   )
+   ```
+
+---
+
+## Consequences
+
+### Positives
+
+- Auto-promotion des corrections (E -> R propage automatiquement)
+- Pas de regression silencieuse sur des donnees zero
+- Compatible avec la republication Enedis sans intervention manuelle
+- Deterministe et testable
+
+### Negatives
+
+- Une republication de qualite inferieure est silencieusement ignoree (logguee uniquement)
+- La table `promotion_event` ne capture pas encore les skips (spec future)
+
+---
+
+## Implementation
+
+### Batch upsert (Sprint 7)
+
+Pour resoudre le N+1 query initial, l'implementation finale utilise 3 queries par chunk de 1000 rows :
+
+1. `SELECT` batch fetch des rows existantes (1 query via `tuple_(*cols).in_(...)`)
+2. `INSERT` batch des nouvelles rows (1 query via `bulk_save_objects`)
+3. `UPDATE` batch des rows existantes a ecraser (1 query via `bulk_update_mappings`)
+
+Gain : 3 queries / 1000 rows (vs 2000+ dans la version naive). Sur 100k rows : 300 queries au lieu de 200 000.
+
+### Fichier
+
+`backend/data_staging/engine.py::_upsert_quality_first()`
+
+Testes par :
+- `tests/test_sf5_e2e.py::TestE2ESF5Pipeline::test_full_chain_matched_and_promoted` (verifie que la qualite est correctement propagee)
+- `tests/test_sf5_e2e.py::TestE2ESF5Pipeline::test_incremental_mode_respects_high_water_mark` (verifie que les re-runs ne creent pas de doublons)
+
+---
+
+## Bugs corriges par ce pattern
+
+1. **P0 `or` vs `is not None`** (Sprint 3 audit) : le `or` perdait les valeurs zero
+2. **P0 HWM mode incremental** (Sprint 5 audit) : `_load_last_hwm()` lit depuis le dernier `completed` run, pas depuis `max(id)` courant
+
+---
+
+## References
+
+- Spec SF5 : `docs/specs/feature-enedis-sge-5-data-staging.md` (section D4)
+- Doctrine CDC : `.claude/skills/promeos-enedis/references/courbes-charge-doctrine.md`

--- a/docs/adr/008-recommendation-engine-rules.md
+++ b/docs/adr/008-recommendation-engine-rules.md
@@ -1,0 +1,136 @@
+# ADR-008: Recommendation Engine — Règles métier hardcodées
+
+**Date**: 2026-04-12
+**Statut**: Accepted
+**Sprint**: Sprint 7 — Push vers le 10
+
+---
+
+## Contexte
+
+Les services analytiques PROMEOS (load_profile, energy_signature, enedis_benchmarks) calculent une quinzaine de KPIs (baseload, load factor, thermosensibilite, score d'atypie, etc.). Mais ces KPIs en eux-memes ne sont pas des actions : l'utilisateur voit des chiffres, pas des recommandations.
+
+Le modele DB `Recommendation` existe depuis longtemps, avec ICE scoring (Impact/Confidence/Ease), mais aucun code ne transforme les KPIs en objets `Recommendation`.
+
+---
+
+## Probleme
+
+Comment transformer les KPIs analytiques en `Recommendation` objects persistes, avec ICE scoring et priorisation ?
+
+Options :
+
+### Option A: Knowledge Base (KB) + regles YAML/DB
+
+- (+) Configurable sans redeploiement
+- (+) Auditable, versionnable
+- (-) Sur-engineering pour un POC : necessite loader, parser, validator
+- (-) Les regles metier sont stables (on ne les change pas toutes les semaines)
+- (-) PROMEOS a deja une architecture KB mais elle n'est pas wired pour les recommandations
+
+### Option B: Moteur de regles generique (Drools, Camunda DMN)
+
+- (+) Standard, industriel
+- (-) Ecrasant pour 6 regles
+- (-) Dependance externe
+
+### Option C: Fonctions Python pures (choisi)
+
+- 1 fonction par regle, prenant un KPI dict en entree, retournant `(Anomaly_dict, Recommendation_dict)` ou `None`
+- Une liste `_RULES` qui orchestre l'application
+- Un dispatcher `generate_recommendations_for_site(db, site_id)` qui collecte les analytics et applique les regles
+
+---
+
+## Decision
+
+**Option C : Rules as pure Python functions.**
+
+### Architecture
+
+```python
+# backend/services/recommendation_engine.py
+
+def _rule_baseload_excessive(load_profile: dict, meter_id: int) -> tuple[dict, dict] | None:
+    if load_profile["baseload"]["verdict"] != "eleve": return None
+    if load_profile["baseload"]["baseload_pct_of_mean"] < 60: return None
+    return (anomaly_dict, recommendation_dict)
+
+_RULES = [
+    ("load_profile", _rule_baseload_excessive),
+    ("load_profile", _rule_low_load_factor),
+    ("load_profile", _rule_night_day_ratio_high),
+    ("load_profile", _rule_data_quality_low),
+    ("signature", _rule_thermosensitivity_high),
+    ("benchmark", _rule_atypicity_high),
+]
+
+def generate_recommendations_for_site(db, site_id, persist=True):
+    analytics = {
+        "load_profile": compute_load_profile(db, site_id),
+        "signature": compute_energy_signature_advanced(db, site_id),
+        "benchmark": compute_benchmark(db, site_id),
+    }
+    generated = []
+    for source_key, rule_fn in _RULES:
+        result = rule_fn(analytics[source_key], meter_id)
+        if result:
+            generated.append(result)
+    # Trier par ICE, persister dans Anomaly + Recommendation tables
+    ...
+```
+
+### Regles implementees (Sprint 7)
+
+| Regle | Seuil | Severity | ICE typique |
+|---|---|---|---|
+| Baseload excessive | pct > 60% | high | 7.9 (9/8/7) |
+| Load factor faible | LF < 0.15 | medium | 7.6 (7/7/9) |
+| Ratio nuit/jour eleve | > 0.5 | high | 6.9 (8/7/6) |
+| Thermosensibilite elevee | part > 40% + heating | medium | 5.8 (8/6/4) |
+| Atypie sectorielle | score > 0.50 | medium | 5.9 (6/5/7) |
+| Qualite donnees faible | score < 0.80 | low | 5.9 (3/10/9) |
+
+### ICE scoring : moyenne geometrique (pas produit)
+
+```python
+def _ice(impact: int, confidence: int, ease: int) -> float:
+    return round((impact * confidence * ease) ** (1 / 3), 2)
+```
+
+Rationale : la moyenne geometrique penalise fortement les dimensions faibles (ex. facilite = 2 tire le score vers le bas), alors que le produit brut explose les scores hauts (10 * 10 * 10 = 1000 vs 5 * 5 * 5 = 125, ratio 8x pour une variation lineaire 2x).
+
+---
+
+## Consequences
+
+### Positives
+
+- **Testable** : 22 tests unitaires (`test_recommendation_engine.py`), 1 test par regle + pipeline complet
+- **Debuggable** : stack trace claire, pas de moteur opaque
+- **Rapide a iterer** : ajouter une regle = ecrire 20 lignes Python
+- **ICE transparent** : formule claire, tests explicites
+- **Persistance immediate** : les recommandations apparaissent dans la table `recommendation` existante, donc dans l'inbox cockpit sans frontend additionnel
+
+### Negatives
+
+- **Pas reconfigurable sans redeploiement** : si les seuils changent (ex. baseload > 70% au lieu de 60%), il faut un commit
+- **Pas d'audit trail** : pas de log "telle regle a ete declenchee par telles valeurs"
+- **Pas de KB integration** : la traceabilite `kb_rule_id` dans le modele Anomaly n'est pas utilisee
+- **Pas d'explicabilite multi-factor** : chaque regle decide en isolation, pas de regle composite
+
+### Migration future
+
+Si le besoin se presente :
+- Extraire les seuils dans `config/recommendation_thresholds.yaml`
+- Ajouter un `RuleKbEntry` model pour versioner les regles
+- Wrapper les fonctions dans un `Rule` class avec metadata
+
+---
+
+## References
+
+- Fichier : `backend/services/recommendation_engine.py`
+- Tests : `backend/tests/test_recommendation_engine.py` (22 tests)
+- Modeles DB : `Anomaly`, `Recommendation` dans `backend/models/energy_models.py`
+- Endpoint : `POST /api/usages/recommendations/generate/{site_id}`

--- a/frontend/FIGMA_RULES.md
+++ b/frontend/FIGMA_RULES.md
@@ -1,0 +1,176 @@
+# PROMEOS Figma Design System Rules
+
+Règles d'intégration Figma → code pour le cockpit PROMEOS. Utilisé par Claude Code + Figma MCP pour générer du code conforme au design system existant.
+
+## 1. Design tokens
+
+### Emplacement
+- **Couleurs/accents sémantiques** : `src/ui/colorTokens.js` (`KPI_ACCENTS`, `SEVERITY_TINT`, `HERO_ACCENTS`)
+- **Spacing / grid** : `src/ui/conventions.js` (`LAYOUT`)
+- **Typographie** : `src/ui/conventions.js` (`TYPO`)
+- **Labels FR** : `src/ui/conventions.js` (`LABELS_FR`)
+- **Glossaire métier** : `src/ui/glossary.js` (`GLOSSARY`)
+- **Navigation / tints** : `src/layout/NavRegistry.js` (`NAV_MODULES`, `TINT_PALETTE`)
+
+### Règle d'or : neutral-first + accents contrôlés
+```
+Pas de fond plein (bg-red-500). Toujours bg-{color}-50/60 + text-{color}-700 + border-{color}-200.
+```
+
+### Mapping sémantique Figma → code
+| Figma (intent) | Token code | Exemple |
+|----------------|------------|---------|
+| Critique / alerte | `Badge status="crit"` | `bg-red-50 text-red-700 border-red-200` |
+| Warning / à risque | `Badge status="warn"` | `bg-amber-50 text-amber-700 border-amber-200` |
+| Succès / conforme | `Badge status="ok"` | `bg-green-50 text-green-700 border-green-200` |
+| Info / neutre | `Badge status="info"` | `bg-blue-50 text-blue-700 border-blue-200` |
+
+## 2. Bibliothèque de composants
+
+### Emplacement unique : `src/ui/`
+**Règle absolue** : avant de créer un nouveau composant UI, chercher dans `src/ui/` et `src/components/` s'il existe déjà.
+
+### Composants disponibles (35+)
+```
+Button, Input, Select, Combobox, Badge, Toggle, Progress, Tooltip
+Table, Card, KpiCard, MetricCard, PageShell
+Drawer, Modal, Dialog
+FilterBar, ActiveFiltersBar, Tabs
+EvidenceDrawer, Explain, CommandPalette
+Skeleton (SkeletonCard, SkeletonKpi, SkeletonTable)
+EmptyState, ErrorState, AsyncState
+Pagination, Sparkline, InfoTip
+```
+
+### Imports conventionnels
+```jsx
+// Toujours via le barrel export
+import { Card, Button, Badge, PageShell } from '../ui';
+// Pour Badge et composants courants, l'import nommé est OK :
+import Badge from '../ui/Badge';
+```
+
+## 3. Stack technique
+
+- **Framework** : React 18
+- **Bundler** : Vite 5
+- **Styling** : Tailwind CSS v4 (utility-first, aucun CSS-in-JS)
+- **Icônes** : `lucide-react` EXCLUSIVEMENT
+- **Routing** : React Router 6
+- **State** : React Context + localStorage (pas de Redux/Zustand)
+- **HTTP** : Axios (via `src/services/api/core.js`)
+- **Tests** : Vitest (node env, structural guards)
+
+## 4. Icônes
+
+**Règle** : `lucide-react` uniquement. Jamais d'autres lib, jamais d'SVG inline.
+
+```jsx
+import { Search, Building2, CheckCircle2, AlertTriangle } from 'lucide-react';
+<Search size={16} className="text-gray-400" />
+```
+
+**Taille standard** : `size={14}` inline, `size={16}` input, `size={20}` headers, `size={32}` hero.
+
+## 5. Layout & responsivité
+
+### Page template obligatoire
+```jsx
+import { PageShell } from '../ui';
+export default function MyPage() {
+  return (
+    <PageShell>
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold text-gray-900">Titre</h1>
+        {/* ... */}
+      </div>
+    </PageShell>
+  );
+}
+```
+
+### Responsive
+- **Mobile-first** : `md:`, `lg:` prefixes
+- **Grilles standards** : `LAYOUT.cardGrid3` (1 col mobile → 3 col desktop) et `LAYOUT.cardGrid4`
+- **Spacing page** : `LAYOUT.page` (px-6 py-6)
+- **Spacing section** : `LAYOUT.sectionGap` (space-y-6)
+
+## 6. Organisation du code
+
+```
+src/
+├── pages/              # 1 fichier = 1 route
+├── components/         # Sous-organisé par domaine (patrimoine/, purchase/, ...)
+├── ui/                 # Design system primitives
+├── layout/             # AppShell, Sidebar, NavRegistry
+├── contexts/           # React Context (Auth, Scope, Demo, ExpertMode)
+├── hooks/              # Custom hooks
+├── services/
+│   ├── api/            # Clients API par domaine (patrimoine.js, billing.js, ...)
+│   ├── logger.js
+│   └── tracker.js
+├── utils/              # format.js (fmtEur, fmtArea, fmtKwh, ...)
+└── __tests__/          # Tests structurels
+```
+
+### Règle de nommage fichiers
+- Pages : `PascalCase.jsx` (ex: `SireneOnboardingPage.jsx`)
+- Composants : `PascalCase.jsx`
+- Services : `camelCase.js`
+- Tests : `*.test.js` (Vitest)
+
+## 7. Patterns métier spécifiques PROMEOS
+
+### Step indicator / Wizard
+Quand Figma montre un flow multi-étapes, utiliser le pattern de `SireneOnboardingPage::StepIndicator`. Ne PAS créer un nouveau stepper.
+
+### KPI Card
+Utiliser `KpiCard` depuis `src/ui/KpiCard.jsx` avec le `kpiType` sémantique (`conformite`, `risque`, `alertes`, `actions`). Les couleurs sont auto-résolues via `KPI_ACCENTS`.
+
+### Hub de CTA post-action
+Pattern `NextStepsHub` (voir `SireneOnboardingPage`) : grille 2×2 de cards avec icône, impact badge, CTA. À réutiliser pour toute page "success" qui doit chaîner vers les étapes suivantes.
+
+### Format helpers (obligatoires pour afficher des chiffres)
+```jsx
+import { fmtEur, fmtEurFull, fmtKwh, fmtKw, fmtArea, fmtPct, fmtDateFR } from '../utils/format';
+fmtEur(23995)       // "24 k€"
+fmtEurFull(23995)   // "23 995 €"
+fmtKwh(125000)      // "125 MWh"
+fmtArea(11600)      // "11,6k m²"
+```
+
+**Ne jamais hardcoder `€`, `kWh`, `m²` en JSX. Toujours passer par ces helpers.**
+
+## 8. Règles d'intégration Figma MCP
+
+Quand on importe un design Figma :
+
+1. **Vérifier d'abord si un composant `src/ui/*` correspond** avant de copier la structure Figma.
+2. **Mapper les couleurs Figma aux tokens PROMEOS** via `colorTokens.js` (pas de hex dur).
+3. **Remplacer les icônes Figma par leur équivalent `lucide-react`**.
+4. **Convertir les labels anglais Figma en français** via `LABELS_FR` ou glossaire.
+5. **Appliquer `PageShell` comme wrapper** si c'est une page.
+6. **Formats numériques** : passer par `utils/format.js`, jamais en dur.
+7. **Animations** : utiliser les keyframes de `src/index.css` (`fadeIn`, `slideInUp`, `slideInRight`, `slideInLeft`).
+
+## 9. Anti-patterns à refuser
+
+- ❌ Créer un composant UI sans vérifier `src/ui/`
+- ❌ Utiliser MUI, shadcn, Ant Design, Chakra (stack interdite)
+- ❌ CSS-in-JS (styled-components, emotion)
+- ❌ Hex colors hardcodés hors `colorTokens.js`
+- ❌ Icônes hors `lucide-react`
+- ❌ Labels en anglais (projet 100% FR)
+- ❌ Emojis sauf si explicitement demandé
+- ❌ `fontSize: 12px` → utiliser `text-xs`, `text-sm`, etc.
+- ❌ `bg-red-500` → toujours `bg-red-50 text-red-700 border-red-200`
+
+## 10. Tests de conformité design
+
+Les tests `src/__tests__/*.test.js` vérifient :
+- Présence des imports de tokens
+- Pas de calculs hardcodés (source guards)
+- Pas de valeurs CO2/kWh en dur
+- Structure de navigation cohérente
+
+**Tout nouveau composant Figma-importé doit passer** ces guards.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -46,6 +46,7 @@ const AdminUsersPage = lazy(() => import('./pages/AdminUsersPage'));
 const AdminRolesPage = lazy(() => import('./pages/AdminRolesPage'));
 const AdminAssignmentsPage = lazy(() => import('./pages/AdminAssignmentsPage'));
 const AdminAuditLogPage = lazy(() => import('./pages/AdminAuditLogPage'));
+const EnedisPromotionHealthPage = lazy(() => import('./pages/EnedisPromotionHealthPage'));
 const ConsumptionExplorerPage = lazy(() => import('./pages/ConsumptionExplorerPage'));
 // EnergyCopilotPage — dead code, no active route (Sprint B P0-7)
 // const EnergyCopilotPage = lazy(() => import('./pages/EnergyCopilotPage'));
@@ -531,6 +532,14 @@ function App() {
                       element={
                         <PageSuspense>
                           <AdminAuditLogPage />
+                        </PageSuspense>
+                      }
+                    />
+                    <Route
+                      path="/admin/enedis-health"
+                      element={
+                        <PageSuspense>
+                          <EnedisPromotionHealthPage />
                         </PageSuspense>
                       }
                     />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -67,6 +67,7 @@ const OnboardingPage = lazy(() => import('./pages/OnboardingPage'));
 const SireneOnboardingPage = lazy(() => import('./pages/SireneOnboardingPage'));
 const AperPage = lazy(() => import('./pages/AperPage'));
 const UsagesDashboardPage = lazy(() => import('./pages/UsagesDashboardPage'));
+const FlexPage = lazy(() => import('./pages/FlexPage'));
 
 function PageSuspense({ children }) {
   return (
@@ -472,6 +473,14 @@ function App() {
                       element={
                         <PageSuspense>
                           <ContractRadarPage />
+                        </PageSuspense>
+                      }
+                    />
+                    <Route
+                      path="/flex"
+                      element={
+                        <PageSuspense>
+                          <FlexPage />
                         </PageSuspense>
                       }
                     />

--- a/frontend/src/__tests__/nav_v7_parity.test.js
+++ b/frontend/src/__tests__/nav_v7_parity.test.js
@@ -76,15 +76,16 @@ describe('Nav V7 — Source guard (labels interdits)', () => {
 });
 
 describe('Nav V7 — Structure', () => {
-  it('5 modules visible in normal mode (rail stable)', () => {
+  it('6 modules visible in normal mode (+Flex strategic)', () => {
     const normalModules = NAV_MODULES.filter((m) => !m.expertOnly);
-    expect(normalModules).toHaveLength(5);
+    expect(normalModules).toHaveLength(6);
     expect(normalModules.map((m) => m.key)).toEqual([
       'cockpit',
       'conformite',
       'energie',
       'patrimoine',
       'achat',
+      'flex',
     ]);
   });
 
@@ -94,16 +95,16 @@ describe('Nav V7 — Structure', () => {
     expect(expertModules[0].key).toBe('admin');
   });
 
-  it('13 items visible in normal mode (1 page per concept, no tab duplicates)', () => {
+  it('14 items visible in normal mode (+Flex)', () => {
     const mainSections = NAV_SECTIONS.filter((s) => !s.expertOnly);
     const items = mainSections.flatMap((s) => getVisibleItems(s.items, false));
-    expect(items).toHaveLength(13);
+    expect(items).toHaveLength(14);
   });
 
   it('same count in expert mode (no expertOnly items left)', () => {
     const mainSections = NAV_SECTIONS.filter((s) => !s.expertOnly);
     const items = mainSections.flatMap((s) => getVisibleItems(s.items, true));
-    expect(items).toHaveLength(13);
+    expect(items).toHaveLength(14);
   });
 
   it('zero expertOnly items in main modules (tabs merged into parent pages)', () => {

--- a/frontend/src/__tests__/sirene_onboarding.test.js
+++ b/frontend/src/__tests__/sirene_onboarding.test.js
@@ -71,6 +71,34 @@ describe('API Sirene service — structure', () => {
   });
 });
 
+describe('NextStepsHub — strategic wedge V115', () => {
+  const pagePath = resolve(SRC, 'pages/SireneOnboardingPage.jsx');
+
+  it('contient le composant NextStepsHub', () => {
+    const src = readFileSync(pagePath, 'utf-8');
+    expect(src).toContain('function NextStepsHub');
+  });
+
+  it('guide vers les 4 CTA strategiques (connecteurs, billing, conformite, patrimoine)', () => {
+    const src = readFileSync(pagePath, 'utf-8');
+    expect(src).toContain("navigate('/connectors')");
+    expect(src).toContain("navigate('/billing')");
+    expect(src).toContain("navigate('/conformite')");
+  });
+
+  it('classe les CTA par impact business (Critique > Eleve > Normal)', () => {
+    const src = readFileSync(pagePath, 'utf-8');
+    expect(src).toContain("impact: 'Critique'");
+    expect(src).toContain("impact: 'Eleve'");
+    expect(src).toContain("impact: 'Normal'");
+  });
+
+  it('affiche le claim strategique TTFI "3 min"', () => {
+    const src = readFileSync(pagePath, 'utf-8');
+    expect(src).toContain('3 min');
+  });
+});
+
 describe('App.jsx — route sirene', () => {
   const appPath = resolve(SRC, 'App.jsx');
 

--- a/frontend/src/__tests__/step24b_nav_clean.test.js
+++ b/frontend/src/__tests__/step24b_nav_clean.test.js
@@ -99,14 +99,14 @@ describe('Step 24b — CommandPalette hidden pages', () => {
 });
 
 describe('Step 24b — NavRail modules V7', () => {
-  it('NAV_MODULES has 6 entries (5 normal + admin expert)', () => {
+  it('NAV_MODULES has 7 entries (6 normal + admin expert)', () => {
     const src = fs.readFileSync(navFile, 'utf8');
     const start = src.indexOf('export const NAV_MODULES');
     const block = src.slice(start, start + 3000);
     const firstClose = block.indexOf('];');
     const moduleBlock = block.slice(0, firstClose);
     const keys = moduleBlock.match(/key:\s*['"][^'"]+['"]/g) || [];
-    expect(keys.length).toBe(6);
+    expect(keys.length).toBe(7);
   });
 
   it('NAV_MODULES V7 includes cockpit, conformite, energie, patrimoine, achat, admin', () => {

--- a/frontend/src/components/CrossModuleCTA.jsx
+++ b/frontend/src/components/CrossModuleCTA.jsx
@@ -1,0 +1,43 @@
+/**
+ * PROMEOS — Cross-Module CTA
+ * Bannière de suggestion pour transformer la nav passive en funnel.
+ * Usage: <CrossModuleCTA icon={Zap} title="..." desc="..." to="..." label="..." tint="violet" />
+ */
+import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+
+const TINT_CLASSES = {
+  violet: 'from-violet-50 to-purple-50 border-violet-100 text-violet-700 hover:bg-violet-100',
+  amber: 'from-amber-50 to-yellow-50 border-amber-100 text-amber-700 hover:bg-amber-100',
+  emerald: 'from-emerald-50 to-teal-50 border-emerald-100 text-emerald-700 hover:bg-emerald-100',
+  indigo: 'from-indigo-50 to-blue-50 border-indigo-100 text-indigo-700 hover:bg-indigo-100',
+  yellow: 'from-yellow-50 to-amber-50 border-yellow-100 text-yellow-700 hover:bg-yellow-100',
+};
+
+export default function CrossModuleCTA({ icon: Icon, title, desc, to, label, tint = 'violet' }) {
+  const tintClass = TINT_CLASSES[tint] || TINT_CLASSES.violet;
+  const [gradient, border, text, hover] = tintClass.split(' ');
+
+  return (
+    <Link
+      to={to}
+      className={`flex items-center gap-3 p-4 rounded-xl border ${border} bg-gradient-to-r ${gradient} transition-all group`}
+    >
+      {Icon && (
+        <div className="p-2 bg-white/80 rounded-lg shrink-0">
+          <Icon size={18} className={text} />
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        <h4 className={`text-sm font-semibold ${text}`}>{title}</h4>
+        <p className="text-xs text-gray-600 mt-0.5 truncate">{desc}</p>
+      </div>
+      <div
+        className={`flex items-center gap-1 px-3 py-1.5 rounded-lg bg-white/80 border ${border} text-xs font-medium ${text} group-hover:${hover} transition`}
+      >
+        {label}
+        <ArrowRight size={12} />
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/layout/NavPanel.jsx
+++ b/frontend/src/layout/NavPanel.jsx
@@ -5,7 +5,7 @@
  */
 import { useState, useEffect, useMemo, useCallback, useRef, Fragment } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
-import { Star, X, Search, Clock } from 'lucide-react';
+import { Star, X, Search, Clock, Sparkles } from 'lucide-react';
 import {
   getActiveSite,
   clearActiveSite,
@@ -336,6 +336,25 @@ export default function NavPanel({ activeModule, pins, onTogglePin, badges }) {
           <h2 className="text-sm font-semibold text-slate-800">{mod.label}</h2>
         </div>
         <p className="text-[11px] text-slate-400 mt-0.5 leading-snug">{mod.desc}</p>
+      </div>
+
+      {/* Demander à PROMEOS — entrée sémantique (ouvre CommandPalette via Ctrl+K) */}
+      <div className="px-2 pt-2">
+        <button
+          type="button"
+          onClick={() => {
+            const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true });
+            document.dispatchEvent(event);
+          }}
+          className="w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-[11px] text-slate-400 hover:text-slate-700 bg-slate-50/70 hover:bg-white border border-slate-200/60 rounded-md transition-all group"
+          aria-label="Demander à PROMEOS (Ctrl+K)"
+        >
+          <Sparkles size={11} className="text-violet-400 group-hover:text-violet-600 shrink-0" />
+          <span className="flex-1 truncate">Demander à PROMEOS&hellip;</span>
+          <kbd className="text-[9px] text-slate-400 bg-slate-100 rounded px-1 py-px font-mono">
+            ⌘K
+          </kbd>
+        </button>
       </div>
 
       {/* Quick actions — Raccourcis (expert only) */}

--- a/frontend/src/layout/NavRegistry.js
+++ b/frontend/src/layout/NavRegistry.js
@@ -59,6 +59,7 @@ import {
   Building,
   SearchCheck,
   PieChart,
+  Radio,
 } from 'lucide-react';
 
 /* ── Route → module mapping ── */
@@ -113,6 +114,9 @@ export const ROUTE_MODULE_MAP = {
   // Achat
   '/achat-energie': 'achat',
   '/renouvellements': 'achat',
+
+  // Flex
+  '/flex': 'flex',
 
   // Admin
   '/import': 'admin',
@@ -238,12 +242,21 @@ export const NAV_MODULES = [
     desc: 'Échéances & arbitrage énergie',
   },
   {
+    key: 'flex',
+    label: 'Flex',
+    icon: Radio,
+    tint: 'yellow',
+    expertOnly: false,
+    order: 6,
+    desc: 'Effacement & valorisation',
+  },
+  {
     key: 'admin',
     label: 'Administration',
     icon: Settings,
     tint: 'slate',
     expertOnly: true,
-    order: 6,
+    order: 7,
     desc: 'Import, utilisateurs et système',
   },
 ];
@@ -334,6 +347,23 @@ export const TINT_PALETTE = {
     pillBg: 'bg-violet-50',
     pillText: 'text-violet-700',
     pillRing: 'ring-violet-200/60',
+  },
+  yellow: {
+    headerBand: 'from-yellow-50/50 to-transparent',
+    panelHeader: 'from-yellow-50/30 to-transparent',
+    softBg: 'bg-yellow-50/40',
+    hoverBg: 'bg-yellow-50/30',
+    activeBg: 'bg-yellow-50/60',
+    activeText: 'text-yellow-700',
+    activeBorder: 'border-yellow-500',
+    railActiveBg: 'bg-yellow-50/70',
+    railActiveRing: 'ring-yellow-300/50',
+    railActiveText: 'text-yellow-600',
+    dot: 'bg-yellow-400',
+    icon: 'text-yellow-500',
+    pillBg: 'bg-yellow-50',
+    pillText: 'text-yellow-700',
+    pillRing: 'ring-yellow-200/60',
   },
   slate: {
     headerBand: 'from-slate-100/50 to-transparent',
@@ -646,13 +676,42 @@ export const NAV_SECTIONS = [
     ],
   },
 
+  // === FLEX (yellow) — valorisation effacement / NEBEF / Tempo ===
+  {
+    key: 'flex',
+    module: 'flex',
+    label: 'Flex',
+    expertOnly: false,
+    order: 6,
+    items: [
+      {
+        to: '/flex',
+        icon: Radio,
+        label: 'Flexibilité',
+        desc: 'Score, potentiel, effacement NEBEF',
+        keywords: [
+          'flex',
+          'flexibilite',
+          'nebef',
+          'effacement',
+          'tempo',
+          'capacite',
+          'fcr',
+          'afrr',
+          'valorisation',
+          'agregateur',
+        ],
+      },
+    ],
+  },
+
   // === ADMIN (slate) — module expertOnly ===
   {
     key: 'admin-data',
     module: 'admin',
     label: 'Données',
     expertOnly: true,
-    order: 6,
+    order: 7,
     items: [
       {
         to: '/import',

--- a/frontend/src/layout/__tests__/NavRegistry.test.js
+++ b/frontend/src/layout/__tests__/NavRegistry.test.js
@@ -25,18 +25,26 @@ import {
 
 /* ── Module definitions V7 ── */
 describe('NAV_MODULES V7', () => {
-  it('has exactly 6 modules (5 normal + admin expert)', () => {
-    expect(NAV_MODULES).toHaveLength(6);
+  it('has exactly 7 modules (6 normal + admin expert)', () => {
+    expect(NAV_MODULES).toHaveLength(7);
   });
 
   it('modules are in correct order with correct keys', () => {
     const keys = NAV_MODULES.map((m) => m.key);
-    expect(keys).toEqual(['cockpit', 'conformite', 'energie', 'patrimoine', 'achat', 'admin']);
+    expect(keys).toEqual([
+      'cockpit',
+      'conformite',
+      'energie',
+      'patrimoine',
+      'achat',
+      'flex',
+      'admin',
+    ]);
   });
 
-  it('order field is sequential 1-6', () => {
+  it('order field is sequential 1-7', () => {
     const orders = NAV_MODULES.map((m) => m.order);
-    expect(orders).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(orders).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
   it('each module has icon, label, tint, expertOnly, desc', () => {
@@ -51,15 +59,16 @@ describe('NAV_MODULES V7', () => {
     }
   });
 
-  it('normal mode shows 5 modules (rail stable)', () => {
+  it('normal mode shows 6 modules (+Flex strategic)', () => {
     const normal = NAV_MODULES.filter((m) => !m.expertOnly);
-    expect(normal).toHaveLength(5);
+    expect(normal).toHaveLength(6);
     expect(normal.map((m) => m.key)).toEqual([
       'cockpit',
       'conformite',
       'energie',
       'patrimoine',
       'achat',
+      'flex',
     ]);
   });
 
@@ -113,8 +122,8 @@ describe('MODULE_TINTS', () => {
 
 /* ── Section definitions V7 ── */
 describe('NAV_SECTIONS V7', () => {
-  it('has exactly 6 sections (one per module)', () => {
-    expect(NAV_SECTIONS).toHaveLength(6);
+  it('has exactly 7 sections (one per module)', () => {
+    expect(NAV_SECTIONS).toHaveLength(7);
   });
 
   it('every section references a valid module', () => {
@@ -176,18 +185,18 @@ describe('NAV_SECTIONS V7', () => {
 
 /* ── Expert filtering (item level) ── */
 describe('Expert filtering V7', () => {
-  it('normal mode: 13 visible items (1 page per concept)', () => {
+  it('normal mode: 14 visible items (+Flex)', () => {
     const normal = NAV_SECTIONS.filter((s) => !s.expertOnly).flatMap((s) =>
       getVisibleItems(s.items, false)
     );
-    expect(normal).toHaveLength(13);
+    expect(normal).toHaveLength(14);
   });
 
-  it('expert mode: same 13 items (no expertOnly items left)', () => {
+  it('expert mode: same 14 items (no expertOnly items left)', () => {
     const expert = NAV_SECTIONS.filter((s) => !s.expertOnly).flatMap((s) =>
       getVisibleItems(s.items, true)
     );
-    expect(expert).toHaveLength(13);
+    expect(expert).toHaveLength(14);
   });
 
   it('zero expert-only items (all tabs merged into parent pages)', () => {
@@ -477,8 +486,8 @@ describe('NAV_MAIN_SECTIONS', () => {
     expect(adminInMain).toBeUndefined();
   });
 
-  it('has 5 main sections', () => {
-    expect(NAV_MAIN_SECTIONS).toHaveLength(5);
+  it('has 6 main sections (+Flex)', () => {
+    expect(NAV_MAIN_SECTIONS).toHaveLength(6);
   });
 
   it('is synchronized with NAV_SECTIONS (same items)', () => {

--- a/frontend/src/pages/Cockpit.jsx
+++ b/frontend/src/pages/Cockpit.jsx
@@ -4,7 +4,17 @@
  */
 import { useMemo, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FileText, ArrowRight, Search, AlertTriangle, Clock } from 'lucide-react';
+import {
+  FileText,
+  ArrowRight,
+  Search,
+  AlertTriangle,
+  Clock,
+  ShieldCheck,
+  ShoppingCart,
+  Radio,
+} from 'lucide-react';
+import CrossModuleCTA from '../components/CrossModuleCTA';
 import { useScope } from '../contexts/ScopeContext';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { useActionDrawer } from '../contexts/ActionDrawerContext';
@@ -453,6 +463,34 @@ const Cockpit = () => {
         </div>
       }
     >
+      {/* ── Cross-module funnel CTAs (stratégique : Accueil → modules valeur) ── */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
+        <CrossModuleCTA
+          icon={ShieldCheck}
+          title="Conformité"
+          desc="Score, obligations à traiter"
+          to="/conformite"
+          label="Voir"
+          tint="emerald"
+        />
+        <CrossModuleCTA
+          icon={ShoppingCart}
+          title="Arbitrer vos achats"
+          desc="Scénarios & échéances"
+          to="/achat-energie"
+          label="Achat"
+          tint="violet"
+        />
+        <CrossModuleCTA
+          icon={Radio}
+          title="Valoriser flex"
+          desc="Effacement, Tempo, capacité"
+          to="/flex"
+          label="Flex"
+          tint="yellow"
+        />
+      </div>
+
       {/* ── Error banner ── */}
       {error && (
         <ErrorState

--- a/frontend/src/pages/ConformitePage.jsx
+++ b/frontend/src/pages/ConformitePage.jsx
@@ -7,7 +7,7 @@
  */
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ShieldCheck, Plus, RotateCcw, RefreshCw, Coins } from 'lucide-react';
+import { ShieldCheck, Plus, RotateCcw, RefreshCw, Coins, ShoppingCart, Radio } from 'lucide-react';
 import { toUsages } from '../services/routes';
 import { Button, PageShell, ActiveFiltersBar, Explain } from '../ui';
 import ObligationsTab from './conformite-tabs/ObligationsTab';
@@ -34,6 +34,7 @@ import { SkeletonKpi, SkeletonTable } from '../ui/Skeleton';
 import { buildWatchlist, buildBriefing, computeHealthState } from '../models/dashboardEssentials';
 import { computeObligationProfileTags } from '../models/complianceProfileRules';
 import HealthSummary from '../components/HealthSummary';
+import CrossModuleCTA from '../components/CrossModuleCTA';
 import DossierPrintView from '../components/DossierPrintView';
 import RegulatoryTimeline from '../components/compliance/RegulatoryTimeline';
 import { REG_LABELS, STATUT_LABELS, COCKPIT_TABS } from '../domain/compliance/complianceLabels.fr';
@@ -624,6 +625,26 @@ export default function ConformitePage() {
       {isExpert && complianceHealth && (
         <HealthSummary healthState={complianceHealth} onNavigate={navigate} compact />
       )}
+
+      {/* Cross-module CTAs — transforme la nav passive en funnel */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 my-4">
+        <CrossModuleCTA
+          icon={ShoppingCart}
+          title="Arbitrer vos contrats énergie"
+          desc="Comparer scénarios d'achat alignés avec vos obligations"
+          to="/achat-energie"
+          label="Scénarios"
+          tint="violet"
+        />
+        <CrossModuleCTA
+          icon={Radio}
+          title="Valoriser vos flexibilités"
+          desc="Effacement NEBEF, Tempo, capacité — gisements détectés"
+          to="/flex"
+          label="Flex"
+          tint="yellow"
+        />
+      </div>
 
       {/* Step 21: Compliance Summary Banner — messages actionnables */}
       {summary && (

--- a/frontend/src/pages/EnedisPromotionHealthPage.jsx
+++ b/frontend/src/pages/EnedisPromotionHealthPage.jsx
@@ -1,0 +1,432 @@
+/**
+ * PROMEOS - Enedis Promotion Health Dashboard
+ * Monitoring du pipeline SF5 : dernier run, volumes, backlog, alertes.
+ */
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  RefreshCw,
+  Database,
+  PlayCircle,
+} from 'lucide-react';
+import {
+  getPromotionHealth,
+  getPromotionRuns,
+  getPromotionBacklog,
+  triggerPromotion,
+  getOpendataFreshness,
+  refreshOpendata,
+} from '../services/api/enedis';
+import { PageShell } from '../ui';
+import { useToast } from '../ui/ToastProvider';
+
+const STATUS_CONFIG = {
+  healthy: { color: 'bg-green-100 text-green-700', icon: CheckCircle2, label: 'En bonne santé' },
+  warning: { color: 'bg-yellow-100 text-yellow-700', icon: AlertTriangle, label: 'Attention' },
+  stale: { color: 'bg-orange-100 text-orange-700', icon: Clock, label: 'Données périmées' },
+  error: { color: 'bg-red-100 text-red-700', icon: XCircle, label: 'Erreur' },
+  running: { color: 'bg-blue-100 text-blue-700', icon: Activity, label: 'En cours' },
+  never_ran: { color: 'bg-gray-100 text-gray-700', icon: Clock, label: 'Jamais exécuté' },
+  unknown: { color: 'bg-gray-100 text-gray-700', icon: Clock, label: 'Inconnu' },
+};
+
+function StatusBadge({ status }) {
+  const config = STATUS_CONFIG[status] || STATUS_CONFIG.unknown;
+  const Icon = config.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${config.color}`}
+    >
+      <Icon size={16} />
+      {config.label}
+    </span>
+  );
+}
+
+function KpiTile({ label, value, sublabel, icon: Icon, color = 'text-gray-700' }) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex items-start justify-between mb-2">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</span>
+        {Icon && <Icon size={16} className="text-gray-400" />}
+      </div>
+      <div className={`text-2xl font-semibold ${color}`}>{value}</div>
+      {sublabel && <div className="text-xs text-gray-500 mt-1">{sublabel}</div>}
+    </div>
+  );
+}
+
+function formatDateTime(iso) {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString('fr-FR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatNumber(n) {
+  if (n == null) return '—';
+  return n.toLocaleString('fr-FR');
+}
+
+export default function EnedisPromotionHealthPage() {
+  const [health, setHealth] = useState(null);
+  const [runs, setRuns] = useState([]);
+  const [backlog, setBacklog] = useState([]);
+  const [freshness, setFreshness] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [triggering, setTriggering] = useState(false);
+  const [refreshingOds, setRefreshingOds] = useState(false);
+  const toast = useToast();
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [h, r, b, f] = await Promise.all([
+        getPromotionHealth(),
+        getPromotionRuns(10, 0),
+        getPromotionBacklog('pending', 20),
+        getOpendataFreshness().catch(() => null),
+      ]);
+      setHealth(h);
+      setRuns(r.items || []);
+      setBacklog(b.items || []);
+      setFreshness(f);
+    } catch (e) {
+      toast?.error?.('Erreur chargement du health pipeline');
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  const handleRefreshOds = async () => {
+    setRefreshingOds(true);
+    try {
+      const result = await refreshOpendata('sup36');
+      toast?.success?.(`ODS refresh : ${result.total_rows || 0} rows importées`);
+      fetchAll();
+    } catch (e) {
+      toast?.error?.(`Erreur ODS refresh : ${e?.response?.data?.detail || e.message}`);
+    } finally {
+      setRefreshingOds(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAll();
+    const interval = setInterval(fetchAll, 30000); // Auto-refresh 30s
+    return () => clearInterval(interval);
+  }, [fetchAll]);
+
+  const handleTrigger = async (dryRun = false) => {
+    setTriggering(true);
+    try {
+      const result = await triggerPromotion('incremental', dryRun);
+      toast?.success?.(
+        `Run #${result.run_id} : ${result.prms_matched}/${result.prms_total} PRMs, ${result.rows_load_curve} CDC`
+      );
+      fetchAll();
+    } catch (e) {
+      toast?.error?.(`Erreur : ${e?.response?.data?.detail || e.message}`);
+    } finally {
+      setTriggering(false);
+    }
+  };
+
+  if (loading && !health) {
+    return (
+      <PageShell title="Enedis — Promotion Pipeline">
+        <div className="text-gray-400 animate-pulse">Chargement…</div>
+      </PageShell>
+    );
+  }
+
+  const lastRun = health?.last_run;
+  const volumes = health?.volumes || {};
+
+  return (
+    <PageShell
+      title="Enedis — Promotion Pipeline"
+      subtitle="Monitoring SF5 — staging → tables fonctionnelles"
+    >
+      {/* Status banner + actions */}
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-4">
+        <div className="flex items-center gap-4">
+          <StatusBadge status={health?.status} />
+          <span className="text-sm text-gray-500">
+            Vérifié : {formatDateTime(health?.checked_at)}
+          </span>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => fetchAll()}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            <RefreshCw size={14} />
+            Rafraîchir
+          </button>
+          <button
+            onClick={() => handleTrigger(true)}
+            disabled={triggering || health?.status === 'running'}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+          >
+            <PlayCircle size={14} />
+            Dry-run
+          </button>
+          <button
+            onClick={() => handleTrigger(false)}
+            disabled={triggering || health?.status === 'running'}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+          >
+            <PlayCircle size={14} />
+            Lancer promotion
+          </button>
+        </div>
+      </div>
+
+      {/* Alerts */}
+      {health?.alerts?.length > 0 && (
+        <div className="mb-6 space-y-2">
+          {health.alerts.map((alert, i) => (
+            <div
+              key={i}
+              className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-md text-sm text-amber-800"
+            >
+              <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
+              <span>{alert}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* KPI Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <KpiTile
+          label="CDC promues"
+          value={formatNumber(volumes.meter_load_curve_total)}
+          sublabel="meter_load_curve"
+          icon={Database}
+          color="text-blue-700"
+        />
+        <KpiTile
+          label="PRMs en backlog"
+          value={formatNumber(volumes.backlog_pending)}
+          sublabel={`${volumes.backlog_resolved || 0} résolus`}
+          icon={AlertTriangle}
+          color={volumes.backlog_pending > 100 ? 'text-red-600' : 'text-gray-700'}
+        />
+        <KpiTile
+          label="Dernier run"
+          value={lastRun ? `#${lastRun.id}` : '—'}
+          sublabel={
+            lastRun ? `${lastRun.mode} — ${formatDateTime(lastRun.started_at)}` : 'Aucun run'
+          }
+          icon={Activity}
+        />
+        <KpiTile
+          label="PRMs matchés"
+          value={lastRun ? `${lastRun.prms_matched}/${lastRun.prms_total}` : '—'}
+          sublabel={lastRun ? `${lastRun.rows_promoted || 0} rows promues` : ''}
+          icon={CheckCircle2}
+          color="text-green-700"
+        />
+      </div>
+
+      {/* ODS Freshness section */}
+      {freshness && (
+        <div className="bg-white rounded-lg border border-gray-200 p-5 mb-6">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-gray-700">
+              Open Data Enedis — fraîcheur des benchmarks NAF
+            </h2>
+            <button
+              onClick={handleRefreshOds}
+              disabled={refreshingOds}
+              className="inline-flex items-center gap-2 px-3 py-1.5 text-xs border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+            >
+              <RefreshCw size={12} />
+              {refreshingOds ? 'Import…' : 'Refresh ODS'}
+            </button>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="flex items-center gap-3">
+              <div
+                className={`w-2 h-2 rounded-full ${
+                  freshness.status === 'fresh'
+                    ? 'bg-green-500'
+                    : freshness.status === 'aging'
+                      ? 'bg-yellow-500'
+                      : freshness.status === 'stale'
+                        ? 'bg-orange-500'
+                        : 'bg-gray-400'
+                }`}
+              />
+              <div>
+                <div className="text-xs text-gray-500 uppercase">Status</div>
+                <div className="text-sm font-medium">{freshness.status}</div>
+              </div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-500 uppercase">conso-sup36</div>
+              <div className="text-sm">
+                {formatNumber(freshness.sup36?.count)} rows
+                {freshness.sup36?.age_days != null && (
+                  <span className="text-gray-500 ml-2">(il y a {freshness.sup36.age_days}j)</span>
+                )}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-500 uppercase">conso-inf36</div>
+              <div className="text-sm">
+                {formatNumber(freshness.inf36?.count)} rows
+                {freshness.inf36?.age_days != null && (
+                  <span className="text-gray-500 ml-2">(il y a {freshness.inf36.age_days}j)</span>
+                )}
+              </div>
+            </div>
+          </div>
+          {freshness.alerts?.length > 0 && (
+            <div className="mt-3 p-2 bg-amber-50 border border-amber-200 rounded text-xs text-amber-700">
+              {freshness.alerts.join(' — ')}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Last run detail */}
+      {lastRun && (
+        <div className="bg-white rounded-lg border border-gray-200 p-5 mb-6">
+          <h2 className="text-sm font-semibold text-gray-700 mb-3">Dernier run (détails)</h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+            <div>
+              <div className="text-gray-500 text-xs uppercase mb-1">ID</div>
+              <div className="font-mono">#{lastRun.id}</div>
+            </div>
+            <div>
+              <div className="text-gray-500 text-xs uppercase mb-1">Status</div>
+              <div>{lastRun.status}</div>
+            </div>
+            <div>
+              <div className="text-gray-500 text-xs uppercase mb-1">Mode</div>
+              <div>{lastRun.mode}</div>
+            </div>
+            <div>
+              <div className="text-gray-500 text-xs uppercase mb-1">Déclencheur</div>
+              <div>{lastRun.triggered_by}</div>
+            </div>
+            <div>
+              <div className="text-gray-500 text-xs uppercase mb-1">Démarré</div>
+              <div>{formatDateTime(lastRun.started_at)}</div>
+            </div>
+            <div>
+              <div className="text-gray-500 text-xs uppercase mb-1">Terminé</div>
+              <div>{formatDateTime(lastRun.finished_at)}</div>
+            </div>
+            <div>
+              <div className="text-gray-500 text-xs uppercase mb-1">PRMs total</div>
+              <div>{formatNumber(lastRun.prms_total)}</div>
+            </div>
+            <div>
+              <div className="text-gray-500 text-xs uppercase mb-1">PRMs non matchés</div>
+              <div className={lastRun.prms_unmatched > 0 ? 'text-orange-600' : ''}>
+                {formatNumber(lastRun.prms_unmatched)}
+              </div>
+            </div>
+          </div>
+          {lastRun.error_message && (
+            <div className="mt-3 p-2 bg-red-50 border border-red-200 rounded text-xs text-red-700 font-mono">
+              {lastRun.error_message}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Recent runs */}
+      {runs.length > 0 && (
+        <div className="bg-white rounded-lg border border-gray-200 p-5 mb-6">
+          <h2 className="text-sm font-semibold text-gray-700 mb-3">Runs récents ({runs.length})</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-xs text-gray-500 uppercase border-b">
+                <tr>
+                  <th className="text-left py-2 px-2">ID</th>
+                  <th className="text-left py-2 px-2">Status</th>
+                  <th className="text-left py-2 px-2">Mode</th>
+                  <th className="text-left py-2 px-2">Démarré</th>
+                  <th className="text-right py-2 px-2">PRMs</th>
+                  <th className="text-right py-2 px-2">CDC</th>
+                  <th className="text-right py-2 px-2">Index</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((r) => (
+                  <tr key={r.id} className="border-b border-gray-100">
+                    <td className="py-2 px-2 font-mono text-xs">#{r.id}</td>
+                    <td className="py-2 px-2">
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded text-xs ${
+                          r.status === 'completed'
+                            ? 'bg-green-100 text-green-700'
+                            : r.status === 'failed'
+                              ? 'bg-red-100 text-red-700'
+                              : 'bg-blue-100 text-blue-700'
+                        }`}
+                      >
+                        {r.status}
+                      </span>
+                    </td>
+                    <td className="py-2 px-2 text-gray-600">{r.mode}</td>
+                    <td className="py-2 px-2 text-gray-600 text-xs">
+                      {formatDateTime(r.started_at)}
+                    </td>
+                    <td className="py-2 px-2 text-right">
+                      {r.prms_matched}/{r.prms_total}
+                    </td>
+                    <td className="py-2 px-2 text-right">{formatNumber(r.rows_load_curve)}</td>
+                    <td className="py-2 px-2 text-right">{formatNumber(r.rows_energy_index)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Backlog */}
+      {backlog.length > 0 && (
+        <div className="bg-white rounded-lg border border-gray-200 p-5">
+          <h2 className="text-sm font-semibold text-gray-700 mb-3">
+            Backlog PRMs non résolus ({backlog.length})
+          </h2>
+          <div className="space-y-2">
+            {backlog.slice(0, 10).map((u) => (
+              <div
+                key={u.id}
+                className="flex items-center justify-between p-2 bg-gray-50 rounded text-xs"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-gray-700">{u.point_id}</span>
+                  <span className="text-orange-600">{u.block_reason}</span>
+                </div>
+                <div className="text-gray-500">
+                  {u.measures_count} mesures — {formatDateTime(u.last_seen_at)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/FlexPage.jsx
+++ b/frontend/src/pages/FlexPage.jsx
@@ -10,7 +10,7 @@ import FlexPotentialCard from '../components/flex/FlexPotentialCard';
 import FlexScoreCard from '../components/flex/FlexScoreCard';
 import TariffWindowsCard from '../components/flex/TariffWindowsCard';
 import FlexNebcoCard from '../components/usages/FlexNebcoCard';
-import ScopeSummary from '../components/ScopeSummary';
+import { ScopeSummary } from '../ui';
 
 export default function FlexPage() {
   return (

--- a/frontend/src/pages/FlexPage.jsx
+++ b/frontend/src/pages/FlexPage.jsx
@@ -1,0 +1,69 @@
+/**
+ * PROMEOS — Flex (module stratégique)
+ * Route: /flex
+ * Vue portefeuille flexibilité : scoring, quick wins, potentiel NEBEF/FCR/Tempo.
+ */
+import { PageShell } from '../ui';
+import { Zap, TrendingUp, Target } from 'lucide-react';
+import FlexPortfolioSummary from '../components/flex/FlexPortfolioSummary';
+import FlexPotentialCard from '../components/flex/FlexPotentialCard';
+import FlexScoreCard from '../components/flex/FlexScoreCard';
+import TariffWindowsCard from '../components/flex/TariffWindowsCard';
+import FlexNebcoCard from '../components/usages/FlexNebcoCard';
+import ScopeSummary from '../components/ScopeSummary';
+
+export default function FlexPage() {
+  return (
+    <PageShell icon={Zap} title="Flexibilité énergétique" subtitle={<ScopeSummary />}>
+      <div className="space-y-5 max-w-7xl">
+        {/* Intro éditoriale */}
+        <div className="bg-gradient-to-r from-yellow-50 to-amber-50 border border-amber-100 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <div className="p-2 bg-amber-100 rounded-lg">
+              <TrendingUp size={18} className="text-amber-700" />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-gray-900 mb-1">
+                Transformez vos contraintes tarifaires en revenus
+              </h3>
+              <p className="text-xs text-gray-600 leading-relaxed">
+                PROMEOS identifie automatiquement les gisements de flexibilité sur votre
+                portefeuille : effacement NEBEF, participation capacité, arbitrage HP/HC dynamique,
+                Tempo Bleu/Blanc/Rouge. Chaque site est scoré sur son potentiel économique annuel.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Portfolio summary */}
+        <FlexPortfolioSummary />
+
+        {/* Cards row */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FlexScoreCard />
+          <FlexPotentialCard />
+        </div>
+
+        {/* Tariff windows + NEBCO */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <TariffWindowsCard />
+          <FlexNebcoCard />
+        </div>
+
+        {/* Call to action */}
+        <div className="bg-gray-50 border border-gray-200 rounded-xl p-5 flex items-center gap-4">
+          <Target size={24} className="text-violet-600 shrink-0" />
+          <div className="flex-1">
+            <h4 className="text-sm font-semibold text-gray-900">
+              Prêt à valoriser vos effacements ?
+            </h4>
+            <p className="text-xs text-gray-600">
+              PROMEOS vous met en relation avec les agrégateurs NEBEF partenaires (commission
+              marketplace).
+            </p>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/SireneOnboardingPage.jsx
+++ b/frontend/src/pages/SireneOnboardingPage.jsx
@@ -27,6 +27,89 @@ const STEPS = [
   { id: 'confirm', label: 'Confirmer', icon: CheckCircle2 },
 ];
 
+// NextStepsHub — transforme la vallee morte post-Sirene en funnel actif vers le premier insight.
+// Ordre = impact business decroissant (connecteurs > facture > conformite > patrimoine).
+function NextStepsHub({ result, navigate }) {
+  const firstSiteId = result.sites[0]?.id;
+  const cards = [
+    {
+      icon: '⚡',
+      title: 'Connecter Enedis / GRDF',
+      desc: 'Donnees de consommation reelles en J+1',
+      cta: 'Activer les connecteurs',
+      impact: 'Critique',
+      impactStatus: 'crit',
+      onClick: () => navigate('/connectors'),
+    },
+    {
+      icon: '🧾',
+      title: 'Uploader une facture',
+      desc: 'Shadow billing immediat + detection anomalies',
+      cta: 'Importer une facture',
+      impact: 'Eleve',
+      impactStatus: 'warn',
+      onClick: () => navigate('/billing'),
+    },
+    {
+      icon: '📋',
+      title: 'Verifier la conformite',
+      desc: 'Scoring Decret Tertiaire / BACS / APER',
+      cta: 'Voir le diagnostic',
+      impact: 'Eleve',
+      impactStatus: 'warn',
+      onClick: () => navigate('/conformite'),
+    },
+    {
+      icon: '🏢',
+      title: 'Completer le patrimoine',
+      desc: 'Batiments, compteurs, surfaces',
+      cta: 'Editer le patrimoine',
+      impact: 'Normal',
+      impactStatus: 'info',
+      onClick: () => navigate(firstSiteId ? `/sites/${firstSiteId}` : '/patrimoine'),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-semibold text-gray-900 mb-1">
+          Maximisez votre valeur en 3 min
+        </h3>
+        <p className="text-xs text-gray-500">
+          Patrimoine cree. Prochaine etape : connecter vos donnees energie pour obtenir votre
+          premier insight.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {cards.map((c) => (
+          <button
+            key={c.title}
+            onClick={c.onClick}
+            className="text-left p-4 border border-gray-200 rounded-lg hover:border-indigo-300 hover:bg-indigo-50/30 transition-colors group"
+          >
+            <div className="flex items-start justify-between gap-2 mb-2">
+              <span className="text-2xl">{c.icon}</span>
+              <Badge status={c.impactStatus}>{c.impact}</Badge>
+            </div>
+            <div className="font-medium text-gray-900 text-sm">{c.title}</div>
+            <div className="text-xs text-gray-500 mt-0.5 mb-2">{c.desc}</div>
+            <div className="text-xs text-indigo-600 font-medium group-hover:underline">
+              {c.cta} →
+            </div>
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={() => navigate('/onboarding')}
+        className="w-full text-center text-xs text-gray-400 hover:text-gray-600 pt-2"
+      >
+        Plus tard — aller au tableau de bord d'activation
+      </button>
+    </div>
+  );
+}
+
 // ── Step indicator ──
 function StepIndicator({ steps, current }) {
   return (
@@ -406,32 +489,7 @@ function ConfirmStep({ uniteLegale, selectedSirets, onBack }) {
           </p>
         </div>
 
-        <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-700">
-          <p className="font-medium mb-1">Prochaines etapes</p>
-          <ul className="text-xs space-y-0.5">
-            <li>· Completez les batiments et compteurs dans le patrimoine</li>
-            <li>· Connectez les donnees energie (Enedis, GRDF)</li>
-            <li>· Ajoutez les contrats et factures</li>
-            <li>· Verifiez la conformite reglementaire</li>
-          </ul>
-        </div>
-
-        <div className="flex items-center gap-3 pt-2">
-          <button
-            onClick={() => navigate('/patrimoine')}
-            className="flex-1 px-4 py-2.5 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 text-center"
-          >
-            Aller au patrimoine
-          </button>
-          {result.sites.length > 0 && (
-            <button
-              onClick={() => navigate(`/sites/${result.sites[0].id}`)}
-              className="px-4 py-2.5 border border-gray-200 text-sm font-medium rounded-lg hover:bg-gray-50 text-center"
-            >
-              Voir le premier site
-            </button>
-          )}
-        </div>
+        <NextStepsHub result={result} navigate={navigate} />
       </div>
     );
   }

--- a/frontend/src/services/api/enedis.js
+++ b/frontend/src/services/api/enedis.js
@@ -1,0 +1,37 @@
+/**
+ * PROMEOS - API Enedis
+ * Promotion pipeline health, runs, backlog + NAF estimator
+ */
+import api from './core';
+
+// ── Promotion pipeline ──
+export const getPromotionHealth = () => api.get('/enedis/promotion/health').then((r) => r.data);
+
+export const getPromotionRuns = (limit = 20, offset = 0) =>
+  api.get(`/enedis/promotion/runs?limit=${limit}&offset=${offset}`).then((r) => r.data);
+
+export const getPromotionRun = (id) => api.get(`/enedis/promotion/runs/${id}`).then((r) => r.data);
+
+export const getPromotionBacklog = (status = 'pending', limit = 50) =>
+  api.get(`/enedis/promotion/backlog?status=${status}&limit=${limit}`).then((r) => r.data);
+
+export const triggerPromotion = (mode = 'incremental', dryRun = false) =>
+  api.post(`/enedis/promotion/promote?mode=${mode}&dry_run=${dryRun}`).then((r) => r.data);
+
+// ── NAF estimator ──
+export const estimateReferenceCurve = (nafCode, powerKva, months = 12) =>
+  api
+    .get(
+      `/usages/estimate/reference-curve?naf_code=${encodeURIComponent(nafCode)}&power_kva=${powerKva}&months=${months}`
+    )
+    .then((r) => r.data);
+
+// ── ODS freshness ──
+export const getOpendataFreshness = () => api.get('/enedis/opendata/freshness').then((r) => r.data);
+
+export const refreshOpendata = (dataset = 'sup36', dateFrom = null, dateTo = null) => {
+  const params = new URLSearchParams({ dataset });
+  if (dateFrom) params.append('date_from', dateFrom);
+  if (dateTo) params.append('date_to', dateTo);
+  return api.post(`/enedis/opendata/refresh?${params}`).then((r) => r.data);
+};


### PR DESCRIPTION
> ⚠️ Cette PR a élargi son scope depuis sa création. Elle contient maintenant 3 briques stratégiques : nav strategic (initial), Sirene V115, et Sprints 1-8 Enedis.

## Summary

6 commits couvrant 3 briques stratégiques :

### 🌊 Brique 1 — Sprints 1-8 Enedis (commit 7bda6755, le plus gros)

Pipeline complet CDC + Analytics + Monitoring + Recommendations :

**Backend :**
- Pipeline SF5 complet : staging → promotion → tables fonctionnelles (meter_load_curve, meter_energy_index, meter_power_peak, promotion_run, promotion_event, unmatched_prm)
- Bridge dual-source promoted/legacy avec conversion kW→kWh correcte et hot-path skip
- 4 services analytiques : load_profile, energy_signature (modèles 2P/3P/4P/5P), enedis_benchmarks, naf_estimator
- **Recommendation Engine** : 6 règles métier → Anomaly + Recommendation avec ICE scoring persistés en DB
- Batch upsert quality-first (3 queries/chunk de 1000 au lieu de N queries N+1)
- Rate limit promotion (60s window, dry-run exempt)
- Metrics endpoint Prometheus-compatible (/api/enedis/promotion/metrics)
- 13 endpoints nouveaux sur /api/enedis/* et /api/usages/*

**Frontend :**
- Dashboard admin `/admin/enedis-health` : status, runs, backlog, triggers, ODS freshness
- services/api/enedis.js (8 endpoints exposés)

**Tests :**
- 118/118 backend verts
- 5 tests E2E SF5 (détection + fix bug HWM mode incremental)
- 22 tests Recommendation Engine (6 règles individuelles + pipeline)

**Docs :**
- 3 ADRs : 006 dual-source bridge, 007 quality-first upsert, 008 recommendation engine rules
- 3 fichiers reference skill promeos-enedis (doctrine, formules, benchmark NAF)

### 🌊 Brique 2 — Sirene V115 + V115.1

Wedge stratégique onboarding via INSEE Sirene :
- V115 : funnel wiring + RGPD + NextStepsHub
- V115.1 : NAF25 time-aware resolver (transition INSEE 2027)
- test(sirene) : strict ValidationError vs catch-all Exception

### 🌊 Brique 3 — Nav strategic + Flex fix

- 3 strategic improvements : Module Flex (6ème module, 12% revenu cible), Cross-module CTAs, Demander à PROMEOS semantic search
- Fix import ScopeSummary from ui/ (path correction)

## Commits

```
7bda6755 feat(enedis): Sprints 5-8 — NAF estimator + recommendation engine + monitoring
043db49a test(sirene): strict ValidationError instead of catch-all Exception
3f5149fc feat(sirene): V115.1 — NAF25 time-aware resolver (INSEE 2027 transition)
06d030ed fix(flex): import ScopeSummary from ui/ not components/
a62e98c0 feat(nav-strategic): 3 strategic improvements — Flex, CTAs, semantic search
2997f8c0 feat(sirene): V115 strategic wedge — funnel wiring + RGPD + NextStepsHub
```

## Métriques

| Indicateur | Valeur |
|---|---|
| Commits | 6 |
| Fichiers Sprint 1-8 Enedis | 13 nouveaux + 4 modifiés |
| Lignes ajoutées (Enedis seul) | 2701 |
| Tests backend | 118/118 verts |
| Endpoints API nouveaux | 13 (Enedis) |
| Tables DB nouvelles | 8 |
| ADRs | 3 |
| Passes d'audit | 4 (Sprint 3, 4, simplify, final) |
| Bugs P0 trouvés et corrigés | 3 |

## Test plan

- [x] 118/118 tests backend Enedis verts (vérifié 2×)
- [x] Lint ruff + eslint + prettier passés (pre-commit hook)
- [x] 4 passes audit : 25+ bugs trouvés et corrigés
- [x] Live verification : health, metrics, recommendations (4 générées en DB), rate limit (200 → 429)
- [x] E2E SF5 complet : staging → promotion → bridge → endpoint
- [x] Pas de conflit avec main
- [ ] Review du diff GitHub avant merge
- [ ] Smoke test manuel des endpoints Enedis post-merge
- [ ] Manual nav : cliquer rail Flex → /flex, voir les 5 cards
- [ ] Manual Sirene : onboarding from-sirene (3 étapes)

## Bugs P0 corrigés par les audits

1. **HWM mode incremental cassé** (Sprint 5 E2E) : `_get_high_water_marks()` lisait `max(id)` courant au lieu du dernier run completed → nouvelles rows ignorées
2. **kW→kWh conversion broken** (Sprint 4 audit) : `_query_promoted` ne sélectionnait pas `pas_minutes` → puissance kW retournée comme kWh
3. **Zero-value data loss** (Sprint 3 audit) : `or` operator perdait les valeurs 0.0 légitimes dans l'upsert
4. **No auth on promotion endpoints** : ajout gate + rate limit

## Breaking changes

Aucun. Le bridge dual-source garantit qu'aucun service existant ne casse (fallback vers MeterReading legacy si pas de données promues).

## Documentation

- 3 ADRs dans `docs/adr/006-008`
- Spec SF5 : `docs/specs/feature-enedis-sge-5-data-staging.md`
- Doctrine CDC skill : `.claude/skills/promeos-enedis/references/`
- Rapport exploration Enedis : `docs/audit/RAPPORT_ENEDIS_EXPLORATION.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)