### PR TITLE
feat(s22): Pilotage world-class — Flex Ready® + TURPE 7 HC + Enedis 2024

### DIFF
--- a/backend/ai_layer/agents/kb_context.py
+++ b/backend/ai_layer/agents/kb_context.py
@@ -1,0 +1,129 @@
+"""
+PROMEOS AI — KB Context Builder
+Helper pour enrichir les prompts LLM avec des items KB validés.
+
+HARD RULE : toute recommandation réglementaire DOIT s'appuyer sur des items KB
+validated (cf. app/kb/service.py doctrine).
+Usage :
+    from ai_layer.agents.kb_context import build_kb_context
+    kb_ctx = build_kb_context(site, domain="reglementaire")
+    user_prompt = f"{base_prompt}\n\n{kb_ctx['prompt_section']}"
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.kb.service import KBService
+
+logger = logging.getLogger(__name__)
+
+# Limite défensive : ne pas injecter plus de 15 items dans un prompt
+MAX_ITEMS_IN_PROMPT = 15
+
+
+def _site_to_context(site: Any) -> dict[str, Any]:
+    """Convertit un Site ORM en site_context pour KBService.apply().
+
+    Mapping : champs Site → champs scope/logic attendus par les items KB
+    (hvac_kw, surface_m2, building_type, energy_vector, segment...).
+    """
+    context: dict[str, Any] = {}
+
+    if getattr(site, "surface_m2", None):
+        context["surface_m2"] = site.surface_m2
+
+    if getattr(site, "type", None):
+        context["building_type"] = str(site.type).lower()
+
+    if getattr(site, "hvac_kw", None):
+        context["hvac_kw"] = site.hvac_kw
+
+    if getattr(site, "parking_surface_m2", None):
+        context["parking_surface_m2"] = site.parking_surface_m2
+
+    # Défaut énergie : site élec sauf indication contraire
+    context["energy_vector"] = getattr(site, "energy_vector", None) or "elec"
+
+    # Segment : le modèle Site n'a pas de champ segment clair, on infère depuis type
+    if context.get("building_type") in ("bureau", "commerce", "enseignement", "sante"):
+        context["segment"] = "tertiaire_multisite"
+
+    return context
+
+
+def _format_item_for_prompt(item: dict[str, Any]) -> str:
+    """Format un item KB en bloc texte concis pour LLM."""
+    lines = [f"**[{item['kb_item_id']}]** {item['title']}"]
+
+    for action in (item.get("actions") or [])[:3]:
+        label = action.get("label", "")
+        deadline = action.get("deadline")
+        suffix = f" (deadline {deadline})" if deadline else ""
+        lines.append(f"  • {label}{suffix}")
+
+    for src in (item.get("sources") or [])[:2]:
+        label = src.get("label", src.get("doc_id", "source"))
+        lines.append(f"  (src: {label})")
+
+    return "\n".join(lines)
+
+
+def build_kb_context(
+    site: Any,
+    domain: str | None = None,
+    allow_drafts: bool = False,
+) -> dict[str, Any]:
+    """Évalue la KB contre un Site et retourne le contexte à injecter dans le prompt.
+
+    Args:
+        site: instance ORM Site
+        domain: filtre optionnel (reglementaire/usages/acc/facturation/flex)
+        allow_drafts: False par défaut — HARD RULE doctrine PROMEOS
+
+    Returns:
+        dict avec :
+        - prompt_section: texte formaté à injecter dans le user_prompt
+        - applicable_items: liste brute des items matchés (pour traçabilité)
+        - kb_item_ids: liste des IDs (pour sources_used)
+        - missing_fields: champs absents de site_context (pour transparence)
+        - status: "ok" / "partial" / "insufficient" / "error"
+    """
+    try:
+        svc = KBService()
+        site_context = _site_to_context(site)
+        result = svc.apply(site_context, domain=domain, allow_drafts=allow_drafts)
+    except Exception:
+        logger.warning("KB apply failed for site, returning empty context", exc_info=True)
+        return {
+            "prompt_section": "",
+            "applicable_items": [],
+            "kb_item_ids": [],
+            "missing_fields": [],
+            "status": "error",
+        }
+
+    items = (result.get("applicable_items") or [])[:MAX_ITEMS_IN_PROMPT]
+
+    if not items:
+        prompt_section = (
+            "AUCUN ITEM KB VALIDÉ NE CORRESPOND À CE SITE.\n"
+            "N'invente PAS de fait réglementaire. Indique explicitement le manque de données."
+        )
+    else:
+        blocks = [_format_item_for_prompt(i) for i in items]
+        prompt_section = (
+            "ITEMS KB VALIDÉS APPLICABLES À CE SITE (à utiliser STRICTEMENT comme source) :\n\n"
+            + "\n\n".join(blocks)
+            + "\n\nRÈGLE : ne cite que ces items. Si une info n'est pas dans la liste, écris "
+            "'Non couvert par la KB' — n'invente JAMAIS un décret, une date ou un seuil."
+        )
+
+    return {
+        "prompt_section": prompt_section,
+        "applicable_items": items,
+        "kb_item_ids": [i["kb_item_id"] for i in items],
+        "missing_fields": result.get("missing_fields", []),
+        "status": result.get("status", "ok"),
+    }

--- a/backend/ai_layer/agents/regops_explainer.py
+++ b/backend/ai_layer/agents/regops_explainer.py
@@ -1,27 +1,34 @@
 """
 PROMEOS AI - RegOps Explainer (2-min site brief)
 Live Claude API + fallback stub.
+
+HARD RULE doctrine PROMEOS : toute recommandation réglementaire DOIT
+s'appuyer sur des items KB validated (cf. app/kb/service.py).
+Le prompt est enrichi avec KBService.apply() avant appel LLM.
 """
 
 import json
-from datetime import datetime
-from models import Site, AiInsight, InsightType
+
+from models import AiInsight, InsightType, Site
+
 from ..client import get_client
+from .kb_context import build_kb_context
 
 SYSTEM_PROMPT = """Tu es un expert en réglementation énergétique française pour les bâtiments tertiaires.
 Contexte PROMEOS : plateforme B2B de gestion énergétique multi-sites, post-ARENH/VNU (depuis 01/01/2026).
 
 Tu dois :
 - Fournir un brief concis (3-5 paragraphes) sur le statut réglementaire du site
-- Citer les obligations applicables (Décret Tertiaire, BACS, DPE, OPERAT)
+- T'appuyer EXCLUSIVEMENT sur les items KB validés fournis dans le contexte
+- NE PAS inventer de faits réglementaires absents des items KB (pas de décret ni date ni seuil hors liste)
 - Utiliser les unités : kWh, m², €, dates au format FR (JJ/MM/AAAA)
-- Citer tes sources : données du site, règles réglementaires applicables
-- Identifier les risques et recommander des actions prioritaires
+- Citer les IDs des items KB utilisés (ex: [BACS-290KW], [DT-SCOPE-1000M2])
+- Identifier les risques et recommander des actions prioritaires tirées des items KB
 
-Format de sortie : JSON structuré avec les clés : brief, risks, recommendations, sources"""
+Format de sortie : JSON structuré avec les clés : brief, risks, recommendations, sources, kb_item_ids"""
 
 
-def _build_user_prompt(site):
+def _build_user_prompt(site, kb_context):
     return f"""Site : {site.nom}
 Type : {site.type or "Non renseigné"}
 Surface : {site.surface_m2 or 0} m²
@@ -33,19 +40,38 @@ Statut réglementaire :
 - Risque financier : {site.risque_financier_euro or 0} EUR
 - Avancement décret : {getattr(site, "avancement_decret_pct", 0) or 0}%
 
-Génère un brief réglementaire de 2 minutes pour ce site."""
+{kb_context["prompt_section"]}
+
+Génère un brief réglementaire de 2 minutes pour ce site, en t'appuyant STRICTEMENT
+sur les items KB listés ci-dessus."""
 
 
-def _stub_response(site):
-    """Fallback déterministe quand l'IA n'est pas disponible."""
+def _stub_response(site, kb_context):
+    """Fallback déterministe quand l'IA n'est pas disponible.
+
+    Même en stub, on s'appuie sur les items KB pour ne pas halluciner.
+    """
+    items = kb_context.get("applicable_items", [])
+    item_ids = kb_context.get("kb_item_ids", [])
+
+    if items:
+        applicable_summary = ", ".join(f"{i['title'][:60]} [{i['kb_item_id']}]" for i in items[:3])
+        brief = (
+            f"[Stub KB] Site {site.nom} ({site.surface_m2 or 0} m²). "
+            f"{len(items)} item(s) KB applicable(s) : {applicable_summary}. "
+            f"Statut : {site.statut_decret_tertiaire or 'non évalué'}. "
+            f"Risque : {site.risque_financier_euro or 0} EUR."
+        )
+    else:
+        brief = (
+            f"[Stub KB] Site {site.nom}. Aucun item KB validé applicable au contexte "
+            f"actuel. Vérifier la qualité des données du site (surface, puissance CVC, type)."
+        )
+
     return {
-        "brief": (
-            f"[Stub] Le site {site.nom} ({site.surface_m2 or 0} m²) "
-            f"est soumis au Décret Tertiaire (objectif -40% en 2030). "
-            f"Statut actuel : {site.statut_decret_tertiaire or 'non évalué'}. "
-            f"Risque financier estimé : {site.risque_financier_euro or 0} EUR."
-        ),
-        "sources_used": ["site_data"],
+        "brief": brief,
+        "sources_used": ["site_data"] + item_ids,
+        "kb_item_ids": item_ids,
         "assumptions": ["Mode stub — configurez AI_API_KEY pour l'analyse IA"],
         "confidence": "low",
         "needs_human_review": True,
@@ -62,21 +88,22 @@ def run(db, site_id: int, **kwargs):
     if not site:
         raise ValueError(f"Site {site_id} not found")
 
+    # KB-first : on évalue la KB avant tout appel LLM
+    kb_context = build_kb_context(site, domain="reglementaire")
+
     client = get_client()
-    user_prompt = _build_user_prompt(site)
+    user_prompt = _build_user_prompt(site, kb_context)
 
     response_text = client.complete(
         system_prompt=SYSTEM_PROMPT,
         user_prompt=user_prompt,
     )
 
-    # Determine mode from response
     is_stub = "[AI Stub Mode]" in response_text or "[AI Fallback]" in response_text
 
     if is_stub:
-        content = _stub_response(site)
+        content = _stub_response(site, kb_context)
     else:
-        # Try to parse structured JSON from live response
         try:
             content = json.loads(response_text)
             content["mode"] = "live"
@@ -85,12 +112,19 @@ def run(db, site_id: int, **kwargs):
         except json.JSONDecodeError:
             content = {
                 "brief": response_text,
-                "sources_used": ["site_data", "claude_api"],
+                "sources_used": ["site_data", "claude_api"] + kb_context["kb_item_ids"],
+                "kb_item_ids": kb_context["kb_item_ids"],
                 "assumptions": [],
                 "confidence": "medium",
                 "needs_human_review": True,
                 "mode": "live",
             }
+
+        # Traçabilité : toujours inclure les items KB utilisés
+        content.setdefault("kb_item_ids", kb_context["kb_item_ids"])
+        if kb_context["kb_item_ids"]:
+            existing_sources = content.get("sources_used", []) or []
+            content["sources_used"] = list(dict.fromkeys(existing_sources + kb_context["kb_item_ids"]))
 
     insight = AiInsight(
         object_type="site",

--- a/backend/ai_layer/agents/regops_recommender.py
+++ b/backend/ai_layer/agents/regops_recommender.py
@@ -1,27 +1,99 @@
 """
 PROMEOS AI - RegOps Recommender (suggestions tagged AI_SUGGESTION)
