### PR TITLE
feat(cx-instrumentation): T2V + IAR + WAU/MAU drivers [Sprint 1 item #1]

### DIFF
--- a/backend/middleware/cx_logger.py
+++ b/backend/middleware/cx_logger.py
@@ -21,6 +21,7 @@ CX_EVENT_TYPES = frozenset(
         "CX_REPORT_EXPORTED",
         "CX_ONBOARDING_COMPLETED",
         "CX_ACTION_FROM_INSIGHT",
+        "CX_DASHBOARD_OPENED",
     }
 )
 

--- a/backend/routes/actions.py
+++ b/backend/routes/actions.py
@@ -32,6 +32,7 @@ from models import (
 from services.action_hub_service import sync_actions, compute_priority
 from services.action_close_rules import is_operat_action, check_closable
 from middleware.auth import get_optional_auth, AuthContext
+from middleware.cx_logger import log_cx_event
 from services.iam_scope import apply_scope_filter
 from services.scope_utils import resolve_org_id
 
@@ -473,6 +474,7 @@ def patch_action(
     action_id: int,
     data: ActionPatch,
     db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
 ):
     """
     PATCH /api/actions/{action_id}
@@ -509,6 +511,13 @@ def patch_action(
             # Set closed_at when action is marked done
             if new_status == ActionStatus.DONE and action.closed_at is None:
                 action.closed_at = datetime.now(timezone.utc)
+                log_cx_event(
+                    db,
+                    action.org_id,
+                    auth.id if auth else None,
+                    "CX_ACTION_FROM_INSIGHT",
+                    {"action_id": action.id, "source_type": action.source_type.value if action.source_type else None},
+                )
 
     if data.owner is not None:
         old_owner = action.owner

--- a/backend/routes/cockpit.py
+++ b/backend/routes/cockpit.py
@@ -31,6 +31,7 @@ from models import (
 )
 from models.reg_assessment import RegAssessment
 from middleware.auth import get_optional_auth, AuthContext
+from middleware.cx_logger import log_cx_event
 from services.scope_utils import resolve_org_id
 from services.kpi_service import KpiService, KpiScope
 from services.consumption_unified_service import get_portfolio_consumption, ConsumptionSource
@@ -68,6 +69,14 @@ def get_cockpit(
     org = db.query(Organisation).filter(Organisation.id == effective_org_id).first()
     if not org:
         raise HTTPException(status_code=404, detail="Organisation non trouvée")
+
+    log_cx_event(
+        db,
+        effective_org_id,
+        auth.id if auth else None,
+        "CX_DASHBOARD_OPENED",
+        {"endpoint": "cockpit"},
+    )
 
     # Stats sites (exclude soft-deleted, scoped to org)
     q_sites = _sites_for_org(db, effective_org_id)

--- a/backend/routes/cx_dashboard.py
+++ b/backend/routes/cx_dashboard.py
@@ -1,20 +1,43 @@
 """
 PROMEOS — CX Dashboard (usage interne)
-GET /api/admin/cx-dashboard — KPIs CX agrégés par org
+GET /api/admin/cx-dashboard       — KPIs CX agrégés par org (vue générale)
+GET /api/admin/cx-dashboard/t2v   — Time-to-Value (délai account → 1ʳᵉ action validée)
+GET /api/admin/cx-dashboard/iar   — Insight-to-Action Rate (actions validées / findings consultés)
+GET /api/admin/cx-dashboard/wau-mau — Stickiness WAU/MAU (users actifs 7j / 30j)
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import func
+from sqlalchemy import func, distinct
 from sqlalchemy.orm import Session
 
 from database import get_db
 from middleware.auth import require_permission
 from middleware.cx_logger import CX_EVENT_TYPES
-from models.iam import AuditLog
+from models.iam import AuditLog, User
 
 router = APIRouter(prefix="/api/admin", tags=["Admin CX"])
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _percentile(sorted_values: list[float], p: float) -> Optional[float]:
+    if not sorted_values:
+        return None
+    k = (len(sorted_values) - 1) * p
+    lo, hi = int(k), min(int(k) + 1, len(sorted_values) - 1)
+    if lo == hi:
+        return sorted_values[lo]
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * (k - lo)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Vue générale (existant)
+# ─────────────────────────────────────────────────────────────────────────────
 
 
 @router.get("/cx-dashboard")
@@ -45,7 +68,6 @@ def get_cx_dashboard(
         .all()
     )
 
-    # Agrégation par org
     by_org: dict = {}
     for row in events:
         org = by_org.setdefault(row.org_id, {"events": {}, "total": 0, "last_activity": None})
@@ -54,7 +76,6 @@ def get_cx_dashboard(
         if org["last_activity"] is None or (row.last_at and row.last_at > org["last_activity"]):
             org["last_activity"] = row.last_at
 
-    # Détection inactivité
     inactive_threshold = datetime.now(timezone.utc) - timedelta(days=10)
     inactive_orgs = [
         oid for oid, data in by_org.items() if data["last_activity"] and data["last_activity"] < inactive_threshold
@@ -71,4 +92,220 @@ def get_cx_dashboard(
         },
         "inactive_orgs": inactive_orgs,
         "total_events": sum(d["total"] for d in by_org.values()),
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Driver 1 : Time-to-Value
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/cx-dashboard/t2v")
+def get_t2v(
+    days: int = Query(180, le=365, description="Fenêtre d'observation"),
+    db: Session = Depends(get_db),
+    _auth=Depends(require_permission("admin:read")),
+):
+    """
+    Time-to-Value = délai entre création compte user et 1ʳᵉ action validée.
+
+    Signal considéré comme "value delivered" : event CX_ACTION_FROM_INSIGHT
+    (une action passée au statut DONE dans /api/actions).
+
+    Retourne p50, p90, p95 en jours + nombre de users mesurés.
+    Un user sans action validée n'est pas dans l'échantillon (T2V non mesurable).
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    first_action = (
+        db.query(
+            AuditLog.user_id.label("user_id"),
+            AuditLog.resource_id.label("org_id"),
+            func.min(AuditLog.created_at).label("first_action_at"),
+        )
+        .filter(
+            AuditLog.action == "CX_ACTION_FROM_INSIGHT",
+            AuditLog.resource_type == "cx_event",
+            AuditLog.user_id.isnot(None),
+            AuditLog.created_at >= cutoff,
+        )
+        .group_by(AuditLog.user_id, AuditLog.resource_id)
+        .subquery()
+    )
+
+    rows = (
+        db.query(
+            User.id.label("user_id"),
+            User.created_at.label("user_created_at"),
+            first_action.c.org_id,
+            first_action.c.first_action_at,
+        )
+        .join(first_action, first_action.c.user_id == User.id)
+        .all()
+    )
+
+    deltas_days: list[float] = []
+    per_org: dict[str, list[float]] = {}
+    for r in rows:
+        if r.user_created_at is None or r.first_action_at is None:
+            continue
+        user_ref = r.user_created_at
+        if user_ref.tzinfo is None:
+            user_ref = user_ref.replace(tzinfo=timezone.utc)
+        action_ref = r.first_action_at
+        if action_ref.tzinfo is None:
+            action_ref = action_ref.replace(tzinfo=timezone.utc)
+        delta = (action_ref - user_ref).total_seconds() / 86400.0
+        if delta < 0:
+            continue  # incohérence : action antérieure au user (backfill)
+        deltas_days.append(delta)
+        per_org.setdefault(str(r.org_id), []).append(delta)
+
+    deltas_days.sort()
+
+    return {
+        "period_days": days,
+        "sample_size": len(deltas_days),
+        "p50_days": _percentile(deltas_days, 0.5),
+        "p90_days": _percentile(deltas_days, 0.9),
+        "p95_days": _percentile(deltas_days, 0.95),
+        "by_org": {
+            org_id: {
+                "sample_size": len(vals),
+                "p50_days": _percentile(sorted(vals), 0.5),
+                "p95_days": _percentile(sorted(vals), 0.95),
+            }
+            for org_id, vals in per_org.items()
+        },
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Driver 2 : Insight-to-Action Rate
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/cx-dashboard/iar")
+def get_iar(
+    days: int = Query(30, le=365),
+    db: Session = Depends(get_db),
+    _auth=Depends(require_permission("admin:read")),
+):
+    """
+    Insight-to-Action Rate = actions validées / insights consultés sur la période.
+
+    Numérateur : CX_ACTION_FROM_INSIGHT
+    Dénominateur : CX_INSIGHT_CONSULTED
+
+    Retourne le ratio global + décomposition par org.
+    Ratio "null" si dénominateur=0 (pas assez de signal).
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    counts = (
+        db.query(
+            AuditLog.resource_id.label("org_id"),
+            AuditLog.action.label("event_type"),
+            func.count().label("n"),
+        )
+        .filter(
+            AuditLog.action.in_({"CX_INSIGHT_CONSULTED", "CX_ACTION_FROM_INSIGHT"}),
+            AuditLog.resource_type == "cx_event",
+            AuditLog.created_at >= cutoff,
+        )
+        .group_by(AuditLog.resource_id, AuditLog.action)
+        .all()
+    )
+
+    by_org: dict[str, dict[str, int]] = {}
+    for row in counts:
+        org = by_org.setdefault(row.org_id, {"insights": 0, "actions": 0})
+        if row.event_type == "CX_INSIGHT_CONSULTED":
+            org["insights"] = row.n
+        else:
+            org["actions"] = row.n
+
+    def _ratio(actions: int, insights: int) -> Optional[float]:
+        if insights <= 0:
+            return None
+        return round(actions / insights, 4)
+
+    global_insights = sum(d["insights"] for d in by_org.values())
+    global_actions = sum(d["actions"] for d in by_org.values())
+
+    return {
+        "period_days": days,
+        "global": {
+            "insights_consulted": global_insights,
+            "actions_validated": global_actions,
+            "iar": _ratio(global_actions, global_insights),
+        },
+        "by_org": {
+            oid: {
+                "insights_consulted": d["insights"],
+                "actions_validated": d["actions"],
+                "iar": _ratio(d["actions"], d["insights"]),
+            }
+            for oid, d in by_org.items()
+        },
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Driver 3 : WAU / MAU
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/cx-dashboard/wau-mau")
+def get_wau_mau(
+    db: Session = Depends(get_db),
+    _auth=Depends(require_permission("admin:read")),
+):
+    """
+    WAU/MAU stickiness ratio.
+
+    WAU = users distincts avec ≥1 event CX_* sur 7 derniers jours
+    MAU = users distincts avec ≥1 event CX_* sur 30 derniers jours
+    Ratio = WAU / MAU (plus c'est haut, plus les users reviennent souvent)
+
+    Seuil de référence marché B2B SaaS : 20-30% = normal, 40%+ = excellent.
+    """
+    now = datetime.now(timezone.utc)
+
+    wau_cutoff = now - timedelta(days=7)
+    mau_cutoff = now - timedelta(days=30)
+
+    def _distinct_users(since: datetime) -> int:
+        return (
+            db.query(func.count(distinct(AuditLog.user_id)))
+            .filter(
+                AuditLog.action.in_(CX_EVENT_TYPES),
+                AuditLog.resource_type == "cx_event",
+                AuditLog.user_id.isnot(None),
+                AuditLog.created_at >= since,
+            )
+            .scalar()
+            or 0
+        )
+
+    wau = _distinct_users(wau_cutoff)
+    mau = _distinct_users(mau_cutoff)
+    ratio = round(wau / mau, 4) if mau > 0 else None
+
+    return {
+        "as_of": now.isoformat(),
+        "wau": wau,
+        "mau": mau,
+        "stickiness_ratio": ratio,
+        "interpretation": (
+            "excellent"
+            if ratio is not None and ratio >= 0.4
+            else "bon"
+            if ratio is not None and ratio >= 0.3
+            else "à travailler"
+            if ratio is not None and ratio >= 0.2
+            else "faible"
+            if ratio is not None
+            else "signal insuffisant"
+        ),
     }

--- a/backend/services/error_catalog.py
+++ b/backend/services/error_catalog.py
@@ -1,0 +1,157 @@
+"""
+PROMEOS — Catalogue d'erreurs métier en français.
+
+Sprint CX item #3 : traduction des 20 codes d'erreur backend les plus fréquents
+en messages lisibles par un utilisateur non technique, avec suggestion d'action.
+
+Format de chaque entrée :
+    CODE = {
+        "message":    "Ce qui s'est passé, en langage métier (phrase courte)",
+        "suggestion": "Ce que l'utilisateur peut faire maintenant",
+        "http_status": 400|404|409|422|500,
+    }
+
+Usage depuis une route :
+    from services.error_catalog import business_error
+    raise HTTPException(**business_error("ACTION_NOT_FOUND"))
+
+Le helper retourne un kwargs prêt pour HTTPException :
+    { "status_code": 404, "detail": {"code": "...", "message": "...", "suggestion": "..."} }
+"""
+
+from typing import Any
+
+
+ERROR_CATALOG: dict[str, dict[str, Any]] = {
+    # ── Actions ─────────────────────────────────────────────────────────────
+    "ACTION_NOT_FOUND": {
+        "message": "Cette action n'existe plus ou a été supprimée.",
+        "suggestion": "Rafraîchissez la page pour voir la liste à jour.",
+        "http_status": 404,
+    },
+    "ACTION_CLOSE_BLOCKED": {
+        "message": "Cette action ne peut pas être clôturée : certaines conditions ne sont pas remplies.",
+        "suggestion": "Ajoutez les pièces justificatives requises et renseignez le motif de clôture.",
+        "http_status": 400,
+    },
+    "TITLE_REQUIRED": {
+        "message": "Le titre de l'action est obligatoire.",
+        "suggestion": "Ajoutez un titre explicite (ex. « Renégocier contrat site Toulouse »).",
+        "http_status": 422,
+    },
+    "PRIORITY_REQUIRED": {
+        "message": "La priorité est obligatoire.",
+        "suggestion": "Choisissez une valeur de 1 (critique) à 5 (faible).",
+        "http_status": 400,
+    },
+    "PRIORITY_OUT_OF_RANGE": {
+        "message": "La priorité doit être comprise entre 1 et 5.",
+        "suggestion": "Ajustez la valeur : 1 = critique, 5 = faible.",
+        "http_status": 400,
+    },
+    "REASON_REQUIRED": {
+        "message": "Un motif est obligatoire pour cette opération (5 caractères minimum).",
+        "suggestion": "Expliquez brièvement la raison pour garder un historique clair.",
+        "http_status": 400,
+    },
+    # ── Patrimoine & données ────────────────────────────────────────────────
+    "SITE_NOT_FOUND": {
+        "message": "Ce site n'existe plus dans votre patrimoine.",
+        "suggestion": "Rafraîchissez la liste de vos sites ou vérifiez l'identifiant.",
+        "http_status": 404,
+    },
+    "ALERT_NOT_FOUND": {
+        "message": "Cette alerte n'est plus disponible.",
+        "suggestion": "Rafraîchissez la liste pour voir les alertes actives.",
+        "http_status": 404,
+    },
+    # ── Sirene / Onboarding ─────────────────────────────────────────────────
+    "SIREN_INVALID": {
+        "message": "Le SIREN saisi n'est pas valide (9 chiffres attendus).",
+        "suggestion": "Vérifiez le numéro sur votre Kbis et réessayez.",
+        "http_status": 400,
+    },
+    "SIRET_INVALID": {
+        "message": "Le SIRET saisi n'est pas valide (14 chiffres attendus).",
+        "suggestion": "Vérifiez le numéro sur votre document officiel et réessayez.",
+        "http_status": 400,
+    },
+    "ETABLISSEMENT_NOT_FOUND": {
+        "message": "Aucun établissement trouvé pour ce SIRET.",
+        "suggestion": "Utilisez la recherche par SIREN pour voir tous les établissements de l'entreprise.",
+        "http_status": 404,
+    },
+    "INVALID_DATE_FORMAT": {
+        "message": "Le format de date est invalide.",
+        "suggestion": "Utilisez le format AAAA-MM-JJ (ex. 2026-04-17).",
+        "http_status": 400,
+    },
+    # ── Administration / Utilisateurs ───────────────────────────────────────
+    "EMAIL_ALREADY_EXISTS": {
+        "message": "Cette adresse email est déjà utilisée par un autre utilisateur.",
+        "suggestion": "Utilisez une autre adresse ou contactez votre administrateur si c'est une erreur.",
+        "http_status": 409,
+    },
+    "USER_NOT_FOUND": {
+        "message": "Utilisateur introuvable.",
+        "suggestion": "Vérifiez votre sélection ou rafraîchissez la liste des utilisateurs.",
+        "http_status": 404,
+    },
+    "LAST_DG_OWNER_PROTECTION": {
+        "message": "Impossible de retirer le dernier DG OWNER de l'organisation.",
+        "suggestion": "Ajoutez un autre utilisateur avec le rôle DG OWNER avant de retirer celui-ci.",
+        "http_status": 400,
+    },
+    "USER_NO_ROLE_IN_ORG": {
+        "message": "Cet utilisateur n'a aucun rôle dans cette organisation.",
+        "suggestion": "Assignez-lui d'abord un rôle depuis l'administration.",
+        "http_status": 404,
+    },
+    # ── Versioning / Pondération ────────────────────────────────────────────
+    "VERSION_NOT_FOUND": {
+        "message": "Cette version de configuration n'existe pas.",
+        "suggestion": "Vérifiez la liste des versions disponibles.",
+        "http_status": 404,
+    },
+    "VERSION_ALREADY_EXISTS": {
+        "message": "Cette version existe déjà.",
+        "suggestion": "Utilisez un numéro de version différent ou modifiez la version existante.",
+        "http_status": 400,
+    },
+    "WEIGHTS_SUM_INVALID": {
+        "message": "La somme des pondérations doit être égale à 1,0 (100 %).",
+        "suggestion": "Ajustez les poids pour que leur total fasse exactement 1,0.",
+        "http_status": 400,
+    },
+    "NO_PREVIOUS_VERSION": {
+        "message": "Aucune version précédente n'est disponible pour rollback.",
+        "suggestion": "C'est la première version enregistrée.",
+        "http_status": 400,
+    },
+}
+
+
+def business_error(code: str, **context: Any) -> dict[str, Any]:
+    """
+    Formate une entrée du catalogue en kwargs prêt pour HTTPException.
+
+    Args:
+        code: Clé du catalogue (ex. "ACTION_NOT_FOUND")
+        **context: Champs additionnels à ajouter dans `detail` (ex. action_id=42)
+
+    Returns:
+        dict avec status_code et detail, utilisable comme :
+            raise HTTPException(**business_error("ACTION_NOT_FOUND", action_id=42))
+
+    Raises:
+        KeyError: si le code n'existe pas dans le catalogue.
+    """
+    entry = ERROR_CATALOG[code]
+    detail = {
+        "code": code,
+        "message": entry["message"],
+        "suggestion": entry["suggestion"],
+    }
+    if context:
+        detail["context"] = context
+    return {"status_code": entry["http_status"], "detail": detail}

--- a/backend/tests/test_cx_dashboard_drivers.py
+++ b/backend/tests/test_cx_dashboard_drivers.py
@@ -1,0 +1,201 @@
+"""
+Tests for CX Dashboard drivers: T2V, IAR, WAU/MAU.
+Uses isolated in-memory DB + TestClient + DEMO_MODE lenient auth.
+"""
+
+import json
+import sys
+import os
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from main import app
+from models import Base
+from models.iam import AuditLog, User
+from database import get_db
+
+
+@pytest.fixture
+def isolated_client():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    def _override():
+        try:
+            yield session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app), session
+    app.dependency_overrides.clear()
+    session.close()
+
+
+def _seed_user(db, user_id: int, created_days_ago: int) -> User:
+    created_at = datetime.now(timezone.utc) - timedelta(days=created_days_ago)
+    u = User(
+        id=user_id,
+        email=f"u{user_id}@test.promeos.io",
+        hashed_password="x",
+        nom=f"User {user_id}",
+        prenom=f"First{user_id}",
+        created_at=created_at,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _seed_event(db, user_id, org_id, event_type, days_ago):
+    entry = AuditLog(
+        user_id=user_id,
+        action=event_type,
+        resource_type="cx_event",
+        resource_id=str(org_id),
+        detail_json=json.dumps({"org_id": org_id}),
+        created_at=datetime.now(timezone.utc) - timedelta(days=days_ago),
+    )
+    db.add(entry)
+    db.commit()
+
+
+# ─── T2V ────────────────────────────────────────────────────────────────────
+
+
+class TestT2V:
+    def test_empty_db_returns_zero_sample(self, isolated_client):
+        client, _ = isolated_client
+        r = client.get("/api/admin/cx-dashboard/t2v")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["sample_size"] == 0
+        assert body["p50_days"] is None
+
+    def test_single_user_single_action(self, isolated_client):
+        client, db = isolated_client
+        _seed_user(db, user_id=1, created_days_ago=10)
+        _seed_event(db, user_id=1, org_id=42, event_type="CX_ACTION_FROM_INSIGHT", days_ago=5)
+
+        r = client.get("/api/admin/cx-dashboard/t2v")
+        body = r.json()
+        assert body["sample_size"] == 1
+        assert 4.5 < body["p50_days"] < 5.5  # ~5 jours
+        assert "42" in body["by_org"]
+
+    def test_action_before_user_creation_excluded(self, isolated_client):
+        client, db = isolated_client
+        _seed_user(db, user_id=1, created_days_ago=2)
+        _seed_event(db, user_id=1, org_id=1, event_type="CX_ACTION_FROM_INSIGHT", days_ago=10)
+
+        r = client.get("/api/admin/cx-dashboard/t2v")
+        assert r.json()["sample_size"] == 0
+
+    def test_only_first_action_counts_per_user_org(self, isolated_client):
+        client, db = isolated_client
+        _seed_user(db, user_id=1, created_days_ago=30)
+        _seed_event(db, user_id=1, org_id=1, event_type="CX_ACTION_FROM_INSIGHT", days_ago=25)
+        _seed_event(db, user_id=1, org_id=1, event_type="CX_ACTION_FROM_INSIGHT", days_ago=5)
+
+        r = client.get("/api/admin/cx-dashboard/t2v")
+        body = r.json()
+        assert body["sample_size"] == 1
+        assert 4.5 < body["p50_days"] < 5.5  # min = 5j (pas 25)
+
+
+# ─── IAR ────────────────────────────────────────────────────────────────────
+
+
+class TestIAR:
+    def test_empty_returns_null_ratio(self, isolated_client):
+        client, _ = isolated_client
+        r = client.get("/api/admin/cx-dashboard/iar")
+        body = r.json()
+        assert body["global"]["iar"] is None
+        assert body["global"]["insights_consulted"] == 0
+        assert body["global"]["actions_validated"] == 0
+
+    def test_ratio_computed_correctly(self, isolated_client):
+        client, db = isolated_client
+        for _ in range(10):
+            _seed_event(db, 1, 1, "CX_INSIGHT_CONSULTED", 2)
+        for _ in range(3):
+            _seed_event(db, 1, 1, "CX_ACTION_FROM_INSIGHT", 1)
+
+        r = client.get("/api/admin/cx-dashboard/iar")
+        body = r.json()
+        assert body["global"]["iar"] == 0.3
+        assert body["by_org"]["1"]["iar"] == 0.3
+
+    def test_excludes_events_outside_window(self, isolated_client):
+        client, db = isolated_client
+        _seed_event(db, 1, 1, "CX_INSIGHT_CONSULTED", 50)  # hors fenêtre 30j
+        _seed_event(db, 1, 1, "CX_ACTION_FROM_INSIGHT", 5)
+
+        r = client.get("/api/admin/cx-dashboard/iar?days=30")
+        body = r.json()
+        assert body["global"]["insights_consulted"] == 0
+        assert body["global"]["iar"] is None  # dénominateur=0
+
+
+# ─── WAU/MAU ────────────────────────────────────────────────────────────────
+
+
+class TestWauMau:
+    def test_empty_returns_zero(self, isolated_client):
+        client, _ = isolated_client
+        r = client.get("/api/admin/cx-dashboard/wau-mau")
+        body = r.json()
+        assert body["wau"] == 0
+        assert body["mau"] == 0
+        assert body["stickiness_ratio"] is None
+
+    def test_wau_counts_distinct_users_last_7d(self, isolated_client):
+        client, db = isolated_client
+        _seed_event(db, 1, 1, "CX_DASHBOARD_OPENED", 2)
+        _seed_event(db, 2, 1, "CX_INSIGHT_CONSULTED", 3)
+        _seed_event(db, 1, 1, "CX_DASHBOARD_OPENED", 4)  # doublon user 1
+        _seed_event(db, 3, 1, "CX_DASHBOARD_OPENED", 15)  # hors WAU
+
+        r = client.get("/api/admin/cx-dashboard/wau-mau")
+        body = r.json()
+        assert body["wau"] == 2  # users 1+2
+        assert body["mau"] == 3  # users 1+2+3
+
+    def test_null_user_excluded(self, isolated_client):
+        client, db = isolated_client
+        _seed_event(db, None, 1, "CX_DASHBOARD_OPENED", 2)
+        _seed_event(db, 1, 1, "CX_DASHBOARD_OPENED", 2)
+
+        r = client.get("/api/admin/cx-dashboard/wau-mau")
+        assert r.json()["wau"] == 1
+
+    def test_interpretation_tiers(self, isolated_client):
+        client, db = isolated_client
+        # 2 WAU users, 4 MAU users → ratio = 0.5 → excellent
+        for uid in (1, 2):
+            _seed_event(db, uid, 1, "CX_DASHBOARD_OPENED", 2)
+        for uid in (3, 4):
+            _seed_event(db, uid, 1, "CX_DASHBOARD_OPENED", 15)
+
+        r = client.get("/api/admin/cx-dashboard/wau-mau")
+        body = r.json()
+        assert body["stickiness_ratio"] == 0.5
+        assert body["interpretation"] == "excellent"

--- a/backend/tests/test_cx_logger.py
+++ b/backend/tests/test_cx_logger.py
@@ -54,12 +54,13 @@ def test_log_cx_event_no_user(db_session):
 
 
 def test_all_cx_event_types_defined():
-    assert len(CX_EVENT_TYPES) == 5
+    assert len(CX_EVENT_TYPES) == 6
     assert "CX_INSIGHT_CONSULTED" in CX_EVENT_TYPES
     assert "CX_MODULE_ACTIVATED" in CX_EVENT_TYPES
     assert "CX_REPORT_EXPORTED" in CX_EVENT_TYPES
     assert "CX_ONBOARDING_COMPLETED" in CX_EVENT_TYPES
     assert "CX_ACTION_FROM_INSIGHT" in CX_EVENT_TYPES
+    assert "CX_DASHBOARD_OPENED" in CX_EVENT_TYPES
 
 
 def test_log_cx_event_no_context(db_session):

--- a/backend/tests/test_error_catalog.py
+++ b/backend/tests/test_error_catalog.py
@@ -1,0 +1,105 @@
+"""
+Tests for business error catalog (Sprint CX item #3).
+Guarantees: 20 codes, FR messages, suggestions, valid HTTP status.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from services.error_catalog import ERROR_CATALOG, business_error
+
+
+VALID_HTTP_STATUS = {400, 404, 409, 422, 500}
+
+
+def test_catalog_has_at_least_20_codes():
+    assert len(ERROR_CATALOG) >= 20, f"Attendu ≥ 20 codes, trouvé {len(ERROR_CATALOG)}"
+
+
+def test_all_entries_have_required_fields():
+    for code, entry in ERROR_CATALOG.items():
+        assert "message" in entry, f"{code}: champ 'message' manquant"
+        assert "suggestion" in entry, f"{code}: champ 'suggestion' manquant"
+        assert "http_status" in entry, f"{code}: champ 'http_status' manquant"
+
+
+def test_messages_are_non_empty_and_reasonable_length():
+    for code, entry in ERROR_CATALOG.items():
+        msg = entry["message"]
+        assert isinstance(msg, str) and len(msg) > 0, f"{code}: message vide"
+        assert len(msg) >= 15, f"{code}: message trop court ({len(msg)})"
+        assert len(msg) <= 200, f"{code}: message > 200 caractères ({len(msg)})"
+        # Doit terminer par un point (phrase complète)
+        assert msg.rstrip().endswith(".") or msg.rstrip().endswith(")"), (
+            f"{code}: message devrait être une phrase complète terminée par un point"
+        )
+
+
+def test_suggestions_are_actionable():
+    for code, entry in ERROR_CATALOG.items():
+        sug = entry["suggestion"]
+        assert isinstance(sug, str) and len(sug) > 0, f"{code}: suggestion vide"
+        assert len(sug) <= 250, f"{code}: suggestion > 250 caractères ({len(sug)})"
+
+
+def test_http_status_is_valid():
+    for code, entry in ERROR_CATALOG.items():
+        assert entry["http_status"] in VALID_HTTP_STATUS, (
+            f"{code}: status {entry['http_status']} non standard (attendu {VALID_HTTP_STATUS})"
+        )
+
+
+def test_codes_are_screaming_snake_case():
+    for code in ERROR_CATALOG.keys():
+        assert code.isupper(), f"{code} doit être en SCREAMING_SNAKE_CASE"
+        assert "_" in code or code.isalpha(), f"{code}: format invalide"
+
+
+def test_business_error_returns_httpexception_kwargs():
+    kwargs = business_error("ACTION_NOT_FOUND")
+    assert kwargs["status_code"] == 404
+    assert kwargs["detail"]["code"] == "ACTION_NOT_FOUND"
+    assert "message" in kwargs["detail"]
+    assert "suggestion" in kwargs["detail"]
+
+
+def test_business_error_with_context():
+    kwargs = business_error("ACTION_NOT_FOUND", action_id=42, org_id=7)
+    assert kwargs["detail"]["context"] == {"action_id": 42, "org_id": 7}
+
+
+def test_business_error_raises_on_unknown_code():
+    with pytest.raises(KeyError):
+        business_error("NOPE_NOT_A_REAL_CODE")
+
+
+def test_required_codes_present():
+    """Les 20 codes cibles sprint CX item #3 sont tous présents."""
+    REQUIRED = [
+        "ACTION_NOT_FOUND",
+        "ACTION_CLOSE_BLOCKED",
+        "TITLE_REQUIRED",
+        "PRIORITY_REQUIRED",
+        "PRIORITY_OUT_OF_RANGE",
+        "REASON_REQUIRED",
+        "SITE_NOT_FOUND",
+        "ALERT_NOT_FOUND",
+        "SIREN_INVALID",
+        "SIRET_INVALID",
+        "ETABLISSEMENT_NOT_FOUND",
+        "INVALID_DATE_FORMAT",
+        "EMAIL_ALREADY_EXISTS",
+        "USER_NOT_FOUND",
+        "LAST_DG_OWNER_PROTECTION",
+        "USER_NO_ROLE_IN_ORG",
+        "VERSION_NOT_FOUND",
+        "VERSION_ALREADY_EXISTS",
+        "WEIGHTS_SUM_INVALID",
+        "NO_PREVIOUS_VERSION",
+    ]
+    for code in REQUIRED:
+        assert code in ERROR_CATALOG, f"{code} manquant dans le catalogue"

--- a/frontend/src/__tests__/glossary_top10_kpis.test.js
+++ b/frontend/src/__tests__/glossary_top10_kpis.test.js
@@ -1,0 +1,64 @@
+/**
+ * PROMEOS — Sprint CX item #2
+ * Contract test : les 10 KPIs cibles du sprint doivent TOUJOURS être dans le glossaire
+ * avec term + short. Un `long` est exigé pour les KPIs complexes (formule ou réglementation).
+ *
+ * Cible : garantir la pédagogie inline sur les termes énergétiques clés de la facture.
+ */
+import { describe, it, expect } from 'vitest';
+import { GLOSSARY } from '../ui/glossary.js';
+
+// Les 10 KPIs cibles définis par la stratégie CX sprint 1 item #2
+const TOP10_KPIS = [
+  { key: 'turpe', label: 'TURPE', longRequired: true },
+  { key: 'cta', label: 'CTA', longRequired: true },
+  { key: 'accise_electricite', label: 'Accise électricité', longRequired: true },
+  { key: 'car', label: 'CAR', longRequired: true },
+  { key: 'tdn', label: 'TDN', longRequired: true },
+  { key: 'cee', label: 'CEE', longRequired: true },
+  { key: 'vnu', label: 'VNU', longRequired: true },
+  { key: 'capacite', label: 'Capacité', longRequired: true },
+  { key: 'tva', label: 'TVA', longRequired: true },
+  { key: 'compliance_score', label: 'Score conformité', longRequired: true },
+];
+
+describe('Sprint CX item #2 — couverture glossary des 10 KPIs cibles', () => {
+  for (const { key, label, longRequired } of TOP10_KPIS) {
+    describe(`KPI "${label}" (clé: ${key})`, () => {
+      it('existe dans GLOSSARY', () => {
+        expect(GLOSSARY[key]).toBeDefined();
+      });
+
+      it('a un champ `term` non vide', () => {
+        const entry = GLOSSARY[key];
+        expect(entry.term).toBeTruthy();
+        expect(entry.term.length).toBeGreaterThan(0);
+      });
+
+      it('a un champ `short` de 20 à 300 caractères', () => {
+        const entry = GLOSSARY[key];
+        expect(entry.short).toBeTruthy();
+        expect(entry.short.length).toBeGreaterThanOrEqual(20);
+        expect(entry.short.length).toBeLessThanOrEqual(300);
+      });
+
+      if (longRequired) {
+        it('a un champ `long` de 100+ caractères (contexte réglementaire)', () => {
+          const entry = GLOSSARY[key];
+          expect(entry.long).toBeTruthy();
+          expect(entry.long.length).toBeGreaterThanOrEqual(100);
+        });
+      }
+    });
+  }
+
+  it('les 10 clés sont uniques', () => {
+    const keys = TOP10_KPIS.map((k) => k.key);
+    expect(new Set(keys).size).toBe(10);
+  });
+
+  it('les 10 labels sont uniques', () => {
+    const labels = TOP10_KPIS.map((k) => k.label);
+    expect(new Set(labels).size).toBe(10);
+  });
+});

--- a/frontend/src/ui/glossary.js
+++ b/frontend/src/ui/glossary.js
@@ -49,13 +49,44 @@ export const GLOSSARY = {
   cta: {
     term: 'CTA',
     short:
-      "Contribution Tarifaire d'Acheminement. Taxe finançant les retraites des agents des industries électriques et gazières.",
+      "Contribution Tarifaire d'Acheminement. Taxe finançant les retraites des agents des industries électriques et gazières. Assiette : part fixe TURPE (gestion + soutirage).",
+    long: "La CTA est calculée comme un pourcentage de la composante gestion du TURPE (part fixe). Coefficients 2026 en vigueur : 21,93 % pour l'électricité (sur part gestion), 10,11 % pour l'abonnement TURPE. Pré-février 2026, les coefficients historiques étaient 15 %/5 %. CTA gaz : formule additive (20,80 % + 4,71 % × coef_transport). La CTA est soumise à une TVA de 5,5 %. Source : Code de la sécurité sociale, arrêté tarifaire CRE, ParameterStore PROMEOS versionné par date d'effet.",
   },
   tva: {
     term: 'TVA',
     short:
       'Taxe sur la Valeur Ajoutée. CTA : 5,5 %. Abonnement et consommation : 20 % (depuis août 2025 pour les ≤36 kVA, toujours 20 % pour les professionnels).',
-    // Source : LFI 2025. TVA 20% sur abonnement ménages ≤36 kVA depuis 1er août 2025. CTA reste à 5,5%.
+    long: "La TVA s'applique à 3 taux différents selon la composante : CTA à 5,5 % (taux réduit), abonnement à 20 % (depuis 1er août 2025 pour les ménages ≤36 kVA, sinon toujours 20 % pro), consommation (énergie + accise) à 20 %. Le calcul final : TTC = HT × (1 + taux applicable par composante). Source : LFI 2025, Code général des impôts art. 278-0 bis.",
+  },
+  car: {
+    term: 'CAR',
+    short:
+      "Consommation Annuelle de Référence. Volume annuel de gaz consommé par un point de livraison, base de calcul de l'option tarifaire ATRD.",
+    long: "La CAR conditionne l'option tarifaire ATRD applicable : T1 si < 6 MWh/an, T2 si 6–300 MWh/an, T3 si 300–5 000 MWh/an, T4 si ≥ 5 000 MWh/an. Pour T4, un découpage marginal 2 tranches s'applique (< 500 et ≥ 500 MWh/jour). TP (Tarif à Proximité) réservé aux plus gros volumes avec terme capacité distance. Source : délibération CRE n°2024-17 (ATRD7), mise à jour 2025-122 au 1/07/2025 (+6,06 %).",
+  },
+  tdn: {
+    term: 'TDN',
+    short:
+      "Tarif Dynamique de Nouveaux usages. Tarif d'achat d'électricité avec signal prix variable, pensé pour les usages pilotables (VE, batteries, ballons ECS).",
+    long: "Le TDN est un tarif dynamique horaire indexé sur les prix spot du marché, avec une incitation forte à consommer quand l'électricité est abondante (prix bas/négatifs). Cible : clients résidentiels équipés d'actifs pilotables et pro avec flexibilité fine. Articulation avec le mécanisme Tempo (3 couleurs) et les tarifications dynamiques en cours d'élargissement dans le cadre de la réforme HC TURPE 7 (3 phases nov 2025 → mi-2028). Source : CRE, RTE, réforme HC saisonnalisée.",
+  },
+  cee: {
+    term: 'CEE',
+    short:
+      "Certificats d'Économies d'Énergie. Dispositif obligeant les fournisseurs d'énergie à financer des travaux d'efficacité énergétique chez leurs clients. P6 depuis 1/1/2026 : 1 050 TWhc/an.",
+    long: "Les CEE (dispositif obligation nationale) imposent aux fournisseurs d'atteindre un volume de certificats sur la période P6 2026–2030 (1 050 TWhc/an, +50 % vs P5). Impact facture : ~0,731 €/MWh livré en 2026 (vs 0,478 en P5). Le coût est soit assumé par le fournisseur, soit répercuté au client via la composante CEE de la facture (pass-through activé sur le contrat). Nouvelles fiches 2026 : chaleur fatale, data centers, bornes VE. Source : DGEC, arrêté CEE P6, hebdo énergie 6-12 avril 2026.",
+  },
+  vnu: {
+    term: 'VNU',
+    short:
+      "Ventes au Nucléaire Unifié. Mécanisme régulant l'accès à l'électricité nucléaire historique, successeur de l'ARENH depuis le 1/1/2026.",
+    long: "La VNU remplace l'ARENH (fini 31/12/2025) dans le cadre post-bouclier tarifaire. Elle unifie les ventes d'EDF sur un marché de gros régulé (plutôt qu'un prix fixe 42 €/MWh comme ARENH). Fin 2025, l'open interest sur Y_2026 a atteint 24,1 GW (record historique) — signal fort d'anticipation par les acheteurs. PROMEOS intègre la VNU dans les scénarios d'achat Q2-Q3 2026. Source : Loi Énergie-Climat 2019, PPE3 2026–2035, bulletin CRE T4 2025.",
+  },
+  capacite: {
+    term: 'Mécanisme de capacité',
+    short:
+      "Obligation RTE imposant aux fournisseurs de détenir des garanties de capacité proportionnelles à la pointe de leurs clients. Centralisation enchères PL-4/PL-1 prévue nov 2026.",
+    long: "Le mécanisme de capacité assure l'adéquation offre/demande lors des pointes hiver (vague de froid, pointes du soir). Chaque fournisseur doit acheter des certificats auprès des producteurs/effaceurs pour couvrir l'obligation de ses clients. Réforme novembre 2026 : centralisation RTE (enchères PL-4 puis PL-1) remplace le système décentralisé actuel. Impact facture : ligne capacité (EUR/kW ou EUR/MWh selon contrat), en hausse attendue sur 2026–2028. Source : RTE, CRE, hebdo énergie avril 2026.",
   },
   ht: {
     term: 'HT',

--- a/frontend/src/ui/glossary.js
+++ b/frontend/src/ui/glossary.js
@@ -85,7 +85,7 @@ export const GLOSSARY = {
   capacite: {
     term: 'Mécanisme de capacité',
     short:
-      "Obligation RTE imposant aux fournisseurs de détenir des garanties de capacité proportionnelles à la pointe de leurs clients. Centralisation enchères PL-4/PL-1 prévue nov 2026.",
+      'Obligation RTE imposant aux fournisseurs de détenir des garanties de capacité proportionnelles à la pointe de leurs clients. Centralisation enchères PL-4/PL-1 prévue nov 2026.',
     long: "Le mécanisme de capacité assure l'adéquation offre/demande lors des pointes hiver (vague de froid, pointes du soir). Chaque fournisseur doit acheter des certificats auprès des producteurs/effaceurs pour couvrir l'obligation de ses clients. Réforme novembre 2026 : centralisation RTE (enchères PL-4 puis PL-1) remplace le système décentralisé actuel. Impact facture : ligne capacité (EUR/kW ou EUR/MWh selon contrat), en hausse attendue sur 2026–2028. Source : RTE, CRE, hebdo énergie avril 2026.",
   },
   ht: {


### PR DESCRIPTION
## Contexte

Sprint 1 CX — 3/3 items livrés. Fondations pour l'amélioration continue de l'expérience utilisateur PROMEOS (stratégie CX/PX définie 17/04/2026).

## Items livrés

### Item #1 — Instrumentation drivers CX (`f027718b`)

Mesure des 3 drivers North Star CX :
- **T2V** (Time-to-Value) : délai création compte → 1ʳᵉ action validée
- **IAR** (Insight-to-Action Rate) : ratio actions validées / findings consultés
- **WAU/MAU** (Stickiness) : users actifs 7j/30j

3 nouveaux endpoints `/api/admin/cx-dashboard/{t2v,iar,wau-mau}` + 1 nouvel event `CX_DASHBOARD_OPENED` + wiring `CX_ACTION_FROM_INSIGHT` au passage `ActionStatus.DONE`.

### Item #2 — Pédagogie inline sur 10 KPIs énergie (`13cbb9df` + `24f2dfd0`)

Extension du composant `<Explain>` (V105) pour couvrir les 10 KPIs cibles :
- 5 nouveaux : CAR, TDN, CEE, VNU, capacité
- 2 enrichis : CTA (coefficients + CTA gaz), TVA (3 taux par composante)
- 3 existants conservés : TURPE, accise_electricite, compliance_score

Chaque KPI a `short` (tooltip) + `long` (panel) + source réglementaire.
Contract test fige les 10 KPIs obligatoires dans le glossaire.

### Item #3 — Messages d'erreur FR métier (`79a84a7f`)

Catalogue centralisé de 20 codes d'erreur les plus fréquents traduits en langage métier :
- Format unifié : `{code, message, suggestion, http_status}`
- Helper `business_error(code, **context)` pour usage dans HTTPException
- Couvre : Actions (6), Patrimoine (2), Sirene (4), Admin (4), Versioning (4)
- Socle pour remplacer progressivement les 295 HTTPException réparties dans 50 routes

## Drivers CX instrumentés

| Driver | Cible 6m | Cible 12m |
|--------|----------|-----------|
| T2V | < 7 jours | < 3 jours |
| IAR | > 30% | > 45% |
| WAU/MAU | > 40% | > 55% |

## Test plan

- [x] 16 tests CX backend (T2V 4 + IAR 3 + WAU/MAU 4 + cx_logger 5)
- [x] 10 tests error catalog (structure + codes obligatoires)
- [x] 1 test frontend contract glossaire 10 KPIs
- [x] 39 tests régression actions + cockpit (pas de régression)
- [x] ruff check clean sur tous fichiers modifiés
- [ ] Preview live endpoints sur env de dev
- [ ] Validation métier messages erreurs en revue CX

## Notes process

- Branche sous namespace `claude/*` pour éviter hijack par sessions parallèles
- Commits avec `--no-verify` autorisé explicitement pour contourner husky stash qui causait branch-switches sur Windows (feedback mémorisé)
- Travail en worktree isolé `c:/tmp/claude-cx-work/` pour imperméabilité totale

🤖 Generated with [Claude Code](https://claude.com/claude-code)