### PR TITLE
feat: Sprint 1 fondations CX — 5/5 agents AI intégrés KB + endpoints pilotage

### DIFF
--- a/backend/ai_layer/agents/data_quality_agent.py
+++ b/backend/ai_layer/agents/data_quality_agent.py
@@ -1,21 +1,91 @@
 """
 PROMEOS AI - Data Quality Agent
+
+HARD RULE : s'appuie sur la KB usages (archétypes sectoriels + règles anomalies)
+pour qualifier la qualité des données d'un site (ratios kWh/m², profils attendus).
 """
 
 import json
-from models import AiInsight, InsightType
+
+from models import AiInsight, InsightType, Site
+
 from ..client import get_client
+from .kb_context import build_kb_context
+
+SYSTEM_PROMPT = """Expert en qualité de données énergétiques pour bâtiments tertiaires.
+
+Ta mission : évaluer la cohérence des données d'un site en les confrontant aux
+ratios et règles d'anomalie issus de la KB PROMEOS (archétypes sectoriels).
+
+RÈGLES STRICTES :
+- Ne cite QUE des ratios/seuils présents dans les items KB fournis
+- Pour chaque anomalie, référence le kb_item_id d'origine [ID]
+- N'invente PAS de "ratio typique" ni de "seuil métier"
+
+Format JSON : {"anomalies": [...], "missing_data": [...], "quality_score": 0-100, "kb_item_ids": [...]}"""
+
+
+def _stub_analysis(site, kb_context):
+    """Fallback : liste les données manquantes, sans inventer."""
+    missing = []
+    if not site.surface_m2:
+        missing.append("surface_m2 (nécessaire pour ratios KB)")
+    if not getattr(site, "hvac_kw", None):
+        missing.append("hvac_kw (seuils BACS)")
+    if not getattr(site, "type", None):
+        missing.append("type (archétype sectoriel)")
+
+    applicable = kb_context.get("applicable_items", [])
+    quality_score = max(0, 100 - len(missing) * 25)
+
+    return {
+        "anomalies": [],
+        "missing_data": missing,
+        "quality_score": quality_score,
+        "kb_item_ids": kb_context["kb_item_ids"],
+        "kb_items_available": len(applicable),
+        "mode": "stub",
+        "note": "Mode stub — l'analyse IA confrontant les ratios nécessite AI_API_KEY.",
+    }
 
 
 def run(db, site_id: int, **kwargs):
+    site = db.query(Site).filter(Site.id == site_id).first()
+    if not site:
+        raise ValueError(f"Site {site_id} not found")
+
+    kb_context = build_kb_context(site, domain="usages")
+
     client = get_client()
-    response = client.complete("Data quality expert", f"Analyze site {site_id} data quality")
+    user_prompt = (
+        f"Site {site.nom}\n"
+        f"Type : {getattr(site, 'type', 'N/A')}\n"
+        f"Surface : {site.surface_m2 or 0} m²\n"
+        f"CVC : {getattr(site, 'hvac_kw', 0) or 0} kW\n\n"
+        f"{kb_context['prompt_section']}\n\n"
+        f"Évalue la qualité des données du site en les confrontant aux ratios KB ci-dessus."
+    )
+
+    response = client.complete(system_prompt=SYSTEM_PROMPT, user_prompt=user_prompt)
+    is_stub = "[AI Stub Mode]" in response or "[AI Fallback]" in response
+
+    if is_stub:
+        content = _stub_analysis(site, kb_context)
+    else:
+        try:
+            content = json.loads(response)
+            content["mode"] = "live"
+        except json.JSONDecodeError:
+            content = {"analysis": response, "mode": "live_fallback"}
+        content.setdefault("kb_item_ids", kb_context["kb_item_ids"])
+
     insight = AiInsight(
         object_type="site",
         object_id=site_id,
         insight_type=InsightType.DATA_QUALITY,
-        content_json=json.dumps({"analysis": response}),
+        content_json=json.dumps(content, ensure_ascii=False),
         ai_version=client.model,
+        sources_used_json=json.dumps(kb_context["kb_item_ids"]),
     )
     db.add(insight)
     db.commit()

--- a/backend/ai_layer/agents/exec_brief_agent.py
+++ b/backend/ai_layer/agents/exec_brief_agent.py
@@ -1,31 +1,38 @@
 """
 PROMEOS AI - Executive Brief Agent (portfolio narrative)
 Live Claude API + fallback stub.
+
+HARD RULE : le brief exec est enrichi avec les items KB validés du portefeuille
+(reglementaire + facturation + flex) pour éviter toute hallucination de fait.
 """
 
 import json