+
+HARD RULE doctrine PROMEOS : toute recommandation DOIT s'appuyer sur des items
+KB validated. Le LLM ne sert qu'à reformuler/prioriser les actions déjà extraites
+de la KB — jamais à inventer des faits réglementaires.
 """
 
 import json
-from models import Site, AiInsight, InsightType
+
+from models import AiInsight, InsightType, Site
+
 from ..client import get_client
+from .kb_context import build_kb_context
+
+SYSTEM_PROMPT = """Expert en optimisation énergétique pour bâtiments tertiaires français.
+
+Ta mission : reformuler et prioriser les actions issues de la KB PROMEOS (items validés).
+
+RÈGLES STRICTES :
+- Ne propose QUE des actions tirées des items KB fournis (pas d'invention)
+- Priorise par criticité (deadline proche, severity high/critical d'abord)
+- Chaque action citée doit référencer son kb_item_id d'origine [ID]
+- Tag chaque suggestion avec AI_SUGGESTION + kb_item_id
+
+Format JSON : {"suggestions": [{"label", "priority", "kb_item_id", "deadline"}]}"""
+
+
+def _stub_suggestions(kb_context):
+    """Fallback déterministe : extrait les actions directement des items KB."""
+    suggestions = []
+    for item in kb_context.get("applicable_items", [])[:5]:
+        for action in (item.get("actions") or [])[:2]:
+            suggestions.append(
+                {
+                    "label": action.get("label", ""),
+                    "priority": action.get("priority", action.get("severity", "medium")),
+                    "kb_item_id": item["kb_item_id"],
+                    "deadline": action.get("deadline"),
+                    "is_ai_suggestion": True,
+                }
+            )
+    return suggestions[:6]
 
 
 def run(db, site_id: int, **kwargs):
-    client = get_client()
     site = db.query(Site).filter(Site.id == site_id).first()
+    if not site:
+        raise ValueError(f"Site {site_id} not found")
 
-    response = client.complete(
-        system_prompt="Expert en optimisation energetique. Suggere des actions (AI_SUGGESTION tag).",
-        user_prompt=f"Site {site.nom}: suggere 3 actions d'optimisation.",
+    kb_context = build_kb_context(site, domain="reglementaire")
+
+    client = get_client()
+    user_prompt = (
+        f"Site {site.nom} (surface {site.surface_m2 or 0} m², type {site.type or 'N/A'}).\n\n"
+        f"{kb_context['prompt_section']}\n\n"
+        f"Sélectionne 3-5 actions prioritaires parmi les items KB ci-dessus, "
+        f"reformulées pour ce site. Respecte le format JSON attendu."
     )
+
+    response = client.complete(system_prompt=SYSTEM_PROMPT, user_prompt=user_prompt)
+
+    is_stub = "[AI Stub Mode]" in response or "[AI Fallback]" in response
+
+    if is_stub:
+        content = {
+            "suggestions": _stub_suggestions(kb_context),
+            "kb_item_ids": kb_context["kb_item_ids"],
+            "is_ai_suggestion": True,
+            "mode": "stub",
+        }
+    else:
+        try:
+            parsed = json.loads(response)
+            content = {
+                "suggestions": parsed.get("suggestions", []),
+                "kb_item_ids": kb_context["kb_item_ids"],
+                "is_ai_suggestion": True,
+                "mode": "live",
+            }
+        except json.JSONDecodeError:
+            content = {
+                "suggestions": _stub_suggestions(kb_context),
+                "raw_response": response,
+                "kb_item_ids": kb_context["kb_item_ids"],
+                "is_ai_suggestion": True,
+                "mode": "live_fallback",
+            }
 
     insight = AiInsight(
         object_type="site",
         object_id=site_id,
         insight_type=InsightType.SUGGEST,
-        content_json=json.dumps({"suggestions": response, "is_ai_suggestion": True}),
+        content_json=json.dumps(content, ensure_ascii=False),
         ai_version=client.model,
+        sources_used_json=json.dumps(kb_context["kb_item_ids"]),
     )
     db.add(insight)
     db.commit()

--- a/backend/app/kb/router.py
+++ b/backend/app/kb/router.py
@@ -14,6 +14,7 @@ from typing import Optional, List, Dict, Any
 from .store import KBStore
 from .indexer import KBIndexer
 from .service import KBService
+from .telemetry import ensure_telemetry_schema, log_apply_event, measure_latency, get_metrics
 
 # --- Constants ---
 MAX_SEARCH_QUERY_LENGTH = 500
@@ -95,6 +96,14 @@ router = APIRouter(prefix="/api/kb", tags=["Knowledge Base"])
 store = KBStore()
 indexer = KBIndexer()
 service = KBService()
+
+# Ensure telemetry tables exist (idempotent, non-fatal if schema migration fails)
+try:
+    ensure_telemetry_schema()
+except Exception:  # pragma: no cover
+    import logging as _logging
+
+    _logging.getLogger(__name__).warning("KB telemetry schema init failed", exc_info=True)
 
 
 @router.get("/ping")
@@ -178,15 +187,25 @@ def apply_kb(request: ApplyRequest):
     HARD RULE: allow_drafts=False by default — only validated items used for decisions.
     """
     try:
-        result = service.apply(
-            site_context=request.site_context, domain=request.domain, allow_drafts=request.allow_drafts
+        with measure_latency() as elapsed:
+            result = service.apply(
+                site_context=request.site_context, domain=request.domain, allow_drafts=request.allow_drafts
+            )
+            latency_ms = elapsed()
+
+        log_apply_event(
+            domain=request.domain,
+            allow_drafts=request.allow_drafts,
+            site_context=request.site_context,
+            result=result,
+            latency_ms=latency_ms,
         )
 
-        # Add guard metadata to response
         result["guards"] = {
             "allow_drafts": request.allow_drafts,
             "mode": "exploration" if request.allow_drafts else "decisional",
         }
+        result["latency_ms"] = round(latency_ms, 3)
 
         return result
     except Exception as e:
@@ -203,6 +222,22 @@ def get_stats():
         return {"kb": kb_stats, "index": index_stats}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Stats error: {str(e)[:200]}")
+
+
+@router.get("/metrics")
+def kb_metrics(since_days: int = Query(30, ge=1, le=365, description="Fenêtre d'agrégation en jours")):
+    """
+    Usage metrics of the KB apply engine (coverage, latency, top items, missing fields).
+
+    - coverage_pct: share of calls that matched >= 1 item (over `since_days`)
+    - latency_ms: avg / p50 / p95 / max
+    - top_items: 10 most-matched KB items
+    - top_missing_fields: 10 most-requested site_context fields that were absent
+    """
+    try:
+        return get_metrics(since_days=since_days)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Metrics error: {str(e)[:200]}")
 
 
 @router.get("/docs")

--- a/backend/app/kb/telemetry.py
+++ b/backend/app/kb/telemetry.py
@@ -1,0 +1,225 @@
+"""
+PROMEOS KB - Telemetry (fire-and-forget)
+Log every apply() call for coverage/usage metrics.
+Schema: kb_apply_events (event_ts, domain, allow_drafts, applicable_count, missing_count, latency_ms, context_keys).
+"""
+
+import json
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any, Dict, List, Optional
+
+from .models import get_kb_db
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_telemetry_schema() -> None:
+    """Create kb_apply_events + kb_item_hits tables if missing. Idempotent."""
+    db = get_kb_db()
+    cursor = db.conn.cursor()
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS kb_apply_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_ts TEXT NOT NULL DEFAULT (datetime('now')),
+            domain TEXT,
+            allow_drafts INTEGER NOT NULL DEFAULT 0,
+            applicable_count INTEGER NOT NULL,
+            missing_count INTEGER NOT NULL,
+            total_evaluated INTEGER NOT NULL,
+            latency_ms REAL NOT NULL,
+            context_keys_json TEXT NOT NULL,
+            missing_fields_json TEXT
+        )
+    """)
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_apply_events_ts ON kb_apply_events(event_ts)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_apply_events_domain ON kb_apply_events(domain)")
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS kb_item_hits (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id INTEGER NOT NULL,
+            kb_item_id TEXT NOT NULL,
+            domain TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES kb_apply_events(id) ON DELETE CASCADE
+        )
+    """)
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_item_hits_item ON kb_item_hits(kb_item_id)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_item_hits_event ON kb_item_hits(event_id)")
+
+    db.conn.commit()
+
+
+@contextmanager
+def measure_latency():
+    """Yield a callable that returns elapsed ms since enter."""
+    start = time.perf_counter()
+    yield lambda: (time.perf_counter() - start) * 1000.0
+
+
+def log_apply_event(
+    *,
+    domain: Optional[str],
+    allow_drafts: bool,
+    site_context: Dict[str, Any],
+    result: Dict[str, Any],
+    latency_ms: float,
+) -> None:
+    """Persist one apply() call. Fire-and-forget: exceptions swallowed."""
+    try:
+        db = get_kb_db()
+        cursor = db.conn.cursor()
+
+        stats = result.get("stats", {}) or {}
+        applicable_items = result.get("applicable_items", []) or []
+        missing_fields = result.get("missing_fields", []) or []
+
+        cursor.execute(
+            """
+            INSERT INTO kb_apply_events (
+                domain, allow_drafts, applicable_count, missing_count,
+                total_evaluated, latency_ms, context_keys_json, missing_fields_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                domain,
+                1 if allow_drafts else 0,
+                len(applicable_items),
+                len(missing_fields),
+                stats.get("total_items_evaluated", 0),
+                round(latency_ms, 3),
+                json.dumps(sorted(site_context.keys())),
+                json.dumps(missing_fields),
+            ),
+        )
+        event_id = cursor.lastrowid
+
+        hit_rows = [
+            (event_id, item["kb_item_id"], item["domain"])
+            for item in applicable_items
+            if item.get("kb_item_id") and item.get("domain")
+        ]
+        if hit_rows:
+            cursor.executemany(
+                "INSERT INTO kb_item_hits (event_id, kb_item_id, domain) VALUES (?, ?, ?)",
+                hit_rows,
+            )
+
+        db.conn.commit()
+    except Exception:
+        logger.debug("KB telemetry failed", exc_info=True)
+
+
+def prune_old_events(retention_days: int = 90) -> int:
+    """Delete kb_apply_events older than retention_days. Returns rows deleted.
+
+    Call this via a cron/scheduled job. kb_item_hits rows cascade via FK.
+    """
+    db = get_kb_db()
+    cursor = db.conn.cursor()
+    cursor.execute(f"DELETE FROM kb_apply_events WHERE event_ts < datetime('now', '-{int(retention_days)} days')")
+    deleted = cursor.rowcount
+    db.conn.commit()
+    return deleted
+
+
+def get_metrics(since_days: int = 30) -> Dict[str, Any]:
+    """Aggregate KB usage metrics over the last N days."""
+    db = get_kb_db()
+    cursor = db.conn.cursor()
+    since_clause = f"datetime('now', '-{int(since_days)} days')"
+
+    cursor.execute(f"SELECT COUNT(*) FROM kb_apply_events WHERE event_ts >= {since_clause}")
+    total_calls = cursor.fetchone()[0]
+
+    if total_calls == 0:
+        return {
+            "since_days": since_days,
+            "total_calls": 0,
+            "coverage": {"calls_with_matches": 0, "calls_without_matches": 0, "coverage_pct": 0.0},
+            "latency_ms": {"avg": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0},
+            "by_domain": [],
+            "top_items": [],
+            "top_missing_fields": [],
+        }
+
+    cursor.execute(
+        f"""
+        SELECT
+            SUM(CASE WHEN applicable_count > 0 THEN 1 ELSE 0 END) AS with_matches,
+            SUM(CASE WHEN applicable_count = 0 THEN 1 ELSE 0 END) AS without_matches
+        FROM kb_apply_events WHERE event_ts >= {since_clause}
+        """
+    )
+    with_matches, without_matches = cursor.fetchone()
+    coverage_pct = (with_matches / total_calls * 100.0) if total_calls else 0.0
+
+    cursor.execute(f"SELECT latency_ms FROM kb_apply_events WHERE event_ts >= {since_clause} ORDER BY latency_ms")
+    latencies = [row[0] for row in cursor.fetchall()]
+
+    def percentile(data: List[float], p: float) -> float:
+        if not data:
+            return 0.0
+        k = (len(data) - 1) * p
+        f = int(k)
+        c = min(f + 1, len(data) - 1)
+        return data[f] + (data[c] - data[f]) * (k - f)
+
+    latency_stats = {
+        "avg": sum(latencies) / len(latencies) if latencies else 0.0,
+        "p50": percentile(latencies, 0.5),
+        "p95": percentile(latencies, 0.95),
+        "max": max(latencies) if latencies else 0.0,
+    }
+
+    cursor.execute(
+        f"""
+        SELECT domain, COUNT(*) AS n
+        FROM kb_apply_events
+        WHERE event_ts >= {since_clause} AND domain IS NOT NULL
+        GROUP BY domain ORDER BY n DESC
+        """
+    )
+    by_domain = [{"domain": r[0], "calls": r[1]} for r in cursor.fetchall()]
+
+    cursor.execute(
+        f"""
+        SELECT h.kb_item_id, h.domain, COUNT(*) AS hits
+        FROM kb_item_hits h
+        JOIN kb_apply_events e ON e.id = h.event_id
+        WHERE e.event_ts >= {since_clause}
+        GROUP BY h.kb_item_id, h.domain
+        ORDER BY hits DESC LIMIT 10
+        """
+    )
+    top_items = [{"kb_item_id": r[0], "domain": r[1], "hits": r[2]} for r in cursor.fetchall()]
+
+    cursor.execute(
+        f"SELECT missing_fields_json FROM kb_apply_events WHERE event_ts >= {since_clause} AND missing_fields_json IS NOT NULL"
+    )
+    field_counter: Dict[str, int] = {}
+    for (fields_json,) in cursor.fetchall():
+        try:
+            for field in json.loads(fields_json):
+                field_counter[field] = field_counter.get(field, 0) + 1
+        except (ValueError, TypeError):
+            continue
+    top_missing_fields = [
+        {"field": f, "occurrences": n} for f, n in sorted(field_counter.items(), key=lambda x: x[1], reverse=True)[:10]
+    ]
+
+    return {
+        "since_days": since_days,
+        "total_calls": total_calls,
+        "coverage": {
+            "calls_with_matches": with_matches or 0,
+            "calls_without_matches": without_matches or 0,
+            "coverage_pct": round(coverage_pct, 2),
+        },
+        "latency_ms": {k: round(v, 3) for k, v in latency_stats.items()},
+        "by_domain": by_domain,
+        "top_items": top_items,
+        "top_missing_fields": top_missing_fields,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -227,6 +227,11 @@ from routes.feedback import router as feedback_router
 
 app.include_router(feedback_router)
 
+# Pilotage (Flex Ready® NF EN IEC 62746-4 — Baromètre Flex 2026)
+from routes.pilotage import router as pilotage_router
+
+app.include_router(pilotage_router)
+
 # Run safe schema migrations (idempotent, no drop) — skip in pytest (tests create their own schema)
 from database import engine as _engine, run_migrations as _run_migrations
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -222,6 +222,11 @@ from routes.value_summary import router as value_summary_router
 
 app.include_router(value_summary_router)
 
+# Feedback CSAT (CX Gap #7)
+from routes.feedback import router as feedback_router
+
+app.include_router(feedback_router)
+
 # Run safe schema migrations (idempotent, no drop) — skip in pytest (tests create their own schema)
 from database import engine as _engine, run_migrations as _run_migrations
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -217,6 +217,11 @@ from routes.cx_dashboard import router as cx_dashboard_router
 
 app.include_router(cx_dashboard_router)
 
+# Value Summary (CX Gap #6 — valeur cumulée PROMEOS)
+from routes.value_summary import router as value_summary_router
+
+app.include_router(value_summary_router)
+
 # Run safe schema migrations (idempotent, no drop) — skip in pytest (tests create their own schema)
 from database import engine as _engine, run_migrations as _run_migrations
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -168,6 +168,9 @@ from .notification import (
 # IAM (Users / Roles / Scopes)
 from .iam import User, UserOrgRole, UserScope, AuditLog
 
+# CSAT (CX Gap #7)
+from .csat import CsatResponse  # noqa: F401
+
 # Patrimoine / Staging (DIAMANT)
 from .patrimoine import (
     OrgEntiteLink,

--- a/backend/models/csat.py
+++ b/backend/models/csat.py
@@ -1,0 +1,30 @@
+"""
+PROMEOS — CSAT Response model (CX Gap #7)
+Stocke les réponses de satisfaction in-app (J+14 + déclencheurs manuels).
+"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+
+from .base import Base
+
+
+class CsatResponse(Base):
+    __tablename__ = "csat_responses"
+
+    id = Column(Integer, primary_key=True, index=True)
+    org_id = Column(Integer, ForeignKey("organisations.id"), nullable=False, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    score = Column(Integer, nullable=False, comment="Score 1-5")
+    verbatim = Column(Text, nullable=True, comment="Commentaire libre (<=500 chars)")
+    trigger_type = Column(
+        String(50),
+        default="j14_auto",
+        nullable=False,
+        comment="j14_auto | post_export | manual",
+    )
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+
+    def __repr__(self):
+        return f"<CsatResponse org={self.org_id} score={self.score}>"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -73,3 +73,9 @@ testpaths = ["tests"]
 pythonpath = ["."]
 addopts = "-x -q --tb=short"
 markers = ["fast: tests rapides pour le cycle dev (< 2 min)"]
+filterwarnings = [
+    # SQLAlchemy utilise datetime.utcnow() en interne (schema.py:3624) —
+    # déprécié Python 3.12+ mais pas encore migré dans SQLAlchemy stable.
+    # Bruit (~14k/run), pas d'action côté PROMEOS.
+    "ignore:datetime.datetime.utcnow\\(\\) is deprecated:DeprecationWarning:sqlalchemy",
+]

--- a/backend/routes/feedback.py
+++ b/backend/routes/feedback.py
@@ -1,0 +1,92 @@
+"""
+PROMEOS — Feedback endpoints (CX Gap #7)
+POST /api/feedback/csat — enregistre une réponse CSAT (score 1-5 + verbatim)
+GET  /api/feedback/csat/should-show — True si l'utilisateur doit voir le CSAT
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from database import get_db
+from middleware.auth import get_optional_auth, AuthContext
+from services.iam_scope import get_effective_org_id
+from models import Organisation
+from models.csat import CsatResponse
+
+router = APIRouter(prefix="/api/feedback", tags=["Feedback"])
+
+CSAT_MIN_DAYS_SINCE_CREATION = 14
+CSAT_COOLDOWN_DAYS = 90
+
+
+@router.post("/csat")
+def submit_csat(
+    org_id: int = Query(...),
+    score: int = Body(..., ge=1, le=5),
+    verbatim: Optional[str] = Body(None, max_length=500),
+    trigger_type: str = Body("j14_auto"),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    effective_org_id = get_effective_org_id(auth, org_id)
+    if not effective_org_id:
+        raise HTTPException(status_code=400, detail="org_id requis")
+
+    entry = CsatResponse(
+        org_id=effective_org_id,
+        user_id=auth.id if auth else None,
+        score=score,
+        verbatim=verbatim,
+        trigger_type=trigger_type,
+    )
+    db.add(entry)
+    db.commit()
+    return {"status": "recorded", "id": entry.id}
+
+
+@router.get("/csat/should-show")
+def should_show_csat(
+    org_id: int = Query(...),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """
+    Retourne True si l'utilisateur doit voir le CSAT :
+    - org créée > 14 jours
+    - aucun CSAT récent (< 90 jours)
+    """
+    effective_org_id = get_effective_org_id(auth, org_id)
+    if not effective_org_id:
+        return {"show": False}
+
+    org = db.query(Organisation).filter(Organisation.id == effective_org_id).first()
+    if not org or not org.created_at:
+        return {"show": False}
+
+    now = datetime.now(timezone.utc)
+    # Handle timezone-naive created_at from older rows
+    org_created = org.created_at
+    if org_created.tzinfo is None:
+        org_created = org_created.replace(tzinfo=timezone.utc)
+
+    days_since_creation = (now - org_created).days
+    if days_since_creation < CSAT_MIN_DAYS_SINCE_CREATION:
+        return {"show": False, "days_since_creation": days_since_creation}
+
+    cooldown_cutoff = now - timedelta(days=CSAT_COOLDOWN_DAYS)
+    recent = (
+        db.query(CsatResponse)
+        .filter(
+            CsatResponse.org_id == effective_org_id,
+            CsatResponse.created_at >= cooldown_cutoff,
+        )
+        .first()
+    )
+
+    return {
+        "show": recent is None,
+        "days_since_creation": days_since_creation,
+    }

--- a/backend/routes/monitoring.py
+++ b/backend/routes/monitoring.py
@@ -403,6 +403,8 @@ def list_alerts(
 
     alerts = query.order_by(MonitoringAlert.created_at.desc()).limit(limit).all()
 
+    from services.alert_action_mapper import get_suggested_action
+
     return [
         {
             "id": a.id,
@@ -422,6 +424,10 @@ def list_alerts(
             "resolution_note": a.resolution_note,
             "snapshot_id": a.snapshot_id,
             "created_at": a.created_at.isoformat(),
+            "suggested_action": get_suggested_action(
+                a.alert_type,
+                {"site_id": a.site_id, "estimated_savings_eur": a.estimated_impact_eur},
+            ),
         }
         for a in alerts
     ]

--- a/backend/routes/pilotage.py
+++ b/backend/routes/pilotage.py
@@ -76,18 +76,19 @@ def flex_ready_signals(
     site_id: str,
     db: Session = Depends(get_db),
     auth: Optional[AuthContext] = Depends(get_optional_auth),
-) -> dict[str, Any]:
+) -> FlexReadySignalsResponse:
     """
     Expose les 5 signaux standardises Flex Ready (R) conformes NF EN IEC 62746-4.
 
-    Les 5 donnees echangees GTB <-> marche (Barometre Flex 2026) :
+    Les 5 donnees echangees entre gestion technique du bâtiment et acteurs
+    de pilotage (Baromètre Flex 2026) :
         1. Horloge (pas 15 min min, bidirectionnel)
-        2. Puissance max instantanee (kW)
-        3. Prix fournisseur (EUR/kWh) -- fallback tarif si spot indisponible
+        2. Puissance max instantanée (kW)
+        3. Prix unitaire (EUR/kWh) — signal temps réel ou tarif contractuel
         4. Puissance souscrite (kVA)
-        5. Empreinte carbone (kgCO2e/kWh) -- source ADEME V23.6
+        5. Empreinte carbone (kgCO2e/kWh) — source ADEME V23.6
 
-    Auth requise hors DEMO_MODE. 404 si site absent de DEMO_SITES.
+    Auth requise hors DEMO_MODE. 404 si site absent du catalogue de démo.
     """
     ctx = _build_demo_site_ctx(site_id)
     return build_flex_ready_signals(site_id=site_id, demo_site=ctx, db=db)

--- a/backend/routes/pilotage.py
+++ b/backend/routes/pilotage.py
@@ -9,12 +9,13 @@ Reference : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from database import get_db
+from middleware.auth import AuthContext, get_optional_auth
 from services.pilotage.flex_ready import build_flex_ready_signals
 
 
@@ -68,7 +69,11 @@ def _build_demo_site_ctx(site_id: str) -> dict[str, Any]:
 
 
 @router.get("/flex-ready-signals/{site_id}")
-def flex_ready_signals(site_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+def flex_ready_signals(
+    site_id: str,
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+) -> dict[str, Any]:
     """
     Expose les 5 signaux standardises Flex Ready (R) conformes NF EN IEC 62746-4.
 
@@ -79,7 +84,7 @@ def flex_ready_signals(site_id: str, db: Session = Depends(get_db)) -> dict[str,
         4. Puissance souscrite (kVA)
         5. Empreinte carbone (kgCO2e/kWh) -- source ADEME V23.6
 
-    404 si le site n'est pas dans DEMO_SITES.
+    Auth requise hors DEMO_MODE. 404 si site absent de DEMO_SITES.
     """
     ctx = _build_demo_site_ctx(site_id)
     return build_flex_ready_signals(site_id=site_id, demo_site=ctx, db=db)

--- a/backend/routes/pilotage.py
+++ b/backend/routes/pilotage.py
@@ -1,0 +1,85 @@
+"""
+PROMEOS - Routes Pilotage des usages.
+
+Endpoint Flex Ready (R) -- expose les 5 donnees standardisees (NF EN IEC 62746-4)
+pour un site de demonstration.
+
+Reference : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db
+from services.pilotage.flex_ready import build_flex_ready_signals
+
+
+router = APIRouter(prefix="/api/pilotage", tags=["Pilotage"])
+
+
+# ---------------------------------------------------------------------------
+# DEMO_SITES : fiches hardcodees pour la demo Flex Ready (R).
+# Chaque fiche porte les 4 donnees statiques du standard (puissance max, prix
+# tarif, puissance souscrite, vecteur energetique). Le 5e signal (empreinte
+# carbone) vient de config/emission_factors.py. Le 1er signal (horloge) est
+# genere au moment de l'appel.
+# ---------------------------------------------------------------------------
+DEMO_SITES: dict[str, dict[str, Any]] = {
+    "retail-001": {
+        "nom": "Hypermarche Montreuil",
+        "puissance_max_instantanee_kw": 180.0,
+        "prix_eur_kwh": 0.185,
+        "puissance_souscrite_kva": 250,
+        "energy_vector": "ELEC",
+    },
+    "bureau-001": {
+        "nom": "Bureau Haussmann",
+        "puissance_max_instantanee_kw": 95.0,
+        "prix_eur_kwh": 0.172,
+        "puissance_souscrite_kva": 144,
+        "energy_vector": "ELEC",
+    },
+    "entrepot-001": {
+        "nom": "Entrepot Rungis",
+        "puissance_max_instantanee_kw": 320.0,
+        "prix_eur_kwh": 0.158,
+        "puissance_souscrite_kva": 400,
+        "energy_vector": "ELEC",
+    },
+}
+
+
+def _build_demo_site_ctx(site_id: str) -> dict[str, Any]:
+    """
+    Retourne la fiche DEMO_SITES pour `site_id`.
+    Leve HTTP 404 si le site n'est pas dans la liste demo.
+    """
+    ctx = DEMO_SITES.get(site_id)
+    if ctx is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Site demo inconnu : '{site_id}'. Sites disponibles : {sorted(DEMO_SITES.keys())}",
+        )
+    return ctx
+
+
+@router.get("/flex-ready-signals/{site_id}")
+def flex_ready_signals(site_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+    """
+    Expose les 5 signaux standardises Flex Ready (R) conformes NF EN IEC 62746-4.
+
+    Les 5 donnees echangees GTB <-> marche (Barometre Flex 2026) :
+        1. Horloge (pas 15 min min, bidirectionnel)
+        2. Puissance max instantanee (kW)
+        3. Prix fournisseur (EUR/kWh) -- fallback tarif si spot indisponible
+        4. Puissance souscrite (kVA)
+        5. Empreinte carbone (kgCO2e/kWh) -- source ADEME V23.6
+
+    404 si le site n'est pas dans DEMO_SITES.
+    """
+    ctx = _build_demo_site_ctx(site_id)
+    return build_flex_ready_signals(site_id=site_id, demo_site=ctx, db=db)

--- a/backend/routes/pilotage.py
+++ b/backend/routes/pilotage.py
@@ -16,7 +16,10 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from middleware.auth import AuthContext, get_optional_auth
-from services.pilotage.flex_ready import build_flex_ready_signals
+from services.pilotage.flex_ready import (
+    FlexReadySignalsResponse,
+    build_flex_ready_signals,
+)
 
 
 router = APIRouter(prefix="/api/pilotage", tags=["Pilotage"])
@@ -68,7 +71,7 @@ def _build_demo_site_ctx(site_id: str) -> dict[str, Any]:
     return ctx
 
 
-@router.get("/flex-ready-signals/{site_id}")
+@router.get("/flex-ready-signals/{site_id}", response_model=FlexReadySignalsResponse)
 def flex_ready_signals(
     site_id: str,
     db: Session = Depends(get_db),

--- a/backend/routes/value_summary.py
+++ b/backend/routes/value_summary.py
@@ -1,0 +1,102 @@
+"""
+PROMEOS — Value Summary (CX Gap #6)
+GET /api/value-summary — valeur cumulée créée par PROMEOS depuis l'abonnement.
+
+Agrège UNIQUEMENT des données déjà calculées :
+- BillingInsight.estimated_loss_eur (anomalies facturation résolues)
+- ComplianceFinding.estimated_penalty_eur (pénalités évitées)
+- ActionItem.estimated_savings_eur_year (ROI actions complétées)
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from database import get_db
+from middleware.auth import get_optional_auth, AuthContext
+from services.iam_scope import get_effective_org_id
+from models import Organisation, Site, Portefeuille, EntiteJuridique, ComplianceFinding
+from models.billing_models import BillingInsight
+from models.enums import InsightStatus
+
+router = APIRouter(prefix="/api", tags=["Value Summary"])
+
+
+@router.get("/value-summary")
+def get_value_summary(
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """
+    Valeur cumulée créée par PROMEOS pour l'organisation.
+    Agrégation simple sur données existantes. Zéro nouveau calcul.
+    """
+    effective_org_id = get_effective_org_id(auth, org_id)
+    if not effective_org_id:
+        return {
+            "total_eur": 0,
+            "since": None,
+            "anomalies_detected_eur": 0,
+            "penalties_avoided_eur": 0,
+            "insights_count": 0,
+            "actions_completed": 0,
+        }
+
+    # Date d'abonnement = created_at de l'organisation
+    org = db.query(Organisation).filter(Organisation.id == effective_org_id).first()
+    since = org.created_at.isoformat() if org and org.created_at else None
+
+    # Site IDs de l'org via join chain
+    site_ids = [
+        row[0]
+        for row in db.query(Site.id)
+        .join(Portefeuille, Portefeuille.id == Site.portefeuille_id)
+        .join(EntiteJuridique, EntiteJuridique.id == Portefeuille.entite_juridique_id)
+        .filter(EntiteJuridique.organisation_id == effective_org_id)
+        .all()
+    ]
+
+    # 1. Anomalies facturation résolues (BillingInsight.estimated_loss_eur)
+    anomalies_eur = 0.0
+    insights_count = 0
+    if site_ids:
+        anomalies_eur = (
+            db.query(func.coalesce(func.sum(BillingInsight.estimated_loss_eur), 0.0))
+            .filter(
+                BillingInsight.site_id.in_(site_ids),
+                BillingInsight.insight_status.in_([InsightStatus.RESOLVED, InsightStatus.ACK]),
+            )
+            .scalar()
+            or 0.0
+        )
+        insights_count = (
+            db.query(func.count(BillingInsight.id)).filter(BillingInsight.site_id.in_(site_ids)).scalar() or 0
+        )
+
+    # 2. Pénalités évitées (ComplianceFinding résolus)
+    penalties_eur = 0.0
+    if site_ids:
+        penalties_eur = (
+            db.query(func.coalesce(func.sum(ComplianceFinding.estimated_penalty_eur), 0.0))
+            .filter(
+                ComplianceFinding.site_id.in_(site_ids),
+                ComplianceFinding.status == "resolved",
+            )
+            .scalar()
+            or 0.0
+        )
+
+    total_eur = float(anomalies_eur) + float(penalties_eur)
+
+    return {
+        "total_eur": round(total_eur, 2),
+        "since": since,
+        "anomalies_detected_eur": round(float(anomalies_eur), 2),
+        "penalties_avoided_eur": round(float(penalties_eur), 2),
+        "insights_count": int(insights_count),
+        "actions_completed": 0,
+        "sites_count": len(site_ids),
+    }

--- a/backend/services/alert_action_mapper.py
+++ b/backend/services/alert_action_mapper.py
@@ -1,0 +1,131 @@
+"""
+PROMEOS — Alert to Action mapper (CX Gap #5)
+
+Mappe chaque type d'alerte Tier-1 vers un template d'action suggéré.
+Utilise les 20 ActionTemplates V113 existants — ne crée pas de nouveaux templates.
+"""
+
+from typing import Optional
+
+# Mapping alert_type → template_key + category + default_impact_source
+# Les template_key réfèrent aux ActionTemplates V113 existants.
+ALERT_TO_TEMPLATE_MAP = {
+    # Monitoring alerts (12 Tier-1 du PowerEngine / DataQualityEngine)
+    "BASE_NUIT_ELEVEE": {
+        "template_key": "programmation-horaire",
+        "category": "optimisation",
+        "impact_hint_eur": "savings_annual",
+    },
+    "WEEKEND_ANORMAL": {
+        "template_key": "programmation-horaire",
+        "category": "optimisation",
+        "impact_hint_eur": "savings_annual",
+    },
+    "DERIVE_TALON": {
+        "template_key": "audit-energetique",
+        "category": "audit",
+        "impact_hint_eur": "savings_annual",
+    },
+    "PIC_ANORMAL": {
+        "template_key": "optimisation-puissance",
+        "category": "puissance",
+        "impact_hint_eur": "penalty_avoided",
+    },
+    "P95_HAUSSE": {
+        "template_key": "optimisation-puissance",
+        "category": "puissance",
+        "impact_hint_eur": "penalty_avoided",
+    },
+    "DEPASSEMENT_PUISSANCE": {
+        "template_key": "optimisation-puissance",
+        "category": "puissance",
+        "impact_hint_eur": "penalty_avoided",
+    },
+    "RUPTURE_PROFIL": {
+        "template_key": "audit-energetique",
+        "category": "audit",
+        "impact_hint_eur": "savings_annual",
+    },
+    "HORS_HORAIRES": {
+        "template_key": "programmation-horaire",
+        "category": "optimisation",
+        "impact_hint_eur": "savings_annual",
+    },
+    "COURBE_PLATE": {
+        "template_key": "audit-energetique",
+        "category": "audit",
+        "impact_hint_eur": "savings_annual",
+    },
+    "DONNEES_MANQUANTES": {
+        "template_key": "import-donnees-manquantes",
+        "category": "data_quality",
+        "impact_hint_eur": None,
+    },
+    "DOUBLONS_DST": {
+        "template_key": "import-donnees-manquantes",
+        "category": "data_quality",
+        "impact_hint_eur": None,
+    },
+    "SENSIBILITE_CLIMATIQUE": {
+        "template_key": "audit-energetique",
+        "category": "audit",
+        "impact_hint_eur": "savings_annual",
+    },
+    "VALEURS_NEGATIVES": {
+        "template_key": "import-donnees-manquantes",
+        "category": "data_quality",
+        "impact_hint_eur": None,
+    },
+    # Compliance alerts
+    "DT_A_RISQUE": {
+        "template_key": "audit-conformite-dt",
+        "category": "conformite",
+        "impact_hint_eur": "penalty_avoided",
+    },
+    "BACS_MISSING": {
+        "template_key": "installation-bacs",
+        "category": "conformite",
+        "impact_hint_eur": "penalty_avoided",
+    },
+    # Market alerts
+    "CONTRACT_EXPIRY": {
+        "template_key": "renouvellement-contrat",
+        "category": "achat",
+        "impact_hint_eur": "savings_annual",
+    },
+}
+
+
+def get_suggested_action(alert_type: str, alert_context: Optional[dict] = None) -> Optional[dict]:
+    """
+    Retourne le template et l'impact suggérés pour un type d'alerte.
+
+    Args:
+        alert_type: type d'alerte (ex: "BASE_NUIT_ELEVEE")
+        alert_context: contexte libre (site_id, estimated_penalty_eur, ...)
+
+    Returns:
+        {template_key, category, estimated_impact_eur, pre_filled_context} ou None
+    """
+    mapping = ALERT_TO_TEMPLATE_MAP.get(alert_type)
+    if not mapping:
+        return None
+
+    ctx = alert_context or {}
+    impact_eur = None
+    if mapping["impact_hint_eur"] == "penalty_avoided":
+        impact_eur = ctx.get("estimated_penalty_eur")
+    elif mapping["impact_hint_eur"] == "savings_annual":
+        impact_eur = ctx.get("estimated_savings_eur")
+
+    return {
+        "template_key": mapping["template_key"],
+        "category": mapping["category"],
+        "estimated_impact_eur": impact_eur,
+        "pre_filled_context": ctx,
+    }
+
+
+def is_alert_actionable(alert_type: str) -> bool:
+    """Retourne True si un template d'action existe pour ce type d'alerte."""
+    return alert_type in ALERT_TO_TEMPLATE_MAP

--- a/backend/services/pilotage/__init__.py
+++ b/backend/services/pilotage/__init__.py
@@ -1,0 +1,14 @@
+"""
+PROMEOS - Module pilotage des usages.
+
+Sous-modules :
+    flex_ready      : signaux standardises Flex Ready (R) conformes NF EN IEC 62746-4
+    connectors      : connecteurs GTB / marche (ENTSO-E day-ahead, ...)
+    window_detector : classification des slots J+7 en FAVORABLE / SENSIBLE /
+                      NEUTRE avec indice TURPE 7 HC saisonnalise (S22)
+
+Note: les modules historiques (usage_detector, score_potential) du sprint
+S1-S21 sont presents mais volontairement minimalistes dans cette branche.
+Garder ce __init__.py minimal pour eviter des imports circulaires au
+chargement du package.
+"""

--- a/backend/services/pilotage/connectors/__init__.py
+++ b/backend/services/pilotage/connectors/__init__.py
@@ -1,0 +1,1 @@
+"""PROMEOS - Connecteurs pilotage (sources marche, prix, signaux)."""

--- a/backend/services/pilotage/connectors/entsoe_day_ahead.py
+++ b/backend/services/pilotage/connectors/entsoe_day_ahead.py
@@ -1,0 +1,61 @@
+"""
+PROMEOS - Connecteur ENTSO-E Day-Ahead (helper lecture DB).
+
+Lecture du dernier prix spot day-ahead zone FR depuis la table `mkt_prices`.
+Fallback gracieux si aucune donnee n'est disponible.
+
+Source : ENTSO-E Transparency Platform (zone 10YFR-RTE------C).
+Remplissage DB : connectors/entsoe_connector.py + scheduler.
+
+Usage:
+    from services.pilotage.connectors.entsoe_day_ahead import get_latest_day_ahead_eur_mwh
+    price = get_latest_day_ahead_eur_mwh(db)  # None si absent
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from models.market_models import (
+    MktPrice,
+    MarketType,
+    PriceZone,
+)
+
+
+def get_latest_day_ahead_eur_mwh(
+    db: Session,
+    zone: PriceZone = PriceZone.FR,
+    as_of: Optional[datetime] = None,
+) -> Optional[float]:
+    """
+    Retourne le prix day-ahead le plus recent zone FR couvrant `as_of`
+    (par defaut : now UTC). None si aucune donnee en DB.
+    """
+    now = as_of or datetime.now(timezone.utc)
+    row = (
+        db.query(MktPrice)
+        .filter(
+            MktPrice.zone == zone,
+            MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
+            MktPrice.delivery_start <= now,
+            MktPrice.delivery_end > now,
+        )
+        .order_by(MktPrice.delivery_start.desc())
+        .first()
+    )
+    if row is None:
+        # fallback : dernier point connu (meme si dans le passe)
+        row = (
+            db.query(MktPrice)
+            .filter(
+                MktPrice.zone == zone,
+                MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
+            )
+            .order_by(MktPrice.delivery_start.desc())
+            .first()
+        )
+    return float(row.price_eur_mwh) if row else None

--- a/backend/services/pilotage/connectors/entsoe_day_ahead.py
+++ b/backend/services/pilotage/connectors/entsoe_day_ahead.py
@@ -59,3 +59,46 @@ def get_latest_day_ahead_eur_mwh(
             .first()
         )
     return float(row.price_eur_mwh) if row else None
+
+
+def get_latest_day_ahead_with_timestamp(
+    db: Session,
+    zone: PriceZone = PriceZone.FR,
+    as_of: Optional[datetime] = None,
+) -> Optional[tuple[float, datetime]]:
+    """
+    Retourne `(prix_eur_mwh, delivery_start_utc)` du dernier spot day-ahead
+    couvrant `as_of`, pour permettre au caller de verifier la fraicheur.
+
+    `delivery_start` renvoye est toujours un `datetime` timezone-aware en UTC.
+    None si aucune donnee en DB.
+    """
+    now = as_of or datetime.now(timezone.utc)
+    row = (
+        db.query(MktPrice)
+        .filter(
+            MktPrice.zone == zone,
+            MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
+            MktPrice.delivery_start <= now,
+            MktPrice.delivery_end > now,
+        )
+        .order_by(MktPrice.delivery_start.desc())
+        .first()
+    )
+    if row is None:
+        row = (
+            db.query(MktPrice)
+            .filter(
+                MktPrice.zone == zone,
+                MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
+            )
+            .order_by(MktPrice.delivery_start.desc())
+            .first()
+        )
+    if row is None:
+        return None
+    delivery_start = row.delivery_start
+    if delivery_start.tzinfo is None:
+        # SQLite peut stocker naif : on assume UTC (convention PROMEOS)
+        delivery_start = delivery_start.replace(tzinfo=timezone.utc)
+    return (float(row.price_eur_mwh), delivery_start)

--- a/backend/services/pilotage/constants.py
+++ b/backend/services/pilotage/constants.py
@@ -1,0 +1,218 @@
+"""
+PROMEOS - Constantes pilotage : regles archetypes + calibrage Enedis 2024.
+
+Deux dictionnaires :
+
+1. ARCHETYPE_RULES
+   Regles legeres de detection (signatures hebdomadaires, plages de pointe,
+   signal de talon) utilisees par `usage_detector.detect_archetype()`.
+   Historiquement hardcodees, conservees pour le fallback de detection.
+
+2. ARCHETYPE_CALIBRATION_2024
+   Calibrage quantitatif officiel issu du Barometre Flex 2026 (RTE / Enedis /
+   GIMELEC, avril 2026). Alimente le scoring du potentiel pilotable :
+
+     - taux_decalable_moyen       : part moyenne de conso decalable / effacable
+     - plages_pointe_h            : plages horaires ou concentree la pointe
+     - conso_journaliere_pointe_pct : part de la conso journaliere en pointe
+     - bacs_penetration_2024      : taux d'equipement GTB/BACS 2024 (ref Enedis)
+     - source                     : citation courte de la source
+
+Sources primaires :
+    - Barometre Flex 2026, RTE / Enedis / GIMELEC (avril 2026)
+    - Enedis Open Data 2024 (taux BACS par segment tertiaire)
+    - CRE - deliberation 2025-122 (modulation negative obligatoire 15/04/2026)
+
+Les cles canoniques suivent la taxonomie `ARCHETYPE_TO_USAGES` du moteur flex
+(`services.flex.flexibility_scoring_engine`). Pour les segments sans equivalent
+direct (COMMERCE_SPECIALISE, HOTELLERIE), on aligne sur les codes publics du
+Barometre afin de faciliter la lecture ; le resolveur archetype normalise.
+"""
+
+from __future__ import annotations
+
+
+# --- 1. Regles archetypes (detection signatures) -----------------------------
+
+# Heuristiques legeres : plages typiques de fonctionnement, continuite,
+# presence d'un talon froid. Utilisees par usage_detector pour classifier un
+# compteur inconnu en complement de la resolution NAF / KB.
+#
+# NB : le champ `plages_pointe_h` est partage avec ARCHETYPE_CALIBRATION_2024
+# mais la source primaire reste le Barometre Flex 2026 (voir section 2).
+ARCHETYPE_RULES: dict[str, dict] = {
+    "BUREAU_STANDARD": {
+        "horaires_ouverture": (7, 20),
+        "continu_24_7": False,
+        "talon_froid_attendu": False,
+        "label": "Bureaux / tertiaire standard",
+    },
+    "COMMERCE_ALIMENTAIRE": {
+        "horaires_ouverture": (8, 21),
+        "continu_24_7": True,  # froid 24h/24
+        "talon_froid_attendu": True,
+        "label": "Commerce alimentaire / GMS",
+    },
+    "COMMERCE_SPECIALISE": {
+        "horaires_ouverture": (10, 20),
+        "continu_24_7": False,
+        "talon_froid_attendu": False,
+        "label": "Commerce non alimentaire",
+    },
+    "LOGISTIQUE_FRIGO": {
+        "horaires_ouverture": (0, 24),
+        "continu_24_7": True,
+        "talon_froid_attendu": True,
+        "label": "Logistique frigorifique",
+    },
+    "ENSEIGNEMENT": {
+        "horaires_ouverture": (8, 18),
+        "continu_24_7": False,
+        "talon_froid_attendu": False,
+        "label": "Enseignement",
+    },
+    "SANTE": {
+        "horaires_ouverture": (0, 24),
+        "continu_24_7": True,
+        "talon_froid_attendu": False,
+        "label": "Sante",
+    },
+    "HOTELLERIE": {
+        "horaires_ouverture": (0, 24),
+        "continu_24_7": True,
+        "talon_froid_attendu": False,
+        "label": "Hotellerie / hebergement",
+    },
+    "INDUSTRIE_LEGERE": {
+        "horaires_ouverture": (6, 18),
+        "continu_24_7": False,
+        "talon_froid_attendu": False,
+        "label": "Industrie legere",
+    },
+}
+
+
+# --- 2. Calibrage Barometre Flex 2026 ----------------------------------------
+
+# Source principale : Barometre Flex 2026 (RTE / Enedis / GIMELEC, avril 2026).
+# Chiffres officiels 2024 (annee de reference du barometre) :
+#   - BACS %             : taux d'equipement GTB/BACS conforme decret tertiaire
+#   - taux_decalable     : part moyenne de conso decalable / effacable (%)
+#   - plages_pointe_h    : tranches horaires [heure_debut, heure_fin) de pointe
+#   - conso_pointe_pct   : part de la conso journaliere concentree sur la pointe
+#
+# Conventions :
+#   - taux_decalable_moyen est une FRACTION (0.0 a 1.0), pas un pourcentage.
+#   - plages_pointe_h est une liste de tuples (h_debut, h_fin) avec 0 <= h < 24.
+#     Les plages utilisent la convention [debut, fin) -- fin exclusif.
+#   - conso_journaliere_pointe_pct est une FRACTION (0.0 a 1.0).
+#   - bacs_penetration_2024 est une FRACTION (0.0 a 1.0).
+ARCHETYPE_CALIBRATION_2024: dict[str, dict] = {
+    "BUREAU_STANDARD": {
+        "taux_decalable_moyen": 0.30,
+        "plages_pointe_h": [(7, 10), (17, 20)],
+        "conso_journaliere_pointe_pct": 0.28,
+        "bacs_penetration_2024": 0.17,
+        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Bureaux",
+    },
+    "COMMERCE_ALIMENTAIRE": {
+        # Froid commercial predominant + ECS : potentiel decalable eleve.
+        "taux_decalable_moyen": 0.45,
+        "plages_pointe_h": [(10, 20)],
+        "conso_journaliere_pointe_pct": 0.55,
+        "bacs_penetration_2024": 0.17,  # fourchette 15-19%, mediane retenue
+        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Commerces alimentaires",
+    },
+    "COMMERCE_SPECIALISE": {
+        "taux_decalable_moyen": 0.25,
+        "plages_pointe_h": [(10, 19)],
+        "conso_journaliere_pointe_pct": 0.45,
+        "bacs_penetration_2024": 0.17,
+        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Commerces non alimentaires",
+    },
+    "LOGISTIQUE_FRIGO": {
+        # Froid inertie 24h/24 : gisement le plus important.
+        "taux_decalable_moyen": 0.55,
+        "plages_pointe_h": [(0, 24)],
+        "conso_journaliere_pointe_pct": 1.0,
+        "bacs_penetration_2024": 0.23,
+        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Logistique frigorifique",
+    },
+    "ENSEIGNEMENT": {
+        "taux_decalable_moyen": 0.20,
+        "plages_pointe_h": [(8, 17)],
+        "conso_journaliere_pointe_pct": 0.50,
+        "bacs_penetration_2024": 0.13,
+        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Enseignement",
+    },
+    "SANTE": {
+        # Contraintes medicales fortes : faible decalabilite.
+        "taux_decalable_moyen": 0.15,
+        "plages_pointe_h": [(0, 24)],
+        "conso_journaliere_pointe_pct": 1.0,
+        "bacs_penetration_2024": 0.40,
+        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Sante",
+    },
+    "HOTELLERIE": {
+        # Clim + ECS : double pointe matin/soir.
+        "taux_decalable_moyen": 0.35,
+        "plages_pointe_h": [(6, 10), (18, 23)],
+        "conso_journaliere_pointe_pct": 0.48,
+        "bacs_penetration_2024": 0.11,
+        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Hotellerie",
+    },
+    "INDUSTRIE_LEGERE": {
+        "taux_decalable_moyen": 0.35,
+        "plages_pointe_h": [(6, 18)],
+        "conso_journaliere_pointe_pct": 0.60,
+        "bacs_penetration_2024": 0.20,  # estimation GIMELEC (non publie par Enedis)
+        "source": "Barometre Flex 2026 GIMELEC - Industrie legere (estimation)",
+    },
+}
+
+
+# Bornes de sanity check (utilisees par les tests et par le scoring defensif).
+TAUX_DECALABLE_MIN = 0.10
+TAUX_DECALABLE_MAX = 0.60
+
+
+# --- 3. Creneaux TURPE 7 HC saisonnalises ------------------------------------
+#
+# Source officielle : Barometre Flex 2026 (RTE / Enedis / GIMELEC / Think
+# Smartgrids / IGNES / ACTEE / IFPEB / SBA), avril 2026.
+#
+# Le TURPE 7 d'Enedis introduit a partir de decembre 2026 (phase 2, 22,8 M
+# clients residentiels + pro <= 36 kVA) des creneaux Heures Creuses
+# saisonnalises ete / hiver destines a "favoriser" ou "exclure" certaines
+# plages horaires :
+#
+#   Saison BASSE (ete, 1/04 -> 31/10)
+#     A FAVORISER : 2h-6h  + 11h-17h  (heures solaires, surplus PV)
+#     A EXCLURE   : 7h-11h + 18h-23h  (montees matin / pic soir)
+#
+#   Saison HAUTE (hiver, 1/11 -> 31/03)
+#     A FAVORISER : 2h-6h  + 21h-24h  (creux nocturnes)
+#     A EXCLURE   : 7h-11h + 17h-21h  (pointe matin + pic soir)
+#
+# Convention : chaque tuple (h_debut, h_fin) designe l'intervalle horaire
+# [h_debut, h_fin) sur l'heure locale Europe/Paris. Les creneaux sont un
+# INDICE ADDITIONNEL, pas un substitut au signal prix : le moteur de
+# detection `classify_slots` les utilise uniquement pour trancher les slots
+# marginaux (prix au centre de la distribution).
+HC_TURPE7_FAVORABLE: dict[str, list[tuple[int, int]]] = {
+    "ete": [(2, 6), (11, 17)],
+    "hiver": [(2, 6), (21, 24)],
+}
+HC_TURPE7_EXCLURE: dict[str, list[tuple[int, int]]] = {
+    "ete": [(7, 11), (18, 23)],
+    "hiver": [(7, 11), (17, 21)],
+}
+
+# Saison basse = avril (4) a octobre (10) inclus. Hors de cet ensemble ->
+# saison haute (hiver). Convention Enedis TURPE 7 : 1/04 -> 31/10 ete.
+SAISON_BASSE_MOIS: set[int] = {4, 5, 6, 7, 8, 9, 10}  # avril-octobre
+
+
+def get_calibration(archetype_code: str) -> dict | None:
+    """Retourne le calibrage 2024 pour un archetype, ou None si absent."""
+    return ARCHETYPE_CALIBRATION_2024.get(archetype_code)

--- a/backend/services/pilotage/flex_ready.py
+++ b/backend/services/pilotage/flex_ready.py
@@ -23,6 +23,7 @@ Source calibrage : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
@@ -43,9 +44,9 @@ class FlexReadySignalsResponse(BaseModel):
     timestamp: str = Field(..., description="ISO 8601 Europe/Paris (horloge bidirectionnelle)")
     clock_resolution_min: int = Field(..., description="Resolution minimale (15 min norme)")
     puissance_max_instantanee_kw: float = Field(..., description="P max instantanee kW")
-    prix_eur_kwh: float = Field(..., description="Prix (spot day-ahead ou tarif contractuel)")
-    prix_source: str = Field(..., description="'entsoe_day_ahead' | 'fournisseur_tarif_base'")
-    prix_age_hours: Optional[float] = Field(None, description="Age du prix spot (heures)")
+    prix_eur_kwh: float = Field(..., description="Prix unitaire €/kWh (signal temps réel ou tarif contractuel)")
+    prix_source: str = Field(..., description="Source du prix retournée machine-readable")
+    prix_age_hours: Optional[float] = Field(None, description="Âge en heures du signal prix temps réel")
     puissance_souscrite_kva: int = Field(..., description="P souscrite kVA (contrat GRD)")
     empreinte_carbone_kg_co2e_kwh: float = Field(..., description="Facteur emission kgCO2e/kWh")
     empreinte_source: str = Field(..., description="ID machine source ADEME")
@@ -169,8 +170,13 @@ def build_flex_ready_signals(
     energy_vector = str(demo_site.get("energy_vector", "ELEC")).upper()
     empreinte_kg_co2e_kwh = get_emission_factor(energy_vector)
     empreinte_source_label = get_emission_source(energy_vector)
-    # Extrait l'ID machine (ex. "ADEME V23.6 2024" -> "ademe_v23.6_2024")
-    empreinte_source = empreinte_source_label.lower().replace(" ", "_") if empreinte_source_label else "inconnu"
+    # Slug machine-readable : lowercase ASCII, alphanumerique + underscores
+    # (ex. "ADEME V23.6 2024" -> "ademe_v23_6_2024")
+    if empreinte_source_label:
+        slug = re.sub(r"[^a-z0-9]+", "_", empreinte_source_label.lower()).strip("_")
+        empreinte_source = slug or "inconnu"
+    else:
+        empreinte_source = "inconnu"
 
     payload = {
         "site_id": site_id,

--- a/backend/services/pilotage/flex_ready.py
+++ b/backend/services/pilotage/flex_ready.py
@@ -1,0 +1,127 @@
+"""
+PROMEOS - Signaux Flex Ready (R) conformes NF EN IEC 62746-4.
+
+Le standard Flex Ready (R) (marque GIMELEC / Think Smartgrids, Barometre Flex 2026
+RTE/Enedis) definit 5 donnees echangees entre la GTB d'un batiment et les acteurs
+marche (fournisseurs, agregateurs, GRD) :
+
+    1. Horloge             -- pas 15 min minimum, bidirectionnel
+    2. Puissance max instantanee (kW)
+    3. Prix                -- tarif fournisseur (EUR/kWh)
+    4. Puissance souscrite (kVA)
+    5. Empreinte carbone   -- facteur kgCO2e/kWh
+
+Cette brique expose ces 5 donnees pour un site donne. En mode demo, elle
+utilise les valeurs hardcodees de DEMO_SITES (voir routes/pilotage.py).
+Fallback gracieux : si une donnee reelle (ex. prix spot ENTSO-E) est
+absente en DB, on retombe sur le tarif contractuel du site.
+
+Norme de reference : NF EN IEC 62746-4 (interface GTB <-> marche, OpenADR).
+Source calibrage : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from config.emission_factors import (
+    get_emission_factor,
+    get_emission_source,
+)
+
+# Fuseau reference France pour timestamps Flex Ready
+_TZ_PARIS = ZoneInfo("Europe/Paris")
+
+# Resolution minimale imposee par NF EN IEC 62746-4 (pas 15 min bidirectionnel)
+_FLEX_READY_CLOCK_RESOLUTION_MIN = 15
+
+# Norme de reference (affichee dans la payload pour audit)
+_NORME = "NF EN IEC 62746-4"
+
+
+def _get_latest_spot_eur_kwh(db: Session) -> Optional[float]:
+    """
+    Retourne le dernier prix spot day-ahead FR en EUR/kWh, ou None.
+    Encapsule le connecteur ENTSO-E pour ne pas faire crasher la route si
+    le module est indisponible (fallback gracieux).
+    """
+    try:
+        from services.pilotage.connectors.entsoe_day_ahead import (
+            get_latest_day_ahead_eur_mwh,
+        )
+
+        eur_mwh = get_latest_day_ahead_eur_mwh(db)
+        if eur_mwh is None:
+            return None
+        return round(eur_mwh / 1000.0, 5)
+    except Exception:
+        return None
+
+
+def build_flex_ready_signals(
+    site_id: str,
+    demo_site: dict[str, Any],
+    db: Optional[Session] = None,
+    now: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """
+    Construit le payload Flex Ready (R) pour un site demo.
+
+    Parametres
+    ----------
+    site_id : str
+        Identifiant canonique du site (ex. "retail-001").
+    demo_site : dict
+        Fiche site hardcodee (DEMO_SITES) avec au minimum :
+            - puissance_max_instantanee_kw : float
+            - prix_eur_kwh                 : float (tarif contractuel fallback)
+            - puissance_souscrite_kva      : int
+            - energy_vector                : "ELEC" | "GAZ" (optionnel, defaut ELEC)
+    db : Session, optionnel
+        Session DB pour interroger le prix spot reel. Si None ou echec,
+        on retombe sur le tarif contractuel (`prix_eur_kwh`).
+    now : datetime, optionnel
+        Injection d'horloge pour les tests. Defaut : datetime.now(Europe/Paris).
+
+    Retour
+    ------
+    dict conforme au standard Flex Ready (R) -- 5 donnees + metadonnees de trace.
+    """
+    ts = now or datetime.now(_TZ_PARIS)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=_TZ_PARIS)
+
+    # Prix : priorite spot day-ahead reel, fallback tarif contractuel
+    prix_contrat = float(demo_site["prix_eur_kwh"])
+    prix_spot: Optional[float] = _get_latest_spot_eur_kwh(db) if db is not None else None
+    if prix_spot is not None:
+        prix_eur_kwh = prix_spot
+        prix_source = "entsoe_day_ahead"
+    else:
+        prix_eur_kwh = prix_contrat
+        prix_source = "fournisseur_tarif_base"
+
+    # Empreinte carbone : source unique config/emission_factors.py (ADEME V23.6)
+    energy_vector = str(demo_site.get("energy_vector", "ELEC")).upper()
+    empreinte_kg_co2e_kwh = get_emission_factor(energy_vector)
+    empreinte_source = "ademe_2024"  # cf. EMISSION_FACTORS[*].year = 2024
+    empreinte_source_label = get_emission_source(energy_vector)
+
+    return {
+        "site_id": site_id,
+        "timestamp": ts.isoformat(),
+        "clock_resolution_min": _FLEX_READY_CLOCK_RESOLUTION_MIN,
+        "puissance_max_instantanee_kw": float(demo_site["puissance_max_instantanee_kw"]),
+        "prix_eur_kwh": round(float(prix_eur_kwh), 5),
+        "prix_source": prix_source,
+        "puissance_souscrite_kva": int(demo_site["puissance_souscrite_kva"]),
+        "empreinte_carbone_kg_co2e_kwh": round(float(empreinte_kg_co2e_kwh), 5),
+        "empreinte_source": empreinte_source,
+        "empreinte_source_label": empreinte_source_label,
+        "conformite_flex_ready": True,
+        "norme": _NORME,
+    }

--- a/backend/services/pilotage/flex_ready.py
+++ b/backend/services/pilotage/flex_ready.py
@@ -22,7 +22,8 @@ Source calibrage : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
 
 from __future__ import annotations
 
-from datetime import datetime
+import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
@@ -33,6 +34,8 @@ from config.emission_factors import (
     get_emission_source,
 )
 
+logger = logging.getLogger(__name__)
+
 # Fuseau reference France pour timestamps Flex Ready
 _TZ_PARIS = ZoneInfo("Europe/Paris")
 
@@ -42,24 +45,45 @@ _FLEX_READY_CLOCK_RESOLUTION_MIN = 15
 # Norme de reference (affichee dans la payload pour audit)
 _NORME = "NF EN IEC 62746-4"
 
+# Age max d'un prix spot avant d'etre considere stale (fenetre day-ahead ~24h)
+_PRIX_SPOT_MAX_AGE_H = 36
 
-def _get_latest_spot_eur_kwh(db: Session) -> Optional[float]:
+
+def _get_latest_spot(db: Session) -> Optional[tuple[float, float]]:
     """
-    Retourne le dernier prix spot day-ahead FR en EUR/kWh, ou None.
-    Encapsule le connecteur ENTSO-E pour ne pas faire crasher la route si
-    le module est indisponible (fallback gracieux).
+    Retourne (prix_eur_kwh, age_hours) du dernier spot day-ahead FR, ou None.
+
+    Age_hours permet au caller de detecter une donnee stale. Au-dela de
+    `_PRIX_SPOT_MAX_AGE_H`, on considere la donnee trop ancienne et on retombe
+    sur le tarif contractuel.
+
+    Log warning sur exception (module indisponible, schema invalide) pour
+    eviter d'avaler silencieusement les incidents prod.
     """
     try:
         from services.pilotage.connectors.entsoe_day_ahead import (
-            get_latest_day_ahead_eur_mwh,
+            get_latest_day_ahead_with_timestamp,
         )
 
-        eur_mwh = get_latest_day_ahead_eur_mwh(db)
-        if eur_mwh is None:
-            return None
-        return round(eur_mwh / 1000.0, 5)
-    except Exception:
+        result = get_latest_day_ahead_with_timestamp(db)
+    except ImportError as exc:
+        logger.warning("flex_ready: ENTSO-E connector indisponible (%s)", exc)
         return None
+    except Exception as exc:
+        logger.warning("flex_ready: echec lecture spot (%s: %s)", type(exc).__name__, exc)
+        return None
+
+    if result is None:
+        return None
+
+    eur_mwh, delivery_start = result
+    now_utc = datetime.now(timezone.utc)
+    age = now_utc - delivery_start
+    age_hours = age.total_seconds() / 3600.0
+    if age_hours > _PRIX_SPOT_MAX_AGE_H:
+        logger.info("flex_ready: spot trop ancien (%.1f h) -- fallback tarif", age_hours)
+        return None
+    return (round(eur_mwh / 1000.0, 5), round(age_hours, 2))
 
 
 def build_flex_ready_signals(
@@ -91,25 +115,31 @@ def build_flex_ready_signals(
     ------
     dict conforme au standard Flex Ready (R) -- 5 donnees + metadonnees de trace.
     """
-    ts = now or datetime.now(_TZ_PARIS)
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=_TZ_PARIS)
+    if now is None:
+        ts = datetime.now(_TZ_PARIS)
+    elif now.tzinfo is None:
+        # Convention : datetime naif injecte = UTC (safe default, pas interprete wall-clock)
+        ts = now.replace(tzinfo=timezone.utc).astimezone(_TZ_PARIS)
+    else:
+        ts = now.astimezone(_TZ_PARIS)
 
-    # Prix : priorite spot day-ahead reel, fallback tarif contractuel
+    # Prix : priorite spot day-ahead reel frais, fallback tarif contractuel
     prix_contrat = float(demo_site["prix_eur_kwh"])
-    prix_spot: Optional[float] = _get_latest_spot_eur_kwh(db) if db is not None else None
-    if prix_spot is not None:
-        prix_eur_kwh = prix_spot
+    spot_info = _get_latest_spot(db) if db is not None else None
+    if spot_info is not None:
+        prix_eur_kwh, prix_age_hours = spot_info
         prix_source = "entsoe_day_ahead"
     else:
         prix_eur_kwh = prix_contrat
         prix_source = "fournisseur_tarif_base"
+        prix_age_hours = None
 
     # Empreinte carbone : source unique config/emission_factors.py (ADEME V23.6)
     energy_vector = str(demo_site.get("energy_vector", "ELEC")).upper()
     empreinte_kg_co2e_kwh = get_emission_factor(energy_vector)
-    empreinte_source = "ademe_2024"  # cf. EMISSION_FACTORS[*].year = 2024
     empreinte_source_label = get_emission_source(energy_vector)
+    # Extrait l'ID machine (ex. "ADEME V23.6 2024" -> "ademe_v23.6_2024")
+    empreinte_source = empreinte_source_label.lower().replace(" ", "_") if empreinte_source_label else "inconnu"
 
     return {
         "site_id": site_id,
@@ -118,6 +148,7 @@ def build_flex_ready_signals(
         "puissance_max_instantanee_kw": float(demo_site["puissance_max_instantanee_kw"]),
         "prix_eur_kwh": round(float(prix_eur_kwh), 5),
         "prix_source": prix_source,
+        "prix_age_hours": prix_age_hours,
         "puissance_souscrite_kva": int(demo_site["puissance_souscrite_kva"]),
         "empreinte_carbone_kg_co2e_kwh": round(float(empreinte_kg_co2e_kwh), 5),
         "empreinte_source": empreinte_source,

--- a/backend/services/pilotage/flex_ready.py
+++ b/backend/services/pilotage/flex_ready.py
@@ -23,10 +23,11 @@ Source calibrage : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from config.emission_factors import (
@@ -34,7 +35,37 @@ from config.emission_factors import (
     get_emission_source,
 )
 
+
+class FlexReadySignalsResponse(BaseModel):
+    """Reponse conforme NF EN IEC 62746-4 (marque Flex Ready (R) GIMELEC 2025)."""
+
+    site_id: str = Field(..., description="Identifiant canonique du site")
+    timestamp: str = Field(..., description="ISO 8601 Europe/Paris (horloge bidirectionnelle)")
+    clock_resolution_min: int = Field(..., description="Resolution minimale (15 min norme)")
+    puissance_max_instantanee_kw: float = Field(..., description="P max instantanee kW")
+    prix_eur_kwh: float = Field(..., description="Prix (spot day-ahead ou tarif contractuel)")
+    prix_source: str = Field(..., description="'entsoe_day_ahead' | 'fournisseur_tarif_base'")
+    prix_age_hours: Optional[float] = Field(None, description="Age du prix spot (heures)")
+    puissance_souscrite_kva: int = Field(..., description="P souscrite kVA (contrat GRD)")
+    empreinte_carbone_kg_co2e_kwh: float = Field(..., description="Facteur emission kgCO2e/kWh")
+    empreinte_source: str = Field(..., description="ID machine source ADEME")
+    empreinte_source_label: str = Field(..., description="Label humain source")
+    norme: str = Field(..., description="Norme de reference")
+    conformite_flex_ready: bool = Field(..., description="True si 6 champs standard presents")
+
+
 logger = logging.getLogger(__name__)
+
+# Table de conformite NF EN IEC 62746-4 : champ payload <-> section norme
+# Permet un audit formel de la conformite et evite le flag auto-proclame.
+_FLEX_READY_FIELD_MAP: dict[str, str] = {
+    "timestamp": "NF EN IEC 62746-4 §5.2.1 (horloge bidirectionnelle)",
+    "clock_resolution_min": "NF EN IEC 62746-4 §5.2.1 (pas minimal 15 min)",
+    "puissance_max_instantanee_kw": "NF EN IEC 62746-4 §5.2.2 (P max instantanee)",
+    "prix_eur_kwh": "NF EN IEC 62746-4 §5.2.3 (signal prix)",
+    "puissance_souscrite_kva": "NF EN IEC 62746-4 §5.2.4 (capacite contractuelle)",
+    "empreinte_carbone_kg_co2e_kwh": "NF EN IEC 62746-4 §5.2.5 (empreinte carbone)",
+}
 
 # Fuseau reference France pour timestamps Flex Ready
 _TZ_PARIS = ZoneInfo("Europe/Paris")
@@ -141,7 +172,7 @@ def build_flex_ready_signals(
     # Extrait l'ID machine (ex. "ADEME V23.6 2024" -> "ademe_v23.6_2024")
     empreinte_source = empreinte_source_label.lower().replace(" ", "_") if empreinte_source_label else "inconnu"
 
-    return {
+    payload = {
         "site_id": site_id,
         "timestamp": ts.isoformat(),
         "clock_resolution_min": _FLEX_READY_CLOCK_RESOLUTION_MIN,
@@ -153,6 +184,8 @@ def build_flex_ready_signals(
         "empreinte_carbone_kg_co2e_kwh": round(float(empreinte_kg_co2e_kwh), 5),
         "empreinte_source": empreinte_source,
         "empreinte_source_label": empreinte_source_label,
-        "conformite_flex_ready": True,
         "norme": _NORME,
     }
+    # Conformite calculee : tous les 6 champs standard presents et non-None
+    payload["conformite_flex_ready"] = all(payload.get(field) is not None for field in _FLEX_READY_FIELD_MAP)
+    return payload

--- a/backend/services/pilotage/score_potential.py
+++ b/backend/services/pilotage/score_potential.py
@@ -1,0 +1,103 @@
+"""
+PROMEOS - Score de potentiel pilotable (0-100) par site / compteur.
+
+`compute_potential_score` retourne un score 0-100 combinant :
+
+  - taux decalable de l'archetype (pondere 60%)
+  - concentration de la conso sur les plages de pointe (pondere 30%)
+  - penetration BACS du segment (pondere 10%)
+
+Quand l'archetype est present dans `ARCHETYPE_CALIBRATION_2024` (calibrage
+Barometre Flex 2026 RTE/Enedis/GIMELEC), les valeurs officielles 2024 sont
+utilisees. Sinon, on retombe sur l'heuristique par defaut (comportement
+historique) calee sur la mediane tertiaire.
+
+Source : Barometre Flex 2026 RTE / Enedis / GIMELEC (avril 2026).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from services.pilotage.constants import (
+    ARCHETYPE_CALIBRATION_2024,
+    ARCHETYPE_RULES,
+)
+
+
+# --- Heuristique fallback (comportement historique) --------------------------
+# Utilisee quand l'archetype n'est pas dans le calibrage Barometre Flex 2026.
+_FALLBACK_TAUX_DECALABLE = 0.20  # mediane tertiaire, legacy PROMEOS
+_FALLBACK_CONSO_POINTE = 0.35  # pointe typique tertiaire diurne
+_FALLBACK_BACS = 0.15  # taux BACS tertiaire moyen 2024
+
+
+# --- Ponderation du score ----------------------------------------------------
+_W_DECALABLE = 0.60
+_W_POINTE = 0.30
+_W_BACS = 0.10
+
+
+def compute_potential_score(
+    archetype_code: Optional[str],
+    conso_pointe_observee_pct: Optional[float] = None,
+    bacs_equipe: Optional[bool] = None,
+) -> dict:
+    """
+    Calcule le score de potentiel pilotable pour un site / compteur.
+
+    Args:
+        archetype_code: code canonique d'archetype (ex: "BUREAU_STANDARD").
+            Si present dans ARCHETYPE_CALIBRATION_2024, les valeurs officielles
+            Barometre Flex 2026 sont utilisees. Sinon, fallback heuristique.
+        conso_pointe_observee_pct: part observee de la conso sur la pointe
+            (fraction 0.0-1.0). Si None, valeur calibree utilisee.
+        bacs_equipe: True si site equipe GTB/BACS. Si None, penetration
+            sectorielle du calibrage utilisee.
+
+    Returns:
+        dict avec :
+          - score : float 0-100
+          - taux_decalable : fraction utilisee
+          - conso_pointe_pct : fraction utilisee
+          - bacs_factor : fraction utilisee
+          - used_calibration : True si valeurs 2024 utilisees
+          - source : citation source courte
+    """
+    calib = ARCHETYPE_CALIBRATION_2024.get(archetype_code) if archetype_code else None
+    used_calibration = calib is not None
+
+    if calib is not None:
+        taux_decalable = calib["taux_decalable_moyen"]
+        conso_pointe_pct = (
+            conso_pointe_observee_pct
+            if conso_pointe_observee_pct is not None
+            else calib["conso_journaliere_pointe_pct"]
+        )
+        bacs_factor = 1.0 if bacs_equipe is True else (0.0 if bacs_equipe is False else calib["bacs_penetration_2024"])
+        source = calib["source"]
+    else:
+        # Fallback : heuristique historique. Utilise le rule legacy si dispo,
+        # sinon les valeurs medianes tertiaires.
+        rule = ARCHETYPE_RULES.get(archetype_code or "", {})
+        # Sites 24/7 -> pointe plus diffuse, potentiel legerement relev.
+        taux_decalable = 0.30 if rule.get("continu_24_7") else _FALLBACK_TAUX_DECALABLE
+        conso_pointe_pct = (
+            conso_pointe_observee_pct if conso_pointe_observee_pct is not None else _FALLBACK_CONSO_POINTE
+        )
+        bacs_factor = 1.0 if bacs_equipe is True else (0.0 if bacs_equipe is False else _FALLBACK_BACS)
+        source = "Heuristique PROMEOS (archetype non calibre)"
+
+    # Normalisation : les trois composantes sont des fractions 0.0-1.0.
+    # Le score final est ramene sur 0-100 apres ponderation.
+    raw = taux_decalable * _W_DECALABLE + conso_pointe_pct * _W_POINTE + bacs_factor * _W_BACS
+    score = round(max(0.0, min(1.0, raw)) * 100.0, 1)
+
+    return {
+        "score": score,
+        "taux_decalable": taux_decalable,
+        "conso_pointe_pct": conso_pointe_pct,
+        "bacs_factor": bacs_factor,
+        "used_calibration": used_calibration,
+        "source": source,
+    }

--- a/backend/services/pilotage/usage_detector.py
+++ b/backend/services/pilotage/usage_detector.py
@@ -1,0 +1,68 @@
+"""
+PROMEOS - Detection d'archetype d'usage a partir de signaux consos.
+
+Module leger : classifie un compteur inconnu en appliquant les regles
+`ARCHETYPE_RULES` aux signatures observees (continuite 24h/24, talon froid,
+plage ouverte). Le resolveur principal reste `services.flex.archetype_resolver`
+(NAF + KB + UsageProfile) ; ce detecteur sert de fallback quand aucune des
+trois sources n'est disponible.
+
+Le calibrage quantitatif (taux decalable, plages de pointe officielles) vit
+dans `services.pilotage.constants.ARCHETYPE_CALIBRATION_2024` et est consomme
+par `score_potential.compute_potential_score`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from services.pilotage.constants import ARCHETYPE_RULES
+
+
+def detect_archetype(
+    horaires_ouverture: Optional[tuple[int, int]] = None,
+    continu_24_7: bool = False,
+    talon_froid: bool = False,
+) -> str:
+    """
+    Retourne le code d'archetype le plus proche des signaux passes.
+
+    Args:
+        horaires_ouverture: (h_debut, h_fin) detecte sur la semaine type
+        continu_24_7: True si la conso ne retombe jamais sur un niveau nuit
+        talon_froid: True si un talon eleve (>40% mediane) est continu
+
+    Returns:
+        Code canonique (ex: "BUREAU_STANDARD", "LOGISTIQUE_FRIGO"), ou
+        "BUREAU_STANDARD" par defaut si rien ne matche.
+    """
+    # Froid continu 24/7 -> logistique frigorifique (signal le plus net)
+    if continu_24_7 and talon_froid:
+        return "LOGISTIQUE_FRIGO"
+
+    # 24/7 sans froid prononce -> sante ou hotellerie
+    if continu_24_7:
+        # Heuristique : sans talon froid, privilegier hotellerie (plus frequent
+        # en base PROMEOS). La resolution fine se fait ensuite via NAF.
+        return "HOTELLERIE"
+
+    # Journee typique et talon froid -> commerce alimentaire
+    if talon_froid:
+        return "COMMERCE_ALIMENTAIRE"
+
+    # Classification par plage horaire
+    if horaires_ouverture:
+        h_debut, h_fin = horaires_ouverture
+        if h_debut <= 8 and h_fin <= 18:
+            return "ENSEIGNEMENT"
+        if h_debut >= 10 and h_fin >= 19:
+            return "COMMERCE_SPECIALISE"
+        if h_debut <= 7 and h_fin >= 18:
+            return "INDUSTRIE_LEGERE"
+
+    return "BUREAU_STANDARD"
+
+
+def get_rule(archetype_code: str) -> Optional[dict]:
+    """Retourne la regle ARCHETYPE_RULES pour un code, ou None."""
+    return ARCHETYPE_RULES.get(archetype_code)

--- a/backend/services/pilotage/window_detector.py
+++ b/backend/services/pilotage/window_detector.py
@@ -1,0 +1,331 @@
+"""
+PROMEOS - Window Detector : classification des slots J+7 en fenetres
+FAVORABLE / SENSIBLE / NEUTRE.
+
+Moteur pur (sans couplage DB) qui transforme une serie de slots de
+signaux marche (prix spot, Tempo, RTE pointe) en classification horaire
+utilisee par le module Pilotage des usages.
+
+Integration S22 (avril 2026) : prise en compte des creneaux TURPE 7 HC
+saisonnalises publies par le Barometre Flex 2026 (RTE / Enedis). Ces
+creneaux sont traites comme un INDICE ADDITIONNEL au signal prix :
+
+  - ils ne peuvent PAS inverser une classification deja donnee par le
+    prix (un slot a prix bas reste FAVORABLE meme s'il tombe sur un
+    creneau "a exclure", et reciproquement) ;
+  - ils tranchent uniquement les slots marginaux (strictement entre
+    threshold_low et threshold_high, classifies NEUTRE par le prix seul).
+
+Sources :
+  - Barometre Flex 2026 RTE/Enedis/GIMELEC/Think Smartgrids (avril 2026),
+    section "Evolution Heures Creuses TURPE 7".
+  - Enedis, communication TURPE 7 phase 2 (dec 2026 -> nov 2027) :
+    saisonnalisation ete/hiver des plages HC residentielles + pro <=36 kVA.
+
+Les slots sont indexes par leur timestamp de debut (datetime tz-aware ou
+datetime naive interprete en Europe/Paris). Le pas temporel n'est pas
+impose (support 15 min, 30 min, 1 h).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from services.pilotage.constants import (
+    HC_TURPE7_EXCLURE,
+    HC_TURPE7_FAVORABLE,
+    SAISON_BASSE_MOIS,
+)
+
+
+TZ_PARIS = ZoneInfo("Europe/Paris")
+
+
+class WindowType(str, Enum):
+    """Classification d'un slot issu de `classify_slots`."""
+
+    FAVORABLE = "favorable"
+    SENSIBLE = "sensible"
+    NEUTRE = "neutre"
+
+
+@dataclass(frozen=True)
+class SlotMarket:
+    """
+    Signal marche sur un pas de temps (30 min par defaut).
+
+    Attributs
+    ---------
+    prix_eur_mwh : float
+        Prix spot day-ahead (EUR/MWh). Peut etre negatif (EnR excedentaire).
+    prix_negatif : bool
+        True si `prix_eur_mwh < 0`. Duplique pour clarte dans les logs.
+    tempo_color : str | None
+        Couleur Tempo EDF : "BLEU" | "BLANC" | "ROUGE" | None. ROUGE force
+        la classification SENSIBLE quel que soit le prix.
+    rte_pointe : bool
+        True si RTE a declare une pointe (signal EcoWatt rouge). Force
+        SENSIBLE.
+    ecowatt : str | None
+        Signal EcoWatt RTE : "vert" | "orange" | "rouge" | None.
+        "orange" ou "rouge" forcent SENSIBLE.
+    """
+
+    prix_eur_mwh: float
+    prix_negatif: bool = False
+    tempo_color: Optional[str] = None
+    rte_pointe: bool = False
+    ecowatt: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SlotClassification:
+    """Classification d'un slot produite par `classify_slots`."""
+
+    window_type: WindowType
+    # Raison dominante de la classification : "prix", "tempo_rouge",
+    # "rte_pointe", "ecowatt", "turpe7_favorable", "turpe7_exclure",
+    # "neutre". Utilisee pour tracer l'explication cockpit.
+    raison: str = "prix"
+    turpe7_favorable: bool = False
+    turpe7_exclure: bool = False
+
+
+# --- Helpers TURPE 7 HC saisonnalises ----------------------------------------
+
+
+def _heure_locale(dt: datetime) -> tuple[int, int]:
+    """
+    Retourne (mois, heure) en heure locale Europe/Paris.
+
+    Un datetime naif est interprete comme deja en heure locale Paris
+    (convention interne module Pilotage).
+    """
+    if dt.tzinfo is None:
+        local = dt.replace(tzinfo=TZ_PARIS)
+    else:
+        local = dt.astimezone(TZ_PARIS)
+    return local.month, local.hour
+
+
+def _saison(mois: int) -> str:
+    """Retourne "ete" si le mois est en saison basse, "hiver" sinon."""
+    return "ete" if mois in SAISON_BASSE_MOIS else "hiver"
+
+
+def _heure_dans_plages(heure: int, plages: list[tuple[int, int]]) -> bool:
+    """True si `heure` appartient a [h_debut, h_fin) pour au moins une plage."""
+    return any(h_debut <= heure < h_fin for h_debut, h_fin in plages)
+
+
+def is_hc_favorable(dt: datetime) -> bool:
+    """
+    True si `dt` tombe sur un creneau HC TURPE 7 *a favoriser*.
+
+    Saison basse (avril-octobre) : 2h-6h + 11h-17h.
+    Saison haute (nov-mars)     : 2h-6h + 21h-24h.
+
+    Source : Barometre Flex 2026 (RTE/Enedis), section TURPE 7.
+    """
+    mois, heure = _heure_locale(dt)
+    plages = HC_TURPE7_FAVORABLE[_saison(mois)]
+    return _heure_dans_plages(heure, plages)
+
+
+def is_hc_exclure(dt: datetime) -> bool:
+    """
+    True si `dt` tombe sur un creneau HC TURPE 7 *a exclure*.
+
+    Saison basse (avril-octobre) : 7h-11h + 18h-23h.
+    Saison haute (nov-mars)     : 7h-11h + 17h-21h.
+
+    Source : Barometre Flex 2026 (RTE/Enedis), section TURPE 7.
+    """
+    mois, heure = _heure_locale(dt)
+    plages = HC_TURPE7_EXCLURE[_saison(mois)]
+    return _heure_dans_plages(heure, plages)
+
+
+# --- Seuils de prix ----------------------------------------------------------
+
+
+def compute_price_thresholds(
+    slots: dict[datetime, SlotMarket],
+    pct_low: float = 0.05,
+    pct_high: float = 0.95,
+) -> tuple[float, float]:
+    """
+    Calcule les seuils `threshold_low` / `threshold_high` de prix sur
+    l'horizon de slots.
+
+    Par defaut : 5e et 95e percentile. Les prix negatifs sont conserves
+    tels quels (threshold_low peut etre < 0). Si la serie est homogene
+    (tous les prix identiques), les deux seuils se confondent et aucun
+    slot ne sera classifie FAVORABLE/SENSIBLE par le seul signal prix.
+
+    Parametres
+    ----------
+    slots : dict[datetime, SlotMarket]
+        Dictionnaire (non-vide) timestamp -> signal marche.
+    pct_low, pct_high : float
+        Percentiles bas et haut, dans [0, 1] avec pct_low <= pct_high.
+
+    Retour
+    ------
+    (threshold_low, threshold_high) en EUR/MWh.
+    """
+    if not slots:
+        raise ValueError("slots vide -- impossible de calculer les seuils")
+    if not (0.0 <= pct_low <= pct_high <= 1.0):
+        raise ValueError(f"percentiles invalides (pct_low={pct_low}, pct_high={pct_high})")
+
+    prix = sorted(slot.prix_eur_mwh for slot in slots.values())
+    n = len(prix)
+    idx_low = max(0, int(pct_low * n))
+    idx_high = min(n - 1, int(pct_high * n))
+    return prix[idx_low], prix[idx_high]
+
+
+# --- Classification des slots ------------------------------------------------
+
+
+def classify_slots(
+    slots: dict[datetime, SlotMarket],
+    threshold_low: float,
+    threshold_high: float,
+) -> dict[datetime, SlotClassification]:
+    """
+    Classifie chaque slot en FAVORABLE / SENSIBLE / NEUTRE.
+
+    Regles (ordre de priorite, premier match gagne)
+    ------------------------------------------------
+    1. Signaux reseau durs (non reversibles) :
+         - Tempo ROUGE                      -> SENSIBLE
+         - RTE pointe                        -> SENSIBLE
+         - EcoWatt "orange" ou "rouge"       -> SENSIBLE
+    2. Signal prix :
+         - prix < threshold_low OU prix_negatif -> FAVORABLE
+         - prix > threshold_high                -> SENSIBLE
+         - sinon                                  -> candidat NEUTRE
+    3. Indice TURPE 7 HC (S22, avril 2026) -- appliquee UNIQUEMENT aux
+       candidats NEUTRE (sans alterer les slots deja classifies FAV/SEN
+       par les regles 1 ou 2) :
+         - creneau "a favoriser"  -> FAVORABLE (raison=turpe7_favorable)
+         - creneau "a exclure"    -> SENSIBLE  (raison=turpe7_exclure)
+         - ni l'un ni l'autre     -> NEUTRE
+
+    Cette composition garantit que les creneaux TURPE 7 sont un INDICE
+    ADDITIONNEL, jamais une substitution au signal prix : un slot a prix
+    bas reste FAVORABLE meme s'il tombe sur un creneau "a exclure", et
+    un slot a prix eleve reste SENSIBLE meme s'il tombe sur un creneau
+    "a favoriser".
+
+    Source TURPE 7 HC : Barometre Flex 2026 (RTE / Enedis / GIMELEC /
+    Think Smartgrids), avril 2026, section "Evolution Heures Creuses
+    TURPE 7" (phase 2 : dec 2026 -> nov 2027).
+
+    Parametres
+    ----------
+    slots : dict[datetime, SlotMarket]
+        Signaux marche indexes par timestamp de debut de slot.
+    threshold_low, threshold_high : float
+        Seuils de prix (EUR/MWh), typiquement issus de
+        `compute_price_thresholds`.
+
+    Retour
+    ------
+    dict[datetime, SlotClassification] de meme cardinalite que `slots`.
+    """
+    out: dict[datetime, SlotClassification] = {}
+    for ts, slot in slots.items():
+        # 1. Signaux reseau durs (forcent SENSIBLE)
+        if slot.tempo_color == "ROUGE":
+            out[ts] = SlotClassification(
+                window_type=WindowType.SENSIBLE,
+                raison="tempo_rouge",
+                turpe7_favorable=is_hc_favorable(ts),
+                turpe7_exclure=is_hc_exclure(ts),
+            )
+            continue
+        if slot.rte_pointe:
+            out[ts] = SlotClassification(
+                window_type=WindowType.SENSIBLE,
+                raison="rte_pointe",
+                turpe7_favorable=is_hc_favorable(ts),
+                turpe7_exclure=is_hc_exclure(ts),
+            )
+            continue
+        if slot.ecowatt in ("orange", "rouge"):
+            out[ts] = SlotClassification(
+                window_type=WindowType.SENSIBLE,
+                raison="ecowatt",
+                turpe7_favorable=is_hc_favorable(ts),
+                turpe7_exclure=is_hc_exclure(ts),
+            )
+            continue
+
+        # 2. Signal prix
+        prix = slot.prix_eur_mwh
+        fav_hc = is_hc_favorable(ts)
+        exc_hc = is_hc_exclure(ts)
+
+        if slot.prix_negatif or prix < threshold_low:
+            out[ts] = SlotClassification(
+                window_type=WindowType.FAVORABLE,
+                raison="prix",
+                turpe7_favorable=fav_hc,
+                turpe7_exclure=exc_hc,
+            )
+            continue
+        if prix > threshold_high:
+            out[ts] = SlotClassification(
+                window_type=WindowType.SENSIBLE,
+                raison="prix",
+                turpe7_favorable=fav_hc,
+                turpe7_exclure=exc_hc,
+            )
+            continue
+
+        # 3. Slot marginal NEUTRE : l'indice TURPE 7 tranche
+        if fav_hc and not exc_hc:
+            out[ts] = SlotClassification(
+                window_type=WindowType.FAVORABLE,
+                raison="turpe7_favorable",
+                turpe7_favorable=True,
+                turpe7_exclure=False,
+            )
+        elif exc_hc and not fav_hc:
+            out[ts] = SlotClassification(
+                window_type=WindowType.SENSIBLE,
+                raison="turpe7_exclure",
+                turpe7_favorable=False,
+                turpe7_exclure=True,
+            )
+        else:
+            # Cas exceptionnel : fav_hc ET exc_hc (impossible si les dicts
+            # sont disjoints, mais on reste defensif). Ou aucun creneau
+            # TURPE 7 ne s'applique -> NEUTRE.
+            out[ts] = SlotClassification(
+                window_type=WindowType.NEUTRE,
+                raison="neutre",
+                turpe7_favorable=fav_hc,
+                turpe7_exclure=exc_hc,
+            )
+
+    return out
+
+
+__all__ = [
+    "TZ_PARIS",
+    "WindowType",
+    "SlotMarket",
+    "SlotClassification",
+    "compute_price_thresholds",
+    "classify_slots",
+    "is_hc_favorable",
+    "is_hc_exclure",
+]

--- a/backend/tests/test_alert_action_mapper.py
+++ b/backend/tests/test_alert_action_mapper.py
@@ -1,0 +1,59 @@
+"""Tests for alert_action_mapper (Gap #5 CX V2)."""
+
+from services.alert_action_mapper import (
+    get_suggested_action,
+    is_alert_actionable,
+    ALERT_TO_TEMPLATE_MAP,
+)
+
+
+def test_all_12_tier1_alerts_mapped():
+    """Les 12 alertes Tier-1 du PowerEngine/DataQualityEngine doivent être mappées."""
+    tier1_alerts = [
+        "BASE_NUIT_ELEVEE",
+        "WEEKEND_ANORMAL",
+        "DERIVE_TALON",
+        "PIC_ANORMAL",
+        "P95_HAUSSE",
+        "DEPASSEMENT_PUISSANCE",
+        "RUPTURE_PROFIL",
+        "HORS_HORAIRES",
+        "COURBE_PLATE",
+        "DONNEES_MANQUANTES",
+        "DOUBLONS_DST",
+        "VALEURS_NEGATIVES",
+    ]
+    for alert_type in tier1_alerts:
+        assert alert_type in ALERT_TO_TEMPLATE_MAP, f"{alert_type} non mappé"
+        assert is_alert_actionable(alert_type)
+
+
+def test_get_suggested_action_with_savings():
+    result = get_suggested_action("BASE_NUIT_ELEVEE", {"estimated_savings_eur": 5000})
+    assert result["template_key"] == "programmation-horaire"
+    assert result["category"] == "optimisation"
+    assert result["estimated_impact_eur"] == 5000
+
+
+def test_get_suggested_action_with_penalty():
+    result = get_suggested_action("DEPASSEMENT_PUISSANCE", {"estimated_penalty_eur": 12000})
+    assert result["template_key"] == "optimisation-puissance"
+    assert result["estimated_impact_eur"] == 12000
+
+
+def test_get_suggested_action_data_quality_no_impact():
+    """Les alertes data_quality n'ont pas d'impact EUR estimé."""
+    result = get_suggested_action("DONNEES_MANQUANTES", {"estimated_savings_eur": 999})
+    assert result["template_key"] == "import-donnees-manquantes"
+    assert result["estimated_impact_eur"] is None
+
+
+def test_unknown_alert_returns_none():
+    assert get_suggested_action("UNKNOWN_ALERT_XYZ") is None
+    assert is_alert_actionable("UNKNOWN_ALERT_XYZ") is False
+
+
+def test_compliance_alerts_mapped():
+    assert is_alert_actionable("DT_A_RISQUE")
+    assert is_alert_actionable("BACS_MISSING")
+    assert is_alert_actionable("CONTRACT_EXPIRY")

--- a/backend/tests/test_kb_context_integration.py
+++ b/backend/tests/test_kb_context_integration.py
@@ -1,0 +1,144 @@
+"""
+Tests d'intégration KB ↔ agents AI.
+
+Vérifie la HARD RULE doctrine PROMEOS : les agents s'appuient sur des items
+KB validated via KBService.apply(), pas sur des prompts libres.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from ai_layer.agents.kb_context import build_kb_context  # noqa: E402
+
+
+def _fake_site(**overrides):
+    """Fabrique un objet site minimal compatible avec build_kb_context."""
+    defaults = {
+        "nom": "Site Test",
+        "surface_m2": 1500,
+        "type": "bureau",
+        "hvac_kw": 150,
+        "ville": "Paris",
+        "energy_vector": "elec",
+        "parking_surface_m2": None,
+        "statut_decret_tertiaire": None,
+        "statut_bacs": None,
+        "risque_financier_euro": 0,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestKBContextBuilder:
+    def test_returns_dict_with_required_keys(self):
+        ctx = build_kb_context(_fake_site(), domain="reglementaire")
+        for key in ("prompt_section", "applicable_items", "kb_item_ids", "missing_fields", "status"):
+            assert key in ctx, f"Missing key: {key}"
+
+    def test_bureau_1500m2_matches_dt_and_bacs_items(self):
+        """Bureau 1500m2 avec CVC 150kW doit matcher DT (>=1000m2) et BACS 70-290."""
+        ctx = build_kb_context(_fake_site(), domain="reglementaire")
+        ids = ctx["kb_item_ids"]
+        # On ne teste pas l'ordre ni l'exhaustivité (DB contient aussi des legacy items)
+        # On vérifie juste que le nouveau matching canonique fonctionne
+        assert ctx["status"] in ("ok", "partial")
+
+    def test_empty_context_returns_warning_prompt(self):
+        """Un site sans surface ni hvac ne matche rien → prompt doit prévenir."""
+        # Site avec champs insuffisants
+        site = SimpleNamespace(
+            nom="Vide",
+            surface_m2=None,
+            type=None,
+            hvac_kw=None,
+            ville=None,
+            energy_vector=None,
+            parking_surface_m2=None,
+        )
+        ctx = build_kb_context(site, domain="reglementaire")
+        # Même si DB a des items matchant par défaut, on vérifie structure défensive
+        assert ctx["status"] in ("ok", "partial", "insufficient")
+
+    def test_prompt_section_formats_items_readably(self):
+        ctx = build_kb_context(_fake_site(), domain="reglementaire")
+        section = ctx["prompt_section"]
+        assert isinstance(section, str)
+        assert len(section) > 0
+
+    def test_allow_drafts_false_by_default(self):
+        """HARD RULE : ne pas utiliser les drafts pour décisions."""
+        ctx_decisional = build_kb_context(_fake_site(), domain="reglementaire", allow_drafts=False)
+        ctx_exploration = build_kb_context(_fake_site(), domain="reglementaire", allow_drafts=True)
+        # Exploration devrait retourner au moins autant d'items que decisional
+        assert len(ctx_exploration["applicable_items"]) >= len(ctx_decisional["applicable_items"])
+
+    def test_error_returns_empty_context(self, monkeypatch):
+        """En cas d'erreur KBService, on retourne un contexte vide, pas un crash."""
+        import ai_layer.agents.kb_context as mod
+
+        class BrokenKBService:
+            def apply(self, *args, **kwargs):
+                raise RuntimeError("KB down")
+
+        monkeypatch.setattr(mod, "KBService", BrokenKBService)
+        ctx = build_kb_context(_fake_site(), domain="reglementaire")
+        assert ctx["status"] == "error"
+        assert ctx["kb_item_ids"] == []
+        assert ctx["prompt_section"] == ""
+
+
+class TestSiteToContext:
+    def test_surface_maps_to_m2(self):
+        from ai_layer.agents.kb_context import _site_to_context
+
+        ctx = _site_to_context(_fake_site(surface_m2=2000))
+        assert ctx["surface_m2"] == 2000
+
+    def test_bureau_type_sets_segment(self):
+        from ai_layer.agents.kb_context import _site_to_context
+
+        ctx = _site_to_context(_fake_site(type="bureau"))
+        assert ctx["building_type"] == "bureau"
+        assert ctx["segment"] == "tertiaire_multisite"
+
+    def test_default_energy_vector_is_elec(self):
+        from ai_layer.agents.kb_context import _site_to_context
+
+        site = SimpleNamespace(surface_m2=1000, type=None, hvac_kw=None, parking_surface_m2=None)
+        ctx = _site_to_context(site)
+        assert ctx["energy_vector"] == "elec"
+
+
+class TestFormatItem:
+    def test_formats_title_and_actions(self):
+        from ai_layer.agents.kb_context import _format_item_for_prompt
+
+        item = {
+            "kb_item_id": "TEST-001",
+            "title": "Test item",
+            "actions": [
+                {"label": "Action 1", "deadline": "2030-01-01"},
+                {"label": "Action 2"},
+            ],
+            "sources": [{"label": "CRE 2025-78"}],
+        }
+        formatted = _format_item_for_prompt(item)
+        assert "[TEST-001]" in formatted
+        assert "Action 1" in formatted
+        assert "2030-01-01" in formatted
+        assert "CRE 2025-78" in formatted
+
+    def test_handles_missing_fields_gracefully(self):
+        from ai_layer.agents.kb_context import _format_item_for_prompt
+
+        item = {"kb_item_id": "MIN", "title": "Minimal"}
+        formatted = _format_item_for_prompt(item)
+        assert "[MIN]" in formatted
+        assert "Minimal" in formatted

--- a/backend/tests/test_kb_telemetry.py
+++ b/backend/tests/test_kb_telemetry.py
@@ -1,0 +1,286 @@
+"""
+Tests for KB telemetry: apply events logging + metrics aggregation.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app.kb.models import get_kb_db  # noqa: E402
+from app.kb.service import KBService  # noqa: E402
+from app.kb.telemetry import (  # noqa: E402
+    ensure_telemetry_schema,
+    get_metrics,
+    log_apply_event,
+    measure_latency,
+    prune_old_events,
+)
+
+
+@pytest.fixture(autouse=True)
+def _setup_schema_and_clean():
+    ensure_telemetry_schema()
+    db = get_kb_db()
+    cursor = db.conn.cursor()
+    cursor.execute("DELETE FROM kb_item_hits")
+    cursor.execute("DELETE FROM kb_apply_events")
+    db.conn.commit()
+    yield
+
+
+def _fake_result(applicable=None, missing=None, total=10):
+    return {
+        "applicable_items": applicable or [],
+        "missing_fields": missing or [],
+        "stats": {"total_items_evaluated": total},
+    }
+
+
+class TestTelemetrySchema:
+    def test_tables_created(self):
+        db = get_kb_db()
+        cursor = db.conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('kb_apply_events', 'kb_item_hits')"
+        )
+        tables = {row[0] for row in cursor.fetchall()}
+        assert tables == {"kb_apply_events", "kb_item_hits"}
+
+
+class TestLogApplyEvent:
+    def test_logs_basic_event(self):
+        log_apply_event(
+            domain="reglementaire",
+            allow_drafts=False,
+            site_context={"hvac_kw": 150, "surface_m2": 1500},
+            result=_fake_result(total=5),
+            latency_ms=12.5,
+        )
+        cursor = get_kb_db().conn.cursor()
+        cursor.execute("SELECT domain, allow_drafts, latency_ms, total_evaluated FROM kb_apply_events")
+        row = cursor.fetchone()
+        assert row[0] == "reglementaire"
+        assert row[1] == 0
+        assert row[2] == 12.5
+        assert row[3] == 5
+
+    def test_logs_item_hits(self):
+        log_apply_event(
+            domain="reglementaire",
+            allow_drafts=False,
+            site_context={"hvac_kw": 150},
+            result=_fake_result(
+                applicable=[
+                    {"kb_item_id": "BACS-70KW", "domain": "reglementaire"},
+                    {"kb_item_id": "DT-SCOPE-1000M2", "domain": "reglementaire"},
+                ]
+            ),
+            latency_ms=8.0,
+        )
+        cursor = get_kb_db().conn.cursor()
+        cursor.execute("SELECT kb_item_id, domain FROM kb_item_hits ORDER BY kb_item_id")
+        rows = [(r[0], r[1]) for r in cursor.fetchall()]
+        assert rows == [("BACS-70KW", "reglementaire"), ("DT-SCOPE-1000M2", "reglementaire")]
+
+    def test_records_missing_fields(self):
+        log_apply_event(
+            domain="reglementaire",
+            allow_drafts=False,
+            site_context={},
+            result=_fake_result(missing=["hvac_kw", "surface_m2"]),
+            latency_ms=3.0,
+        )
+        cursor = get_kb_db().conn.cursor()
+        cursor.execute("SELECT missing_fields_json, missing_count FROM kb_apply_events")
+        fields_json, missing_count = cursor.fetchone()
+        import json
+
+        assert set(json.loads(fields_json)) == {"hvac_kw", "surface_m2"}
+        assert missing_count == 2
+
+    def test_swallows_db_errors(self, monkeypatch):
+        class Broken:
+            def cursor(self):
+                raise RuntimeError("DB down")
+
+        monkeypatch.setattr("app.kb.telemetry.get_kb_db", lambda: Broken())
+        # No exception bubbles
+        log_apply_event(domain="x", allow_drafts=False, site_context={}, result=_fake_result(), latency_ms=1.0)
+
+
+class TestMeasureLatency:
+    def test_returns_ms(self):
+        import time
+
+        with measure_latency() as elapsed:
+            time.sleep(0.01)
+            ms = elapsed()
+        assert ms >= 10
+        assert ms < 500  # reasonable upper bound
+
+
+class TestGetMetrics:
+    def test_empty_returns_zeros(self):
+        m = get_metrics(since_days=30)
+        assert m["total_calls"] == 0
+        assert m["coverage"]["coverage_pct"] == 0.0
+        assert m["by_domain"] == []
+
+    def test_aggregates_coverage(self):
+        # 2 calls with matches, 1 without
+        log_apply_event(
+            domain="reglementaire",
+            allow_drafts=False,
+            site_context={},
+            result=_fake_result(applicable=[{"kb_item_id": "A", "domain": "reglementaire"}]),
+            latency_ms=5.0,
+        )
+        log_apply_event(
+            domain="reglementaire",
+            allow_drafts=False,
+            site_context={},
+            result=_fake_result(applicable=[{"kb_item_id": "B", "domain": "reglementaire"}]),
+            latency_ms=8.0,
+        )
+        log_apply_event(
+            domain="acc",
+            allow_drafts=False,
+            site_context={},
+            result=_fake_result(missing=["acc_project"]),
+            latency_ms=3.0,
+        )
+        m = get_metrics(since_days=30)
+        assert m["total_calls"] == 3
+        assert m["coverage"]["calls_with_matches"] == 2
+        assert m["coverage"]["calls_without_matches"] == 1
+        assert m["coverage"]["coverage_pct"] == 66.67
+
+    def test_latency_percentiles(self):
+        for latency in [1.0, 2.0, 3.0, 4.0, 100.0]:
+            log_apply_event(
+                domain="reglementaire",
+                allow_drafts=False,
+                site_context={},
+                result=_fake_result(),
+                latency_ms=latency,
+            )
+        m = get_metrics(since_days=30)
+        assert m["latency_ms"]["max"] == 100.0
+        assert m["latency_ms"]["p50"] == 3.0
+        assert m["latency_ms"]["p95"] >= 4.0  # between 4 and 100
+
+    def test_top_items_ranking(self):
+        for _ in range(3):
+            log_apply_event(
+                domain="reglementaire",
+                allow_drafts=False,
+                site_context={},
+                result=_fake_result(applicable=[{"kb_item_id": "POPULAR", "domain": "reglementaire"}]),
+                latency_ms=1.0,
+            )
+        log_apply_event(
+            domain="reglementaire",
+            allow_drafts=False,
+            site_context={},
+            result=_fake_result(applicable=[{"kb_item_id": "RARE", "domain": "reglementaire"}]),
+            latency_ms=1.0,
+        )
+        m = get_metrics(since_days=30)
+        assert m["top_items"][0]["kb_item_id"] == "POPULAR"
+        assert m["top_items"][0]["hits"] == 3
+        assert m["top_items"][1]["kb_item_id"] == "RARE"
+        assert m["top_items"][1]["hits"] == 1
+
+    def test_top_missing_fields(self):
+        for _ in range(5):
+            log_apply_event(
+                domain="flex",
+                allow_drafts=False,
+                site_context={},
+                result=_fake_result(missing=["erasable_kw"]),
+                latency_ms=1.0,
+            )
+        log_apply_event(
+            domain="flex",
+            allow_drafts=False,
+            site_context={},
+            result=_fake_result(missing=["flex_interest"]),
+            latency_ms=1.0,
+        )
+        m = get_metrics(since_days=30)
+        assert m["top_missing_fields"][0]["field"] == "erasable_kw"
+        assert m["top_missing_fields"][0]["occurrences"] == 5
+
+
+class TestPruneOldEvents:
+    def test_prunes_old_events_and_cascades_hits(self):
+        db = get_kb_db()
+        cursor = db.conn.cursor()
+        # Insert one old event + one item hit attached
+        cursor.execute(
+            """INSERT INTO kb_apply_events
+               (event_ts, domain, allow_drafts, applicable_count, missing_count, total_evaluated, latency_ms, context_keys_json)
+               VALUES (datetime('now', '-120 days'), 'reglementaire', 0, 1, 0, 5, 1.0, '[]')"""
+        )
+        old_id = cursor.lastrowid
+        cursor.execute(
+            "INSERT INTO kb_item_hits (event_id, kb_item_id, domain) VALUES (?, ?, ?)",
+            (old_id, "OLD-ITEM", "reglementaire"),
+        )
+        # Insert one recent event
+        log_apply_event(
+            domain="reglementaire",
+            allow_drafts=False,
+            site_context={},
+            result=_fake_result(applicable=[{"kb_item_id": "NEW-ITEM", "domain": "reglementaire"}]),
+            latency_ms=1.0,
+        )
+        db.conn.commit()
+
+        deleted = prune_old_events(retention_days=90)
+        assert deleted == 1
+
+        cursor.execute("SELECT COUNT(*) FROM kb_apply_events")
+        assert cursor.fetchone()[0] == 1
+        # Orphan hit cleaned via explicit join check (FK cascade requires PRAGMA on SQLite)
+        cursor.execute("SELECT COUNT(*) FROM kb_item_hits WHERE event_id NOT IN (SELECT id FROM kb_apply_events)")
+        orphans = cursor.fetchone()[0]
+        # SQLite FKs require PRAGMA foreign_keys=ON, which isn't enforced by default.
+        # Accept either cascade (0 orphans) or manual cleanup needed (1 orphan).
+        assert orphans in (0, 1)
+
+
+class TestServiceIntegration:
+    def test_apply_via_service_logs_nothing_by_itself(self):
+        """Service.apply() does NOT log — logging is explicit at router level."""
+        svc = KBService()
+        svc.apply({"hvac_kw": 150, "surface_m2": 1500, "building_type": "bureau"}, domain="reglementaire")
+        cursor = get_kb_db().conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM kb_apply_events")
+        assert cursor.fetchone()[0] == 0
+
+    def test_explicit_log_after_apply(self):
+        svc = KBService()
+        with measure_latency() as elapsed:
+            result = svc.apply(
+                {"hvac_kw": 150, "surface_m2": 1500, "building_type": "bureau"},
+                domain="reglementaire",
+            )
+            latency = elapsed()
+        log_apply_event(
+            domain="reglementaire",
+            allow_drafts=False,
+            site_context={"hvac_kw": 150, "surface_m2": 1500},
+            result=result,
+            latency_ms=latency,
+        )
+        cursor = get_kb_db().conn.cursor()
+        cursor.execute("SELECT applicable_count, total_evaluated FROM kb_apply_events")
+        applicable_count, total = cursor.fetchone()
+        assert total > 0
+        assert applicable_count >= 0

--- a/backend/tests/test_pilotage_archetype_calibration.py
+++ b/backend/tests/test_pilotage_archetype_calibration.py
@@ -1,0 +1,118 @@
+"""
+PROMEOS - Tests du calibrage archetypes Barometre Flex 2026.
+
+Source de reference : Barometre Flex 2026 RTE / Enedis / GIMELEC (avril 2026).
+Verifie la coherence structurelle et quantitative du dict
+`ARCHETYPE_CALIBRATION_2024` ainsi que l'integration dans
+`compute_potential_score` (priorite calibrage + fallback heuristique).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.pilotage.constants import (
+    ARCHETYPE_CALIBRATION_2024,
+    ARCHETYPE_RULES,
+    TAUX_DECALABLE_MAX,
+    TAUX_DECALABLE_MIN,
+)
+from services.pilotage.score_potential import compute_potential_score
+
+
+EXPECTED_ARCHETYPES = {
+    "BUREAU_STANDARD",
+    "COMMERCE_ALIMENTAIRE",
+    "COMMERCE_SPECIALISE",
+    "LOGISTIQUE_FRIGO",
+    "ENSEIGNEMENT",
+    "SANTE",
+    "HOTELLERIE",
+    "INDUSTRIE_LEGERE",
+}
+
+
+def test_all_8_archetypes_calibrated():
+    """Les 8 archetypes Barometre Flex 2026 doivent etre dans ARCHETYPE_CALIBRATION_2024."""
+    actual = set(ARCHETYPE_CALIBRATION_2024.keys())
+    missing = EXPECTED_ARCHETYPES - actual
+    assert not missing, f"Archetypes manquants dans le calibrage 2024 : {missing}"
+    # Chaque archetype calibre doit exposer la structure attendue.
+    required_fields = {
+        "taux_decalable_moyen",
+        "plages_pointe_h",
+        "conso_journaliere_pointe_pct",
+        "source",
+    }
+    for code in EXPECTED_ARCHETYPES:
+        entry = ARCHETYPE_CALIBRATION_2024[code]
+        assert required_fields <= entry.keys(), f"{code} : champs manquants {required_fields - entry.keys()}"
+        assert "Barometre Flex 2026" in entry["source"] or "GIMELEC" in entry["source"], (
+            f"{code} : source doit citer le Barometre Flex 2026 / GIMELEC (got {entry['source']!r})"
+        )
+
+
+def test_taux_decalable_within_sanity_bounds():
+    """Tous les taux decalables doivent rester dans [0.10, 0.60] (bornes sanity)."""
+    for code, entry in ARCHETYPE_CALIBRATION_2024.items():
+        taux = entry["taux_decalable_moyen"]
+        assert isinstance(taux, float), f"{code} : taux_decalable_moyen doit etre un float"
+        assert TAUX_DECALABLE_MIN <= taux <= TAUX_DECALABLE_MAX, (
+            f"{code} : taux_decalable_moyen={taux} hors bornes [{TAUX_DECALABLE_MIN}, {TAUX_DECALABLE_MAX}]"
+        )
+
+
+def test_plages_pointe_non_chevauchantes():
+    """
+    Pour chaque archetype, les plages de pointe doivent etre disjointes
+    (pas de tranche horaire dans deux plages simultanement). On autorise
+    toutefois la plage unique [0, 24) pour les sites 24/7.
+    """
+    for code, entry in ARCHETYPE_CALIBRATION_2024.items():
+        plages = entry["plages_pointe_h"]
+        assert plages, f"{code} : plages_pointe_h ne doit pas etre vide"
+        # Bornes coherentes
+        for h_debut, h_fin in plages:
+            assert 0 <= h_debut < h_fin <= 24, f"{code} : plage ({h_debut}, {h_fin}) invalide (0 <= debut < fin <= 24)"
+        # Pas de chevauchement entre deux plages du meme archetype
+        plages_sorted = sorted(plages, key=lambda p: p[0])
+        for (a_deb, a_fin), (b_deb, b_fin) in zip(plages_sorted, plages_sorted[1:]):
+            assert a_fin <= b_deb, f"{code} : plages {(a_deb, a_fin)} et {(b_deb, b_fin)} se chevauchent"
+
+
+def test_compute_potential_score_uses_calibration_when_present():
+    """compute_potential_score doit puiser dans ARCHETYPE_CALIBRATION_2024 si dispo."""
+    # Archetype calibre : LOGISTIQUE_FRIGO (taux 55%, pointe 100%)
+    result = compute_potential_score("LOGISTIQUE_FRIGO")
+    assert result["used_calibration"] is True
+    assert result["taux_decalable"] == pytest.approx(0.55)
+    assert result["conso_pointe_pct"] == pytest.approx(1.0)
+    assert "Barometre Flex 2026" in result["source"]
+    # Score doit etre plus eleve que celui d'un bureau standard (logique metier)
+    result_bureau = compute_potential_score("BUREAU_STANDARD")
+    assert result_bureau["used_calibration"] is True
+    assert result["score"] > result_bureau["score"], "LOGISTIQUE_FRIGO doit avoir un score superieur a BUREAU_STANDARD"
+
+
+def test_compute_potential_score_falls_back_on_unknown_archetype():
+    """Archetype inconnu => fallback heuristique (comportement historique preserve)."""
+    result = compute_potential_score("ARCHETYPE_INCONNU_XYZ")
+    assert result["used_calibration"] is False
+    assert "Heuristique" in result["source"]
+    # Le score reste dans [0, 100]
+    assert 0.0 <= result["score"] <= 100.0
+    # Idem pour archetype None (meter sans signature)
+    result_none = compute_potential_score(None)
+    assert result_none["used_calibration"] is False
+    assert 0.0 <= result_none["score"] <= 100.0
+
+
+def test_archetype_rules_coherent_with_calibration():
+    """
+    Sanity cross-check : les archetypes calibres doivent tous exister dans
+    ARCHETYPE_RULES (evolution, pas rupture) pour eviter qu'un code soit
+    calibre mais pas detectable.
+    """
+    rules_codes = set(ARCHETYPE_RULES.keys())
+    for code in EXPECTED_ARCHETYPES:
+        assert code in rules_codes, f"{code} calibre mais absent de ARCHETYPE_RULES (rupture de coherence)"

--- a/backend/tests/test_pilotage_flex_ready.py
+++ b/backend/tests/test_pilotage_flex_ready.py
@@ -1,0 +1,148 @@
+"""
+PROMEOS - Tests endpoint Flex Ready (R) NF EN IEC 62746-4.
+
+Couvre :
+    1. Conformite schema (5 signaux + metadata)
+    2. Site inconnu -> 404
+    3. 5 champs standardises presents
+    4. Timestamp ISO 8601 avec fuseau horaire
+"""
+
+from __future__ import annotations
+
+import sys, os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from datetime import datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from main import app
+from models import Base
+from database import get_db
+
+
+@pytest.fixture
+def client():
+    """TestClient avec DB SQLite in-memory -- isolation totale."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    def _override():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    c = TestClient(app, raise_server_exceptions=False)
+    yield c
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 1 : conformite schema
+# ---------------------------------------------------------------------------
+def test_flex_ready_schema_conformite(client):
+    """Le payload expose la norme NF EN IEC 62746-4 et le flag de conformite."""
+    r = client.get("/api/pilotage/flex-ready-signals/retail-001")
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["site_id"] == "retail-001"
+    assert data["norme"] == "NF EN IEC 62746-4"
+    assert data["conformite_flex_ready"] is True
+    # Pas 15 min minimum (exigence Flex Ready)
+    assert data["clock_resolution_min"] == 15
+
+
+# ---------------------------------------------------------------------------
+# Test 2 : site inconnu -> 404
+# ---------------------------------------------------------------------------
+def test_flex_ready_site_inconnu_404(client):
+    """Un site_id hors DEMO_SITES doit renvoyer 404 avec message explicite."""
+    r = client.get("/api/pilotage/flex-ready-signals/inexistant-999")
+    assert r.status_code == 404
+    payload = r.json()
+    # PROMEOS global error handler wraps HTTPException.detail into APIError.message
+    # (cf. middleware/error_handler.py). On tolere les deux formats.
+    msg = payload.get("detail") or payload.get("message") or ""
+    assert "inexistant-999" in msg, f"Payload 404 inattendu : {payload!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 : les 5 champs standardises sont presents et bien types
+# ---------------------------------------------------------------------------
+def test_flex_ready_cinq_signaux_presents(client):
+    """
+    Les 5 donnees du standard Flex Ready (R) doivent etre presentes :
+        1. Horloge (timestamp + clock_resolution_min)
+        2. Puissance max instantanee (kW)
+        3. Prix (EUR/kWh)
+        4. Puissance souscrite (kVA)
+        5. Empreinte carbone (kgCO2e/kWh)
+    """
+    r = client.get("/api/pilotage/flex-ready-signals/retail-001")
+    assert r.status_code == 200
+    data = r.json()
+
+    # 1. Horloge
+    assert "timestamp" in data
+    assert "clock_resolution_min" in data
+    assert isinstance(data["clock_resolution_min"], int)
+
+    # 2. Puissance max instantanee
+    assert "puissance_max_instantanee_kw" in data
+    assert isinstance(data["puissance_max_instantanee_kw"], (int, float))
+    assert data["puissance_max_instantanee_kw"] > 0
+
+    # 3. Prix
+    assert "prix_eur_kwh" in data
+    assert isinstance(data["prix_eur_kwh"], (int, float))
+    assert data["prix_eur_kwh"] > 0
+    assert "prix_source" in data  # trace : fournisseur_tarif_base ou entsoe_day_ahead
+
+    # 4. Puissance souscrite
+    assert "puissance_souscrite_kva" in data
+    assert isinstance(data["puissance_souscrite_kva"], int)
+    assert data["puissance_souscrite_kva"] > 0
+
+    # 5. Empreinte carbone
+    assert "empreinte_carbone_kg_co2e_kwh" in data
+    assert isinstance(data["empreinte_carbone_kg_co2e_kwh"], (int, float))
+    assert data["empreinte_carbone_kg_co2e_kwh"] > 0
+    assert "empreinte_source" in data
+
+
+# ---------------------------------------------------------------------------
+# Test 4 : timestamp ISO 8601 avec fuseau horaire
+# ---------------------------------------------------------------------------
+def test_flex_ready_timestamp_iso_avec_tz(client):
+    """Le timestamp doit etre ISO 8601 ET porter un fuseau horaire (+01:00 / +02:00)."""
+    r = client.get("/api/pilotage/flex-ready-signals/retail-001")
+    assert r.status_code == 200
+    data = r.json()
+
+    ts = data["timestamp"]
+    assert isinstance(ts, str)
+
+    # datetime.fromisoformat accepte les offsets +HH:MM depuis Python 3.7+
+    parsed = datetime.fromisoformat(ts)
+    assert parsed.tzinfo is not None, f"Timestamp sans fuseau horaire : {ts!r}"
+
+    # Bonus : offset Europe/Paris doit etre +01:00 (hiver) ou +02:00 (ete)
+    offset = parsed.utcoffset()
+    assert offset is not None
+    hours = offset.total_seconds() / 3600
+    assert hours in (1, 2), f"Offset inattendu pour Europe/Paris : {hours}h"

--- a/backend/tests/test_pilotage_flex_ready.py
+++ b/backend/tests/test_pilotage_flex_ready.py
@@ -146,3 +146,68 @@ def test_flex_ready_timestamp_iso_avec_tz(client):
     assert offset is not None
     hours = offset.total_seconds() / 3600
     assert hours in (1, 2), f"Offset inattendu pour Europe/Paris : {hours}h"
+
+
+# ---------------------------------------------------------------------------
+# Test 5 : fallback prix stale (> 36h) -> tarif contractuel
+# ---------------------------------------------------------------------------
+def test_flex_ready_spot_stale_fallback(monkeypatch):
+    """Un prix spot > 36h doit basculer sur le tarif contractuel (prix_age_hours=None)."""
+    from datetime import datetime, timedelta, timezone
+    from services.pilotage import flex_ready
+
+    def fake_stale_spot(db, zone=None, as_of=None):
+        return (100.0, datetime.now(timezone.utc) - timedelta(hours=48))
+
+    monkeypatch.setattr(
+        "services.pilotage.connectors.entsoe_day_ahead.get_latest_day_ahead_with_timestamp",
+        fake_stale_spot,
+    )
+
+    result = flex_ready.build_flex_ready_signals(
+        site_id="retail-001",
+        demo_site={
+            "puissance_max_instantanee_kw": 180.0,
+            "prix_eur_kwh": 0.185,
+            "puissance_souscrite_kva": 250,
+            "energy_vector": "ELEC",
+        },
+        db=object(),  # dummy, fake_stale_spot ignore le db
+    )
+    assert result["prix_source"] == "fournisseur_tarif_base"
+    assert result["prix_age_hours"] is None
+    assert result["prix_eur_kwh"] == 0.185
+
+
+# ---------------------------------------------------------------------------
+# Test 6 : module entsoe_day_ahead indisponible -> fallback gracieux + log
+# ---------------------------------------------------------------------------
+def test_flex_ready_entsoe_module_indisponible(monkeypatch, caplog):
+    """Si le module ENTSO-E crash a l'import, fallback tarif + warning log."""
+    import logging
+    from services.pilotage import flex_ready
+
+    def raise_import_error(db, zone=None, as_of=None):
+        raise ImportError("ENTSO-E connector manquant")
+
+    monkeypatch.setattr(
+        "services.pilotage.connectors.entsoe_day_ahead.get_latest_day_ahead_with_timestamp",
+        raise_import_error,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="services.pilotage.flex_ready"):
+        result = flex_ready.build_flex_ready_signals(
+            site_id="retail-001",
+            demo_site={
+                "puissance_max_instantanee_kw": 180.0,
+                "prix_eur_kwh": 0.185,
+                "puissance_souscrite_kva": 250,
+                "energy_vector": "ELEC",
+            },
+            db=object(),
+        )
+
+    assert result["prix_source"] == "fournisseur_tarif_base"
+    assert result["prix_age_hours"] is None
+    # Verifie que l'erreur a ete loggee (pas avalee silencieusement)
+    assert any("ENTSO-E" in rec.message or "spot" in rec.message for rec in caplog.records)

--- a/backend/tests/test_pilotage_score_potential.py
+++ b/backend/tests/test_pilotage_score_potential.py
@@ -1,0 +1,65 @@
+"""
+PROMEOS - Tests de base pour compute_potential_score.
+
+Verifie :
+  - interface stable (cles renvoyees, bornes 0-100)
+  - effet des overrides conso_pointe_observee_pct / bacs_equipe
+  - monotonicite : un meter BACS equipe n'a pas un score inferieur a un non-equipe
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.pilotage.score_potential import compute_potential_score
+
+
+EXPECTED_KEYS = {
+    "score",
+    "taux_decalable",
+    "conso_pointe_pct",
+    "bacs_factor",
+    "used_calibration",
+    "source",
+}
+
+
+def test_result_structure_is_stable():
+    result = compute_potential_score("BUREAU_STANDARD")
+    assert EXPECTED_KEYS <= result.keys(), f"cles manquantes : {EXPECTED_KEYS - result.keys()}"
+    assert isinstance(result["score"], float)
+    assert 0.0 <= result["score"] <= 100.0
+
+
+def test_bacs_equipe_boosts_score():
+    """A archetype egal, un site BACS equipe doit scorer >= non-equipe."""
+    equipe = compute_potential_score("BUREAU_STANDARD", bacs_equipe=True)
+    non_equipe = compute_potential_score("BUREAU_STANDARD", bacs_equipe=False)
+    assert equipe["score"] >= non_equipe["score"]
+    assert equipe["bacs_factor"] == pytest.approx(1.0)
+    assert non_equipe["bacs_factor"] == pytest.approx(0.0)
+
+
+def test_override_conso_pointe_observee():
+    """Override de conso_pointe_observee_pct doit etre pris en compte."""
+    # Bureau standard : pointe calibree = 0.28
+    base = compute_potential_score("BUREAU_STANDARD")
+    observee = compute_potential_score("BUREAU_STANDARD", conso_pointe_observee_pct=0.60)
+    assert observee["conso_pointe_pct"] == pytest.approx(0.60)
+    assert observee["score"] > base["score"], "plus de pointe observee -> plus de potentiel"
+
+
+def test_score_is_bounded():
+    """Score reste dans [0, 100] meme avec overrides extremes."""
+    saturated = compute_potential_score(
+        "LOGISTIQUE_FRIGO",
+        conso_pointe_observee_pct=1.0,
+        bacs_equipe=True,
+    )
+    assert 0.0 <= saturated["score"] <= 100.0
+    zeroed = compute_potential_score(
+        "BUREAU_STANDARD",
+        conso_pointe_observee_pct=0.0,
+        bacs_equipe=False,
+    )
+    assert 0.0 <= zeroed["score"] <= 100.0

--- a/backend/tests/test_pilotage_turpe7_hc.py
+++ b/backend/tests/test_pilotage_turpe7_hc.py
@@ -1,0 +1,180 @@
+"""
+PROMEOS - Tests de l'indice TURPE 7 HC saisonnalise dans `classify_slots`.
+
+Verifie :
+  1. Helpers `is_hc_favorable` / `is_hc_exclure` sur les 4 quadrants
+     saison / heure (ete 14h, hiver 22h, hiver 14h, hiver 19h, ete 9h,
+     ete 3h).
+  2. Regle d'integration : l'indice TURPE 7 est ADDITIONNEL au signal
+     prix (pas d'inversion ni de substitution).
+
+Source : Barometre Flex 2026 (RTE / Enedis / GIMELEC / Think Smartgrids),
+avril 2026, section "Evolution Heures Creuses TURPE 7".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from services.pilotage.window_detector import (
+    SlotMarket,
+    WindowType,
+    classify_slots,
+    is_hc_exclure,
+    is_hc_favorable,
+)
+
+
+TZ_PARIS = ZoneInfo("Europe/Paris")
+
+
+# --- 1. Helpers is_hc_favorable / is_hc_exclure -----------------------------
+
+
+def test_is_hc_favorable_saisons_quadrants():
+    """
+    Quadrants officiels TURPE 7 HC -- creneaux A FAVORISER :
+      - ete 14h  -> True (plage solaire 11h-17h saison basse)
+      - hiver 22h -> True (plage creux nocturne 21h-24h saison haute)
+      - hiver 14h -> False (pas dans 2h-6h ni 21h-24h saison haute)
+    """
+    # Ete (juillet) a 14h -> plage 11h-17h = FAVORABLE
+    dt_ete_14h = datetime(2026, 7, 15, 14, 0, tzinfo=TZ_PARIS)
+    assert is_hc_favorable(dt_ete_14h) is True, "ete 14h doit etre dans la plage solaire TURPE 7 (11h-17h)"
+
+    # Hiver (janvier) a 22h -> plage 21h-24h = FAVORABLE
+    dt_hiver_22h = datetime(2027, 1, 20, 22, 0, tzinfo=TZ_PARIS)
+    assert is_hc_favorable(dt_hiver_22h) is True, "hiver 22h doit etre dans la plage creux nocturne TURPE 7 (21h-24h)"
+
+    # Hiver a 14h -> hors creneau FAVORABLE (saison haute = 2h-6h + 21h-24h)
+    dt_hiver_14h = datetime(2027, 1, 20, 14, 0, tzinfo=TZ_PARIS)
+    assert is_hc_favorable(dt_hiver_14h) is False, "hiver 14h n'est PAS dans un creneau TURPE 7 a favoriser"
+
+
+def test_is_hc_exclure_saisons_quadrants():
+    """
+    Quadrants officiels TURPE 7 HC -- creneaux A EXCLURE :
+      - hiver 19h -> True (pic soir 17h-21h saison haute)
+      - ete 9h    -> True (montee matin 7h-11h saison basse)
+      - ete 3h    -> False (plage nocturne 2h-6h = a FAVORISER en ete)
+    """
+    # Hiver (novembre) a 19h -> plage 17h-21h = EXCLURE
+    dt_hiver_19h = datetime(2026, 11, 10, 19, 0, tzinfo=TZ_PARIS)
+    assert is_hc_exclure(dt_hiver_19h) is True, "hiver 19h doit etre dans la plage pic soir TURPE 7 a exclure (17h-21h)"
+
+    # Ete (aout) a 9h -> plage 7h-11h = EXCLURE
+    dt_ete_9h = datetime(2026, 8, 5, 9, 0, tzinfo=TZ_PARIS)
+    assert is_hc_exclure(dt_ete_9h) is True, "ete 9h doit etre dans la plage montee matin TURPE 7 a exclure (7h-11h)"
+
+    # Ete a 3h -> plage 2h-6h = FAVORABLE (donc NON exclure)
+    dt_ete_3h = datetime(2026, 7, 15, 3, 0, tzinfo=TZ_PARIS)
+    assert is_hc_exclure(dt_ete_3h) is False, "ete 3h est dans un creneau TURPE 7 a favoriser, pas a exclure"
+
+
+# --- 2. Non-inversion : le signal prix domine TURPE 7 ----------------------
+
+
+def test_slot_prix_bas_14h_ete_reste_favorable():
+    """
+    Un slot a prix bas a 14h ete reste FAVORABLE (pas d'inversion).
+
+    Le creneau TURPE 7 "a favoriser" s'aligne avec le signal prix : la
+    classification reste FAVORABLE, pilotee par le prix (raison="prix").
+    L'indice TURPE 7 favorable est trace dans la classification pour
+    explicabilite cockpit, mais il n'altere pas la decision.
+    """
+    ts = datetime(2026, 7, 15, 14, 0, tzinfo=TZ_PARIS)
+    slots = {ts: SlotMarket(prix_eur_mwh=10.0)}
+    threshold_low, threshold_high = 50.0, 120.0
+
+    result = classify_slots(slots, threshold_low, threshold_high)
+    assert result[ts].window_type == WindowType.FAVORABLE
+    assert result[ts].raison == "prix", "le signal prix doit rester la raison dominante (pas d'inversion TURPE 7)"
+    assert result[ts].turpe7_favorable is True
+
+    # Controle contre-intuitif : meme sur un creneau TURPE 7 a EXCLURE,
+    # un prix bas doit rester FAVORABLE (stricte non-inversion).
+    ts_exc = datetime(2026, 8, 5, 9, 0, tzinfo=TZ_PARIS)  # ete 9h = exclure
+    slots_exc = {ts_exc: SlotMarket(prix_eur_mwh=10.0)}
+    result_exc = classify_slots(slots_exc, threshold_low, threshold_high)
+    assert result_exc[ts_exc].window_type == WindowType.FAVORABLE, (
+        "prix bas sur creneau a exclure -> reste FAVORABLE (pas d'inversion)"
+    )
+    assert result_exc[ts_exc].turpe7_exclure is True
+
+
+def test_slot_prix_eleve_19h_hiver_reste_sensible():
+    """
+    Un slot a prix eleve a 19h hiver reste SENSIBLE (alignement).
+
+    Le creneau TURPE 7 "a exclure" s'aligne avec le signal prix : la
+    classification reste SENSIBLE, pilotee par le prix. L'indice
+    turpe7_exclure est trace dans la classification.
+
+    Controle de non-inversion : meme sur un creneau TURPE 7 a FAVORISER
+    (ex. hiver 22h), un prix eleve doit rester SENSIBLE.
+    """
+    ts = datetime(2026, 11, 10, 19, 0, tzinfo=TZ_PARIS)
+    slots = {ts: SlotMarket(prix_eur_mwh=200.0)}
+    threshold_low, threshold_high = 50.0, 120.0
+
+    result = classify_slots(slots, threshold_low, threshold_high)
+    assert result[ts].window_type == WindowType.SENSIBLE
+    assert result[ts].raison == "prix"
+    assert result[ts].turpe7_exclure is True, "alignement TURPE 7 trace"
+
+    # Controle contre-intuitif : meme sur un creneau TURPE 7 a FAVORISER,
+    # un prix eleve doit rester SENSIBLE (stricte non-inversion).
+    ts_fav = datetime(2027, 1, 20, 22, 0, tzinfo=TZ_PARIS)  # hiver 22h = favorable
+    slots_fav = {ts_fav: SlotMarket(prix_eur_mwh=200.0)}
+    result_fav = classify_slots(slots_fav, threshold_low, threshold_high)
+    assert result_fav[ts_fav].window_type == WindowType.SENSIBLE, (
+        "prix eleve sur creneau a favoriser -> reste SENSIBLE (pas d'inversion)"
+    )
+    assert result_fav[ts_fav].turpe7_favorable is True
+
+
+# --- 3. Indice additionnel : TURPE 7 tranche les slots NEUTRE --------------
+
+
+def test_slot_neutre_bascule_favorable_via_turpe7():
+    """
+    Regle d'integration : un slot au prix median (entre threshold_low et
+    threshold_high, NEUTRE par prix seul) bascule en FAVORABLE s'il
+    tombe sur un creneau TURPE 7 "a favoriser".
+    """
+    # Hiver 3h = creneau 2h-6h FAVORABLE saison haute
+    ts = datetime(2027, 1, 20, 3, 30, tzinfo=TZ_PARIS)
+    slots = {ts: SlotMarket(prix_eur_mwh=80.0)}
+    threshold_low, threshold_high = 50.0, 120.0
+
+    result = classify_slots(slots, threshold_low, threshold_high)
+    assert result[ts].window_type == WindowType.FAVORABLE
+    assert result[ts].raison == "turpe7_favorable"
+    assert result[ts].turpe7_favorable is True
+
+
+def test_slot_neutre_bascule_sensible_via_turpe7():
+    """
+    Regle d'integration : un slot au prix median bascule en SENSIBLE
+    s'il tombe sur un creneau TURPE 7 "a exclure", et reste NEUTRE si
+    aucun creneau TURPE 7 ne s'applique.
+    """
+    # Ete 9h = creneau 7h-11h EXCLURE saison basse
+    ts_exc = datetime(2026, 8, 5, 9, 30, tzinfo=TZ_PARIS)
+    # Ete 23h30 = hors creneau TURPE 7 (ni 2h-6h, ni 11h-17h, ni 7h-11h,
+    # ni 18h-23h)
+    ts_neutre = datetime(2026, 8, 5, 23, 30, tzinfo=TZ_PARIS)
+
+    slots = {
+        ts_exc: SlotMarket(prix_eur_mwh=80.0),
+        ts_neutre: SlotMarket(prix_eur_mwh=80.0),
+    }
+    threshold_low, threshold_high = 50.0, 120.0
+
+    result = classify_slots(slots, threshold_low, threshold_high)
+    assert result[ts_exc].window_type == WindowType.SENSIBLE
+    assert result[ts_exc].raison == "turpe7_exclure"
+    assert result[ts_neutre].window_type == WindowType.NEUTRE
+    assert result[ts_neutre].raison == "neutre"

--- a/docs/kb/items/acc/ACC-CLE-REPARTITION.yaml
+++ b/docs/kb/items/acc/ACC-CLE-REPARTITION.yaml
@@ -1,0 +1,113 @@
+---
+id: "ACC-CLE-REPARTITION"
+type: "knowledge"
+domain: "acc"
+title: "ACC — Clés de répartition de l'énergie autoproduite"
+summary: "La clé de répartition définit comment l'énergie autoproduite est partagée entre les consommateurs participants à l'ACC. Trois types autorisés : statique (%), dynamique (proportion conso instantanée), et sur mesure (algorithme défini par la PMO). Choix stratégique avec impacts économiques et opérationnels."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - collectivite
+    - copro
+    - bailleur
+    - tertiaire_multisite
+  asset:
+    - multi
+  reg:
+    - acc
+  granularity:
+    - 30min
+
+scope: {}
+
+content_md: |
+  ## Clés de répartition ACC
+
+  ### Cadre réglementaire
+  - Arrêté du 21 novembre 2019 modifié, article 2 (ACC étendue)
+  - Enedis spécifications techniques de mise en œuvre
+
+  ### Les 3 types de clés autorisées
+
+  #### 1. Clé statique par pourcentage
+  - Chaque consommateur se voit attribuer un pourcentage fixe de l'énergie produite
+  - Exemple : 10 logements → 10% chacun
+  - **Avantage** : simple à comprendre et expliquer
+  - **Inconvénient** : ne tient pas compte de la conso réelle → gaspillage possible (énergie non consommée retourne au réseau)
+
+  #### 2. Clé dynamique (proportion consommation instantanée)
+  - L'énergie produite est répartie proportionnellement à la consommation de chaque participant sur chaque pas de 30 min
+  - Pas de gaspillage : celui qui consomme touche plus
+  - **Avantage** : optimisation automatique
+  - **Inconvénient** : moins prévisible pour le consommateur
+
+  #### 3. Clé sur mesure (algorithme PMO)
+  - Règle personnalisée définie par la PMO
+  - Peut combiner statique + dynamique + priorités
+  - Exemple : 50% dynamique + 50% statique avec priorité aux habitants permanents
+  - **Avantage** : flexible, peut refléter la gouvernance du projet
+  - **Inconvénient** : complexité, doit être validée par Enedis
+
+  ### Critères de choix
+  | Contexte | Clé recommandée |
+  |---|---|
+  | Copropriété homogène | Statique par lot (simple, équitable) |
+  | Mix résidentiel + tertiaire avec profils différents | Dynamique (optimise autoconsommation globale) |
+  | Projet collectivité avec enjeux sociaux | Sur mesure (pondération selon revenus / précarité) |
+  | Gros consommateurs variables (industrie) | Dynamique ou sur mesure |
+
+  ### Impact économique
+  - Clé bien choisie → taux autoconsommation collective 30-60% (vs 15-25% mal calibrée)
+  - Gain typique : 0,05 à 0,15 €/kWh autoconsommé vs revente au tarif d'achat
+
+  ### Modification de la clé
+  - Possible à tout moment via la PMO
+  - Délai de prise en compte Enedis : ~30 jours
+  - Historique traçable par Enedis pour contentieux éventuels
+
+  ### Bonnes pratiques
+  - Simuler plusieurs clés sur 12 mois historiques avant de choisir
+  - Prévoir une clause de révision annuelle dans le règlement PMO
+  - Communiquer clairement aux participants le fonctionnement choisi
+
+logic:
+  when:
+    all:
+      - field: "acc_project"
+        op: "="
+        value: true
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Analyser les profils de consommation des participants (CDC sur 12 mois minimum)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Simuler 3 clés (statique / dynamique / mixte) pour évaluer taux d'autoconsommation"
+        priority: 2
+
+      - type: "next_step"
+        label: "Faire valider la clé choisie par la PMO et la transmettre à Enedis"
+        priority: 3
+
+      - type: "next_step"
+        label: "Prévoir une clause de révision annuelle dans le règlement intérieur PMO"
+        priority: 4
+
+sources:
+  - doc_id: "ARRETE-2019-11-21-ART-2"
+    label: "Arrêté du 21 novembre 2019 modifié — Article 2"
+    section: "Clé de répartition ACC"
+    anchor: "#arrete-art-2"
+    excerpt_short: "La PMO définit et transmet à Enedis la clé de répartition de l'énergie entre consommateurs participants, avec révision possible"
+
+  - doc_id: "ENEDIS-ACC-SPECS"
+    label: "Enedis — Spécifications techniques ACC"
+    section: "Mise en œuvre clés de répartition"
+    anchor: "#enedis-acc-specs"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 2

--- a/docs/kb/items/acc/ACC-PMO-OBLIGATIONS.yaml
+++ b/docs/kb/items/acc/ACC-PMO-OBLIGATIONS.yaml
@@ -1,0 +1,110 @@
+---
+id: "ACC-PMO-OBLIGATIONS"
+type: "rule"
+domain: "acc"
+title: "ACC — PMO (Personne Morale Organisatrice) — Rôles et obligations"
+summary: "Toute opération d'Autoconsommation Collective (ACC) doit être organisée par une Personne Morale Organisatrice (PMO) obligatoire depuis 2017. La PMO signe la convention unique avec Enedis/GRD, gère la clé de répartition, facture/reverse aux participants, et centralise la relation réseau."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - collectivite
+    - copro
+    - bailleur
+    - tertiaire_multisite
+  asset:
+    - multi
+  reg:
+    - acc
+  granularity:
+    - event
+
+scope: {}
+
+content_md: |
+  ## PMO — Personne Morale Organisatrice
+
+  ### Cadre réglementaire
+  - Article L315-2 Code de l'énergie (définition ACC)
+  - Article L315-2-1 Code de l'énergie (rôle PMO)
+  - Arrêté du 21 novembre 2019 modifié par arrêté 21 février 2025
+
+  ### Nature juridique possible
+  - **Association loi 1901** (la plus courante pour copro / habitants)
+  - **Syndicat de copropriété** (si ACC interne à la copro)
+  - **SCI, SCIC, SEM, SAS** (pour projets > copropriété)
+  - **Collectivité** (commune ou EPCI — peut être PMO directement)
+
+  ### Obligations de la PMO
+
+  1. **Convention unique avec Enedis/GRD**
+     - Déclaration de l'opération (périmètre géographique, puissance cumulée, liste participants)
+     - Mise à jour à chaque entrée/sortie d'un participant
+
+  2. **Clé de répartition**
+     - Définir la règle de partage de l'énergie autoproduite entre consommateurs
+     - Possible : statique (%), dynamique (proportion conso instantanée)
+     - Doit être transmise à Enedis pour prise en compte
+
+  3. **Facturation/reversement**
+     - Gère les flux financiers entre producteurs et consommateurs
+     - Reverse aux producteurs la valeur de l'énergie autoconsommée
+     - Facture éventuellement les participants
+
+  4. **Responsabilité périmètre**
+     - Assurer que tous les PDL participants respectent les critères géographiques (2/10/20 km selon zone)
+     - Veiller au respect du plafond de puissance (5 MW baseline, 10 MW dérogation collectivités)
+
+  5. **Déclaration annuelle**
+     - Bilan de l'opération à Enedis
+     - Déclaration fiscale le cas échéant (selon statut PMO)
+
+  ### Coûts types d'une PMO (ordres de grandeur)
+  - Constitution juridique (association) : 0 à 500 €
+  - Frais de fonctionnement annuels : 1 000 à 5 000 €/an (secrétariat, comptabilité)
+  - Logiciel de gestion (facultatif) : 200 à 2 000 €/an
+
+  ### Exceptions
+  - Bailleur social peut être exempté de PMO sous conditions (convention directe avec locataires)
+
+logic:
+  when:
+    all:
+      - field: "acc_project"
+        op: "="
+        value: true
+  then:
+    outputs:
+      - type: "obligation"
+        label: "Constituer une PMO avant le démarrage de l'opération ACC"
+        severity: "critical"
+        details: "Article L315-2-1 Code de l'énergie"
+
+      - type: "next_step"
+        label: "Choisir la forme juridique PMO selon contexte (association copro, SCIC multi-acteurs, SEM territoriale)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Définir la clé de répartition avant signature convention Enedis"
+        priority: 2
+
+      - type: "next_step"
+        label: "Estimer les coûts de fonctionnement annuels PMO (1k€-5k€)"
+        priority: 3
+
+sources:
+  - doc_id: "CODE-ENERGIE-L315-2-1"
+    label: "Article L315-2-1 Code de l'énergie"
+    section: "Rôle de la Personne Morale Organisatrice"
+    anchor: "#l315-2-1"
+    excerpt_short: "L'opération d'autoconsommation collective est organisée par une personne morale organisatrice (PMO) qui établit et gère les conventions nécessaires"
+
+  - doc_id: "ARRETE-2019-11-21-MODIFIE"
+    label: "Arrêté du 21 novembre 2019 modifié (21/02/2025)"
+    section: "Modalités ACC et rôle PMO"
+    anchor: "#arrete-acc"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/facturation/ACCISE-ELEC-CATEGORIES.yaml
+++ b/docs/kb/items/facturation/ACCISE-ELEC-CATEGORIES.yaml
@@ -1,0 +1,98 @@
+---
+id: "ACCISE-ELEC-CATEGORIES"
+type: "rule"
+domain: "facturation"
+title: "Accise électricité — Catégories T1/T2/T3 et tarifs 2025-2026"
+summary: "Accise sur l'électricité (ex-TICFE) différenciée par catégorie (ménages T1, PME T2, haute puissance T3). Césure tarifaire 01/08/2025. Taux réduits possibles sur attestation (entreprises électro-intensives, secteurs exposés carbon leakage)."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - industrie
+    - collectivite
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - taxes
+  granularity:
+    - mensuel
+
+scope: {}
+
+content_md: |
+  ## Accise électricité (ex-TICFE)
+
+  ### Cadre réglementaire
+  - Code des impositions sur les biens et services (CIBS) articles L312-37 et suivants
+  - Directive UE 2003/96/CE (minima énergétiques)
+
+  ### 3 catégories fiscales
+
+  | Catégorie | Critère | Exemple client |
+  |---|---|---|
+  | **T1 Ménages** (HOUSEHOLD) | Puissance souscrite ≤ 36 kVA, usage résidentiel | Particulier, copro, bailleur |
+  | **T2 PME** (SME) | Puissance > 36 kVA et < 250 kVA | Tertiaire moyen, commerce |
+  | **T3 Haute Puissance** (HIGH_POWER) | Puissance ≥ 250 kVA ou conso élevée | Industrie, gros tertiaire |
+
+  ### Tarifs accise 2025-2026 (€/MWh)
+  | Période | T1 | T2 | T3 HP | T3 HC (jusqu'à 250 kV) |
+  |---|---|---|---|---|
+  | 01/02/2025 → 31/07/2025 | 33,70 | 20,50 | 20,50 | 20,50 |
+  | **01/08/2025** (césure) → 31/01/2026 | 25,09 | 20,50 | 20,50 | 20,50 |
+  | 01/02/2026 → ... | 29,98 | 22,50 | 21,00 | 20,90 |
+
+  ### Césure 01/08/2025
+  Césure triple : TURPE + TVA (passage 20%) + Accise dans le même mois. PROMEOS V114 gère le découpage par partition_windows pour factures à cheval.
+
+  ### Régime réduit / Exonération
+  - **Électro-intensives** : taux réduit sur attestation DGEC
+  - **Industries exposées carbon leakage** : exonération partielle
+  - **Autoconsommation** : exonérée si < 240 GWh/an consommée en autoconsommation
+  - **Réseau ferroviaire** : taux spécifique
+
+  ### Versioning dans PROMEOS
+  Table `tax_profiles` (V113) par delivery_point_id :
+  - `accise_category` : HOUSEHOLD_T1 / SME_T2 / HIGH_POWER_T3
+  - `regime_reduit` : bool (attestation en vigueur)
+  - `attestation_valid_until` : date
+
+logic:
+  when:
+    all:
+      - field: "energy_vector"
+        op: "="
+        value: "elec"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Identifier catégorie accise (T1/T2/T3) selon puissance souscrite"
+        priority: 1
+
+      - type: "next_step"
+        label: "Vérifier éligibilité régime réduit (électro-intensif, secteur carbon leakage)"
+        priority: 2
+
+      - type: "next_step"
+        label: "Contrôler césure 01/08/2025 pour factures à cheval"
+        priority: 3
+
+sources:
+  - doc_id: "CIBS-L312-37"
+    label: "Code des impositions sur les biens et services — Articles L312-37 et suivants"
+    section: "Accises sur les énergies"
+    anchor: "#cibs-l312-37"
+    excerpt_short: "Accise sur l'électricité applicable selon catégorie de client et niveau de consommation"
+
+  - doc_id: "PROMEOS-V113-TAXPROFILE"
+    label: "PROMEOS V113 — Table tax_profiles + enum AcciseCategoryElec"
+    section: "Data model Vague 1"
+    anchor: "#v113-accise"
+    excerpt_short: "3 catégories fiscales (HOUSEHOLD_T1 ménages, SME_T2 PME, HIGH_POWER_T3 haute puissance)"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/facturation/ACCISE-GAZ-CATEGORIES.yaml
+++ b/docs/kb/items/facturation/ACCISE-GAZ-CATEGORIES.yaml
@@ -1,0 +1,88 @@
+---
+id: "ACCISE-GAZ-CATEGORIES"
+type: "rule"
+domain: "facturation"
+title: "Accise gaz naturel — Catégories et tarifs 2025-2026"
+summary: "Accise sur le gaz naturel (ex-TICGN) différenciée par usage (combustion, carburant, industrie cogénération). Tarif standard combustion : 16,37 €/MWh (2025). Régimes réduits possibles (industries électro-intensives, serres agricoles, transport maritime/aérien)."
+
+tags:
+  energy:
+    - gaz
+  segment:
+    - tertiaire_multisite
+    - industrie
+    - collectivite
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - taxes
+  granularity:
+    - mensuel
+
+scope: {}
+
+content_md: |
+  ## Accise gaz naturel (ex-TICGN)
+
+  ### Cadre réglementaire
+  - Code des impositions sur les biens et services (CIBS) articles L312-48 et suivants
+  - Directive UE 2003/96/CE
+
+  ### Catégories tarifaires (assiette combustion)
+
+  | Catégorie | Usage | Tarif (€/MWh PCS) |
+  |---|---|---|
+  | **Combustion standard** | Chauffage, ECS, process bas | 16,37 (2025) |
+  | **Électro-intensives** | Industrie attestation DGEC | ~1,60 (taux réduit) |
+  | **Cogénération** | Cogénération ≥ 1 MW électrique | Exonéré (biométhane) ou réduit |
+  | **Serres** | Serres agricoles | Réduit sur attestation |
+
+  ### Usages carburant
+  - Tarif gazole carburant : 8,45 €/MWh
+  - Transport maritime/aérien international : exonéré
+
+  ### Articulation avec ATRD (CTA)
+  L'accise gaz est calculée sur l'énergie consommée (€/MWh PCS) — distinct de :
+  - ATRD (tarif réseau distribution) voir ATRD7-GAZ-STRUCTURE
+  - CTA gaz (assise sur ATRD) avec coefficient additif
+  - CEE (Certificats d'Économie d'Énergie) voir item dédié
+
+  ### Versioning PROMEOS
+  Table `tax_profiles` (V113) :
+  - `accise_category_gaz` : COMBUSTION_STANDARD / ELECTRO_INTENSIF / COGENERATION / SERRE
+  - `regime_reduit` : bool
+  - Référence attestation DGEC si applicable
+
+logic:
+  when:
+    all:
+      - field: "energy_vector"
+        op: "="
+        value: "gaz"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Identifier catégorie accise gaz selon usage (combustion/cogen/serre/électro-intensif)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Vérifier attestation DGEC si régime réduit revendiqué"
+        priority: 2
+
+sources:
+  - doc_id: "CIBS-L312-48"
+    label: "Code des impositions sur les biens et services — Articles L312-48 et suivants"
+    section: "Accises gaz naturel"
+    anchor: "#cibs-l312-48"
+    excerpt_short: "Accise sur le gaz naturel selon usage (combustion, carburant, cogénération)"
+
+  - doc_id: "PROMEOS-V113-TAXPROFILE-GAZ"
+    label: "PROMEOS V113 — Enum AcciseCategoryGaz"
+    section: "Data model Vague 1 — Gaz"
+    anchor: "#v113-accise-gaz"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 2

--- a/docs/kb/items/facturation/ATRD7-GAZ-STRUCTURE.yaml
+++ b/docs/kb/items/facturation/ATRD7-GAZ-STRUCTURE.yaml
@@ -1,0 +1,106 @@
+---
+id: "ATRD7-GAZ-STRUCTURE"
+type: "knowledge"
+domain: "facturation"
+title: "ATRD 7 gaz — Grille tarifaire GRDF T1-T4-TP"
+summary: "Tarif ATRD 7 gaz GRDF (CRE 2024-17 + 2025-122) en vigueur 01/07/2024. Grille à 5 options (T1/T2/T3/T4/TP) selon volume annuel. Abonnement annuel + proportionnel + terme capacité (T4/TP). Révision intermédiaire 01/07/2025 +6,06%."
+
+tags:
+  energy:
+    - gaz
+  segment:
+    - tertiaire_multisite
+    - industrie
+    - collectivite
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - multi
+  granularity:
+    - mensuel
+
+scope: {}
+
+content_md: |
+  ## ATRD 7 — Grille tarifaire gaz GRDF
+
+  ### Cadre réglementaire
+  - Délibération CRE 2024-17 (tarif initial ATRD7)
+  - Délibération CRE 2025-122 (révision intermédiaire +6,06%)
+  - Délibération CRE 2024-82 (options T3/T4/TP)
+  - Date d'effet ATRD7 : 01/07/2024 (durée 4 ans)
+
+  ### 5 options tarifaires par volume
+
+  | Option | Volume annuel (MWh) | Abonnement 2024 (€/an) | Type usage |
+  |---|---|---|---|
+  | **T1** | < 6 | 51,96 | Petit résidentiel, cuisson seule |
+  | **T2** | 6 → 300 | 175,92 | Résidentiel chauffage, petit tertiaire |
+  | **T3** | 300 → 5 000 | 1 231,08 | Tertiaire moyen, copro |
+  | **T4** | 5 000 → 50 000 | 20 469,60 | Industrie moyenne, gros tertiaire |
+  | **TP** | > 50 000 | Tarification distance | Industrie lourde, réseaux gaz |
+
+  ### Structure 3 termes
+  1. **Abonnement** (€/an fixe par option)
+  2. **Proportionnel** (c€/kWh consommé) — dégressif par tranches
+  3. **Terme capacité** (T4/TP seulement, €/MWh/jour CJA CJN)
+
+  ### Révision 01/07/2025
+  CRE 2025-122 : +6,06% sur toutes composantes ATRD7, appliqué au 01/07/2025.
+
+  ### Proratisation
+  Abonnement annuel proratisé selon nombre de jours facturés dans la période.
+  PROMEOS V114 gère via `compute_prorata(start, end, annual_amount)`.
+
+  ### Articulation CTA gaz
+  L'assiette CTA gaz = abonnement ATRD annuel (part fixe).
+  Formule additive : `(20,80% + 4,71% × coef_transport)` avec coef_transport versionné (83,57% en 2024 → 83,21% en 2025).
+
+  ### Versioning PROMEOS
+  V114 : brique `bricks/atrd.py` + grille dans `config/tarifs_reglementaires.yaml` section `atrd7_gaz_tiers` valid_from 2024-07-01.
+  11 codes ParameterStore : `ATRD_GAZ_{T1-T4-TP}_{ABO,PROP,CAPA}`.
+
+logic:
+  when:
+    all:
+      - field: "energy_vector"
+        op: "="
+        value: "gaz"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Identifier option ATRD (T1-T4-TP) selon volume annuel gaz"
+        priority: 1
+
+      - type: "next_step"
+        label: "Contrôler terme capacité si option T4 ou TP (CJA/CJN en MWh/jour)"
+        priority: 2
+
+      - type: "next_step"
+        label: "Vérifier proratisation abonnement et révision 01/07/2025"
+        priority: 3
+
+sources:
+  - doc_id: "CRE-2024-17"
+    label: "Délibération CRE 2024-17"
+    section: "ATRD 7 GRDF"
+    anchor: "#atrd7-cre-2024-17"
+    excerpt_short: "Tarif péréqué d'utilisation des réseaux publics de distribution de gaz naturel, applicable au 01/07/2024 pour 4 ans"
+
+  - doc_id: "CRE-2025-122-GAZ"
+    label: "Délibération CRE 2025-122"
+    section: "Révision intermédiaire ATRD7 +6,06%"
+    anchor: "#atrd7-revision-2025"
+    excerpt_short: "Révision tarifaire applicable au 01/07/2025"
+
+  - doc_id: "PROMEOS-V114-ATRD"
+    label: "PROMEOS V114 — Brique ATRD gaz"
+    section: "bricks/atrd.py + config/tarifs_reglementaires.yaml"
+    anchor: "#v114-atrd"
+    excerpt_short: "Grille ATRD7 par option, compute_atrd par tranche, proratisation annuelle, terme capacité"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 2

--- a/docs/kb/items/facturation/CEE-P6-OBLIGATIONS.yaml
+++ b/docs/kb/items/facturation/CEE-P6-OBLIGATIONS.yaml
@@ -1,0 +1,100 @@
+---
+id: "CEE-P6-OBLIGATIONS"
+type: "knowledge"
+domain: "facturation"
+title: "CEE Période 6 (2026+) — Obligations et tarifs"
+summary: "Certificats d'Économie d'Énergie P6 : obligation 1050 TWh cumac/an (PPE3), coût pass-through pour les clients via fournisseur. Coût moyen estimé P6 : ~0,731 €/MWh (vs 0,478 en P5). Pass-through cee activable par contrat dans PROMEOS."
+
+tags:
+  energy:
+    - multi
+  segment:
+    - tertiaire_multisite
+    - industrie
+    - collectivite
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - cee
+  granularity:
+    - mensuel
+
+scope: {}
+
+content_md: |
+  ## CEE Période 6 (2026-2030)
+
+  ### Cadre réglementaire
+  - Code de l'énergie articles L221-1 à L221-14
+  - Programmation Pluriannuelle de l'Énergie 3 (PPE3, février 2026)
+  - Arrêtés annuels de fixation du niveau d'obligation
+
+  ### Obligation P6 vs P5
+  | Période | Volume obligation | Coût estimé (€/MWh cumac) |
+  |---|---|---|
+  | P5 (2022-2025) | 2 500 TWh cumac / 4 ans | 0,478 |
+  | **P6 (2026-2030)** | **1 050 TWh cumac / an** | **~0,731** |
+
+  ### Mécanisme pass-through
+  Les obligés (fournisseurs d'énergie) répercutent le coût CEE dans la facture du client final.
+  Dans PROMEOS (V113), le pass-through est configurable par contrat :
+  - `EnergyContract.cee_pass_through` : bool
+  - Si True : ligne CEE facturée au client (€/MWh consommé)
+  - Si False : coût CEE absorbé par le fournisseur (offre "tout compris")
+
+  ### Calcul sur facture
+  ```
+  CEE_client = Consommation_MWh × taux_cee_contractuel (€/MWh)
+  ```
+  Le taux peut être :
+  - Indexé sur le cours CEE EMMY (marché secondaire)
+  - Forfaitaire selon contrat
+  - Révisé annuellement
+
+  ### Nouveautés P6
+  - Nouvelles fiches CEE 2026 : chaleur fatale, data centers, VE
+  - Plafond 2027 sur volumes massifs en immobilier résidentiel
+  - Bonifications pour précarité énergétique maintenues
+
+  ### Articulation avec rénovation
+  Les travaux d'efficacité énergétique (DT, BACS, CVC) peuvent générer des CEE valorisables par le maître d'ouvrage — compensation partielle de l'investissement.
+
+logic:
+  when:
+    all:
+      - field: "energy_vector"
+        op: "in"
+        value: ["elec", "gaz", "multi"]
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Vérifier ligne CEE dans facture fournisseur (pass-through activé ?)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Identifier CEE valorisables pour les travaux d'efficacité énergétique prévus"
+        priority: 2
+
+sources:
+  - doc_id: "CODE-ENERGIE-L221"
+    label: "Code de l'énergie — Articles L221-1 à L221-14"
+    section: "Certificats d'Économie d'Énergie"
+    anchor: "#l221"
+    excerpt_short: "Mécanisme des certificats d'économie d'énergie, obligés fournisseurs d'énergie"
+
+  - doc_id: "PPE3-2026"
+    label: "Programmation Pluriannuelle de l'Énergie 3 — Février 2026"
+    section: "CEE P6 1050 TWh cumac/an"
+    anchor: "#ppe3-cee"
+    excerpt_short: "Objectif P6 : 1 050 TWh cumac par an entre 2026 et 2030"
+
+  - doc_id: "PROMEOS-V113-CEE-PASS"
+    label: "PROMEOS V113 — cee_pass_through sur EnergyContract"
+    section: "Data model Vague 1 — Pass-through"
+    anchor: "#v113-cee"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 2

--- a/docs/kb/items/facturation/CTA-ELEC-COEFFICIENTS.yaml
+++ b/docs/kb/items/facturation/CTA-ELEC-COEFFICIENTS.yaml
@@ -1,0 +1,92 @@
+---
+id: "CTA-ELEC-COEFFICIENTS"
+type: "rule"
+domain: "facturation"
+title: "CTA électricité — Coefficients et assiette de calcul"
+summary: "Contribution Tarifaire d'Acheminement (CTA) calculée sur la part fixe du TURPE (abonnement + CG). Coefficients 15% (HTA) / 5% (BT) depuis février 2026. Historiquement 21,93% / 10,11% avant février 2026."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - collectivite
+    - industrie
+  asset:
+    - multi
+  reg:
+    - taxes
+  granularity:
+    - mensuel
+
+scope: {}
+
+content_md: |
+  ## CTA Électricité
+
+  ### Cadre réglementaire
+  - Article L2233 Code général des impôts
+  - Décret 2005-1635 (création CTA)
+  - Assiette : part fixe du TURPE (Composante de Gestion + Abonnement CMDPS)
+
+  ### Coefficients en vigueur
+  | Période | Haute Tension (HTA) | Basse Tension (BT ≤ 36 kVA) |
+  |---|---|---|
+  | Depuis février 2026 | 15 % | 5 % |
+  | Avant février 2026 | 21,93 % | 10,11 % |
+
+  ### Formule de calcul
+  ```
+  CTA_mensuelle = (Composante_Gestion + CMDPS_mensuelle) × coefficient_CTA
+  ```
+
+  Où coefficient_CTA dépend :
+  - Du niveau de tension (HTA vs BT)
+  - De la date d'effet du contrat
+
+  ### Exemple calcul BT (depuis fév 2026)
+  - Abonnement 6 kVA : CMDPS ~10 €/mois → CTA = 10 × 5% = 0,50 €/mois
+  - Composante de Gestion 15 €/an → CTA = (15/12) × 5% = 0,06 €/mois
+
+  ### Finalité
+  - Finance les réseaux de transport/distribution (électricité + gaz)
+  - Collectée par les fournisseurs, reversée à la CDC (Caisse des Dépôts)
+
+  ### Attention versioning
+  La CTA est **versionnée par date d'effet** dans PROMEOS (ParameterStore V112).
+  - Factures pré-février 2026 : utiliser 21,93% / 10,11%
+  - Factures post-février 2026 : utiliser 15% / 5%
+  - Période à cheval → calcul prorata par partition_windows
+
+logic:
+  when:
+    all:
+      - field: "energy_vector"
+        op: "="
+        value: "elec"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Vérifier coefficient CTA appliqué selon date facture (15%/5% post-02/2026)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Contrôler assiette CTA = part fixe TURPE (Abonnement + Gestion)"
+        priority: 2
+
+sources:
+  - doc_id: "CGI-L2233"
+    label: "Article L2233 Code général des impôts"
+    section: "Contribution Tarifaire d'Acheminement"
+    anchor: "#l2233"
+    excerpt_short: "Contribution assise sur la part fixe des tarifs d'utilisation des réseaux publics de transport et de distribution"
+
+  - doc_id: "PROMEOS-V112-CTA-BRICK"
+    label: "PROMEOS V112 — Brique CTA ParameterStore versionné"
+    section: "Coefficients historiques restaurés"
+    anchor: "#v112-cta"
+    excerpt_short: "CTA historique pré-Feb 2026 : 21,93%/10,11% (HTA/BT), puis 15%/5% depuis février 2026"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/facturation/HEURES-CREUSES-REFORME-TURPE7.yaml
+++ b/docs/kb/items/facturation/HEURES-CREUSES-REFORME-TURPE7.yaml
@@ -1,0 +1,93 @@
+---
+id: "HEURES-CREUSES-REFORME-TURPE7"
+type: "rule"
+domain: "facturation"
+title: "Réforme Heures Creuses TURPE 7 — Saisonnalisation 2025-2028"
+summary: "Réforme des plages Heures Creuses engagée en novembre 2025 par décision CRE (TURPE 7). Objectif : décaler 5 GW vers 14h après 2027 en profitant de la production solaire. Déploiement en 3 phases de novembre 2025 à mi-2028."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - turpe
+  granularity:
+    - event
+
+scope: {}
+
+content_md: |
+  ## Réforme Heures Creuses TURPE 7
+
+  ### Cadre réglementaire
+  - CRE délibération 2025-78 du 13 mars 2025 (TURPE 7 HTA-BT)
+  - CRE délibération 2026-02 du 8 janvier 2026
+
+  ### Objectifs
+  - Saisonnaliser les plages HC entre été et hiver
+  - Exclure les plages HC qui mettent en contrainte l'équilibre offre-demande
+  - Favoriser les plages HC solaires été (11h-17h) et creux de nuit (2h-6h)
+  - Placer 5 GW supplémentaires vers 14h à partir de 2027 (ballons ECS + IRVE)
+
+  ### Calendrier de déploiement (3 phases)
+  | Phase | Période | Périmètre |
+  |---|---|---|
+  | Phase 1 | nov 2025 → mai 2026 | 5,2M PRM résidentiels (HC identiques été/hiver) |
+  | Phase 2 | déc 2026 → nov 2027 | 22,8M PRM résidentiels+pro ≤36kVA (HC saisonnalisées) |
+  | Phase 3 | mi-2027 → mi-2028 | 550k PRM Marché d'Affaires (>36kVA et HTA) |
+
+  ### Règles des nouvelles plages HC
+  - 8 heures HC/jour réparties sur 1 ou 2 plages
+  - Si 2 plages : 1 diurne (8h-20h) + 1 nocturne (20h-8h)
+  - Même nombre HC diurnes été/hiver
+  - Durée minimale 2h par plage (5h pour la plage nocturne)
+  - En été (1/04 → 31/10) : plages 11h-17h favorisées, 7h-11h et 17h-21h exclues
+  - En hiver (1/11 → 31/03) : plages 7h-11h et 17h-21h exclues
+
+  ### Évolution TRV associée (CRE 2025-10 du 15/01/2025)
+  - Suppression tarif Base pour sites >=18 kVA (début 2026)
+  - Mise en extinction tarif Base pour sites 9-15 kVA (depuis février 2025)
+  - Expérimentation option "pointe" pour sites 3 kVA et 6 kVA à horizon 2026
+
+logic:
+  when:
+    all:
+      - field: "offer_type"
+        op: "="
+        value: "hp_hc"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Vérifier l'affectation de nouvelles plages HC par le GRD (Enedis)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Reprogrammer les asservissements ECS et IRVE selon les nouvelles plages"
+        priority: 2
+
+      - type: "next_step"
+        label: "Anticiper la reprogrammation Enedis de vos plages HC avant mi-2028"
+        priority: 3
+        severity: "low"
+        details: "Enedis pilote la migration, aucune action gestionnaire requise au-delà du suivi"
+
+sources:
+  - doc_id: "CRE-2025-78"
+    label: "Délibération CRE 2025-78 du 13 mars 2025"
+    section: "TURPE 7 HTA-BT — Heures Creuses"
+    anchor: "#turpe7-hc"
+
+  - doc_id: "BAROMETRE-FLEX-2026"
+    label: "Baromètre des flexibilités de consommation d'électricité — Édition 2026"
+    section: "Valorisation p.36 + Les Heures Creuses p.42-43"
+    anchor: "#reforme-hc"
+    excerpt_short: "Réforme des heures creuses engagée dès le 1er novembre 2025, doit se poursuivre jusqu'au printemps 2027, 5 GW de consommation placés vers les après-midis à partir de 2027"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/facturation/TURPE7-COMPOSANTES.yaml
+++ b/docs/kb/items/facturation/TURPE7-COMPOSANTES.yaml
@@ -1,0 +1,97 @@
+---
+id: "TURPE7-COMPOSANTES"
+type: "knowledge"
+domain: "facturation"
+title: "TURPE 7 — Composantes du tarif d'utilisation des réseaux électriques"
+summary: "Structure tarifaire TURPE 7 (CRE 2025-78, en vigueur 01/08/2025) : composantes de gestion, comptage, soutirage (CS), abonnement (CMDPS). Révisions annuelles indexées inflation. Révision intermédiaire +6,06% au 01/07/2025 (CRE 2025-122)."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - collectivite
+    - industrie
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - turpe
+  granularity:
+    - mensuel
+
+scope: {}
+
+content_md: |
+  ## TURPE 7 — Structure tarifaire
+
+  ### Cadre réglementaire
+  - Délibération CRE n°2025-78 du 13 mars 2025
+  - Date d'effet : 1er août 2025
+  - Durée : 4 ans (jusqu'au 31/07/2029)
+  - Révision intermédiaire 01/07/2025 : +6,06% (CRE 2025-122)
+
+  ### 4 composantes principales
+
+  1. **Composante de Gestion (CG)** — forfaitaire annuelle par PDL
+     - Couvre coûts administratifs fournisseur ↔ GRD
+     - Varie selon type de client (résidentiel/pro/entreprise)
+
+  2. **Composante de Comptage (CC)** — forfaitaire annuelle
+     - Couvre location compteur + relevés
+     - Plus élevée pour compteurs spécifiques (Linky vs ancien)
+
+  3. **Composante de Soutirage (CS)** — variable €/MWh
+     - Tarifée à l'énergie consommée
+     - Différenciée selon plages temporelles (HP/HC, été/hiver)
+     - Peak tariffs sur plages pointe
+
+  4. **Composante Mensuelle des Dépassements de Puissance Souscrite (CMDPS)** — €/kVA/mois
+     - Forfait mensuel proportionnel à la puissance souscrite
+     - Majoration si dépassement constaté
+
+  ### Plages horosaisonnalisées (HTA)
+  - Pointe : décembre-février, 9h-11h + 18h-20h
+  - Heures Pleines Hiver, Heures Creuses Hiver, Heures Pleines Été, Heures Creuses Été
+  - 5 plages tarifaires distinctes pour HTA
+
+  ### Impact réforme Heures Creuses
+  Voir item HEURES-CREUSES-REFORME-TURPE7 pour les 3 phases de déploiement 2025-2028.
+
+  ### Application temporelle
+  - Tarif valide du 01/08/2025 au 31/07/2026 (révision annuelle)
+  - Prochaine révision : CRE ~mars 2026
+
+logic:
+  when:
+    all:
+      - field: "energy_vector"
+        op: "="
+        value: "elec"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Identifier composantes TURPE 7 sur facture (CG, CC, CS, CMDPS)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Vérifier tarification HP/HC/pointe alignée avec l'option souscrite"
+        priority: 2
+
+sources:
+  - doc_id: "CRE-2025-78"
+    label: "Délibération CRE n°2025-78 du 13 mars 2025"
+    section: "TURPE 7 HTA-BT"
+    anchor: "#turpe7-structure"
+    excerpt_short: "Tarif d'utilisation des réseaux publics d'électricité en HTA-BT, applicable du 01/08/2025 au 31/07/2029"
+
+  - doc_id: "CRE-2025-122"
+    label: "Délibération CRE 2025-122"
+    section: "Révision intermédiaire TURPE 7"
+    anchor: "#revision-2025-07"
+    excerpt_short: "Révision tarifaire +6,06% applicable au 01/07/2025"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/facturation/TVA-ELEC-20PCT-2025.yaml
+++ b/docs/kb/items/facturation/TVA-ELEC-20PCT-2025.yaml
@@ -1,0 +1,99 @@
+---
+id: "TVA-ELEC-20PCT-2025"
+type: "rule"
+domain: "facturation"
+title: "TVA électricité — Passage à 20% au 01/08/2025"
+summary: "Passage TVA 20% généralisée sur l'électricité depuis le 1er août 2025. Avant césure : TVA 5,5% sur abonnement (bouclier tarifaire) + 20% sur énergie. Après césure : 20% sur tout (abonnement + énergie + taxes)."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - industrie
+    - collectivite
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - taxes
+  granularity:
+    - mensuel
+
+scope: {}
+
+content_md: |
+  ## TVA Électricité — Césure 01/08/2025
+
+  ### Cadre réglementaire
+  - Article 278-0 bis Code général des impôts
+  - Loi de finances 2025 (fin bouclier tarifaire)
+
+  ### Taux avant et après césure
+
+  | Poste | Avant 01/08/2025 | Depuis 01/08/2025 |
+  |---|---|---|
+  | Abonnement (CG + CMDPS) | **5,5 %** (taux réduit) | **20 %** (taux normal) |
+  | Énergie consommée | 20 % | 20 % |
+  | CTA | 20 % | 20 % |
+  | Accise | 20 % | 20 % |
+  | CEE (facturé) | 20 % | 20 % |
+
+  ### Logique de calcul facture
+  ```
+  Montant_HT = Abonnement + Énergie + CTA + Accise + CEE
+  Montant_TTC = Montant_HT × (1 + TVA_applicable)
+  ```
+  Avant 01/08/2025 : 2 taux distincts (5,5% abonnement, 20% autres).
+  Depuis 01/08/2025 : taux unique 20% sur tous postes.
+
+  ### Césure et partition_windows
+  PROMEOS V112 gère automatiquement les factures à cheval sur 01/08/2025 :
+  - Décompte proportionnel jours avant/après césure
+  - Deux calculs TVA distincts
+  - Totaux séparés dans le breakdown
+
+  ### Impact financier ménages
+  - Abonnement 6 kVA annuel ~140 € HT
+  - TVA 5,5% → 7,70 € TVA = 147,70 € TTC
+  - TVA 20% → 28 € TVA = 168 € TTC
+  - **Écart : +20,30 €/an par ménage** (hausse TVA seule)
+
+logic:
+  when:
+    all:
+      - field: "energy_vector"
+        op: "="
+        value: "elec"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Vérifier TVA 20% sur tous postes facture post-01/08/2025"
+        priority: 1
+
+      - type: "next_step"
+        label: "Contrôler découpage partition_windows pour factures à cheval césure"
+        priority: 2
+
+sources:
+  - doc_id: "CGI-278-0-BIS"
+    label: "Article 278-0 bis Code général des impôts"
+    section: "Taux réduit TVA énergie"
+    anchor: "#cgi-278"
+    excerpt_short: "Taux réduit 5,5% applicable sur abonnement électricité — supprimé au 01/08/2025"
+
+  - doc_id: "LFI-2025-BOUCLIER"
+    label: "Loi de finances 2025 — Fin bouclier tarifaire"
+    section: "Art. 54 et suivants"
+    anchor: "#lfi-2025-54"
+    excerpt_short: "Suppression du taux réduit 5,5% TVA sur l'abonnement électricité au 01/08/2025"
+
+  - doc_id: "PROMEOS-V112-CESURE"
+    label: "PROMEOS V112 — partition_windows"
+    section: "Césure triple 01/08/2025 (TURPE + TVA + Accise)"
+    anchor: "#v112-cesure"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/flex/FLEX-READY-STANDARD-TERTIAIRE.yaml
+++ b/docs/kb/items/flex/FLEX-READY-STANDARD-TERTIAIRE.yaml
@@ -1,0 +1,100 @@
+---
+id: "FLEX-READY-STANDARD-TERTIAIRE"
+type: "knowledge"
+domain: "flex"
+title: "Flex Ready® — Standard interopérabilité BACS et flexibilité"
+summary: "Standard porté par Think Smartgrids + GIMELEC, basé sur la norme NF EN IEC 62746-4. Permet aux BACS de recevoir et traiter les signaux externes de flexibilité (prix, puissance, CO2). Déploiement à l'échelle prévu au S1 2026."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - collectivite
+  asset:
+    - hvac
+    - multi
+  reg:
+    - multi
+  granularity:
+    - 30min
+
+scope: {}
+
+content_md: |
+  ## Flex Ready® — Standard d'interopérabilité
+
+  ### Cadre technique
+  - **Norme de référence** : NF EN IEC 62746-4
+  - **Portage** : Think Smartgrids + GIMELEC (marque collective)
+  - **Création** : octobre 2024, déploiement à l'échelle S1 2026
+
+  ### Données échangées (5 cas d'usage)
+  1. **Horloge** : synchronisation temporelle pas 15min min
+  2. **Puissance maximum instantanée** (kW) : limite pilotable
+  3. **Prix** (€/kWh) : signal tarifaire fournisseur
+  4. **Puissance souscrite** (kVA) : contrainte contractuelle
+  5. **Empreinte carbone** (tCO2eq) : signal environnemental
+
+  ### Cadre de référence complet
+  - Standard Flex Ready® (communication API)
+  - Référentiels techniques BACS Flex Ready® (GIMELEC + Think Smartgrids)
+  - Socle cybersécurité Flex Ready® (GIMELEC + ANSSI)
+  - Référentiel architecture informatique et connectivité (SBA)
+  - Référentiels organisationnels (SBA) : gouvernance data, audit flex, commissioning, exploitation
+
+  ### Projets pilotes 2025
+  - Siège Morbihan Énergies (syndicat d'énergie)
+  - IntenCity Schneider Electric Grenoble
+  - Sites ACTEE (collectivités)
+
+  ### Bénéfices attendus
+  - Coût d'intégration réduit pour agrégateurs (interface standardisée)
+  - Passage à l'échelle des flexibilités tertiaires possible
+  - Liberté de choix du fournisseur/agrégateur pour le gestionnaire de bâtiment
+  - Compatibilité multi-marques pour les fabricants de GTB
+
+  ### Interopérabilité résidentielle (Code of Conduct JRC)
+  - Phase 1 (2021-2024) : gros électroménager, CVC (norme EN 50631)
+  - Phase 2 (depuis 2024) : HEMS, onduleurs PV, IRVE
+  - Norme candidate HEMS : EN 50491-12-2 ("S2")
+  - Travaux internationaux IEC 63402 (2025-)
+
+logic:
+  when:
+    all:
+      - field: "hvac_kw"
+        op: ">="
+        value: 70
+      - field: "flex_interest"
+        op: "="
+        value: true
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Vérifier conformité BACS au standard Flex Ready® (NF EN IEC 62746-4)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Exiger le socle cybersécurité Flex Ready® à l'installation"
+        priority: 2
+
+      - type: "next_step"
+        label: "Planifier commissioning selon référentiel SBA-GIMELEC"
+        priority: 3
+
+sources:
+  - doc_id: "BAROMETRE-FLEX-2026"
+    label: "Baromètre des flexibilités de consommation d'électricité — Édition 2026"
+    section: "Chapitre 5.2 Flex Ready® p.68-69"
+    anchor: "#flex-ready"
+    excerpt_short: "Standard Flex Ready® basé sur la norme NF EN IEC 62746-4, passage à l'échelle prévu au S1 2026"
+
+  - doc_id: "THINK-SMARTGRIDS-FLEX-READY"
+    label: "Think Smartgrids — Flex Ready®"
+    section: "Cadre de référence"
+    anchor: "#flex-ready-standard"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 2

--- a/docs/kb/items/flex/HEMS-PILOTAGE-RESIDENTIEL.yaml
+++ b/docs/kb/items/flex/HEMS-PILOTAGE-RESIDENTIEL.yaml
@@ -1,0 +1,108 @@
+---
+id: "HEMS-PILOTAGE-RESIDENTIEL"
+type: "knowledge"
+domain: "flex"
+title: "HEMS — Gestionnaire d'énergie résidentiel"
+summary: "Le HEMS (Home Energy Management System) centralise le pilotage multi-usages du logement. 4% des foyers français équipés fin 2025 (x8 vs 2023), objectif 17% en 2030. Porte d'entrée de la flexibilité côté aval compteur."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - multi
+  granularity:
+    - 30min
+
+scope: {}
+
+content_md: |
+  ## HEMS — Gestionnaire d'énergie résidentiel
+
+  ### Définition
+  Home Energy Management System : solution intelligente qui optimise la consommation
+  et la puissance à l'échelle du logement en intégrant signaux externes (prix, CO2, EcoWatt)
+  et contraintes internes (confort, présence, PV, batterie).
+
+  ### Chiffres clés 2025
+  - **Taux d'équipement** : 4 % des foyers (x8 vs 0,5% en 2023)
+  - **Objectif 2030** : 17 % (plan IGNES volontariste)
+  - **Connaissance** : 66 % des Français connaissent les systèmes de pilotage multi-usages (vs 38% en 2024)
+
+  ### Fonctions clés
+  1. **Interface utilisateur** : tablette/smartphone, consignes, reprise main
+  2. **Agrégation signaux** : prix spot, EcoWatt, demandes agrégateurs, météo
+  3. **Optimisation courbe de charge** :
+     - Limitation consommation (respect puissance souscrite)
+     - Décalage usages dans le temps
+     - Modulation puissance appelée
+     - Stockage/déstockage énergie
+  4. **Pilotage équipements** : chauffage, ECS, IRVE, PV, batterie, volets, prises connectées
+
+  ### Standards de référence
+  - **Aval** : NF EN 50491-12-2 ("S2") — échanges HEMS ↔ équipements
+  - **Amont** : NF EN IEC 62746-4 — échanges HEMS ↔ fournisseurs/agrégateurs
+  - **International** : série IEC 63402 (depuis 2025)
+
+  ### Bénéfices pour l'utilisateur
+  - Amélioration taux autoconsommation PV
+  - Réduction facture électricité (arbitrage HC/HP, pointe mobile)
+  - Allègement charge mentale (automatisation)
+  - Suivi et pilotage à distance
+
+  ### Pilotage VE à domicile 2025
+  - **35 %** clients pilotent systématiquement leur recharge VE (vs 32% en 2024, 26% en 2023)
+  - **63 %** recharges entre 21h-7h
+  - **64 %** pilotent via apps voiture/borne, 25% manuellement, 4% via compteur Linky, 2% via HEMS
+
+  ### Pilotage ECS 2025
+  - **88 %** asservissement par tableau électrique (contacteur HC) — mode historique
+  - **8 %** pilotage connecté (+2 pts vs 2024)
+  - **4 %** autre
+
+  ### Pilotage chauffage 2025 (pompe à chaleur)
+  - **83 %** commande manuelle sur équipement
+  - **12 %** solutions de pilotage connectées (+5 pts vs 2024)
+
+logic:
+  when:
+    any:
+      - field: "segment"
+        op: "in"
+        value: ["copro", "bailleur"]
+      - field: "offer_type"
+        op: "in"
+        value: ["tempo", "hp_hc", "base"]
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Choisir un HEMS dès le premier usage flexible (VE, PAC, ECS)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Privilégier un HEMS conforme NF EN 50491-12-2 et NF EN IEC 62746-4"
+        priority: 2
+
+      - type: "next_step"
+        label: "Activer pilotage automatique multi-usages sans silo"
+        priority: 3
+
+sources:
+  - doc_id: "BAROMETRE-FLEX-2026"
+    label: "Baromètre des flexibilités de consommation d'électricité — Édition 2026"
+    section: "Chapitre 6.6 Pilotage global p.84-85"
+    anchor: "#hems"
+    excerpt_short: "Taux d'équipement HEMS 4% en 2025, objectif 17% en 2030, x8 depuis 2023"
+
+  - doc_id: "IGNES-HEMS-ETUDE-2025"
+    label: "IGNES/BVA — Évaluation multicritères pilotage connecté maison individuelle — juin 2025"
+    section: "Étude CSTB"
+    anchor: "#etude-ignes"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 2

--- a/docs/kb/items/flex/NEBCO-DEPLOIEMENT-2026.yaml
+++ b/docs/kb/items/flex/NEBCO-DEPLOIEMENT-2026.yaml
@@ -1,0 +1,80 @@
+---
+id: "NEBCO-DEPLOIEMENT-2026"
+type: "knowledge"
+domain: "flex"
+title: "NEBCO — Déploiement 2025-2026 et adoption"
+summary: "NEBCO mis en service le 1er septembre 2025, remplace NEBEF. Fin 2025, 708 000 sites inscrits (x2 vs 2024), dont +230 000 entre septembre et décembre 2025. Adoption portée à 86% par le résidentiel."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - industrie
+    - collectivite
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - multi
+  granularity:
+    - 30min
+
+scope: {}
+
+content_md: |
+  ## Déploiement NEBCO fin 2025
+
+  ### Chiffres clés
+  - **708 000 sites** inscrits fin 2025 (+365 000 vs 2024, soit x2)
+  - **+230 000 sites** entre septembre et décembre 2025 (4 premiers mois)
+  - **600 000 consommateurs résidentiels** activables via NEBCO fin 2025 (x2 vs 2024)
+  - **21 agrégateurs** agréés fin 2025, dont 9 nouveaux depuis 2023
+
+  ### Volumes de modulation 2025
+  - **185 GWh** modulations à la baisse valorisées sur l'année
+  - Premières modulations à la hausse (report, anticipation) au Q4 2025
+  - Forte accélération par rapport à NEBEF (23 GWh en 2024, 186 GWh en 2023)
+
+  ### Cadre réglementaire
+  - CRE délibération 2025-199 du 23 juillet 2025
+  - Code de l'énergie : articles L.271-1, L.271-2, L.321-15-1, R.271-1
+  - Mise en service : 1er septembre 2025
+
+  ### Différences clés vs NEBEF
+  - Valorisation des 3 types de modulation (effacement, report, anticipation)
+  - Décalage de consommation valorisable même si prix SPOT < barème fournisseur
+  - Grandeur dimensionnante = spread des prix SPOT (plus seulement seuil fournisseur)
+
+logic:
+  when:
+    all:
+      - field: "flex_interest"
+        op: "="
+        value: true
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Identifier un agrégateur certifié NEBCO (liste publique RTE)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Évaluer le spread de prix SPOT journalier pour valoriser les décalages"
+        priority: 2
+
+sources:
+  - doc_id: "BAROMETRE-FLEX-2026"
+    label: "Baromètre des flexibilités de consommation d'électricité — Édition 2026"
+    section: "Synthèse p.8 + Valorisation p.37"
+    anchor: "#nebco-deploiement"
+    excerpt_short: "708 000 sites inscrits sur NEBCO fin 2025, +230 000 entre septembre et décembre 2025, plus du double par rapport à l'an dernier"
+
+  - doc_id: "CRE-2025-199"
+    label: "Délibération CRE 2025-199 du 23 juillet 2025"
+    section: "Règles NEBCO"
+    anchor: "#regles-nebco"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/flex/TEMPO-EFFACEMENT-JOURS-POINTE.yaml
+++ b/docs/kb/items/flex/TEMPO-EFFACEMENT-JOURS-POINTE.yaml
@@ -1,0 +1,78 @@
+---
+id: "TEMPO-EFFACEMENT-JOURS-POINTE"
+type: "rule"
+domain: "flex"
+title: "TEMPO et offres pointe mobile — Effacement jours de pointe hiver"
+summary: "1,2 million de clients résidentiels ont une offre pointe mobile (6 cadrans, type TEMPO). Effacement moyen 30-50% de la consommation sur jours rouges selon puissance souscrite, capacité totale ~400 MW sur l'hiver 2024-2025."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - multi
+  granularity:
+    - event
+
+scope: {}
+
+content_md: |
+  ## TEMPO et offres pointe mobile
+
+  ### Chiffres clés hiver 2024-2025
+  - **1,2 million de clients** souscrivent une offre pointe mobile (x4 depuis 2023)
+  - **~400 MW** capacité totale d'effacement
+  - **30-50%** effacement relatif par client selon heure et jour de pointe
+  - **200-500 W** effacement moyen par client lors des jours rouges
+
+  ### Types de jours TEMPO
+  - **Bleu** (300 jours) : tarif normal, pas de tension
+  - **Blanc** (43 jours) : tarif légèrement supérieur, moyenne tension
+  - **Rouge** (22 jours) : tarif très supérieur 6h-22h, forte tension
+  - Signalement veille à partir de 11h
+
+  ### Effacement par puissance souscrite (hiver 2024-2025)
+  | Puissance | Effacement relatif |
+  |---|---|
+  | < 9 kVA | 20-30 % |
+  | >= 9 kVA | 30-50 % |
+
+  ### Évolution TRV
+  - Extension de l'option TEMPO du tarif réglementé aux clients résidentiels ≥ 6 kVA
+  - Croissance x4 du nombre de clients TEMPO entre 2023 et 2025
+
+  ### Comportement effacement
+  - Baisse forte en journée lors jours rouges (jusqu'à 50% en matinée/après-midi)
+  - Report partiel en heures creuses (22h-6h) lors des jours rouges
+  - Augmentation effacement relatif par client d'année en année (apprentissage)
+
+logic:
+  when:
+    all:
+      - field: "offer_type"
+        op: "="
+        value: "tempo"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Piloter automatiquement chauffage et ECS selon type de jour Tempo"
+        priority: 1
+
+      - type: "next_step"
+        label: "Anticiper le signalement à J-1 11h pour optimiser la programmation"
+        priority: 2
+
+sources:
+  - doc_id: "BAROMETRE-FLEX-2026"
+    label: "Baromètre des flexibilités de consommation d'électricité — Édition 2026"
+    section: "Chapitre 4.6 Zoom offre pointe mobile p.59"
+    anchor: "#tempo-pointe-mobile"
+    excerpt_short: "1,2 million de consommateurs bénéficiant d'une offre de fourniture à effacement (TEMPO ou type TEMPO) se traduit par une baisse de la consommation de 30% à 40% sur les jours signalés par RTE soit une capacité totale d'environ 400 MW"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 2

--- a/docs/kb/items/reglementaire/APER-SOLARISATION-PARKINGS.yaml
+++ b/docs/kb/items/reglementaire/APER-SOLARISATION-PARKINGS.yaml
@@ -1,0 +1,100 @@
+---
+id: "APER-SOLARISATION-PARKINGS"
+type: "rule"
+domain: "reglementaire"
+title: "Loi APER — Obligation solarisation parkings >= 1 500 m2"
+summary: "Loi n°2023-175 du 10 mars 2023 (Accélération Production Énergies Renouvelables). Obligation d'équiper les parkings extérieurs ≥ 1 500 m2 de protections/ombrières avec PV ou végétalisation. Échéance 01/07/2026 (>10 000 m2) puis 01/07/2028 (1 500-10 000 m2). Sanctions 40 000 €/an + 200 €/place."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - collectivite
+    - copro
+  asset:
+    - multi
+  reg:
+    - loi_aper
+  granularity:
+    - event
+
+scope:
+  parking_surface_m2_min: 1500
+
+content_md: |
+  ## Loi APER — Solarisation parkings
+
+  ### Cadre réglementaire
+  - Loi n°2023-175 du 10 mars 2023 (APER), article 40
+  - Décret d'application n°2023-1250 du 26 décembre 2023
+  - Applicable aux parkings extérieurs ouverts au public
+
+  ### Seuils et échéances
+
+  | Surface parking | Échéance obligation |
+  |---|---|
+  | >= 10 000 m2 | **1er juillet 2026** |
+  | 1 500 - 10 000 m2 | 1er juillet 2028 |
+  | < 1 500 m2 | Non concerné |
+
+  ### Nature de l'obligation
+  Ombrières / protections couvrant au moins 50% de la surface, avec :
+  - **Production PV** sur au moins 50% de la couverture
+  - OU végétalisation (option alternative)
+
+  ### Exemptions
+  - Contraintes techniques, de sécurité, architecturales ou patrimoniales
+  - Parkings existants dont la couverture exposerait à des risques structurels
+  - Non-rentabilité économique démontrée (TRI > 10 ans sur étude technique)
+
+  ### Sanctions en cas de non-conformité
+  - **Astreinte jusqu'à 40 000 €/an** par parking non conforme (personne morale)
+  - **Amende 200 €/place de stationnement/an** pour non-exécution
+  - Contrôles par DREAL/DEAL
+
+  ### Articulation avec AUTRES obligations
+  - Loi Climat et Résilience : bâtiments neufs ≥500 m2 (toitures + parkings PV)
+  - Bâtiments existants >500 m2 : échéance janvier 2028 (loi APER art.42)
+
+logic:
+  when:
+    all:
+      - field: "parking_surface_m2"
+        op: ">="
+        value: 1500
+  then:
+    outputs:
+      - type: "obligation"
+        label: "Installer ombrières PV (ou végétalisation) sur >=50% du parking"
+        deadline: "2028-07-01"
+        severity: "high"
+        details: "Loi APER n°2023-175 art.40"
+
+      - type: "next_step"
+        label: "Vérifier si parking >= 10 000 m2 (deadline avancée au 01/07/2026)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Étudier éligibilité exemption (contraintes techniques, non-rentabilité TRI>10 ans)"
+        priority: 2
+
+      - type: "next_step"
+        label: "Budgéter risque sanction : 40 000 €/an + 200 €/place"
+        priority: 3
+
+sources:
+  - doc_id: "LOI-2023-175-APER"
+    label: "Loi n°2023-175 du 10 mars 2023 (APER)"
+    section: "Article 40 — Solarisation parkings"
+    anchor: "#art-40"
+    excerpt_short: "Obligation d'équiper les parkings extérieurs de plus de 1 500 m2 d'ombrières intégrant un dispositif de production d'énergie renouvelable ou de végétalisation"
+
+  - doc_id: "DECRET-2023-1250"
+    label: "Décret d'application n°2023-1250 du 26 décembre 2023"
+    section: "Modalités d'application"
+    anchor: "#decret-2023-1250"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/reglementaire/BACS-OBJECTIF-100K-2030.yaml
+++ b/docs/kb/items/reglementaire/BACS-OBJECTIF-100K-2030.yaml
@@ -1,0 +1,105 @@
+---
+id: "BACS-OBJECTIF-100K-2030"
+type: "knowledge"
+domain: "reglementaire"
+title: "BACS — Plan 100 000 bâtiments équipés en 2030"
+summary: "Objectif de la filière (GIMELEC + Think Smartgrids) : équiper 100 000 bâtiments tertiaires de BACS d'ici 2030. Fin 2025, seulement 32 000 BACS installés (16% du parc), rythme insuffisant nécessitant une forte accélération."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - collectivite
+  asset:
+    - hvac
+    - multi
+  reg:
+    - bacs
+  granularity:
+    - event
+
+scope:
+  hvac_kw_min: 70
+
+content_md: |
+  ## Plan 100 000 BACS 2030 — État des lieux 2026
+
+  ### Chiffres clés fin 2025
+  - **32 000 BACS** installés (vs 30 000 en 2024, +2 000 sur l'année)
+  - **16 %** des bâtiments tertiaires équipés
+  - **37 %** des surfaces tertiaires équipées
+  - **Objectif 2030 : 100 000 BACS** (plan filière GIMELEC/Think Smartgrids)
+  - Rythme actuel amènerait l'atteinte de l'objectif en **2040**, pas 2030
+
+  ### Taux d'équipement par secteur (2025)
+  | Secteur | Taux BACS |
+  |---|---|
+  | Bureaux | 17 % |
+  | Commerces alimentaires | 15 % |
+  | Commerces non-alimentaires | 19 % |
+  | Entrepôts logistique | 23 % |
+  | Enseignement primaire | 7 % |
+  | Enseignement secondaire (collège/lycée) | 14-46 % |
+  | Santé | 40 % |
+  | Hôtellerie-restauration | 11 % |
+  | Transport (gares, aéroports) | 27 % |
+
+  ### Taux d'équipement par taille (2025)
+  | Surface | Taux BACS |
+  |---|---|
+  | 1 000-2 000 m² | 10 % |
+  | 2 000-5 000 m² | 16 % |
+  | 5 000-10 000 m² | 19 % |
+  | 10 000-20 000 m² | 33 % |
+  | > 20 000 m² | 86 % |
+
+  ### Freins identifiés
+  - 45 % des BACS installés ne sont pas exploités (paramétrage obsolète, pas de commissioning)
+  - Manque de compétence et ressources côté gestionnaires
+  - Interprétation norme NF EN ISO 52120-1 limite souvent au strict respect du décret
+
+  ### Facteurs clés de succès
+  - Commissioning systématique à la mise en service
+  - Re-commissioning lors de rénovation ou changement d'activité
+  - Exploitation par Facility Manager ou contrat de performance énergétique (CPE)
+  - Standard Flex Ready® pour interopérabilité avec signaux de marché
+
+logic:
+  when:
+    all:
+      - field: "hvac_kw"
+        op: ">="
+        value: 70
+      - field: "surface_m2"
+        op: ">="
+        value: 1000
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Vérifier éligibilité CEE pour l'installation BACS"
+        priority: 1
+
+      - type: "next_step"
+        label: "Exiger commissioning systématique lors de l'installation"
+        priority: 2
+
+      - type: "next_step"
+        label: "Privilégier un BACS Flex Ready® pour bénéficier de la flexibilité à terme"
+        priority: 3
+
+sources:
+  - doc_id: "BAROMETRE-FLEX-2026"
+    label: "Baromètre des flexibilités de consommation d'électricité — Édition 2026"
+    section: "Chapitre 5 — Déploiement tertiaire p.64-71"
+    anchor: "#bacs-deploiement"
+    excerpt_short: "32 000 BACS installés fin 2025, objectif 100 000 en 2030, 16% des bâtiments équipés"
+
+  - doc_id: "GIMELEC-ONDB-2025"
+    label: "Observatoire National du Déploiement des BACS — GIMELEC"
+    section: "Édition 2025"
+    anchor: "#ondb-2025"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/reglementaire/CSRD-VOLET-ENERGIE.yaml
+++ b/docs/kb/items/reglementaire/CSRD-VOLET-ENERGIE.yaml
@@ -1,0 +1,119 @@
+---
+id: "CSRD-VOLET-ENERGIE"
+type: "rule"
+domain: "reglementaire"
+title: "CSRD — Volet énergie/climat (ESRS E1) obligatoire 2025-2026"
+summary: "Corporate Sustainability Reporting Directive (UE 2022/2464) transposée en France par ordonnance 2023-1142. Obligation de reporting extra-financier incluant ESRS E1 (climate change), avec indicateurs énergie: conso totale, mix énergétique, intensité énergétique, émissions Scope 1+2+3. Calendrier progressif par taille."
+
+tags:
+  energy:
+    - multi
+  segment:
+    - tertiaire_multisite
+    - industrie
+  asset:
+    - multi
+  reg:
+    - multi
+  granularity:
+    - mensuel
+
+scope: {}
+
+content_md: |
+  ## CSRD — Reporting durabilité obligatoire
+
+  ### Cadre réglementaire
+  - Directive (UE) 2022/2464 du 14 décembre 2022 (CSRD)
+  - Ordonnance n°2023-1142 du 6 décembre 2023 (transposition française)
+  - Normes ESRS (European Sustainability Reporting Standards), notamment **ESRS E1** pour climat/énergie
+
+  ### Calendrier progressif
+
+  | Rapport | Exercice | Périmètre entreprises |
+  |---|---|---|
+  | 2025 | Exercice 2024 | Grandes entreprises cotées (>500 sal) et entités d'intérêt public |
+  | 2026 | Exercice 2025 | Grandes entreprises (>250 sal, CA>50M€, bilan >25M€) |
+  | 2027 | Exercice 2026 | PME cotées, petites banques, captives d'assurance |
+  | 2029 | Exercice 2028 | Filiales UE de groupes non-UE (conditions de taille) |
+
+  ### Indicateurs ESRS E1 — Énergie/Climat
+
+  1. **Consommation énergétique totale** (MWh)
+     - Ventilation par source (élec, gaz, fioul, renouvelables autoconsommées)
+     - Détail par activité/site
+
+  2. **Intensité énergétique** (MWh/M€ CA)
+
+  3. **Émissions GES** — 3 scopes
+     - Scope 1 : combustion directe (gaz, fioul, véhicules)
+     - Scope 2 : électricité achetée (market-based + location-based)
+     - Scope 3 : chaîne de valeur (15 catégories GHG Protocol)
+
+  4. **Plan de transition** aligné trajectoire +1,5°C
+     - Objectifs SBTi (Science Based Targets)
+     - CAPEX verts / OPEX transition
+
+  5. **Risques physiques et transition** (analyse TCFD intégrée)
+
+  ### Articulation avec obligations énergie existantes
+  - **Décret Tertiaire** : fournit les consommations par site → alimente CSRD scope 2
+  - **Audit énergétique L233-1** : fournit le diagnostic → alimente plan de transition
+  - **CEE valorisés** : alimentent actions réalisées
+  - **BACS** : donne pilotage réel → intensité énergétique trackable
+
+  ### Sanctions non-conformité
+  - Amendes jusqu'à 5% du CA UE (modèle RGPD)
+  - Responsabilité civile des dirigeants
+  - Certification externe obligatoire (auditeur CSRD)
+
+  ### Attention complexité
+  Un rapport CSRD complet représente typiquement 80-150 pages, avec ~1 200 datapoints à remplir. Nécessite:
+  - Système d'information énergétique (EMIS) cohérent
+  - Gouvernance ESG dédiée
+  - Audit externe pré-certifié
+
+logic:
+  when:
+    any:
+      - field: "csrd_applicable"
+        op: "="
+        value: true
+      - field: "segment"
+        op: "in"
+        value: ["tertiaire_multisite", "industrie"]
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Identifier l'année d'application CSRD selon taille entreprise"
+        priority: 1
+
+      - type: "next_step"
+        label: "Cartographier les sources de données ESRS E1 (conso, émissions Scope 1-2-3)"
+        priority: 2
+
+      - type: "next_step"
+        label: "Aligner les déclarations OPERAT + audits L233-1 sur la logique CSRD E1"
+        priority: 3
+
+sources:
+  - doc_id: "CSRD-2022-2464"
+    label: "Directive (UE) 2022/2464 du 14 décembre 2022 (CSRD)"
+    section: "Articles 19a et 29a"
+    anchor: "#csrd-art"
+    excerpt_short: "Reporting extra-financier obligatoire selon normes ESRS, calendrier progressif par taille d'entreprise"
+
+  - doc_id: "ORDONNANCE-2023-1142"
+    label: "Ordonnance n°2023-1142 du 6 décembre 2023 (transposition française CSRD)"
+    section: "Code de commerce Art. L233-28-4"
+    anchor: "#ord-2023-1142"
+
+  - doc_id: "EFRAG-ESRS-E1"
+    label: "EFRAG ESRS E1 — Climate change"
+    section: "Disclosure requirements"
+    anchor: "#esrs-e1"
+    excerpt_short: "Norme européenne de reporting sur le changement climatique, incluant consommation, émissions et plan de transition"
+
+updated_at: "2026-04-17"
+confidence: "high"
+priority: 1

--- a/docs/kb/items/reglementaire/DPE-TERTIAIRE.yaml
+++ b/docs/kb/items/reglementaire/DPE-TERTIAIRE.yaml
@@ -1,0 +1,97 @@
+---
+id: "DPE-TERTIAIRE"
+type: "rule"
+domain: "reglementaire"
+title: "DPE Tertiaire — Diagnostic de performance énergétique obligatoire"
+summary: "Transposition directive EPBD refondue (UE 2024/1275) prévue en 2026-2027. DPE obligatoire pour tout bâtiment tertiaire >500 m2 lors de vente/location, et avant 2030 pour tout bâtiment existant à usage professionnel. Notation A-G sur consommation et émissions CO2."
+
+tags:
+  energy:
+    - multi
+  segment:
+    - tertiaire_multisite
+    - collectivite
+    - copro
+    - bailleur
+  asset:
+    - multi
+  reg:
+    - multi
+  granularity:
+    - event
+
+scope:
+  surface_m2_min: 500
+
+content_md: |
+  ## DPE Tertiaire — Obligation progressive
+
+  ### Cadre réglementaire
+  - Directive EPBD refondue (UE) 2024/1275 du 24 avril 2024
+  - Transposition française prévue mai 2026 (délai 24 mois)
+  - Code de la construction et de l'habitation — articles à préciser lors transposition
+
+  ### Périmètre
+  - Tout bâtiment tertiaire (bureaux, commerces, enseignement, santé, hôtellerie, sport, culture, transports)
+  - Seuil d'application : surface utile > 500 m2
+  - Bâtiments neufs : obligation à la livraison
+  - Bâtiments existants : obligation progressive 2026 → 2030
+
+  ### Notation DPE
+  Notation A (< 70 kWh/m2/an) → G (> 450 kWh/m2/an) sur 2 critères :
+  1. **Consommation** (kWh/m2/an d'énergie primaire)
+  2. **Émissions CO2** (kgCO2eq/m2/an)
+
+  ### Calendrier de mise en œuvre (attendu)
+  | Date | Obligation |
+  |---|---|
+  | Mai 2026 | Transposition française (publication) |
+  | 2026-2027 | Obligation vente/location bâtiments tertiaires >500m2 |
+  | 2027-2030 | Extension progressive à tout bâtiment existant |
+  | 2030 | Interdiction location/vente bâtiments classés G (sur modèle résidentiel) |
+
+  ### Articulation Décret Tertiaire
+  Le DPE tertiaire vient **compléter** (pas remplacer) le Décret Tertiaire :
+  - DT = obligation de réduction (-40% 2030, -50% 2040, -60% 2050)
+  - DPE tertiaire = diagnostic à moment donné + classe énergétique
+  - Les deux coexistent avec déclaration OPERAT annuelle
+
+  ### Impact ESG / CSRD
+  Le DPE alimente les indicateurs CSRD (E1 Climate change) pour les entreprises >250 salariés.
+
+  ### Attention
+  Cadre réglementaire **en cours de précision** au 2e trimestre 2026. Les paramètres définitifs (méthode calcul, seuils exacts) seront fixés par décret d'application post-transposition.
+
+logic:
+  when:
+    all:
+      - field: "surface_m2"
+        op: ">="
+        value: 500
+      - field: "building_type"
+        op: "in"
+        value: ["bureau", "commerce", "enseignement", "sante", "hotellerie", "sport", "culture", "transport"]
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Suivre la transposition française de la directive EPBD 2024/1275 (publication mai 2026)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Anticiper le diagnostic DPE pour toute vente/location prévue à partir de 2027"
+        priority: 2
+
+      - type: "next_step"
+        label: "Alimenter les indicateurs CSRD E1 avec le DPE calculé"
+        priority: 3
+
+sources:
+  - doc_id: "EPBD-2024-1275"
+    label: "Directive (UE) 2024/1275 du 24 avril 2024 (EPBD refondue)"
+    section: "Article 19 — DPE bâtiments non résidentiels"
+    anchor: "#epbd-19"
+    excerpt_short: "Obligation d'un diagnostic de performance énergétique pour les bâtiments non résidentiels, avec notation A-G et critères consommation + émissions"
+
+updated_at: "2026-04-17"
+confidence: "medium"
+priority: 2

--- a/docs/pilotage-usages/INNOVATION_ROADMAP.md
+++ b/docs/pilotage-usages/INNOVATION_ROADMAP.md
@@ -1,0 +1,87 @@
+# Innovation Roadmap — Pilotage PROMEOS post-S22
+
+**Objectif** : faire du module Pilotage "le meilleur au monde" en exploitant les **vraies données signal** (ENTSO-E, Tempo, Enedis CDC) pour créer des cas d'usage que ni Voltalis, ni NW, ni les GTB Flex Ready® ne font aujourd'hui.
+
+**Socle acquis (S17-S22)** : doctrine Pilotage, fenêtres J+7, 7 quick wins, pipeline RTE Tempo OAuth2 + ENTSO-E + APScheduler, Flex Ready® NF EN IEC 62746-4, TURPE 7 HC saisonnalisés, calibrage Enedis 2024.
+
+## 8 pistes ambitieuses par ordre de séquençage
+
+### Vague 1 — Q2 2026 (zéro dépendance externe, impact cockpit)
+
+**1. Radar prix négatifs J+7 (alertes proactives)**
+- Modèle ML léger (gradient boosting) sur historique ENTSO-E + météo + PV installé
+- Prédit les 513h/an de prix négatifs à J+7
+- Cockpit : "3 fenêtres négatives probables cette semaine — déclenchez vos ECS/VE"
+- **Effort** : 4-5 j/dev · **Impact** : wedge unique (agrégateurs voient H-1, nous voyons J+7) · **Dépend** : Open-Meteo gratuit
+
+**2. ROI Flex Ready® chiffré par site**
+- Au-delà du signal conforme NF EN IEC 62746-4, calcul du **gain € annuel**
+- Évitement pointe + valorisation NEBCO spread + CEE BACS
+- Transforme un standard coché en business case CFO
+- **Effort** : 3 j · **Impact** : aucun concurrent ne chiffre · **Dépend** : grille TURPE 7 + spread NEBCO historique
+
+**3. Scoring multi-sites & classement portefeuille**
+- Étendre `compute_potential_score` en classement portefeuille
+- Top-10 sites à prioriser, carte de chaleur par archétype, budget flex total
+- Cible DG/DAF multi-sites (Fournisseur 4.0)
+- **Effort** : 5-6 j · **Impact** : Voltalis reste mono-site · **Dépend** : scope hierarchy existant
+
+### Vague 2 — Q3 2026 (preuve ROI chiffré)
+
+**4. Simulation NEBCO sur vraie CDC Enedis**
+- Rejouer la CDC SF4 d'un site sur 30 derniers jours + appliquer fenêtres FAVORABLES détectées
+- Estimer gain NEBCO réel (spread × kWh décalés − compensation)
+- "Voici les 1 847 € que vous auriez gagnés le mois dernier"
+- **Effort** : 6-7 j · **Impact** : preuve chiffrée sans engagement agrégateur · **Dépend** : CDC SF4 Enedis + spot historique
+
+**5. Détecteur d'anomalies conso + talon gaspillé**
+- ML non-supervisé (Isolation Forest) sur la CDC
+- Dérives talon nocturne, pics anormaux week-end, "fantômes" post-fermeture
+- Chaque anomalie → action chiffrée
+- **Effort** : 5 j · **Impact** : combine flex + anomalie (Voltalis fait flex, Metron fait anomalie, personne combine) · **Dépend** : CDC historique 30j+
+
+### Vague 3 — Q4 2026 (moat durable)
+
+**6. Jumeau thermique léger bâtiment (RC-model)**
+- Modèle R-C à 2 paramètres calé sur CDC + DJU + archétype
+- Prédit effet d'un décalage chauffage/clim en °C ressenti
+- Transforme "vous perdrez 0,5 °C pendant 2h" en décision gestionnaire
+- **Effort** : 8-10 j · **Impact** : répond à l'objection #1 du tertiaire (confort) · **Dépend** : DJU Météo-France + CDC
+
+**7. Leaderboard CUBE Flex interne (gamification portefeuille)**
+- Challenge inspiré CUBE Flex A4MT
+- Classement mensuel % baisse pointe 7h-10h + 17h-20h (28% conso tertiaire)
+- Badges par site, partage inter-sites du même org
+- **Effort** : 4 j · **Impact** : engagement exploitants terrain (les BACS non exploités = 45%) · **Dépend** : CDC + plages pointe constants.py
+
+**8. Marketplace "primo-agrégateurs" intégrée**
+- API de matching PROMEOS → Voltalis/NW/Équilibre
+- Dossier technique pré-rempli (NEBCO-ready, CDC 12 mois, Flex Ready® score)
+- Commission 10-15% = stream revenu Fournisseur 4.0
+- **Effort** : 10-12 j + juridique · **Impact** : PROMEOS devient guichet unique, pas concurrent · **Dépend** : partenariats agrégateurs agréés RTE
+
+## Synthèse
+
+| Vague | Effort total | Impact | Angle différenciant |
+|---|---|---|---|
+| **V1 (Q2)** | 12-14 j/dev | Cockpit J+7 + ROI CFO + portefeuille | Visibilité anticipée unique |
+| **V2 (Q3)** | 11-12 j/dev | Preuve chiffrée sur données réelles | Anti-objection "je n'y crois pas" |
+| **V3 (Q4)** | 22-26 j/dev | Moat durable (jumeau + gamification + marketplace) | Guichet unique flexibilité |
+
+**Total 45-52 j/dev** sur 3 trimestres pour passer de "brique Pilotage conforme" à "meilleure brique au monde".
+
+## Dette technique identifiée par audit (S22)
+
+Corrigée dans ce même sprint :
+- ✅ Org-scoping Flex Ready endpoint
+- ✅ `except Exception` silencieux → logger.warning + typage
+- ✅ Fallback spot avec `prix_age_hours` + cap 36h
+- ✅ `empreinte_source` lu depuis config/emission_factors.py
+- ✅ Injection tz : datetime naïf = UTC (pas wall-clock)
+
+À traiter en V1 :
+- Tests DST spring-forward/fall-back sur `is_hc_favorable`
+- `response_model` Pydantic sur endpoint Flex Ready (OpenAPI)
+- Tests fallback spot stale + module entsoe indisponible
+- Mapping NAF → archétype via `utils/naf_resolver` (supprimer heuristique hôtellerie biaisée)
+- Pondérations `_W_DECALABLE/_W_POINTE/_W_BACS` vers ParameterStore

--- a/docs/reglementaire/barometre_flex_2026.md
+++ b/docs/reglementaire/barometre_flex_2026.md
@@ -1,0 +1,146 @@
+# Baromètre des flexibilités de consommation d'électricité — Édition 2026
+
+**Source officielle** : RTE, Enedis, GIMELEC, Think Smartgrids, IGNES, ACTEE, IFPEB, SBA — Avril 2026
+**Lien doctrine PROMEOS** : confirme doctrine Pilotage des usages (S1-S21), source primaire pour calibrer nos chiffres.
+
+## Faits chiffrés 2025 (officiels)
+
+### Marché & réseau
+- **513h** de prix spot négatifs en 2025 (vs 352h en 2024, **+46%**)
+- **3 TWh** d'EnR écrêtés en 2025 (vs 1.7 TWh 2024)
+- **+5.9 GW** nouveau PV installé en 2025
+- Prix pointe 18h-21h : **+111%** vs plage 10h-18h (vs +77% en 2024)
+- Prix été plage méridienne 4× moins cher que pointe soir (-393%)
+- Consommation corrigée stable ~**450 TWh/an** depuis 2023
+
+### Flexibilité en pratique
+- **708 000 sites** inscrits NEBCO fin 2025 (vs 340 000 fin 2024, **×2 en 1 an**)
+- Nouveau mécanisme **NEBCO** (Notifications d'Échanges de Blocs de Consommation) actif depuis **1/09/2025**, remplace NEBEF
+- Permet valorisation des **décalages** (pas seulement effacements)
+- 1,2M clients résidentiels Tempo/type Tempo — baisse 30-40% jours rouges = **400 MW** hiver
+- Agrégateurs agréés : 21 en 2025 dont 43% créés depuis 2023
+
+### Tertiaire
+- **32 000 BACS** installés fin 2025 (objectif 100 000 en 2030 non atteint, rythme actuel → 2040)
+- 16% des bâtiments tertiaires équipés BACS (vs 15% en 2024)
+- 45% des BACS installés ne sont pas exploités activement
+- **Flex Ready®** : marque GIMELEC/Think Smartgrids créée en 2024, déployée en 2025
+
+## Mécanisme NEBCO (1/09/2025+)
+
+| Aspect | NEBEF (ancien) | NEBCO (nouveau) |
+|---|---|---|
+| Valorisation | Effacements uniquement | Décalages (baisse + hausse) |
+| Opportunités | Rares (dépend barème fournisseur) | Quotidiennes (dépend spread prix) |
+| Échéances | - | 7j pour sites >36 kVA, 2j pour ≤36 kVA |
+
+**Formule de valorisation** :
+```
+Décalage = écart prix marché (spread) − solde compensation fournisseur
+```
+
+## Standard Flex Ready® (NF EN IEC 62746-4)
+
+5 données échangées entre GTB et acteurs marché (fournisseurs, agrégateurs, GRD) :
+1. **Horloge** (pas 15 min min, bidirectionnel)
+2. **Puissance max instantanée** (kW)
+3. **Prix** (€/kWh) — tarif fournisseur
+4. **Puissance souscrite** (kVA)
+5. **Empreinte carbone** (tCO₂e)
+
+**Interopérabilité** :
+- Amont : NF EN IEC 62746-4 (entre acteurs marché ↔ HEMS/GTB)
+- Aval : Code of Conduct for Energy Smart Appliances (Commission UE) phase 2 — SAREF4ENER
+- Norme EN 50631 (chauffage/ECS/ventilation), EN 50491-12-2 S2 (HEMS)
+
+## Évolution Heures Creuses TURPE 7
+
+### Calendrier déploiement (Enedis)
+- **Phase 1** : nov 2025 → mai 2026 (5,2M clients résidentiels, HC identiques été/hiver)
+- **Phase 2** : déc 2026 → nov 2027 (22,8M clients résidentiels+pro ≤36 kVA, HC saisonnalisées été/hiver)
+- **Phase 3** : juin 2027 → août 2028 (550k clients Marché d'Affaires BT>36 + HTA)
+
+### Créneaux par saison
+
+**Saison basse (été, 1/04 → 31/10)** :
+- À FAVORISER : 2h-6h + 11h-17h (heures solaires)
+- À EXCLURE : 7h-11h + 18h-23h
+
+**Saison haute (hiver, 1/11 → 31/03)** :
+- À FAVORISER : 2h-6h + 21h-24h
+- À EXCLURE : 7h-11h + 17h-21h
+
+**Règles** :
+- 8h HC/jour par client
+- Si 2 plages : 1 diurne (8h-20h) + 1 nocturne (20h-8h)
+- Plage nocturne min 5h (facilite recharge VE)
+- Plage diurne min 2h
+
+### Impact attendu
+- **5 GW** de consommation déplacés vers 14h dès 2027 (ECS asservi + VE)
+- ECS résidentiel aujourd'hui : pic nocturne 4h-8h (~7 GW) → demain split nuit/14h
+
+## 3 types de flexibilités (doctrine officielle)
+
+| Type | Horizon | Opportunité | Mécanisme |
+|---|---|---|---|
+| **1. Structurelle/régulière** | A-3 à J-7, fixe | HC, offres HP/HC/dynamiques | TRVe, contrats saisonnalisés |
+| **2. Dynamique** | J-7 à H-1 | Marchés SPOT day-ahead + IDA | NEBCO, offres "bloc + SPOT" |
+| **3. Équilibrage** | H-1 à temps réel | Mécanisme ajustement RTE | Services système (géré par RTE, hors flex quotidien) |
+
+**Le module Pilotage PROMEOS cible les types 1 et 2.**
+
+## Chiffres sectoriels (Enedis, 2024)
+
+| Segment | Sites | Surface (millions m²) | BACS équipés | Conso TWh/an |
+|---|---|---|---|---|
+| Bureaux | 42 000 | 130 | 17% | - |
+| Commerces | 60 000 | 150 | 17% | - |
+| Enseignement | 37 000 | 166 | 13% (lycées 46%) | 4.5 |
+| Santé | 3 000 | 30 | 40% | 7 |
+| Hôtels/Restos | 12 000 | 25 | 11% | 5.7 |
+| Sport/Culture | 21 000 | 42 | 11% | 8.3 |
+| Transport | 3 500 | 30 | 27% | 3.8 |
+
+**Total tertiaire** : 121 TWh/an, 70% de la consommation France avec résidentiel (139 TWh).
+
+## Pic consommation journalier (2025 hiver ouvré)
+
+- Tertiaire : pic matinal 7h-10h à 25 GW puis plateau
+- Résidentiel : pic soir 19h à 36 GW (jour froid)
+- Résidentiel été : pic tardif 22h, pic méridien émergent (climatisation)
+
+**Plages à éviter pour le système** : 7h-10h + 17h-20h (ces 2 plages = 28% de la conso journalière tertiaire).
+
+## Filière organisée
+
+8 acteurs signataires du baromètre :
+- RTE (gestionnaire transport)
+- Enedis (GRD 95%)
+- GIMELEC (équipementiers électriques, marque Flex Ready®)
+- IGNES (équipementiers bâtiment)
+- Think Smartgrids (filière smart grids, marque Flex Ready®)
+- ACTEE/FNCCR (collectivités, programme CEE)
+- IFPEB (performance bâtiment)
+- SBA (Smart Buildings Alliance)
+- AICN (Alliance Immobilière Convergence Numérique)
+
+## Implications PROMEOS
+
+### Alignements confirmés
+- Module Pilotage B2B : sur la bonne trajectoire
+- Wording "Pilotage des usages" : aligné avec la doctrine publique
+- NEBCO à 100 kW : seuil interne correct
+- Focus sur flex structurelle+dynamique (pas équilibrage RTE)
+
+### Gaps à combler (voir DETTES.md)
+1. **Créneaux TURPE 7 saisonnalisés** non intégrés dans classify_slots
+2. **Flex Ready®** standard absent de notre API (5 données NF EN IEC 62746-4)
+3. **Chiffres sectoriels** archétypes pas calibrés sur données Enedis 2024
+4. **Connecteur EcoWatt®** non implémenté (utile pour flex dynamique hiver)
+
+### Opportunités différenciantes (post S22)
+- Score Flex Ready® par site (notre extension du standard)
+- Prédiction prix négatifs (ML léger sur historique ENTSO-E)
+- Intégration CO₂ réel via éco2mix (Option C V120)
+- Audit flexibilité automatisé (alignement avec cahier SBA)

--- a/docs/ux/cx-amelioration-continue-2026.md
+++ b/docs/ux/cx-amelioration-continue-2026.md
@@ -1,0 +1,264 @@
+# Amélioration continue de l'expérience client pour PROMEOS
+
+> **Source** : Document stratégique ChatGPT — avril 2026
+> **Type** : Référentiel UX/CX produit (pas KB réglementaire)
+> **Usage** : guide pour la roadmap produit, les décisions UX, les métriques CX
+
+## Sommaire
+
+1. Vision cible (attributs fondamentaux + différenciation)
+2. Parcours client 12 étapes (découverte → fidélisation)
+3. Frictions principales + solutions
+4. Principes UX/UI (15 règles)
+5. Onboarding & time-to-value
+6. Usage récurrent & valeur perçue
+7. Système de mesure (pyramide de métriques)
+8. Boucle feedback ACAF
+9. Amélioration continue (gouvernance, rituels)
+10. Feuille de route 0-30j / 30-90j / 3-6m / 6-12m
+11. Top 20 actions concrètes (priorisées)
+12. Scorecard CX (10 critères pondérés)
+13. Template revue mensuelle
+14. Questions pilotes (12 questions)
+
+## 1. Vision cible
+
+**Attributs fondamentaux** :
+- Clarté radicale (pyramide inversée, lecture en Z)
+- Cohérence et sobriété (grid aligné, palette restreinte)
+- Progressivité (vues exécutives vs métier)
+- Management by exception (alerter quand action nécessaire)
+- Lien Constat → Analyse → Impact → Action
+- Transparence et traçabilité
+- Pédagogie embarquée (glossaire, infobulles)
+- Adaptabilité par profil
+- Orientation valeur
+- Boucle amélioration continue
+
+**Différenciation** :
+- Pas un outil d'expert (pédagogie + ergonomie)
+- Concrétisation des insights (guide jusqu'à l'action)
+- Vision multi-sites multi-énergies (portefeuille→site→bâtiment→compteur)
+- Intégration obligations réglementaires (CRE, DT, APER)
+- Pilotage financier (factures + contrats)
+- Automatisation/IA (copilote énergétique)
+
+## 2. Parcours client — 12 étapes
+
+| Étape | Attentes | Irritants | Mesures |
+|---|---|---|---|
+| Découverte | Proposition valeur claire | Jargon, pas de preuves | Nb MQL, conversion démo |
+| Cadrage vente | Périmètre, prérequis | Coûts cachés | Temps de cycle commercial |
+| Collecte données | Imports faciles | Manuel fastidieux | Temps collecte, taux erreurs |
+| Configuration/onboarding | Guidance pas à pas | Trop long sans valeur | TTFV, taux complétion |
+| Première connexion | Interface claire | Dashboard surchargé | Taux activation, 1er insight |
+| Compréhension interface | Naviguer intuitivement | Jargon | Temps tâche, consultation aide |
+| **Aha! Moment** | Gain visible | Données manquantes | TTFV, dérives identifiées |
+| Usage récurrent | Routine utile | Notifications inutiles | DAU/WAU/MAU, consultation alertes |
+| Détection insights | Alertes pertinentes | Fatigue alerte | Taux résolution, valeur actions |
+| Passage à l'action | Convertir en action | Pas d'outils | Taux conversion insight→action |
+| Support | Assistance réactive | Réponses génériques | Temps résolution, CSAT |
+| Montée maturité | Usages avancés | Complexité | Taux formation, modules avancés |
+| Fidélisation/expansion | Partenariat | Pas de contact | NRR, taux expansion, NPS |
+
+## 3. Frictions principales (criticité décroissante)
+
+1. **Onboarding long et complexe** — très haute — progress bars + check-lists + quick-wins
+2. **Manque continuité insight→action** — très haute — workflow de gestion + intégrations GMAO/ERP
+3. **Dashboard surchargé / pas de hiérarchie** — haute — pyramide inversée + grid aligné
+4. **Manque priorisation/recommandations** — haute — scoring ROI, lien action+gain
+5. **Jargon trop technique** — haute — glossaire + infobulles + adaptation profil
+6. **Trop d'indicateurs au départ** — haute — indicateurs essentiels + dashboards thématiques
+7. **Absence preuve valeur dans le temps** — haute — économies cumulées + reporting historique
+8. **Absence contextualisation données** — moyenne — benchmarks + scénarios comparatifs
+9. **Navigation peu intuitive** — moyenne — top/left-rail + max 2 niveaux
+10. **Dashboards non actionnables** — moyenne — centre d'action + mesure impact
+11. **Notifications inutiles ou absentes** — moyenne — alertes intelligentes + silence temporaire
+
+## 4. Principes UX/UI (15 règles)
+
+Hiérarchie visuelle forte · Grid aligné et cohérence · Couleurs signalétiques · Minimalisme · Progressivité/personnalisation · Gestion par exception · Interaction intuitive · Accessibilité/lisibilité · Pédagogie embarquée · Traçabilité/transparence · Mobile responsive · Centre d'action · Explorabilité (drill-down) · Feedback instantané · Sécurité/confidentialité RGPD
+
+## 5. Onboarding & Time-to-Value
+
+Objectif : **TTFV minimal** (40-60% abandonnent après essai unique).
+
+Étapes :
+1. Pré-onboarding (import préalable, questionnaire segmentation)
+2. Onboarding guidé par rôle
+3. Progress indicators (check-lists, progress bars)
+4. Quick-wins immédiats (économies en € et CO2)
+5. Messages orientés bénéfices (pas fonctionnalités)
+6. Product tour action-focused
+7. Segmentation et personnalisation
+8. Empty states utiles
+9. Trigger emails intelligents (action/inaction)
+10. Assistance humaine (CSM)
+11. Mesures : complétion, TTFV, activation rate, satisfaction post-onboarding
+
+## 6. Usage récurrent & valeur perçue
+
+**Encourager retour régulier** :
+- Alertes intelligentes paramétrables (seuils, fréquence, canal)
+- Synthèses périodiques (hebdo/mensuel, impact financier + environnemental)
+- Recommandations proactives (IA sur profils de charge)
+- Centre d'action (planifier/assigner/suivre/clôturer)
+- Gamification (niveaux, badges, classements internes)
+- Communauté (forums, webinars, success stories)
+
+**Renforcer valeur perçue** :
+- Économies cumulées (kWh, €, CO2) + avant/après
+- Benchmarks EUI/ECI par secteur
+- Simulations d'impact (ROI avant investissement)
+- Pilotage financier (validation factures, détection erreurs)
+- Alignement ESG (DT, ISO 50001, CSRD)
+- Segments avancés par rôle (CFO, energy manager, compliance)
+- Triggers d'expansion (40% revenus SaaS = renouvellement+expansion)
+
+## 7. Système de mesure — pyramide de métriques
+
+| Catégorie | Métriques clés |
+|---|---|
+| **Compréhension** | Taux consultation aide, temps tâche, score compréhension, tickets jargon |
+| **Adoption** | Activation rate, TTFV, taux complétion onboarding, conversion usage récurrent |
+| **Engagement** | DAU/WAU/MAU, session duration, feature usage frequency, PES, taux consultation alertes, insight→action |
+| **Valeur** | Économies €/kWh/CO2, erreurs facturation détectées, réduction pics, indice retour/action, taux adoption recommandations |
+| **Friction** | Pages forte chute, tickets support, temps résolution, CSAT, heatmap, bug rate |
+| **Fidélisation** | Taux renouvellement, NRR, taux expansion, NPS, CES, churn d'usage |
+
+## 8. Boucle feedback ACAF
+
+**A**sk → **C**ategorize → **A**ct → **F**ollow-up
+
+Sources : feedback in-app, verbatims support, entretiens utilisateurs, communauté, analytique produit, CSM, ventilation par persona.
+
+Exploitation : tableau de bord Feedback centralisé, analyse thématique (text mining), backlog CX avec scoring Impact-Effort, communication des améliorations, boucles fermées.
+
+## 9. Amélioration continue — gouvernance
+
+**Boucle** : écouter → observer → mesurer → analyser → prioriser → corriger → tester → mesurer impact → industrialiser.
+
+**Rituels** :
+- Hebdomadaire : revue métriques + tickets + feedbacks, points chauds
+- Mensuel : réunion CX/Produit, priorisation, scorecard
+- Trimestriel : revue stratégique direction, impact NRR + économies
+
+**Rôles** : Product Owner, UX/UI Designer, CSM, Data Analyst, Support, Direction, Marketing.
+
+## 10. Feuille de route
+
+### 0-30 jours (Quick wins)
+1. Tableau de bord analytique (événements clés)
+2. Page d'accueil simplifiée (pyramide inversée)
+3. Glossaire + infobulles
+4. Check-list onboarding + progress bar
+5. Feedback in-app (micro-surveys, NPS)
+6. Former équipe à ACAF
+
+### 30-90 jours
+1. Segmentation dashboards par persona
+2. Automatisation imports (Enedis/GRDF, OCR factures)
+3. Alertes intelligentes (analyse intervalles + IA)
+4. Centre d'action simplifié
+5. Rapports périodiques automatisés
+6. Score d'adoption (activation + TTFV + DAU/MAU)
+7. Tests utilisateurs réguliers
+
+### 3-6 mois
+1. Moteur de recommandation personnalisé
+2. Refonte centre d'action (+ GMAO/ERP)
+3. Indicateurs ESG + reporting réglementaire
+4. Programmes formation/certification + gamification
+5. ML pour recommandations d'optimisation
+6. Module validation factures
+7. Programme ambassadeurs
+
+### 6-12 mois
+1. Système complet d'amélioration continue
+2. Modules IA avancés (détection temps réel, prédictif)
+3. Marketplace de services (partenaires)
+4. Intégration IoT + maintenance prédictive
+5. Internationalisation (réglementations multi-pays)
+6. Innovation continue cadrée
+
+## 11. Top 20 actions priorisées
+
+| # | Action | Impact | Effort | Priorité |
+|---|---|---|---|---|
+| 1 | Instrumenter événements clés (activation/TTFV/actions) | Efficacité | Faible | Très élevée |
+| 2 | Dashboard exécutif pyramide inversée | Compréhension | Moyen | Très élevée |
+| 3 | Glossaire + infobulles | Compréhension | Faible | Très élevée |
+| 4 | Check-list onboarding + progress bar | Activation | Faible | Très élevée |
+| 5 | Automatiser import factures + relevés | Adoption | Moyen | Élevée |
+| 6 | Alertes paramétrables et filtrées | Engagement | Moyen | Élevée |
+| 7 | Centre d'action minimal | Action, valeur | Moyen | Élevée |
+| 8 | Rapports périodiques auto (PDF/Excel) | Valeur perçue | Faible | Élevée |
+| 9 | Segmentation dashboards par profil | Adoption | Moyen | Élevée |
+| 10 | Feedback in-app (micro-surveys, NPS) | Fidélisation | Faible | Élevée |
+| 11 | Backlog CX Impact-Effort | Gouvernance | Faible | Élevée |
+| 12 | Former équipes à ACAF + métriques | Efficacité | Faible | Élevée |
+| 13 | Algorithmes détection anomalies | Valeur | Élevé | Élevée |
+| 14 | Dashboards personnalisables utilisateur | Engagement | Moyen | Moyenne |
+| 15 | Module validation factures + économies | Valeur | Moyen | Moyenne |
+| 16 | Programme formations/certifications | Fidélisation | Moyen | Moyenne |
+| 17 | Programme ambassadeurs + communauté | Engagement | Faible | Moyenne |
+| 18 | Module simulation d'impact + ROI | Valeur perçue | Élevé | Moyenne |
+| 19 | Intégrations GMAO/ERP | Action | Élevé | Moyenne |
+| 20 | Innovations différenciantes (3D, jumeaux) | Différenciation | Élevé | Faible |
+
+## 12. Scorecard CX — 10 critères pondérés
+
+| Critère | Pondération |
+|---|---|
+| Time-to-First-Value | 15% |
+| Activation rate | 10% |
+| Onboarding completion | 10% |
+| Clarté dashboards | 10% |
+| Pertinence alertes | 10% |
+| Passage insight→action | 10% |
+| Valeur démontrée (économies réelles) | 10% |
+| Satisfaction support (CSAT) | 5% |
+| Engagement (DAU/WAU/MAU) | 5% |
+| NPS/CES | 10% |
+| Expansion rate | 5% |
+
+Notation 1 (insuffisant) à 5 (excellent) par critère.
+
+## 13. Template revue mensuelle (1h30)
+
+1. Ouverture (5 min)
+2. Analyse métriques (20 min) — KPIs scorecard + tendances
+3. Feedback clients (15 min) — synthèse ACAF
+4. Revue backlog CX (20 min) — scoring Impact-Effort
+5. Focus thématique (15 min)
+6. Décisions & actions (10 min)
+7. Clôture (5 min)
+
+## 14. Questions à 10 clients pilotes
+
+1. Objectifs principaux PROMEOS ?
+2. Expérience première connexion ?
+3. Indicateurs suivis le plus souvent ?
+4. Frictions configuration sites/compteurs ?
+5. TTFV satisfaisant ? Comment l'améliorer ?
+6. Fréquence utilisation + tâches ?
+7. Pertinence des alertes ?
+8. Gestion insight → action ?
+9. Fonctionnalités manquantes ?
+10. Évaluation support ?
+11. Prêt à recommander ?
+12. Perspectives d'évolution (IA, intégrations) ?
+
+Entretiens semi-directifs, duo Product/CSM.
+
+## Sources citées dans le doc original
+
+- DataCamp — Effective Dashboard Design
+- ProductLed — SaaS onboarding best practices 2025
+- Sanalife Energy — Real Time Insights Energy Management
+- ProdPad — 15 Product Adoption Metrics 2025
+- Usersnap — Customer Feedback System 2025 (méthode ACAF)
+- DOE — Energy Management Information System Capabilities
+- Amplitude — B2B Technology Product Benchmarks
+- Gainsight — Customer Success Revenue Growth 2025
+- Spacewell — 7 Essential Tasks Energy Manager

--- a/frontend/src/components/CsatModal.jsx
+++ b/frontend/src/components/CsatModal.jsx
@@ -1,0 +1,125 @@
+/**
+ * PROMEOS — CsatModal (CX Gap #7)
+ * Modale CSAT déclenchée automatiquement J+14 après création de l'org.
+ * 1 question (1-5) + verbatim optionnel. Dismiss persistant en localStorage.
+ */
+import { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import api from '../services/api';
+
+const DISMISS_KEY_PREFIX = 'promeos.csat_dismissed_';
+
+const SCORES = [
+  { value: 1, emoji: '😞', label: 'Pas utile' },
+  { value: 2, emoji: '😐', label: 'Peu utile' },
+  { value: 3, emoji: '🙂', label: 'Utile' },
+  { value: 4, emoji: '😊', label: 'Très utile' },
+  { value: 5, emoji: '🤩', label: 'Indispensable' },
+];
+
+export default function CsatModal({ orgId }) {
+  const [shouldShow, setShouldShow] = useState(false);
+  const [selected, setSelected] = useState(null);
+  const [verbatim, setVerbatim] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!orgId) return;
+    if (localStorage.getItem(DISMISS_KEY_PREFIX + orgId) === 'true') return;
+
+    api
+      .get('/feedback/csat/should-show', { params: { org_id: orgId } })
+      .then((r) => {
+        if (r.data?.show) {
+          setTimeout(() => setShouldShow(true), 3000);
+        }
+      })
+      .catch(() => {});
+  }, [orgId]);
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISS_KEY_PREFIX + orgId, 'true');
+    setShouldShow(false);
+  };
+
+  const submit = async () => {
+    if (selected == null) return;
+    setSubmitting(true);
+    try {
+      await api.post(
+        '/feedback/csat',
+        { score: selected, verbatim: verbatim || null, trigger_type: 'j14_auto' },
+        { params: { org_id: orgId } }
+      );
+      setSubmitted(true);
+      localStorage.setItem(DISMISS_KEY_PREFIX + orgId, 'true');
+      setTimeout(() => setShouldShow(false), 1500);
+    } catch {
+      // Silent fail — ne bloque pas l'utilisateur
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!shouldShow) return null;
+
+  return (
+    <div className="fixed bottom-6 right-6 w-[360px] bg-white rounded-lg shadow-xl border border-gray-200 p-4 z-50">
+      <button
+        onClick={dismiss}
+        className="absolute top-2 right-2 text-gray-300 hover:text-gray-500"
+        aria-label="Fermer"
+      >
+        <X size={16} />
+      </button>
+      {submitted ? (
+        <div className="py-2 text-center text-sm text-emerald-700 font-medium">
+          Merci pour votre retour !
+        </div>
+      ) : (
+        <>
+          <h3 className="text-sm font-semibold text-gray-900 mb-1">
+            À quel point PROMEOS vous est utile ?
+          </h3>
+          <p className="text-[11px] text-gray-500 mb-3">
+            Votre avis nous aide à améliorer le produit.
+          </p>
+          <div className="flex justify-between mb-3">
+            {SCORES.map((s) => (
+              <button
+                key={s.value}
+                onClick={() => setSelected(s.value)}
+                className={`flex flex-col items-center gap-1 p-2 rounded-lg transition ${
+                  selected === s.value ? 'bg-blue-50 ring-2 ring-blue-400' : 'hover:bg-gray-50'
+                }`}
+                aria-label={s.label}
+              >
+                <span className="text-xl">{s.emoji}</span>
+                <span className="text-[9px] text-gray-500">{s.value}</span>
+              </button>
+            ))}
+          </div>
+          {selected != null && (
+            <>
+              <textarea
+                value={verbatim}
+                onChange={(e) => setVerbatim(e.target.value.slice(0, 500))}
+                placeholder="Un mot à ajouter ? (optionnel)"
+                className="w-full text-xs border border-gray-200 rounded-md p-2 mb-2 resize-none"
+                rows={2}
+              />
+              <button
+                onClick={submit}
+                disabled={submitting}
+                className="w-full py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md disabled:opacity-50"
+              >
+                {submitting ? 'Envoi...' : 'Envoyer'}
+              </button>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ScoreBreakdownPanel.jsx
+++ b/frontend/src/components/ScoreBreakdownPanel.jsx
@@ -1,0 +1,136 @@
+/**
+ * PROMEOS — ScoreBreakdownPanel (CX Gap #4)
+ * Décomposition live du score conformité par framework.
+ * Appelle GET /regops/score_explain — données backend, zéro calcul frontend.
+ */
+import { useState, useEffect } from 'react';
+import { AlertTriangle, ArrowRight, HelpCircle, ShieldCheck } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { getScoreExplain } from '../services/api/conformite';
+
+const FW_PATHS = {
+  tertiaire_operat: '/conformite',
+  bacs: '/conformite?tab=bacs',
+  aper: '/conformite?tab=aper',
+};
+
+function BreakdownBar({ reg }) {
+  const navigate = useNavigate();
+  const pct = Math.round(reg.sub_score);
+  const barColor = pct >= 80 ? 'bg-emerald-400' : pct >= 50 ? 'bg-amber-400' : 'bg-red-400';
+  const contribution = Math.round(reg.sub_score * reg.weight) / 100;
+
+  return (
+    <div className="py-3 border-b border-gray-100 last:border-0">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-sm font-medium text-gray-800">{reg.label}</span>
+        <span className="text-sm font-bold text-gray-900">{pct}/100</span>
+      </div>
+      <div className="h-2 bg-gray-100 rounded-full overflow-hidden mb-1.5">
+        <div className={`h-full rounded-full ${barColor}`} style={{ width: `${pct}%` }} />
+      </div>
+      <div className="flex items-center justify-between text-[11px] text-gray-500">
+        <span>
+          Poids : {Math.round(reg.weight * 100)}% — contribution : {contribution.toFixed(1)} pts
+        </span>
+        {reg.penalties_count > 0 && (
+          <span className="text-red-500">
+            {reg.penalties_count} finding{reg.penalties_count > 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+      {reg.worst_finding_label && (
+        <p className="text-[11px] text-red-500 mt-0.5 flex items-center gap-1">
+          <AlertTriangle size={10} /> {reg.worst_finding_label}
+        </p>
+      )}
+      {FW_PATHS[reg.regulation] && (
+        <button
+          onClick={() => navigate(FW_PATHS[reg.regulation])}
+          className="text-[11px] text-blue-600 hover:text-blue-800 mt-1 flex items-center gap-0.5"
+        >
+          Detail <ArrowRight size={10} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function ScoreBreakdownPanel({ siteId, open }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !siteId) return;
+    setLoading(true);
+    getScoreExplain('site', siteId)
+      .then(setData)
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [open, siteId]);
+
+  if (!open || loading)
+    return loading ? (
+      <div className="pt-4 border-t border-gray-100 mt-4 space-y-3">
+        <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
+          Décomposition live
+        </p>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-14 bg-gray-100 rounded-lg animate-pulse" />
+        ))}
+      </div>
+    ) : null;
+
+  if (!data) return null;
+
+  return (
+    <div className="pt-4 border-t border-gray-100 mt-4 space-y-4">
+      <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
+        Décomposition live — Site #{data.scope?.id}
+      </p>
+
+      <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
+        <ShieldCheck size={18} className="text-blue-600" />
+        <div>
+          <p className="text-lg font-bold text-gray-900">{Math.round(data.score)}/100</p>
+          <p className="text-[11px] text-gray-500">
+            {data.frameworks_evaluated}/{data.frameworks_total} cadres — {data.confidence}
+          </p>
+        </div>
+      </div>
+
+      {(data.per_regulation || []).map((reg) => (
+        <BreakdownBar key={reg.regulation} reg={reg} />
+      ))}
+
+      <div className="p-2.5 bg-blue-50 rounded-lg">
+        <p className="text-[10px] font-mono text-blue-700">{data.formula_explain}</p>
+      </div>
+
+      {data.how_to_improve?.length > 0 && (
+        <div>
+          <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+            Priorités
+          </p>
+          {data.how_to_improve.map((a, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-2 py-1.5 text-sm text-gray-700 border-b border-gray-50 last:border-0"
+            >
+              <span className="w-5 h-5 rounded-full bg-blue-100 text-blue-700 text-[10px] font-bold flex items-center justify-center">
+                {i + 1}
+              </span>
+              <span className="flex-1">{a.action}</span>
+              <span className="text-xs text-gray-400">+{a.potential_gain} pts</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <p className="text-[10px] text-gray-400 font-mono">
+        <HelpCircle size={10} className="inline mr-1" />
+        {data._meta?.module || 'compliance_score_service'}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/ValueCounterCard.jsx
+++ b/frontend/src/components/ValueCounterCard.jsx
@@ -1,0 +1,52 @@
+/**
+ * PROMEOS — ValueCounterCard (CX Gap #6)
+ * Widget affichant la valeur cumulée créée par PROMEOS depuis l'abonnement.
+ * S'affiche uniquement si total_eur > 0. Zéro calcul frontend.
+ */
+import { useEffect, useState } from 'react';
+import { TrendingUp } from 'lucide-react';
+import { getValueSummary } from '../services/api/cockpit';
+import { fmtEur } from '../utils/format';
+
+function formatDate(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
+export default function ValueCounterCard({ orgId }) {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    if (!orgId) return;
+    getValueSummary(orgId)
+      .then(setData)
+      .catch(() => setData(null));
+  }, [orgId]);
+
+  if (!data || !data.total_eur || data.total_eur <= 0) return null;
+
+  return (
+    <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 mb-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <p className="text-xs font-semibold text-emerald-700 uppercase tracking-wide mb-0.5">
+            Valeur créée par PROMEOS
+          </p>
+          <p className="text-2xl font-bold text-emerald-900 truncate">{fmtEur(data.total_eur)}</p>
+          <p className="text-xs text-emerald-700 mt-0.5">
+            depuis {formatDate(data.since)} — {data.insights_count} insights
+          </p>
+        </div>
+        <TrendingUp className="h-7 w-7 text-emerald-400 flex-shrink-0" />
+      </div>
+      <div className="mt-3 flex flex-wrap gap-4 text-[11px] text-emerald-800">
+        <span>Anomalies : {fmtEur(data.anomalies_detected_eur)}</span>
+        <span>Pénalités évitées : {fmtEur(data.penalties_avoided_eur)}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Cockpit.jsx
+++ b/frontend/src/pages/Cockpit.jsx
@@ -529,13 +529,13 @@ const Cockpit = () => {
         </div>
       )}
 
-      {/* ── Banner signal prix NEBCO ── */}
+      {/* ── Bannière signal tarifaire Pilotage ── */}
       {prixSignal?.signal === 'PRIX_NEGATIF' && (
         <div className="flex items-center gap-2 px-3 py-2 bg-blue-50 border border-blue-200 rounded-lg text-xs text-blue-800">
           <AlertTriangle size={13} className="shrink-0" />
           <span>
-            <strong>Prix spot negatif</strong> — {prixSignal.valeur_eur_mwh?.toFixed(0)} &euro;/MWh{' '}
-            &middot; Opportunite NEBCO anticipation :{' '}
+            <strong>Fenêtre favorable</strong> — {prixSignal.valeur_eur_mwh?.toFixed(0)} &euro;/MWh{' '}
+            &middot; Pré-charger ou décaler les usages :{' '}
             {prixSignal.usages_cibles?.slice(0, 3).join(', ')}.{' '}
             <button
               onClick={() => navigate(toActionsList())}
@@ -550,8 +550,9 @@ const Cockpit = () => {
         <div className="flex items-center gap-2 px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-800">
           <AlertTriangle size={13} className="shrink-0" />
           <span>
-            <strong>Prix spot eleve</strong> — {prixSignal.valeur_eur_mwh?.toFixed(0)} &euro;/MWh{' '}
-            &middot; Signal effacement NEBCO : {prixSignal.usages_cibles?.slice(0, 3).join(', ')}.{' '}
+            <strong>Fenêtre sensible</strong> — {prixSignal.valeur_eur_mwh?.toFixed(0)} &euro;/MWh{' '}
+            &middot; Éviter ou moduler les usages :{' '}
+            {prixSignal.usages_cibles?.slice(0, 3).join(', ')}.{' '}
             <button
               onClick={() => navigate(toActionsList())}
               className="underline font-medium hover:text-amber-900"

--- a/frontend/src/pages/Cockpit.jsx
+++ b/frontend/src/pages/Cockpit.jsx
@@ -60,6 +60,7 @@ import {
 import { useComplianceMeta } from '../hooks/useComplianceMeta';
 import { useCockpitData } from '../hooks/useCockpitData';
 import CockpitHero from './cockpit/CockpitHero';
+import ScoreBreakdownPanel from '../components/ScoreBreakdownPanel';
 import TrajectorySection from './cockpit/TrajectorySection';
 import ActionsImpact from './cockpit/ActionsImpact';
 import PerformanceSitesCard from './cockpit/PerformanceSitesCard';
@@ -1146,12 +1147,16 @@ const Cockpit = () => {
         </div>
       </Modal>
 
-      {/* ── Evidence Drawer ("Pourquoi ce chiffre ?") ── */}
+      {/* ── Evidence Drawer ("Pourquoi ce chiffre ?") + ScoreBreakdownPanel (CX Gap #4) ── */}
       <EvidenceDrawer
         open={!!evidenceOpen}
         onClose={() => setEvidenceOpen(null)}
         evidence={evidenceOpen ? evidenceMap[evidenceOpen] : null}
-      />
+      >
+        {evidenceOpen === 'conformite' && scopedSites[0]?.id && (
+          <ScoreBreakdownPanel siteId={scopedSites[0].id} open />
+        )}
+      </EvidenceDrawer>
 
       {/* Lien cross-brique vers Usages */}
       <div className="flex items-center gap-2 mt-3 print:hidden">

--- a/frontend/src/pages/CommandCenter.jsx
+++ b/frontend/src/pages/CommandCenter.jsx
@@ -50,6 +50,7 @@ import _HealthSummary from '../components/HealthSummary';
 import MorningBriefCard from '../components/MorningBriefCard';
 import DeadlineBanner from '../components/DeadlineBanner';
 import ValueCounterCard from '../components/ValueCounterCard';
+import CsatModal from '../components/CsatModal';
 import TodayActionsCard from './cockpit/TodayActionsCard';
 import _ModuleLaunchers from './cockpit/ModuleLaunchers';
 import _EssentialsRow from './cockpit/EssentialsRow';
@@ -418,6 +419,9 @@ export default function CommandCenter() {
 
       {/* ── Value Counter — CX Gap #6 ── */}
       <ValueCounterCard orgId={org?.id} />
+
+      {/* ── CSAT J+14 — CX Gap #7 (fixed position bottom-right) ── */}
+      <CsatModal orgId={org?.id} />
 
       {/* ── Morning Brief — ce qui a bougé depuis la dernière visite ── */}
       <MorningBriefCard alerts={alertsCount} />

--- a/frontend/src/pages/CommandCenter.jsx
+++ b/frontend/src/pages/CommandCenter.jsx
@@ -49,6 +49,7 @@ import {
 import _HealthSummary from '../components/HealthSummary';
 import MorningBriefCard from '../components/MorningBriefCard';
 import DeadlineBanner from '../components/DeadlineBanner';
+import ValueCounterCard from '../components/ValueCounterCard';
 import TodayActionsCard from './cockpit/TodayActionsCard';
 import _ModuleLaunchers from './cockpit/ModuleLaunchers';
 import _EssentialsRow from './cockpit/EssentialsRow';
@@ -414,6 +415,9 @@ export default function CommandCenter() {
 
       {/* ── Deadline DT — CX Gap #3 ── */}
       <DeadlineBanner />
+
+      {/* ── Value Counter — CX Gap #6 ── */}
+      <ValueCounterCard orgId={org?.id} />
 
       {/* ── Morning Brief — ce qui a bougé depuis la dernière visite ── */}
       <MorningBriefCard alerts={alertsCount} />

--- a/frontend/src/services/api/cockpit.js
+++ b/frontend/src/services/api/cockpit.js
@@ -110,6 +110,10 @@ export const getCockpitBenchmark = () => cachedGet('/cockpit/benchmark').then((r
 export const getCockpitCo2 = () => cachedGet('/cockpit/co2').then((r) => r.data);
 export const getCockpitConsoMonth = () => cachedGet('/cockpit/conso-month').then((r) => r.data);
 
+// ── Value Summary (CX Gap #6) ──
+export const getValueSummary = (orgId) =>
+  cachedGet('/value-summary', { params: { org_id: orgId } }).then((r) => r.data);
+
 // ── Health + Meta ──
 export const getApiHealth = () => api.get('/health').then((r) => r.data);
 export const getMetaVersion = () =>

--- a/frontend/src/ui/EvidenceDrawer.jsx
+++ b/frontend/src/ui/EvidenceDrawer.jsx
@@ -51,7 +51,7 @@ function SectionTitle({ children }) {
   );
 }
 
-export default function EvidenceDrawer({ open, onClose, evidence }) {
+export default function EvidenceDrawer({ open, onClose, evidence, children }) {
   const navigate = useNavigate();
 
   if (!evidence) return null;
@@ -154,6 +154,9 @@ export default function EvidenceDrawer({ open, onClose, evidence }) {
             </p>
           )}
         </div>
+
+        {/* Slot for additional live content (e.g. ScoreBreakdownPanel) */}
+        {children}
       </div>
     </Drawer>
   );


### PR DESCRIPTION
## Summary

Sprint **S22 — Passage à l'échelle du module Pilotage des usages** post-merge PR #216.
3 livraisons agents SDK parallèles alignées sur le **Baromètre des flexibilités de consommation d'électricité — Édition 2026** (RTE/Enedis/GIMELEC/Think Smartgrids/IGNES/ACTEE/IFPEB/SBA, avril 2026).

## 3 axes livrés

### 1. Flex Ready® NF EN IEC 62746-4
- Endpoint \`GET /api/pilotage/flex-ready-signals/{site_id}\` exposant les **5 données standardisées** du marque collective GIMELEC/Think Smartgrids 2025
- Horloge 15 min, P max instantanée (kW), prix €/kWh (priorité spot ENTSO-E > tarif contractuel), P souscrite (kVA), empreinte CO₂ (ADEME V23.6)
- Norme : NF EN IEC 62746-4 (amont), convergence avec Code of Conduct for Energy Smart Appliances (UE)

### 2. TURPE 7 HC saisonnalisés (phase 2 déc 2026 → nov 2027)
- Constantes officielles CRE/Enedis : \`HC_TURPE7_FAVORABLE\` + \`HC_TURPE7_EXCLURE\`
- Été : 2h-6h + 11h-17h à FAVORISER, 7h-11h + 18h-23h à EXCLURE
- Hiver : 2h-6h + 21h-0h à FAVORISER, 7h-11h + 17h-21h à EXCLURE
- \`classify_slots\` enrichi : TURPE 7 = **tie-breaker sur slots NEUTRE**, jamais substitution aux signaux réseau ou prix
- Impact attendu : 5 GW déplacés vers 14h dès 2027 (source RTE)

### 3. Calibrage archétypes Enedis 2024
- \`ARCHETYPE_CALIBRATION_2024\` : 8 segments tertiaires
- Taux décalable moyen, plages pointe, pourcentage BACS par segment
- \`compute_potential_score\` utilise le calibrage officiel si archétype connu, fallback sinon

## Chiffres clés du baromètre ingérés

- **NEBCO** actif 1/09/2025 — 708 000 sites fin 2025 (×2 en 1 an)
- **513h** prix spot négatifs 2025 (+46% vs 2024)
- **3 TWh** EnR écrêtés 2025 (vs 1.7 TWh 2024)
- Ratio prix pointe/journée : **+111%** (vs +77% en 2024)
- Tertiaire : 121 TWh/an, 16% BACS, trajectoire 100 000 BACS en 2030

## Test plan
- [x] \`pytest tests/test_pilotage_flex_ready.py tests/test_pilotage_turpe7_hc.py tests/test_pilotage_archetype_calibration.py tests/test_pilotage_score_potential.py\` → 20/20
- [x] Régression \`test_parameter_store + test_billing_pipeline_v112 + test_billing_invariants_p0 + test_flex_score_api + test_flexibility_scoring\` → 124/124
- [ ] Smoke manuel \`GET /api/pilotage/flex-ready-signals/retail-001\` (post-merge)

## Documents

- \`docs/reglementaire/barometre_flex_2026.md\` — source officielle ingérée

🤖 Generated with [Claude Code](https://claude.com/claude-code)