### PR TITLE
feat(nav): role-based ordering + smart queries CommandPalette

### DIFF
--- a/frontend/src/__tests__/expertMode.test.js
+++ b/frontend/src/__tests__/expertMode.test.js
@@ -98,9 +98,9 @@ describe('D. Navigation — expert-only filtering', () => {
     expect(src).toContain('isExpert');
   });
 
-  it('NavRail filtre les modules expertOnly', () => {
+  it('NavRail uses getOrderedModules (role-based + expert filtering)', () => {
     const src = readSrc('layout/NavRail.jsx');
-    expect(src).toContain('expertOnly');
+    expect(src).toContain('getOrderedModules');
     expect(src).toContain('isExpert');
   });
 

--- a/frontend/src/layout/NavRail.jsx
+++ b/frontend/src/layout/NavRail.jsx
@@ -4,8 +4,9 @@
  * Tooltip on hover. Logo at top, expert badge at bottom.
  */
 import { TooltipPortal } from '../ui';
-import { NAV_MODULES, TINT_PALETTE } from './NavRegistry';
+import { TINT_PALETTE, getOrderedModules } from './NavRegistry';
 import { useExpertMode } from '../contexts/ExpertModeContext';
+import { useAuth } from '../contexts/AuthContext';
 
 /* ── Module → badge key mapping ── */
 const MODULE_BADGE_KEY = {
@@ -47,8 +48,10 @@ function RailIcon({ mod, isActive, onClick, badgeCount }) {
 /* ── Main Rail ── */
 export default function NavRail({ activeModule, onSelectModule, badges = {} }) {
   const { isExpert } = useExpertMode();
+  const { role } = useAuth();
 
-  const visibleModules = isExpert ? NAV_MODULES : NAV_MODULES.filter((m) => !m.expertOnly);
+  // Order modules based on user role (DG sees Achat first, EM sees Énergie first, etc.)
+  const visibleModules = getOrderedModules(role, isExpert);
 
   return (
     <div

--- a/frontend/src/layout/NavRegistry.js
+++ b/frontend/src/layout/NavRegistry.js
@@ -792,6 +792,40 @@ export function getModuleTint(keyOrPath) {
 }
 
 /* ══════════════════════════════════════════════════════════════════
+ * ROLE-BASED module ordering — each role sees its most relevant
+ * modules first on the rail. Fallback to default order.
+ * ══════════════════════════════════════════════════════════════════ */
+const ROLE_MODULE_ORDER = {
+  // Direction / finance : focus décisionnel
+  dg_owner: ['cockpit', 'achat', 'conformite', 'patrimoine', 'energie', 'flex'],
+  daf: ['cockpit', 'patrimoine', 'achat', 'conformite', 'energie', 'flex'],
+  acheteur: ['cockpit', 'achat', 'patrimoine', 'conformite', 'flex', 'energie'],
+
+  // Technique / opérationnel : focus données + action
+  energy_manager: ['cockpit', 'energie', 'flex', 'conformite', 'patrimoine', 'achat'],
+  resp_conformite: ['cockpit', 'conformite', 'patrimoine', 'energie', 'achat', 'flex'],
+  resp_immobilier: ['cockpit', 'patrimoine', 'conformite', 'energie', 'achat', 'flex'],
+  resp_site: ['cockpit', 'patrimoine', 'energie', 'conformite', 'achat', 'flex'],
+
+  // Default order (no role or unknown)
+  default: ['cockpit', 'conformite', 'energie', 'patrimoine', 'achat', 'flex'],
+};
+
+/**
+ * Reorders NAV_MODULES based on user role. Admin module always last.
+ * @param {string} role - User role key
+ * @param {boolean} isExpert - Expert mode (shows admin)
+ * @returns {Array} Ordered modules
+ */
+export function getOrderedModules(role, isExpert) {
+  const order = ROLE_MODULE_ORDER[role] || ROLE_MODULE_ORDER.default;
+  const byKey = Object.fromEntries(NAV_MODULES.map((m) => [m.key, m]));
+  const ordered = order.map((key) => byKey[key]).filter(Boolean);
+  if (isExpert && byKey.admin) ordered.push(byKey.admin);
+  return ordered;
+}
+
+/* ══════════════════════════════════════════════════════════════════
  * NAV_MAIN_SECTIONS — Miroir de NAV_SECTIONS utilisé par Breadcrumb.jsx.
  * Maintenu synchronisé avec NAV_SECTIONS (même labels, mêmes items).
  * ══════════════════════════════════════════════════════════════════ */

--- a/frontend/src/ui/CommandPalette.jsx
+++ b/frontend/src/ui/CommandPalette.jsx
@@ -17,6 +17,97 @@ import { useScope } from '../contexts/ScopeContext';
 
 const HITS_KEY = 'promeos_cmd_hits';
 
+/* ── Smart queries — structured syntax with direct actions ──
+ * Syntax: <scope>:<verb>  e.g. "sites:non-conformes", "factures:retard"
+ * Each query resolves to a direct navigation with filter params.
+ */
+const SMART_QUERIES = [
+  {
+    match: /^sites?\s*:\s*non[-\s]?conformes?$/i,
+    label: 'Sites non conformes',
+    subtitle: 'Filtre conformité : statut "non conforme"',
+    to: '/patrimoine?filter=non-conformes',
+    section: 'Query',
+  },
+  {
+    match: /^sites?\s*:\s*a[-\s]?evaluer$/i,
+    label: 'Sites à évaluer',
+    subtitle: 'Filtre : statut "à évaluer"',
+    to: '/patrimoine?filter=a-evaluer',
+    section: 'Query',
+  },
+  {
+    match: /^factures?\s*:\s*(retard|impay)/i,
+    label: 'Factures en retard',
+    subtitle: 'Bill Intel filtré sur anomalies de paiement',
+    to: '/bill-intel?filter=retard',
+    section: 'Query',
+  },
+  {
+    match: /^factures?\s*:\s*anomalies?$/i,
+    label: 'Factures avec anomalies',
+    subtitle: 'Écarts détectés par shadow billing',
+    to: '/bill-intel?filter=anomalies',
+    section: 'Query',
+  },
+  {
+    match: /^actions?\s*:\s*urgent/i,
+    label: 'Actions urgentes',
+    subtitle: 'Actions P0 en cours',
+    to: '/anomalies?tab=actions&priority=urgent',
+    section: 'Query',
+  },
+  {
+    match: /^actions?\s*:\s*(retard|en[-\s]?retard)/i,
+    label: 'Actions en retard',
+    subtitle: 'Actions dont la date limite est dépassée',
+    to: '/anomalies?tab=actions&filter=late',
+    section: 'Query',
+  },
+  {
+    match: /^conso\s*:\s*anomalies?$/i,
+    label: 'Anomalies de consommation',
+    subtitle: 'Diagnostic conso — insights détectés',
+    to: '/diagnostic-conso?filter=anomalies',
+    section: 'Query',
+  },
+  {
+    match: /^contrats?\s*:\s*echeance/i,
+    label: 'Contrats à échéance',
+    subtitle: 'Radar renouvellements',
+    to: '/renouvellements',
+    section: 'Query',
+  },
+  {
+    match: /^flex\s*:\s*(potentiel|opportunit)/i,
+    label: 'Gisements flex détectés',
+    subtitle: 'Sites avec potentiel NEBEF / effacement',
+    to: '/flex',
+    section: 'Query',
+  },
+  {
+    match: /^conformite\s*:\s*dt$/i,
+    label: 'Décret Tertiaire',
+    subtitle: 'Obligations DT sur le portefeuille',
+    to: '/conformite?tab=obligations&regulation=dt',
+    section: 'Query',
+  },
+  {
+    match: /^conformite\s*:\s*bacs$/i,
+    label: 'Pilotage bâtiment (BACS)',
+    subtitle: 'Obligations GTB/GTC',
+    to: '/conformite?tab=obligations&regulation=bacs',
+    section: 'Query',
+  },
+];
+
+/** Try to match query against smart syntax. Returns array of results or null. */
+function matchSmartQueries(query) {
+  const matched = SMART_QUERIES.filter((sq) => sq.match.test(query));
+  if (matched.length === 0) return null;
+  return matched.map((sq) => ({ type: 'query', ...sq }));
+}
+
 function loadHits() {
   try {
     return JSON.parse(localStorage.getItem(HITS_KEY) || '{}');
@@ -55,6 +146,11 @@ export default function CommandPalette({ open, onClose, onToggleExpert }) {
   const results = useMemo(() => {
     const q = query.toLowerCase().trim();
     const hits = hitsRef.current;
+
+    // Smart queries first (structured syntax like "sites:non-conformes")
+    const smart = q ? matchSmartQueries(q) : null;
+    if (smart) return smart;
+
     if (!q) {
       // Default: pages ranked by frequency, then shortcuts
       const pages = ALL_MAIN_ITEMS.map((item) => ({
@@ -191,6 +287,19 @@ export default function CommandPalette({ open, onClose, onToggleExpert }) {
               <p className="text-xs text-gray-300 mt-2">
                 Essayez : conformité, actions, patrimoine, monitoring...
               </p>
+              <div className="mt-3 text-[10px] text-gray-400 space-y-0.5">
+                <p className="font-semibold text-gray-500">Smart queries :</p>
+                <p>
+                  <code className="text-violet-500">sites:non-conformes</code> ·{' '}
+                  <code className="text-violet-500">factures:retard</code> ·{' '}
+                  <code className="text-violet-500">actions:urgent</code>
+                </p>
+                <p>
+                  <code className="text-violet-500">flex:potentiel</code> ·{' '}
+                  <code className="text-violet-500">contrats:echeance</code> ·{' '}
+                  <code className="text-violet-500">conformite:dt</code>
+                </p>
+              </div>
             </div>
           )}
           {results.map((item, idx) => {


### PR DESCRIPTION
## Summary
2 next-gen nav improvements that move PROMEOS from \"good B2B UI\" to \"system that knows you\":

### NAV1 — Role-based module ordering
Each role sees its highest-value modules first on the rail:

| Rôle | Ordre |
|---|---|
| DG / Owner | Cockpit, **Achat**, Conformité, Patrimoine, Énergie, Flex |
| DAF | Cockpit, **Patrimoine (facturation)**, Achat, Conformité, Énergie, Flex |
| Energy Manager | Cockpit, **Énergie, Flex**, Conformité, Patrimoine, Achat |
| Resp. Conformité | Cockpit, **Conformité**, Patrimoine, Énergie, Achat, Flex |
| Resp. Immobilier/Site | Cockpit, **Patrimoine**, Énergie, Conformité, Achat, Flex |

Implementation: new \`getOrderedModules(role, isExpert)\` helper in NavRegistry. NavRail consumes \`useAuth().role\`.

### NAV2 — Smart queries CommandPalette
Structured syntax \`<scope>:<verb>\` with 11 pre-baked queries:
- \`sites:non-conformes\`, \`sites:a-evaluer\`
- \`factures:retard\`, \`factures:anomalies\`
- \`actions:urgent\`, \`actions:retard\`
- \`conso:anomalies\`, \`contrats:echeance\`
- \`flex:potentiel\`, \`conformite:dt\`, \`conformite:bacs\`

Each resolves to a deep-linked URL with filter params. Empty-state hint shows examples for discoverability.

## Test plan
- [x] 166/166 test files, 3865 tests pass
- [x] Local build OK
- [x] Prettier clean
- [ ] Manual: login en DG → vérifier que Achat est en 2ème rail
- [ ] Manual: Ctrl+K → taper \`sites:non-conformes\` → lien direct

🤖 Generated with [Claude Code](https://claude.ai/claude-code)