-from sqlalchemy import func
-from models import AiInsight, InsightType, Site, Portefeuille, EntiteJuridique, Organisation
+
+from models import AiInsight, EntiteJuridique, InsightType, Organisation, Portefeuille, Site
+
 from ..client import get_client
+from .kb_context import build_portfolio_kb_context
 
 SYSTEM_PROMPT = """Tu es un directeur énergie-environnement d'un grand groupe tertiaire français.
 Contexte PROMEOS : plateforme B2B de gestion énergétique multi-sites, post-ARENH/VNU (depuis 01/01/2026).
 
 Tu dois :
 - Fournir un brief exécutif de 2 minutes pour le DG
-- Résumer la situation du portefeuille immobilier : conformité, risques, consommation
-- Prioriser les 3 actions les plus urgentes
+- Résumer la situation du portefeuille : conformité, risques, consommation
+- Prioriser les 3 actions les plus urgentes tirées des items KB fournis
+- T'appuyer EXCLUSIVEMENT sur les items KB validés fournis (pas d'invention)
 - Utiliser les unités : kWh, m², €, dates au format FR
 - Être factuel et chiffré, pas de langue de bois
+- Citer les kb_item_ids utilisés pour traçabilité
 
-Format : JSON avec les clés : executive_summary, key_metrics, top_3_actions, risks, outlook"""
+Format JSON : executive_summary, key_metrics, top_3_actions, risks, outlook, kb_item_ids"""
 
 
 def _gather_portfolio_data(db, org_id):
     """Collecte les métriques clés du portefeuille."""
     org = db.query(Organisation).filter(Organisation.id == org_id).first()
     if not org:
-        return {"org_name": "Inconnue", "total_sites": 0}
+        return {"org_name": "Inconnue", "total_sites": 0, "sites": []}
 
     sites = (
         db.query(Site)
@@ -45,21 +52,32 @@ def _gather_portfolio_data(db, org_id):
         "total_surface_m2": total_surface,
         "total_risk_eur": total_risk,
         "avg_avancement_pct": round(avg_avancement, 1),
+        "sites": sites,
     }
 
 
-def _stub_response(data):
-    """Fallback déterministe."""
+def _stub_response(data, kb_context):
+    """Fallback déterministe enrichi avec items KB."""
+    top_actions = []
+    for item in (kb_context.get("applicable_items") or [])[:3]:
+        for action in (item.get("actions") or [])[:1]:
+            top_actions.append(f"[{item['kb_item_id']}] {action.get('label', '')}")
+
+    key_metrics = {k: v for k, v in data.items() if k != "sites"}
+
     return {
         "executive_summary": (
-            f"[Stub] Le portefeuille {data['org_name']} comprend {data['total_sites']} sites "
-            f"pour {data.get('total_surface_m2', 0):,.0f} m². "
-            f"Risque financier total : {data.get('total_risk_eur', 0):,.0f} EUR."
+            f"[Stub KB] Portefeuille {data['org_name']} : {data['total_sites']} sites, "
+            f"{data.get('total_surface_m2', 0):,.0f} m². "
+            f"{kb_context.get('total_items', 0)} items KB applicables. "
+            f"Risque financier : {data.get('total_risk_eur', 0):,.0f} EUR."
         ),
-        "key_metrics": data,
-        "top_3_actions": ["Configurer AI_API_KEY pour l'analyse IA complète"],
+        "key_metrics": key_metrics,
+        "top_3_actions": top_actions[:3] or ["Aucun item KB applicable — enrichir les données sites"],
         "risks": [],
-        "outlook": "Non disponible en mode stub.",
+        "outlook": "Analyse détaillée nécessite AI_API_KEY.",
+        "kb_item_ids": kb_context["kb_item_ids"],
+        "stats_by_domain": kb_context.get("stats_by_domain", {}),
         "mode": "stub",
         "confidence": "low",
     }
@@ -69,13 +87,18 @@ def run(db, org_id: int = 1, **kwargs):
     """Génère un brief exécutif pour le portefeuille de l'organisation."""
     client = get_client()
     data = _gather_portfolio_data(db, org_id)
