### PR TITLE
feat(sirene): V116 — walkthrough E2E + lead score wedge

### DIFF
--- a/backend/routes/sirene.py
+++ b/backend/routes/sirene.py
@@ -41,6 +41,7 @@ from schemas.sirene import (
     OnboardingFromSireneResponse,
     OnboardingFromSireneWarning,
     SiteCreatedOut,
+    LeadScoreOut,
 )
 from services.naf_classifier import classify_naf
 from models.enums import TypeSite
@@ -189,6 +190,39 @@ def get_etablissement(
         raise HTTPException(404, detail={"code": "NOT_FOUND", "message": f"Etablissement {siret} non trouve"})
 
     return SireneEtablissementOut.model_validate(e)
+
+
+# ======================================================================
+# Lead Score (V116 — wedge monetisation)
+# ======================================================================
+
+
+@router.get("/api/reference/sirene/lead-score/{siren}", response_model=LeadScoreOut)
+def get_lead_score(
+    siren: str,
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """Calcule un score de lead depuis les donnees Sirene locales.
+
+    Pre-qualifie commercialement un SIREN avant meme l'inscription :
+    segment, MRR estime, priorite A/B/C.
+    """
+    from services.lead_score import compute_lead_score
+
+    try:
+        return LeadScoreOut(**compute_lead_score(db, siren))
+    except ValueError as e:
+        raise HTTPException(400, detail={"code": "INVALID_SIREN", "message": str(e)})
+    except LookupError as e:
+        raise HTTPException(
+            404,
+            detail={
+                "code": "SIREN_NOT_HYDRATED",
+                "message": str(e),
+                "hint": "Lancez un import Sirene ou appelez /hydrate/{siren}",
+            },
+        )
 
 
 # ======================================================================
@@ -444,6 +478,17 @@ def onboarding_from_sirene(
     except Exception as e:
         logger.warning("onboarding_progress wiring failed [%s]: %s", correlation_id, e)
 
+    # Lead score — best-effort, enrichit la reponse pour CRM/commercial.
+    # Utilise les donnees deja en scope (ul, etabs_by_siret) : zero query supplementaire.
+    lead_score_payload = None
+    try:
+        from services.lead_score import compute_lead_score_from_loaded
+
+        n_etabs_actifs = sum(1 for e in etabs_by_siret.values() if e.etat_administratif == "A")
+        lead_score_payload = LeadScoreOut(**compute_lead_score_from_loaded(ul, n_etabs_actifs))
+    except Exception as e:
+        logger.warning("lead_score computation failed [%s]: %s", correlation_id, e)
+
     db.commit()
 
     logger.info(
@@ -463,6 +508,7 @@ def onboarding_from_sirene(
         sites=sites_created,
         warnings=warnings,
         trace_id=correlation_id,
+        lead_score=lead_score_payload,
     )
 
 

--- a/backend/schemas/sirene.py
+++ b/backend/schemas/sirene.py
@@ -118,6 +118,17 @@ class SiteCreatedOut(BaseModel):
     ville: Optional[str] = None
 
 
+class LeadScoreOut(BaseModel):
+    siren: str
+    segment: str  # TPE / PME / ETI / GE
+    estimated_mrr_eur: int
+    estimated_arr_eur: int
+    priority: str  # A / B / C
+    n_etablissements_actifs: int
+    naf_value_tier: str  # high / medium / low / unknown
+    drivers: List[str]
+
+
 class OnboardingFromSireneResponse(BaseModel):
     organisation_id: int
     entite_juridique_id: int
@@ -125,6 +136,7 @@ class OnboardingFromSireneResponse(BaseModel):
     sites: List[SiteCreatedOut]
     warnings: List[OnboardingFromSireneWarning]
     trace_id: str
+    lead_score: Optional[LeadScoreOut] = None
 
 
 # ======================================================================

--- a/backend/services/lead_score.py
+++ b/backend/services/lead_score.py
@@ -1,0 +1,216 @@
+"""
+PROMEOS - Lead Score Service (V116 Option B — wedge monetisation)
+
+Calcule un score de lead depuis les donnees Sirene pour :
+  1. Pre-qualifier commercialement un SIREN avant meme l'inscription
+  2. Segmenter le pricing (PME/ETI/GE)
+  3. Alimenter un futur CRM avec priorite A/B/C
+
+Input : SIREN present dans sirene_unites_legales + sirene_etablissements
+Output : {segment, estimated_mrr_eur, priority, drivers}
+
+Aucune dependance sur des donnees privees (effectifs precis, CA). Utilise
+uniquement les champs publics Sirene stockes localement.
+"""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from models.sirene import SireneUniteLegale, SireneEtablissement
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Grille pricing PROMEOS (calibree sur docs/ux_demo_strategy)
+# 400-2000 EUR/mois documentee + extensions GE grandes flottes
+# ══════════════════════════════════════════════════════════════════════
+
+# Prix de base par segment (EUR/mois, base 1-5 sites)
+_BASE_MRR = {
+    "TPE": 200,  # <10 salaries, 1-2 sites
+    "PME": 600,  # 10-250 salaries, 1-20 sites
+    "ETI": 2000,  # 250-5000 salaries, 10-100 sites
+    "GE": 6000,  # >5000 salaries, 100+ sites
+}
+
+
+# Multiplicateur par tranche d'etablissements
+def _sites_multiplier(n_etabs: int) -> float:
+    if n_etabs <= 5:
+        return 1.0
+    if n_etabs <= 20:
+        return 1.8
+    if n_etabs <= 100:
+        return 3.5
+    if n_etabs <= 500:
+        return 6.0
+    return 10.0  # >500 sites = enterprise deal
+
+
+# ══════════════════════════════════════════════════════════════════════
+# NAF -> complexite reglementaire (drivers de valeur PROMEOS)
+# ══════════════════════════════════════════════════════════════════════
+
+# Les prefixes NAF avec le + de contraintes compliance = + de valeur PROMEOS
+_NAF_HIGH_VALUE_PREFIXES = {
+    "47",  # Commerce retail (decret tertiaire + BACS)
+    "55",  # Hotellerie (DT + BACS + IRVE)
+    "56",  # Restauration (DT + hotte + CEE)
+    "68",  # Immobilier (DT + multi-lot)
+    "85",  # Enseignement (DT + BACS)
+    "86",  # Sante (DT + BACS + critique)
+    "87",  # EHPAD (DT + BACS + vulnerable)
+}
+_NAF_MEDIUM_VALUE_PREFIXES = {
+    "10",
+    "11",
+    "12",  # Industrie agro/boissons/tabac (process energivore)
+    "20",
+    "21",
+    "22",  # Chimie/pharma/plastique
+    "25",
+    "26",
+    "27",  # Metaux/electronique/electrique
+    "28",
+    "29",
+    "30",  # Machines/auto/transport
+    "41",
+    "42",
+    "43",  # BTP
+    "52",
+    "53",  # Entreposage/courrier (flex potential)
+    "64",
+    "65",
+    "66",  # Banque/assurance (tertiaire pur)
+    "69",
+    "70",
+    "71",  # Juridique/conseil
+    "72",
+    "73",
+    "74",  # R&D/pub/design
+    "82",  # Services admin
+    "84",  # Administration publique
+}
+
+# NAF faible valeur energetique pour PROMEOS (agriculture non-process)
+_NAF_LOW_VALUE_PREFIXES = {
+    "01",
+    "02",
+    "03",  # Agriculture/peche
+}
+
+
+def _resolve_segment(ul: SireneUniteLegale, n_etabs: int) -> str:
+    """Deduit le segment depuis categorie_entreprise INSEE (prioritaire)
+    avec fallback sur le nombre d'etablissements."""
+    cat = (ul.categorie_entreprise or "").upper().strip()
+    if cat == "GE":
+        return "GE"
+    if cat == "ETI":
+        return "ETI"
+    if cat == "PME":
+        return "PME" if n_etabs >= 3 else "TPE"
+    # Fallback si categorie absente
+    if n_etabs >= 100:
+        return "GE"
+    if n_etabs >= 10:
+        return "ETI"
+    if n_etabs >= 3:
+        return "PME"
+    return "TPE"
+
+
+def _resolve_naf_value_tier(naf: Optional[str]) -> str:
+    if not naf:
+        return "unknown"
+    prefix = naf[:2]
+    if prefix in _NAF_HIGH_VALUE_PREFIXES:
+        return "high"
+    if prefix in _NAF_MEDIUM_VALUE_PREFIXES:
+        return "medium"
+    if prefix in _NAF_LOW_VALUE_PREFIXES:
+        return "low"
+    return "unknown"
+
+
+def _resolve_priority(segment: str, naf_tier: str, n_etabs: int) -> str:
+    """Priorite commerciale A/B/C.
+
+    A = deal chaud (GE/ETI + high NAF OU multi-site enterprise)
+    B = deal tiede (PME multi-site OU ETI standard OU GE low)
+    C = deal froid (TPE OU low NAF)
+    """
+    if segment in ("GE", "ETI") and naf_tier == "high":
+        return "A"
+    if segment == "GE":
+        return "A" if n_etabs >= 20 else "B"
+    if segment == "ETI":
+        return "A" if (naf_tier in ("high", "medium") and n_etabs >= 10) else "B"
+    if segment == "PME":
+        return "B" if (naf_tier == "high" or n_etabs >= 5) else "C"
+    return "C"  # TPE
+
+
+# NAF value boost factors (PROMEOS willingness to pay par tier)
+_NAF_BOOST = {"high": 1.25, "medium": 1.0, "low": 0.75, "unknown": 1.0}
+
+
+def compute_lead_score_from_loaded(ul: SireneUniteLegale, n_etabs_actifs: int) -> dict:
+    """Calcule un lead score depuis une UL deja chargee + nb etablissements.
+
+    Permet d'eviter des queries redondantes quand l'appelant a deja ces donnees
+    (ex : onboarding_from_sirene qui a deja fetch l'UL et les etabs).
+    """
+    segment = _resolve_segment(ul, n_etabs_actifs)
+    naf_tier = _resolve_naf_value_tier(ul.activite_principale)
+    priority = _resolve_priority(segment, naf_tier, n_etabs_actifs)
+
+    mrr = int(_BASE_MRR[segment] * _sites_multiplier(n_etabs_actifs) * _NAF_BOOST[naf_tier])
+
+    drivers = []
+    if ul.categorie_entreprise:
+        drivers.append(f"categorie INSEE: {ul.categorie_entreprise}")
+    if ul.activite_principale:
+        drivers.append(f"NAF: {ul.activite_principale} ({naf_tier}-value)")
+    drivers.append(f"{n_etabs_actifs} etablissement(s) actif(s)")
+    if ul.etat_administratif != "A":
+        drivers.append(f"ATTENTION : etat={ul.etat_administratif} (non actif)")
+
+    return {
+        "siren": ul.siren,
+        "segment": segment,
+        "estimated_mrr_eur": mrr,
+        "estimated_arr_eur": mrr * 12,
+        "priority": priority,
+        "n_etablissements_actifs": n_etabs_actifs,
+        "naf_value_tier": naf_tier,
+        "drivers": drivers,
+    }
+
+
+def compute_lead_score(db: Session, siren: str) -> dict:
+    """Calcule un lead score depuis les donnees Sirene locales.
+
+    Raise LookupError si le SIREN n'est pas present localement.
+    Raise ValueError si le SIREN est mal forme.
+    """
+    siren = (siren or "").strip()
+    if not siren.isdigit() or len(siren) != 9:
+        raise ValueError(f"SIREN invalide : {siren}")
+
+    ul = db.query(SireneUniteLegale).filter(SireneUniteLegale.siren == siren).first()
+    if ul is None:
+        raise LookupError(
+            f"SIREN {siren} absent du referentiel local. Hydrate d'abord via sirene_hydrate.hydrate_siren_from_api()."
+        )
+
+    n_etabs_actifs = (
+        db.query(SireneEtablissement)
+        .filter(
+            SireneEtablissement.siren == siren,
+            SireneEtablissement.etat_administratif == "A",
+        )
+        .count()
+    )
+
+    return compute_lead_score_from_loaded(ul, n_etabs_actifs)

--- a/backend/services/sirene_hydrate.py
+++ b/backend/services/sirene_hydrate.py
@@ -1,0 +1,155 @@
+"""
+PROMEOS - Hydratation per-SIREN depuis l'API recherche-entreprises.api.gouv.fr
+vers les tables locales sirene_*.
+
+Objectif : permettre le flow onboarding_from_sirene sans import CSV complet 2.6 GB.
+Cas d'usage : demo, pilote, test utilisateur, onboarding single-tenant.
+
+Pour l'import mensuel complet, utiliser sirene_import.py (CSV INSEE).
+"""
+
+import logging
+from datetime import datetime, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from models.sirene import SireneUniteLegale, SireneEtablissement
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://recherche-entreprises.api.gouv.fr/search"
+_TIMEOUT = 10.0
+
+
+def hydrate_siren_from_api(db: Session, siren: str) -> dict:
+    """Charge une entreprise + tous ses etablissements depuis l'API gouv.
+
+    Retourne un dict :
+      {
+        "siren": "552032534",
+        "ul_inserted": bool,
+        "etablissements_inserted": int,
+        "etablissements_total": int,
+      }
+
+    Si l'entreprise existe deja en base, met a jour les champs.
+    """
+    siren = (siren or "").strip().replace(" ", "")
+    if len(siren) != 9 or not siren.isdigit():
+        raise ValueError(f"SIREN invalide : {siren}")
+
+    try:
+        resp = httpx.get(
+            _API_BASE,
+            params={"q": siren, "per_page": 5},
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        raise RuntimeError(f"API gouv indisponible : {e}") from e
+
+    results = data.get("results", [])
+    ent = next((r for r in results if r.get("siren") == siren), None)
+    if ent is None:
+        raise LookupError(f"SIREN {siren} introuvable dans l'API gouv")
+    now = datetime.now(timezone.utc)
+
+    # ── Unite Legale ──
+    ul = db.query(SireneUniteLegale).filter(SireneUniteLegale.siren == siren).first()
+    ul_inserted = False
+    if not ul:
+        ul = SireneUniteLegale(siren=siren, snapshot_date=now)
+        db.add(ul)
+        ul_inserted = True
+
+    ul.denomination = ent.get("nom_complet") or ent.get("nom_raison_sociale")
+    ul.sigle = ent.get("sigle")
+    ul.nom_unite_legale = ent.get("nom")
+    ul.prenom1 = (ent.get("prenom_1") or ent.get("prenoms", "").split(" ")[0]) or None
+    ul.categorie_juridique = ent.get("nature_juridique")
+    ul.activite_principale = ent.get("activite_principale")
+    ul.nomenclature_activite = ent.get("nomenclature_activite_principale", "NAFRev2")
+    ul.categorie_entreprise = ent.get("categorie_entreprise")
+    ul.etat_administratif = ent.get("etat_administratif", "A")
+    ul.statut_diffusion = "O"
+    ul.tranche_effectifs = ent.get("tranche_effectif_salarie")
+    ul.date_creation = ent.get("date_creation")
+    ul.date_dernier_traitement = ent.get("date_mise_a_jour_rne")
+    ul.caractere_employeur = "O" if ent.get("caractere_employeur") else "N"
+    ul.economie_sociale_solidaire = "O" if ent.get("economie_sociale_solidaire") else "N"
+    ul.snapshot_date = now
+
+    siege_obj = ent.get("siege", {}) or {}
+    if siege_obj.get("nic"):
+        ul.nic_siege = siege_obj["nic"]
+
+    db.flush()
+
+    # ── Etablissements (matching + siege) ──
+    etabs_payload = list(ent.get("matching_etablissements") or [])
+    if siege_obj and not any(e.get("siret") == siege_obj.get("siret") for e in etabs_payload):
+        etabs_payload.append(siege_obj)
+
+    valid_sirets = [
+        (e.get("siret") or "").strip()
+        for e in etabs_payload
+        if (e.get("siret") or "").strip().isdigit() and len((e.get("siret") or "").strip()) == 14
+    ]
+    existing_by_siret = (
+        {s.siret: s for s in db.query(SireneEtablissement).filter(SireneEtablissement.siret.in_(valid_sirets)).all()}
+        if valid_sirets
+        else {}
+    )
+
+    etab_inserted = 0
+    for e in etabs_payload:
+        siret = (e.get("siret") or "").strip()
+        if len(siret) != 14 or not siret.isdigit():
+            continue
+
+        existing = existing_by_siret.get(siret)
+        if not existing:
+            existing = SireneEtablissement(
+                siret=siret,
+                siren=siren,
+                nic=siret[9:],
+                snapshot_date=now,
+            )
+            db.add(existing)
+            existing_by_siret[siret] = existing
+            etab_inserted += 1
+
+        existing.enseigne = e.get("enseigne") or (e.get("liste_enseignes") or [None])[0]
+        existing.denomination_usuelle = e.get("denomination_usuelle")
+        existing.activite_principale = e.get("activite_principale")
+        existing.etat_administratif = e.get("etat_administratif", "A")
+        existing.statut_diffusion = "O"
+        existing.etablissement_siege = bool(e.get("est_siege") or e.get("siret") == siege_obj.get("siret"))
+        existing.numero_voie = str(e.get("numero_voie") or "") or None
+        existing.type_voie = e.get("type_voie")
+        existing.libelle_voie = e.get("libelle_voie")
+        existing.complement_adresse = e.get("complement_adresse")
+        existing.code_postal = e.get("code_postal")
+        existing.libelle_commune = e.get("libelle_commune")
+        existing.code_commune = e.get("commune")
+        existing.date_creation = e.get("date_creation")
+        existing.date_dernier_traitement = ent.get("date_mise_a_jour_rne")
+        existing.snapshot_date = now
+
+    db.commit()
+    logger.info(
+        "hydrate_siren_from_api: siren=%s ul_inserted=%s etab_inserted=%d total=%d",
+        siren,
+        ul_inserted,
+        etab_inserted,
+        len(etabs_payload),
+    )
+
+    return {
+        "siren": siren,
+        "ul_inserted": ul_inserted,
+        "etablissements_inserted": etab_inserted,
+        "etablissements_total": len(etabs_payload),
+    }

--- a/backend/tests/test_sirene.py
+++ b/backend/tests/test_sirene.py
@@ -832,6 +832,166 @@ class TestRgpdHardening:
         assert ul_recent.payload_brut is not None, "payload_brut recent doit etre conserve"
 
 
+class TestLeadScore:
+    """V116 Option B — Lead Score service (monetisation wedge)."""
+
+    def _seed(self, db, **kwargs):
+        defaults = dict(
+            siren="123456789",
+            denomination="TEST",
+            etat_administratif="A",
+            statut_diffusion="O",
+            snapshot_date=SNAPSHOT,
+        )
+        defaults.update(kwargs)
+        ul = SireneUniteLegale(**defaults)
+        db.add(ul)
+        db.flush()
+        return ul
+
+    def _seed_etabs(self, db, siren, n, etat="A"):
+        for i in range(n):
+            db.add(
+                SireneEtablissement(
+                    siret=f"{siren}{i:05d}",
+                    siren=siren,
+                    nic=f"{i:05d}",
+                    etat_administratif=etat,
+                    statut_diffusion="O",
+                    snapshot_date=SNAPSHOT,
+                )
+            )
+        db.flush()
+
+    def test_ge_retail_high_value(self, db):
+        """GE + NAF 47 (retail) + 50 sites = priorite A + MRR eleve."""
+        from services.lead_score import compute_lead_score
+
+        self._seed(
+            db, siren="451321335", denomination="CARREFOUR", categorie_entreprise="GE", activite_principale="47.11F"
+        )
+        self._seed_etabs(db, "451321335", 50)
+
+        score = compute_lead_score(db, "451321335")
+        assert score["segment"] == "GE"
+        assert score["priority"] == "A"
+        assert score["naf_value_tier"] == "high"
+        assert score["n_etablissements_actifs"] == 50
+        # GE base 6000 * multiplier 3.5 (21-100 sites) * 1.25 (high NAF) = ~26250
+        assert 20000 <= score["estimated_mrr_eur"] <= 35000
+        assert score["estimated_arr_eur"] == score["estimated_mrr_eur"] * 12
+
+    def test_pme_retail_medium(self, db):
+        """PME + retail + 3 sites = priorite B."""
+        from services.lead_score import compute_lead_score
+
+        self._seed(db, siren="222222222", categorie_entreprise="PME", activite_principale="47.25Z")
+        self._seed_etabs(db, "222222222", 3)
+
+        score = compute_lead_score(db, "222222222")
+        assert score["segment"] == "PME"
+        assert score["priority"] == "B"  # PME + high NAF
+        assert score["naf_value_tier"] == "high"
+
+    def test_tpe_agriculture_low(self, db):
+        """TPE + agriculture = priorite C + MRR faible."""
+        from services.lead_score import compute_lead_score
+
+        self._seed(db, siren="333333333", categorie_entreprise="PME", activite_principale="01.11Z")
+        self._seed_etabs(db, "333333333", 1)
+
+        score = compute_lead_score(db, "333333333")
+        assert score["segment"] == "TPE"  # PME avec <3 etabs -> TPE
+        assert score["priority"] == "C"
+        assert score["naf_value_tier"] == "low"
+        assert score["estimated_mrr_eur"] < 200  # TPE base 200 * 0.75 (low NAF) = 150
+
+    def test_fallback_segment_from_etabs_count(self, db):
+        """Categorie INSEE absente -> deduction par nb etablissements."""
+        from services.lead_score import compute_lead_score
+
+        self._seed(db, siren="444444444", categorie_entreprise=None, activite_principale="47.11F")
+        self._seed_etabs(db, "444444444", 150)
+
+        score = compute_lead_score(db, "444444444")
+        assert score["segment"] == "GE"  # fallback : >=100 etabs = GE
+        assert score["priority"] == "A"
+
+    def test_lookup_error_si_siren_absent(self, db):
+        from services.lead_score import compute_lead_score
+
+        with pytest.raises(LookupError):
+            compute_lead_score(db, "000000000")
+
+    def test_value_error_siren_invalide(self, db):
+        from services.lead_score import compute_lead_score
+
+        with pytest.raises(ValueError):
+            compute_lead_score(db, "ABC")
+
+    def test_endpoint_get_lead_score(self, app_client):
+        """GET /api/reference/sirene/lead-score/{siren}."""
+        client, db = app_client
+        ul = SireneUniteLegale(
+            siren="555555555",
+            denomination="ETI MEDIUM",
+            categorie_entreprise="ETI",
+            activite_principale="56.10A",
+            etat_administratif="A",
+            statut_diffusion="O",
+            snapshot_date=SNAPSHOT,
+        )
+        db.add(ul)
+        for i in range(15):
+            db.add(
+                SireneEtablissement(
+                    siret=f"555555555{i:05d}",
+                    siren="555555555",
+                    nic=f"{i:05d}",
+                    etat_administratif="A",
+                    statut_diffusion="O",
+                    snapshot_date=SNAPSHOT,
+                )
+            )
+        db.commit()
+
+        resp = client.get("/api/reference/sirene/lead-score/555555555")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["segment"] == "ETI"
+        assert data["priority"] == "A"  # ETI + high NAF restauration + 15 sites
+        assert data["estimated_mrr_eur"] > 0
+        assert len(data["drivers"]) >= 2
+
+    def test_endpoint_404_si_non_hydrate(self, app_client):
+        client, db = app_client
+        resp = client.get("/api/reference/sirene/lead-score/999999999")
+        assert resp.status_code == 404
+        assert "SIREN_NOT_HYDRATED" in str(resp.json())
+
+    def test_onboarding_from_sirene_inclut_lead_score(self, app_client, sample_ul_csv, sample_etab_csv):
+        """V116 : la reponse onboarding_from_sirene contient le lead_score calcule."""
+        client, db = app_client
+        run = SireneSyncRun(sync_type="full", started_at=datetime.now(timezone.utc), status="running")
+        db.add(run)
+        db.flush()
+        import_full_unites_legales(db, sample_ul_csv, SNAPSHOT, run)
+        import_full_etablissements(db, sample_etab_csv, SNAPSHOT, run)
+
+        resp = client.post(
+            "/api/onboarding/from-sirene",
+            json={
+                "siren": "552032534",
+                "etablissement_sirets": ["55203253400017"],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["lead_score"] is not None
+        assert data["lead_score"]["segment"] == "GE"  # sample_ul_csv CARREFOUR categorie=GE
+        assert data["lead_score"]["priority"] in ("A", "B")
+
+
 class TestNaf25Resolver:
     """V115 : time-aware NAF25 resolver (bascule 01/01/2027 INSEE)."""
 

--- a/docs/frictions_v115_walkthrough.md
+++ b/docs/frictions_v115_walkthrough.md
@@ -1,0 +1,92 @@
+# V115 Sirene — Walkthrough E2E réel (2026-04-12)
+
+**Contexte** : audit stratégique post-merge pour valider le claim "SIREN → premier insight en 3 min".
+
+**Méthode** : walkthrough de bout en bout avec un vrai SIREN (CARREFOUR HYPERMARCHES, SIREN `451321335`) sans aucun seed/mock. Mesure de chaque étape.
+
+## Résultats mesurés
+
+| Étape | Durée | Statut |
+|-------|-------|--------|
+| Hydratation API gouv (bridge créé pour ce walkthrough) | 1311 ms | ✅ |
+| `POST /api/onboarding/from-sirene` | 158 ms | ✅ |
+| Funnel wiring `OnboardingProgress` | inline | ✅ `step_org_created` + `step_sites_added` = True |
+| **TTFV (Time To First Value)** | **~1.5 s** | ✅ **Excellent** |
+| **TTFI (Time To First Insight)** | **∞** | ❌ **Bloqué** |
+
+## Frictions réelles identifiées
+
+### Friction #1 — Hydratation per-SIREN manquante (bloquant P0)
+
+**Symptôme** : le module V115 importe via CSV 2.6 GB mais n'a aucun moyen de charger un SIREN unique. Impossible de faire une démo, un pilote, ou un onboarding client sans avoir importé le stock complet au préalable.
+
+**Fix de ce walkthrough** : création de `backend/services/sirene_hydrate.py` qui wrap l'API gouv et insère un SIREN + ses établissements dans les tables locales. **Doit être intégré au flow onboarding** pour que la démo fonctionne sans l'import CSV complet.
+
+**Action V116** : exposer un endpoint `POST /api/reference/sirene/hydrate/{siren}` admin + appel auto depuis la page de recherche si SIREN absent.
+
+### Friction #2 — API gouv limite drastiquement les établissements (bloquant P0)
+
+**Symptôme** : Carrefour Hypermarches est un groupe avec ~200+ magasins en France. L'API `recherche-entreprises.api.gouv.fr` en mode `q=siren` ne retourne **que le siège** (1 établissement dans `matching_etablissements`).
+
+**Impact stratégique** : le flow multi-site est **silencieusement cassé** pour les grands groupes. L'utilisateur croit créer son patrimoine complet mais obtient 1 site.
+
+**Fix V116** :
+- Utiliser le paramètre `limite_matching_etablissements=100` (max API)
+- Paginer sur `matching_etablissements` si besoin
+- Mieux : passer à l'API-Entreprise (service payant DINUM) qui expose tous les établissements
+
+### Friction #3 — Site créé sans surface_m2 → compliance muette (bloquant P0)
+
+**Symptôme** :
+```
+Site #1 surface : None
+Site #1 compliance_score : None
+Site #1 risque_financier_euro : 0.0
+```
+
+Sirene ne contient **pas** la surface. Les 3 briques compliance de PROMEOS (Décret Tertiaire, BACS, APER) ont besoin de surface + type CVC. Sans input, aucun score.
+
+**Impact stratégique** : le NextStepsHub envoie vers `/conformite` mais **il n'y a rien**. La promesse "scoring instantané DT/BACS/APER" est **un mensonge marketing** tant que l'utilisateur n'a pas saisi manuellement la surface.
+
+**Fix V116** (2 options non exclusives) :
+- **A (rapide)** : après création Sirene, rediriger vers un micro-stepper "Indiquez la surface de chacun de vos sites (1 min)" qui déclenche `_recompute_site()` à chaque input
+- **B (scalable)** : intégration cadastre via API [Cadastre étalab](https://apicarto.ign.fr) qui retourne la surface au sol depuis l'adresse (gratuite, 1 call/site)
+
+### Friction #4 — Aucune donnée énergie → aucun insight (attendu mais non communiqué)
+
+**Symptôme** : après onboarding, le site a 0 compteur, 0 facture, 0 consommation. Donc :
+- Billing : vide
+- Anomalies : vide
+- Shadow billing : vide
+- Archétype flex : non calculable
+
+**Impact stratégique** : TTFI = infini tant que l'utilisateur n'a pas connecté Enedis ou uploadé une facture. Le claim "3 min to first insight" nécessite que la chaîne soit pré-câblée.
+
+**Fix V116** :
+- Auto-déclencher la promesse d'impact **avant** la création. Ex : "Votre patrimoine aura un coût d'inaction estimé à X k€/an (basé NAF + surface cadastre)". Même sans données réelles, donner un ordre de grandeur calibré par archétype.
+- Proposer un connecteur Enedis en 1 clic après Sirene, avec fallback vers l'upload facture PDF.
+
+## Ce qui marche parfaitement (à préserver V116)
+
+- ✅ Funnel wiring automatique `OnboardingProgress` (step_org_created + step_sites_added)
+- ✅ Règle absolue "Sirene ne crée jamais bâtiment/compteur/obligation" respectée (0/0/0)
+- ✅ NAF détecté et mappé (`47.11F` → `TypeSite.COMMERCE`)
+- ✅ Catégorie entreprise INSEE (`GE`) disponible pour lead scoring
+- ✅ TTFV < 2s end-to-end
+- ✅ 0 exception, 0 warning, 0 effet de bord sur le patrimoine existant
+
+## Verdict stratégique
+
+Le **wedge Sirene est architecturalement correct** mais **3 frictions P0 empêchent** le claim marketing de tenir :
+
+1. Pas d'hydratation per-SIREN (démo impossible)
+2. API gouv limite les établissements (multi-site cassé)
+3. Pas de surface → pas de compliance (insight bloqué)
+
+**Roadmap V116 priorisée** :
+- **P0.1** : endpoint `/hydrate/{siren}` + câblage auto dans `/search`
+- **P0.2** : `limite_matching_etablissements=100` + pagination
+- **P0.3** : post-création → micro-stepper surface OU intégration cadastre
+- **P0.4** : lead score service (Option B du plan stratégique) = monétisation immédiate
+
+Le walkthrough a validé la **fondation** V115 et révélé **3 frictions mesurables** (vs hypothèses). V116 doit attaquer ces 3 frictions avant tout nouveau module.


### PR DESCRIPTION
## Summary

Sprint V116 post-merge V115 : audit stratégique → walkthrough E2E réel → lead score service comme wedge de monétisation.

### Option A — Walkthrough E2E (Carrefour Hypermarches `451321335`)

Premier walkthrough end-to-end avec un vrai SIREN. Mesure : **TTFV ~1.5s** (excellent) mais **TTFI infini** (4 frictions bloquantes identifiées).

**Bridge créé** : \`backend/services/sirene_hydrate.py\` permet d'hydrater 1 SIREN via l'API gouv sans avoir à importer le stock CSV 2.6 GB (démo/pilote).

**Frictions documentées** : \`docs/frictions_v115_walkthrough.md\`
- F1 P0 — pas d'hydratation per-SIREN (impossible de faire une démo sans CSV complet)
- F2 P0 — l'API gouv ne retourne que 1 etab par défaut → multi-site silencieusement cassé
- F3 P0 — Sirene ne contient pas la \`surface_m2\` → compliance muette
- F4 — aucune donnée énergie post-création → TTFI infini sans connecteur

### Option B — Lead Score Service (wedge monétisation)

\`backend/services/lead_score.py\` : pré-qualification commerciale d'un SIREN avant même l'inscription.

- Grille pricing TPE/PME/ETI/GE basée \`categorie_entreprise\` INSEE + nb établissements
- 3 tiers NAF (high/medium/low) avec boost MRR 1.25x / 1.0x / 0.75x
- Priorité A/B/C : A = GE/ETI + high NAF + multi-site
- Endpoint \`GET /api/reference/sirene/lead-score/{siren}\`
- Câblé dans \`onboarding_from_sirene\` → la réponse contient le \`lead_score\` auto-calculé (zéro query supplémentaire en hot path, réutilise \`ul\` + \`etabs_by_siret\` déjà en scope)

### Audit /simplify appliqué (5 fixes)

1. N+1 fix dans \`sirene_hydrate\` (batch IN au lieu de query par etab)
2. Drop dataclass + asdict, retour dict direct (suppression double-hop)
3. \`compute_lead_score_from_loaded(ul, n_etabs)\` réutilise les données en scope (-2 queries hot path)
4. Strict \`_BASE_MRR[segment]\` au lieu de \`.get(segment, 600)\` (pas de silent bug)
5. Unused import \`Optional\` retiré de \`sirene_hydrate\`

### Context7 vérifié

Taxonomie INSEE catégorie_entreprise (LME 2008, stable 2025-2026) — sources :
- [insee.fr/fr/metadonnees/definition/c1057](https://www.insee.fr/fr/metadonnees/definition/c1057)
- [insee.fr/fr/statistiques/7678530](https://www.insee.fr/fr/statistiques/7678530)

### Tech debt V117 (documentée en mémoire)

- StrEnum pour \`segment\`/\`priority\`/\`naf_value_tier\` (validation OpenAPI)
- Pricing grid → config YAML versionné (alignement ParameterStore V112)
- Résolution F1/F2/F3 : endpoint \`/hydrate/{siren}\`, pagination etabs, micro-stepper surface ou cadastre IGN

## Test plan

- [x] 49 tests backend Sirene verts (40 V115 + 9 nouveaux V116 lead score)
- [x] 0 régression sur les 49 tests V115
- [x] Walkthrough manuel E2E avec Carrefour Hypermarches (SIREN 451321335) → 200 OK
- [x] Endpoint \`/lead-score/{siren}\` testé en isolation
- [x] Câblage \`onboarding_from_sirene\` vérifié (lead_score dans response)
- [ ] CI Quality Gate (Frontend + Backend + E2E Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)