### PR TITLE
feat(nav): strategic improvements (clean) — Flex module + CTAs + semantic search

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -67,6 +67,7 @@ const OnboardingPage = lazy(() => import('./pages/OnboardingPage'));
 const SireneOnboardingPage = lazy(() => import('./pages/SireneOnboardingPage'));
 const AperPage = lazy(() => import('./pages/AperPage'));
 const UsagesDashboardPage = lazy(() => import('./pages/UsagesDashboardPage'));
+const FlexPage = lazy(() => import('./pages/FlexPage'));
 
 function PageSuspense({ children }) {
   return (
@@ -472,6 +473,14 @@ function App() {
                       element={
                         <PageSuspense>
                           <ContractRadarPage />
+                        </PageSuspense>
+                      }
+                    />
+                    <Route
+                      path="/flex"
+                      element={
+                        <PageSuspense>
+                          <FlexPage />
                         </PageSuspense>
                       }
                     />

--- a/frontend/src/__tests__/nav_v7_parity.test.js
+++ b/frontend/src/__tests__/nav_v7_parity.test.js
@@ -76,15 +76,16 @@ describe('Nav V7 — Source guard (labels interdits)', () => {
 });
 
 describe('Nav V7 — Structure', () => {
-  it('5 modules visible in normal mode (rail stable)', () => {
+  it('6 modules visible in normal mode (+Flex strategic)', () => {
     const normalModules = NAV_MODULES.filter((m) => !m.expertOnly);
-    expect(normalModules).toHaveLength(5);
+    expect(normalModules).toHaveLength(6);
     expect(normalModules.map((m) => m.key)).toEqual([
       'cockpit',
       'conformite',
       'energie',
       'patrimoine',
       'achat',
+      'flex',
     ]);
   });
 
@@ -94,16 +95,16 @@ describe('Nav V7 — Structure', () => {
     expect(expertModules[0].key).toBe('admin');
   });
 
-  it('13 items visible in normal mode (1 page per concept, no tab duplicates)', () => {
+  it('14 items visible in normal mode (+Flex)', () => {
     const mainSections = NAV_SECTIONS.filter((s) => !s.expertOnly);
     const items = mainSections.flatMap((s) => getVisibleItems(s.items, false));
-    expect(items).toHaveLength(13);
+    expect(items).toHaveLength(14);
   });
 
   it('same count in expert mode (no expertOnly items left)', () => {
     const mainSections = NAV_SECTIONS.filter((s) => !s.expertOnly);
     const items = mainSections.flatMap((s) => getVisibleItems(s.items, true));
-    expect(items).toHaveLength(13);
+    expect(items).toHaveLength(14);
   });
 
   it('zero expertOnly items in main modules (tabs merged into parent pages)', () => {

--- a/frontend/src/__tests__/step24b_nav_clean.test.js
+++ b/frontend/src/__tests__/step24b_nav_clean.test.js
@@ -99,14 +99,14 @@ describe('Step 24b — CommandPalette hidden pages', () => {
 });
 
 describe('Step 24b — NavRail modules V7', () => {
-  it('NAV_MODULES has 6 entries (5 normal + admin expert)', () => {
+  it('NAV_MODULES has 7 entries (6 normal + admin expert)', () => {
     const src = fs.readFileSync(navFile, 'utf8');
     const start = src.indexOf('export const NAV_MODULES');
     const block = src.slice(start, start + 3000);
     const firstClose = block.indexOf('];');
     const moduleBlock = block.slice(0, firstClose);
     const keys = moduleBlock.match(/key:\s*['"][^'"]+['"]/g) || [];
-    expect(keys.length).toBe(6);
+    expect(keys.length).toBe(7);
   });
 
   it('NAV_MODULES V7 includes cockpit, conformite, energie, patrimoine, achat, admin', () => {

--- a/frontend/src/components/CrossModuleCTA.jsx
+++ b/frontend/src/components/CrossModuleCTA.jsx
@@ -1,0 +1,43 @@
+/**
+ * PROMEOS — Cross-Module CTA
+ * Bannière de suggestion pour transformer la nav passive en funnel.
+ * Usage: <CrossModuleCTA icon={Zap} title="..." desc="..." to="..." label="..." tint="violet" />
+ */
+import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+
+const TINT_CLASSES = {
+  violet: 'from-violet-50 to-purple-50 border-violet-100 text-violet-700 hover:bg-violet-100',
+  amber: 'from-amber-50 to-yellow-50 border-amber-100 text-amber-700 hover:bg-amber-100',
+  emerald: 'from-emerald-50 to-teal-50 border-emerald-100 text-emerald-700 hover:bg-emerald-100',
+  indigo: 'from-indigo-50 to-blue-50 border-indigo-100 text-indigo-700 hover:bg-indigo-100',
+  yellow: 'from-yellow-50 to-amber-50 border-yellow-100 text-yellow-700 hover:bg-yellow-100',
+};
+
+export default function CrossModuleCTA({ icon: Icon, title, desc, to, label, tint = 'violet' }) {
+  const tintClass = TINT_CLASSES[tint] || TINT_CLASSES.violet;
+  const [gradient, border, text, hover] = tintClass.split(' ');
+
+  return (
+    <Link
+      to={to}
+      className={`flex items-center gap-3 p-4 rounded-xl border ${border} bg-gradient-to-r ${gradient} transition-all group`}
+    >
+      {Icon && (
+        <div className="p-2 bg-white/80 rounded-lg shrink-0">
+          <Icon size={18} className={text} />
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        <h4 className={`text-sm font-semibold ${text}`}>{title}</h4>
+        <p className="text-xs text-gray-600 mt-0.5 truncate">{desc}</p>
+      </div>
+      <div
+        className={`flex items-center gap-1 px-3 py-1.5 rounded-lg bg-white/80 border ${border} text-xs font-medium ${text} group-hover:${hover} transition`}
+      >
+        {label}
+        <ArrowRight size={12} />
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/layout/NavPanel.jsx
+++ b/frontend/src/layout/NavPanel.jsx
@@ -5,7 +5,7 @@
  */
 import { useState, useEffect, useMemo, useCallback, useRef, Fragment } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
-import { Star, X, Search, Clock } from 'lucide-react';
+import { Star, X, Search, Clock, Sparkles } from 'lucide-react';
 import {
   getActiveSite,
   clearActiveSite,
@@ -336,6 +336,25 @@ export default function NavPanel({ activeModule, pins, onTogglePin, badges }) {
           <h2 className="text-sm font-semibold text-slate-800">{mod.label}</h2>
         </div>
         <p className="text-[11px] text-slate-400 mt-0.5 leading-snug">{mod.desc}</p>
+      </div>
+
+      {/* Demander à PROMEOS — entrée sémantique (ouvre CommandPalette via Ctrl+K) */}
+      <div className="px-2 pt-2">
+        <button
+          type="button"
+          onClick={() => {
+            const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true });
+            document.dispatchEvent(event);
+          }}
+          className="w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-[11px] text-slate-400 hover:text-slate-700 bg-slate-50/70 hover:bg-white border border-slate-200/60 rounded-md transition-all group"
+          aria-label="Demander à PROMEOS (Ctrl+K)"
+        >
+          <Sparkles size={11} className="text-violet-400 group-hover:text-violet-600 shrink-0" />
+          <span className="flex-1 truncate">Demander à PROMEOS&hellip;</span>
+          <kbd className="text-[9px] text-slate-400 bg-slate-100 rounded px-1 py-px font-mono">
+            ⌘K
+          </kbd>
+        </button>
       </div>
 
       {/* Quick actions — Raccourcis (expert only) */}

--- a/frontend/src/layout/NavRegistry.js
+++ b/frontend/src/layout/NavRegistry.js
@@ -59,6 +59,7 @@ import {
   Building,
   SearchCheck,
   PieChart,
+  Radio,
 } from 'lucide-react';
 
 /* ── Route → module mapping ── */
@@ -113,6 +114,9 @@ export const ROUTE_MODULE_MAP = {
   // Achat
   '/achat-energie': 'achat',
   '/renouvellements': 'achat',
+
+  // Flex
+  '/flex': 'flex',
 
   // Admin
   '/import': 'admin',
@@ -238,12 +242,21 @@ export const NAV_MODULES = [
     desc: 'Échéances & arbitrage énergie',
   },
   {
+    key: 'flex',
+    label: 'Flex',
+    icon: Radio,
+    tint: 'yellow',
+    expertOnly: false,
+    order: 6,
+    desc: 'Effacement & valorisation',
+  },
+  {
     key: 'admin',
     label: 'Administration',
     icon: Settings,
     tint: 'slate',
     expertOnly: true,
-    order: 6,
+    order: 7,
     desc: 'Import, utilisateurs et système',
   },
 ];
@@ -334,6 +347,23 @@ export const TINT_PALETTE = {
     pillBg: 'bg-violet-50',
     pillText: 'text-violet-700',
     pillRing: 'ring-violet-200/60',
+  },
+  yellow: {
+    headerBand: 'from-yellow-50/50 to-transparent',
+    panelHeader: 'from-yellow-50/30 to-transparent',
+    softBg: 'bg-yellow-50/40',
+    hoverBg: 'bg-yellow-50/30',
+    activeBg: 'bg-yellow-50/60',
+    activeText: 'text-yellow-700',
+    activeBorder: 'border-yellow-500',
+    railActiveBg: 'bg-yellow-50/70',
+    railActiveRing: 'ring-yellow-300/50',
+    railActiveText: 'text-yellow-600',
+    dot: 'bg-yellow-400',
+    icon: 'text-yellow-500',
+    pillBg: 'bg-yellow-50',
+    pillText: 'text-yellow-700',
+    pillRing: 'ring-yellow-200/60',
   },
   slate: {
     headerBand: 'from-slate-100/50 to-transparent',
@@ -646,13 +676,42 @@ export const NAV_SECTIONS = [
     ],
   },
 
+  // === FLEX (yellow) — valorisation effacement / NEBEF / Tempo ===
+  {
+    key: 'flex',
+    module: 'flex',
+    label: 'Flex',
+    expertOnly: false,
+    order: 6,
+    items: [
+      {
+        to: '/flex',
+        icon: Radio,
+        label: 'Flexibilité',
+        desc: 'Score, potentiel, effacement NEBEF',
+        keywords: [
+          'flex',
+          'flexibilite',
+          'nebef',
+          'effacement',
+          'tempo',
+          'capacite',
+          'fcr',
+          'afrr',
+          'valorisation',
+          'agregateur',
+        ],
+      },
+    ],
+  },
+
   // === ADMIN (slate) — module expertOnly ===
   {
     key: 'admin-data',
     module: 'admin',
     label: 'Données',
     expertOnly: true,
-    order: 6,
+    order: 7,
     items: [
       {
         to: '/import',

--- a/frontend/src/layout/__tests__/NavRegistry.test.js
+++ b/frontend/src/layout/__tests__/NavRegistry.test.js
@@ -25,18 +25,26 @@ import {
 
 /* ── Module definitions V7 ── */
 describe('NAV_MODULES V7', () => {
-  it('has exactly 6 modules (5 normal + admin expert)', () => {
-    expect(NAV_MODULES).toHaveLength(6);
+  it('has exactly 7 modules (6 normal + admin expert)', () => {
+    expect(NAV_MODULES).toHaveLength(7);
   });
 
   it('modules are in correct order with correct keys', () => {
     const keys = NAV_MODULES.map((m) => m.key);
-    expect(keys).toEqual(['cockpit', 'conformite', 'energie', 'patrimoine', 'achat', 'admin']);
+    expect(keys).toEqual([
+      'cockpit',
+      'conformite',
+      'energie',
+      'patrimoine',
+      'achat',
+      'flex',
+      'admin',
+    ]);
   });
 
-  it('order field is sequential 1-6', () => {
+  it('order field is sequential 1-7', () => {
     const orders = NAV_MODULES.map((m) => m.order);
-    expect(orders).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(orders).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
   it('each module has icon, label, tint, expertOnly, desc', () => {
@@ -51,15 +59,16 @@ describe('NAV_MODULES V7', () => {
     }
   });
 
-  it('normal mode shows 5 modules (rail stable)', () => {
+  it('normal mode shows 6 modules (+Flex strategic)', () => {
     const normal = NAV_MODULES.filter((m) => !m.expertOnly);
-    expect(normal).toHaveLength(5);
+    expect(normal).toHaveLength(6);
     expect(normal.map((m) => m.key)).toEqual([
       'cockpit',
       'conformite',
       'energie',
       'patrimoine',
       'achat',
+      'flex',
     ]);
   });
 
@@ -113,8 +122,8 @@ describe('MODULE_TINTS', () => {
 
 /* ── Section definitions V7 ── */
 describe('NAV_SECTIONS V7', () => {
-  it('has exactly 6 sections (one per module)', () => {
-    expect(NAV_SECTIONS).toHaveLength(6);
+  it('has exactly 7 sections (one per module)', () => {
+    expect(NAV_SECTIONS).toHaveLength(7);
   });
 
   it('every section references a valid module', () => {
@@ -176,18 +185,18 @@ describe('NAV_SECTIONS V7', () => {
 
 /* ── Expert filtering (item level) ── */
 describe('Expert filtering V7', () => {
-  it('normal mode: 13 visible items (1 page per concept)', () => {
+  it('normal mode: 14 visible items (+Flex)', () => {
     const normal = NAV_SECTIONS.filter((s) => !s.expertOnly).flatMap((s) =>
       getVisibleItems(s.items, false)
     );
-    expect(normal).toHaveLength(13);
+    expect(normal).toHaveLength(14);
   });
 
-  it('expert mode: same 13 items (no expertOnly items left)', () => {
+  it('expert mode: same 14 items (no expertOnly items left)', () => {
     const expert = NAV_SECTIONS.filter((s) => !s.expertOnly).flatMap((s) =>
       getVisibleItems(s.items, true)
     );
-    expect(expert).toHaveLength(13);
+    expect(expert).toHaveLength(14);
   });
 
   it('zero expert-only items (all tabs merged into parent pages)', () => {
@@ -477,8 +486,8 @@ describe('NAV_MAIN_SECTIONS', () => {
     expect(adminInMain).toBeUndefined();
   });
 
-  it('has 5 main sections', () => {
-    expect(NAV_MAIN_SECTIONS).toHaveLength(5);
+  it('has 6 main sections (+Flex)', () => {
+    expect(NAV_MAIN_SECTIONS).toHaveLength(6);
   });
 
   it('is synchronized with NAV_SECTIONS (same items)', () => {

--- a/frontend/src/pages/Cockpit.jsx
+++ b/frontend/src/pages/Cockpit.jsx
@@ -4,7 +4,17 @@
  */
 import { useMemo, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FileText, ArrowRight, Search, AlertTriangle, Clock } from 'lucide-react';
+import {
+  FileText,
+  ArrowRight,
+  Search,
+  AlertTriangle,
+  Clock,
+  ShieldCheck,
+  ShoppingCart,
+  Radio,
+} from 'lucide-react';
+import CrossModuleCTA from '../components/CrossModuleCTA';
 import { useScope } from '../contexts/ScopeContext';
 import { useExpertMode } from '../contexts/ExpertModeContext';
 import { useActionDrawer } from '../contexts/ActionDrawerContext';
@@ -453,6 +463,34 @@ const Cockpit = () => {
         </div>
       }
     >
+      {/* ── Cross-module funnel CTAs (stratégique : Accueil → modules valeur) ── */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
+        <CrossModuleCTA
+          icon={ShieldCheck}
+          title="Conformité"
+          desc="Score, obligations à traiter"
+          to="/conformite"
+          label="Voir"
+          tint="emerald"
+        />
+        <CrossModuleCTA
+          icon={ShoppingCart}
+          title="Arbitrer vos achats"
+          desc="Scénarios & échéances"
+          to="/achat-energie"
+          label="Achat"
+          tint="violet"
+        />
+        <CrossModuleCTA
+          icon={Radio}
+          title="Valoriser flex"
+          desc="Effacement, Tempo, capacité"
+          to="/flex"
+          label="Flex"
+          tint="yellow"
+        />
+      </div>
+
       {/* ── Error banner ── */}
       {error && (
         <ErrorState

--- a/frontend/src/pages/ConformitePage.jsx
+++ b/frontend/src/pages/ConformitePage.jsx
@@ -7,7 +7,7 @@
  */
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ShieldCheck, Plus, RotateCcw, RefreshCw, Coins } from 'lucide-react';
+import { ShieldCheck, Plus, RotateCcw, RefreshCw, Coins, ShoppingCart, Radio } from 'lucide-react';
 import { toUsages } from '../services/routes';
 import { Button, PageShell, ActiveFiltersBar, Explain } from '../ui';
 import ObligationsTab from './conformite-tabs/ObligationsTab';
@@ -34,6 +34,7 @@ import { SkeletonKpi, SkeletonTable } from '../ui/Skeleton';
 import { buildWatchlist, buildBriefing, computeHealthState } from '../models/dashboardEssentials';
 import { computeObligationProfileTags } from '../models/complianceProfileRules';
 import HealthSummary from '../components/HealthSummary';
+import CrossModuleCTA from '../components/CrossModuleCTA';
 import DossierPrintView from '../components/DossierPrintView';
 import RegulatoryTimeline from '../components/compliance/RegulatoryTimeline';
 import { REG_LABELS, STATUT_LABELS, COCKPIT_TABS } from '../domain/compliance/complianceLabels.fr';
@@ -624,6 +625,26 @@ export default function ConformitePage() {
       {isExpert && complianceHealth && (
         <HealthSummary healthState={complianceHealth} onNavigate={navigate} compact />
       )}
+
+      {/* Cross-module CTAs — transforme la nav passive en funnel */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 my-4">
+        <CrossModuleCTA
+          icon={ShoppingCart}
+          title="Arbitrer vos contrats énergie"
+          desc="Comparer scénarios d'achat alignés avec vos obligations"
+          to="/achat-energie"
+          label="Scénarios"
+          tint="violet"
+        />
+        <CrossModuleCTA
+          icon={Radio}
+          title="Valoriser vos flexibilités"
+          desc="Effacement NEBEF, Tempo, capacité — gisements détectés"
+          to="/flex"
+          label="Flex"
+          tint="yellow"
+        />
+      </div>
 
       {/* Step 21: Compliance Summary Banner — messages actionnables */}
       {summary && (

--- a/frontend/src/pages/FlexPage.jsx
+++ b/frontend/src/pages/FlexPage.jsx
@@ -10,7 +10,7 @@ import FlexPotentialCard from '../components/flex/FlexPotentialCard';
 import FlexScoreCard from '../components/flex/FlexScoreCard';
 import TariffWindowsCard from '../components/flex/TariffWindowsCard';
 import FlexNebcoCard from '../components/usages/FlexNebcoCard';
-import ScopeSummary from '../components/ScopeSummary';
+import { ScopeSummary } from '../ui';
 
 export default function FlexPage() {
   return (

--- a/frontend/src/pages/FlexPage.jsx
+++ b/frontend/src/pages/FlexPage.jsx
@@ -1,0 +1,69 @@
+/**
+ * PROMEOS — Flex (module stratégique)
+ * Route: /flex
+ * Vue portefeuille flexibilité : scoring, quick wins, potentiel NEBEF/FCR/Tempo.
+ */
+import { PageShell } from '../ui';
+import { Zap, TrendingUp, Target } from 'lucide-react';
+import FlexPortfolioSummary from '../components/flex/FlexPortfolioSummary';
+import FlexPotentialCard from '../components/flex/FlexPotentialCard';
+import FlexScoreCard from '../components/flex/FlexScoreCard';
+import TariffWindowsCard from '../components/flex/TariffWindowsCard';
+import FlexNebcoCard from '../components/usages/FlexNebcoCard';
+import ScopeSummary from '../components/ScopeSummary';
+
+export default function FlexPage() {
+  return (
+    <PageShell icon={Zap} title="Flexibilité énergétique" subtitle={<ScopeSummary />}>
+      <div className="space-y-5 max-w-7xl">
+        {/* Intro éditoriale */}
+        <div className="bg-gradient-to-r from-yellow-50 to-amber-50 border border-amber-100 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <div className="p-2 bg-amber-100 rounded-lg">
+              <TrendingUp size={18} className="text-amber-700" />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-gray-900 mb-1">
+                Transformez vos contraintes tarifaires en revenus
+              </h3>
+              <p className="text-xs text-gray-600 leading-relaxed">
+                PROMEOS identifie automatiquement les gisements de flexibilité sur votre
+                portefeuille : effacement NEBEF, participation capacité, arbitrage HP/HC dynamique,
+                Tempo Bleu/Blanc/Rouge. Chaque site est scoré sur son potentiel économique annuel.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Portfolio summary */}
+        <FlexPortfolioSummary />
+
+        {/* Cards row */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FlexScoreCard />
+          <FlexPotentialCard />
+        </div>
+
+        {/* Tariff windows + NEBCO */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <TariffWindowsCard />
+          <FlexNebcoCard />
+        </div>
+
+        {/* Call to action */}
+        <div className="bg-gray-50 border border-gray-200 rounded-xl p-5 flex items-center gap-4">
+          <Target size={24} className="text-violet-600 shrink-0" />
+          <div className="flex-1">
+            <h4 className="text-sm font-semibold text-gray-900">
+              Prêt à valoriser vos effacements ?
+            </h4>
+            <p className="text-xs text-gray-600">
+              PROMEOS vous met en relation avec les agrégateurs NEBEF partenaires (commission
+              marketplace).
+            </p>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}


### PR DESCRIPTION
## Summary
Version propre des 3 améliorations stratégiques nav, indépendante du travail Enedis/Sirene en cours sur \`feat/nav-strategic\`.

- **STRAT1** Module Flex (6ème module normal) — Flex.jsx route, composants existants réutilisés
- **STRAT2** CrossModuleCTA réutilisable — 5 CTAs (3 Cockpit + 2 Conformité)
- **STRAT3** "Demander à PROMEOS" — bouton sémantique NavPanel ⌘K

## Test plan
- [x] 166/166 test files, 3861 tests pass
- [x] Prettier clean
- [x] Local build OK

🤖 Generated with [Claude Code](https://claude.ai/claude-code)