+    sites = data.pop("sites", [])
+
+    kb_context = build_portfolio_kb_context(sites)
 
     user_prompt = f"""Organisation : {data["org_name"]}
 Portefeuille : {data["total_sites"]} sites, {data.get("total_surface_m2", 0):,.0f} m²
 Risque financier total : {data.get("total_risk_eur", 0):,.0f} EUR
 Avancement moyen Décret Tertiaire : {data.get("avg_avancement_pct", 0)}%
 
-Génère un brief exécutif de 2 minutes."""
+{kb_context["prompt_section"]}
+
+Génère un brief exécutif de 2 minutes en t'appuyant STRICTEMENT sur les items KB."""
 
     response_text = client.complete(
         system_prompt=SYSTEM_PROMPT,
@@ -85,7 +108,7 @@ Génère un brief exécutif de 2 minutes."""
     is_stub = "[AI Stub Mode]" in response_text or "[AI Fallback]" in response_text
 
     if is_stub:
-        content = _stub_response(data)
+        content = _stub_response(data, kb_context)
     else:
         try:
             content = json.loads(response_text)
@@ -98,6 +121,8 @@ Génère un brief exécutif de 2 minutes."""
                 "mode": "live",
                 "confidence": "medium",
             }
+        content.setdefault("kb_item_ids", kb_context["kb_item_ids"])
+        content["stats_by_domain"] = kb_context.get("stats_by_domain", {})
 
     insight = AiInsight(
         object_type="org",
@@ -105,7 +130,7 @@ Génère un brief exécutif de 2 minutes."""
         insight_type=InsightType.EXEC_BRIEF,
         content_json=json.dumps(content, ensure_ascii=False),
         ai_version=client.model,
-        sources_used_json=json.dumps(["portfolio_data"]),
+        sources_used_json=json.dumps(["portfolio_data"] + kb_context["kb_item_ids"]),
     )
     db.add(insight)
     db.commit()

--- a/backend/ai_layer/agents/kb_context.py
+++ b/backend/ai_layer/agents/kb_context.py
@@ -127,3 +127,59 @@ def build_kb_context(
         "missing_fields": result.get("missing_fields", []),
         "status": result.get("status", "ok"),
     }
+
+
+def build_portfolio_kb_context(
+    sites: list[Any],
+    domains: list[str] | None = None,
+) -> dict[str, Any]:
+    """Évalue la KB sur un portefeuille, agrège les items distincts."""
+    domains = domains or ["reglementaire", "facturation", "flex"]
+
+    seen_ids: set[str] = set()
+    all_items: list[dict[str, Any]] = []
+    stats_by_domain: dict[str, int] = {d: 0 for d in domains}
+
+    try:
+        svc = KBService()
+        for site in sites:
+            site_context = _site_to_context(site)
+            for domain in domains:
+                result = svc.apply(site_context, domain=domain, allow_drafts=False)
+                for item in result.get("applicable_items", []):
+                    item_id = item.get("kb_item_id")
+                    if item_id and item_id not in seen_ids:
+                        seen_ids.add(item_id)
+                        all_items.append(item)
+                        stats_by_domain[domain] = stats_by_domain.get(domain, 0) + 1
+    except Exception:
+        logger.warning("KB apply failed for portfolio, returning empty", exc_info=True)
+        return {
+            "prompt_section": "",
+            "kb_item_ids": [],
+            "stats_by_domain": {d: 0 for d in domains},
+            "total_items": 0,
+            "status": "error",
+        }
+
+    all_items.sort(key=lambda x: (x.get("priority", 3), x.get("domain", "zzz")))
+    capped = all_items[:MAX_ITEMS_IN_PROMPT]
+
+    if not capped:
+        prompt_section = "AUCUN ITEM KB VALIDÉ NE CORRESPOND AU PORTEFEUILLE.\nN'invente PAS de fait réglementaire."
+    else:
+        blocks = [_format_item_for_prompt(i) for i in capped]
+        prompt_section = (
+            f"ITEMS KB VALIDÉS APPLICABLES AU PORTEFEUILLE "
+            f"({len(capped)}/{len(all_items)} affichés, {len(sites)} sites scannés) :\n\n"
+            + "\n\n".join(blocks)
+            + "\n\nRÈGLE : ne cite que ces items. N'invente JAMAIS un décret, une date ou un seuil."
+        )
+
+    return {
+        "prompt_section": prompt_section,
+        "kb_item_ids": [i["kb_item_id"] for i in capped],
+        "stats_by_domain": stats_by_domain,
+        "total_items": len(all_items),
+        "status": "ok" if all_items else "insufficient",
+    }

--- a/backend/ai_layer/agents/reg_change_agent.py
+++ b/backend/ai_layer/agents/reg_change_agent.py
@@ -1,21 +1,78 @@
 """
 PROMEOS AI - Regulatory Change Impact Agent
+
+HARD RULE : l'impact d'un changement réglementaire DOIT être évalué contre les
+items KB validated du domaine concerné — pas de jugement libre du LLM.
 """
 
 import json
+
 from models import AiInsight, InsightType
+
 from ..client import get_client
+from .kb_context import build_portfolio_kb_context
+
+SYSTEM_PROMPT = """Expert en analyse d'impact réglementaire pour bâtiments tertiaires français.
+
+Ta mission : évaluer l'impact d'un événement réglementaire sur le portefeuille client,
+en t'appuyant STRICTEMENT sur les items KB validés fournis.
+
+RÈGLES :
+- Ne cite QUE des items KB de la liste fournie
+- Pour chaque site impacté, référence les kb_item_ids concernés
+- Quantifie l'impact quand possible (€, m², deadline)
+
+Format JSON : {"impact_summary", "impacted_kb_item_ids", "recommended_actions", "urgency"}"""
 
 
-def run(db, event_id: int, **kwargs):
+def run(db, event_id: int, sites: list | None = None, **kwargs):
+    """Analyse l'impact d'un événement réglementaire."""
     client = get_client()
-    response = client.complete("Regulatory expert", f"Analyze impact of event {event_id}")
+
+    if sites:
+        kb_context = build_portfolio_kb_context(sites, domains=["reglementaire", "facturation"])
+        context_section = kb_context["prompt_section"]
+        kb_ids = kb_context["kb_item_ids"]
+    else:
+        context_section = "Pas de sites fournis — analyse générique de l'événement."
+        kb_ids = []
+
+    user_prompt = (
+        f"Événement réglementaire : event_id={event_id}\n"
+        f"Portefeuille impacté : {len(sites or [])} sites\n\n"
+        f"{context_section}\n\n"
+        f"Évalue l'impact sur le portefeuille en t'appuyant sur les items KB ci-dessus."
+    )
+
+    response = client.complete(system_prompt=SYSTEM_PROMPT, user_prompt=user_prompt)
+    is_stub = "[AI Stub Mode]" in response or "[AI Fallback]" in response
+
+    if is_stub:
+        content = {
+            "impact_summary": (
+                f"[Stub KB] Événement {event_id} : {len(kb_ids)} item(s) KB applicable(s) "
+                f"au portefeuille. Revue manuelle recommandée."
+            ),
+            "impacted_kb_item_ids": kb_ids,
+            "recommended_actions": [],
+            "urgency": "medium",
+            "mode": "stub",
+        }
+    else:
+        try:
+            content = json.loads(response)
+            content["mode"] = "live"
+        except json.JSONDecodeError:
+            content = {"impact": response, "impacted_kb_item_ids": kb_ids, "mode": "live_fallback"}
+        content.setdefault("impacted_kb_item_ids", kb_ids)
+
     insight = AiInsight(
         object_type="event",
         object_id=event_id,
         insight_type=InsightType.CHANGE_IMPACT,
-        content_json=json.dumps({"impact": response}),
+        content_json=json.dumps(content, ensure_ascii=False),
         ai_version=client.model,
+        sources_used_json=json.dumps(kb_ids),
     )
     db.add(insight)
     db.commit()

--- a/backend/tests/test_kb_context_integration.py
+++ b/backend/tests/test_kb_context_integration.py
@@ -15,7 +15,7 @@ BACKEND_DIR = Path(__file__).resolve().parent.parent
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
-from ai_layer.agents.kb_context import build_kb_context  # noqa: E402
+from ai_layer.agents.kb_context import build_kb_context, build_portfolio_kb_context  # noqa: E402
 
 
 def _fake_site(**overrides):
@@ -114,6 +114,36 @@ class TestSiteToContext:
         site = SimpleNamespace(surface_m2=1000, type=None, hvac_kw=None, parking_surface_m2=None)
         ctx = _site_to_context(site)
         assert ctx["energy_vector"] == "elec"
+
+
+class TestPortfolioKBContext:
+    def test_empty_portfolio_returns_insufficient(self):
+        ctx = build_portfolio_kb_context([])
+        assert ctx["total_items"] == 0
+        assert ctx["kb_item_ids"] == []
+        assert ctx["status"] == "insufficient"
+
+    def test_multi_site_aggregates_unique_items(self):
+        sites = [_fake_site(surface_m2=1500, hvac_kw=150), _fake_site(surface_m2=2000, hvac_kw=300)]
+        ctx = build_portfolio_kb_context(sites)
+        assert len(ctx["kb_item_ids"]) == len(set(ctx["kb_item_ids"]))
+
+    def test_stats_by_domain_structure(self):
+        ctx = build_portfolio_kb_context([_fake_site()], domains=["reglementaire", "facturation"])
+        assert "reglementaire" in ctx["stats_by_domain"]
+        assert "facturation" in ctx["stats_by_domain"]
+
+    def test_broken_kb_returns_empty_defensive(self, monkeypatch):
+        import ai_layer.agents.kb_context as mod
+
+        class BrokenKBService:
+            def apply(self, *a, **kw):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(mod, "KBService", BrokenKBService)
+        ctx = build_portfolio_kb_context([_fake_site()])
+        assert ctx["status"] == "error"
+        assert ctx["kb_item_ids"] == []
 
 
 class TestFormatItem:


### PR DESCRIPTION
## Summary

Sprint 1 fondations CX : KB production-ready avec 5/5 agents AI intégrés via `KBService.apply()`, + 3 endpoints pilotage innovation.

### 🎯 Deux chantiers complémentaires

**1. Intégration KB ↔ Agents AI (commit 7d8421b2)** — chantier critique

Avant : 0/5 agents passaient par la KB. Les recommandations étaient des prompts libres avec faits hardcodés (ex: "Décret Tertiaire -40% 2030" en dur dans le code). Violation de la HARD RULE doctrine PROMEOS.

Maintenant : **5/5 agents consomment `KBService.apply()`** via `ai_layer/agents/kb_context.py` :
- `regops_explainer` : domain=reglementaire
- `regops_recommender` : domain=reglementaire, actions tirées des items KB
- `data_quality_agent` : domain=usages (ratios archétypes)
- `exec_brief_agent` : portfolio multi-domaines (reg + factu + flex)
- `reg_change_agent` : portfolio reg + factu

Garde-fous :
- `allow_drafts=False` par défaut (HARD RULE)
- System prompts enrichis : "Ne cite QUE les items KB fournis"
- Chaque insight contient `kb_item_ids` pour traçabilité
- Défensive : KB down → contexte vide, pas de crash
- Cap tokens : `MAX_ITEMS_IN_PROMPT = 15`

**2. Endpoints pilotage innovation (commit 8b62e399)** — complément métier

3 services pilotage ajoutés :
- `portefeuille_scoring.py` : scoring 0-100 sur critères composites
- `radar_prix_negatifs.py` : détection opportunités J+7 sur prix spot
- `roi_flex_ready.py` : calcul ROI investissement Flex Ready® par site

### 📊 Chiffres

- **+4 modules backend** (kb_context + 3 pilotage services)
- **+12 fichiers modifiés** (4 agents + kb_context + 3 services + 4 tests)
- **+1 716 insertions** / -28 deletions
- **134/134 tests KB verts** (+15 tests intégration KB agents)

### 🧪 Test plan

- [x] `python backend/scripts/kb_validate.py` → 37/37 valid
- [x] `pytest backend/tests/test_kb*.py` → 134/134 passed
- [x] E2E chaîne KB : apply engine + télémétrie + agent context (single + portfolio)
- [x] Anti-pollution : 0 blacklist, scope respecté (tous fichiers dans `backend/`)
- [ ] Review Yannick sur l'intégration agents + pilotage

### 🔗 Context

Suite des sessions KB d'avril 2026 :
- b15e7bfd (#216) : 19 items + contradictions corrigées (déjà mergé)
- eff9e47e (#218) : S22 Pilotage world-class (déjà mergé)
- **Cette PR** : 5/5 agents intégrés + endpoints pilotage

Après merge, les 4 axes du plan KB sont opérationnels : agents ✅ + KPI mesurés ✅ + règles complétion ✅ (37 items sur 5 domaines). Reste UI `/admin/kb-metrics` (backend déjà prêt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
