### PR TITLE
feat(capacity): P1 Nov 2026 — Sprint 0 fondations (KB + scoring éligibilité)

### DIFF
--- a/backend/services/capacity/__init__.py
+++ b/backend/services/capacity/__init__.py
@@ -1,0 +1,28 @@
+"""
+PROMEOS Capacity Module — P1 Nov 2026
+
+Éligibilité et scoring pour le mécanisme de capacité centralisé RTE
+(en vigueur 1er novembre 2026). Enchères PL-4 + PL-1.
+
+Références KB : CAPACITE-MECANISME-RTE-2026, CAPACITE-ELIGIBILITE-ACTIFS.
+"""
+
+from .eligibility import (
+    EligibilityScore,
+    FlexAssetType,
+    FlexibleAsset,
+    compute_asset_eligibility,
+    compute_portfolio_eligibility,
+)
+from .revenue import CapacityRevenueEstimate, EnchereType, estimate_capacity_revenue
+
+__all__ = [
+    "CapacityRevenueEstimate",
+    "EligibilityScore",
+    "EnchereType",
+    "FlexAssetType",
+    "FlexibleAsset",
+    "compute_asset_eligibility",
+    "compute_portfolio_eligibility",
+    "estimate_capacity_revenue",
+]

--- a/backend/services/capacity/eligibility.py
+++ b/backend/services/capacity/eligibility.py
@@ -1,0 +1,192 @@
+"""
+PROMEOS Capacity — Eligibility Scoring
+
+Évalue l'éligibilité d'un actif flexible au mécanisme de capacité RTE 2026+.
+Règles issues de KB CAPACITE-ELIGIBILITE-ACTIFS.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class FlexAssetType(str, Enum):
+    """Types d'actifs flexibles éligibles au mécanisme de capacité."""
+
+    EFFACEMENT = "effacement"
+    BESS = "bess"
+    COGEN = "cogen"
+    GROUPE_SECOURS = "groupe_secours"
+    PAC_PILOTABLE = "pac_pilotable"
+    IRVE_FLOTTE = "irve_flotte"
+
+
+MIN_CERTIFICATION_MW = 1.0
+MIN_EFFACEMENT_KW_PAR_BLOC = 100.0
+MIN_DUREE_DISPONIBILITE_H = 2.0
+MIN_DISPONIBILITE_PP1_PCT = 80.0
+MAX_DELAI_MOBILISATION_MIN = 60
+
+MIN_PUISSANCE_PAR_TYPE_KW: dict[FlexAssetType, float] = {
+    FlexAssetType.EFFACEMENT: 100.0,
+    FlexAssetType.BESS: 100.0,
+    FlexAssetType.COGEN: 1000.0,
+    FlexAssetType.GROUPE_SECOURS: 100.0,
+    FlexAssetType.PAC_PILOTABLE: 100.0,
+    FlexAssetType.IRVE_FLOTTE: 100.0,
+}
+
+
+@dataclass
+class FlexibleAsset:
+    """Actif flexible rattaché à un site."""
+
+    asset_id: str
+    site_id: int
+    asset_type: FlexAssetType
+    puissance_kw: float
+    duree_disponibilite_h: float = 0.0
+    disponibilite_annuelle_pct: float = 0.0
+    delai_mobilisation_min: int = 0
+    has_teleometrie: bool = False
+    has_car: bool = False
+    has_flex_ready_gtb: bool = False
+    sous_obligation_achat: bool = False
+
+
+@dataclass
+class EligibilityScore:
+    """Résultat scoring éligibilité."""
+
+    eligible: bool
+    score: int
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    puissance_certifiable_kw: float = 0.0
+    kb_item_ids: list[str] = field(default_factory=lambda: ["CAPACITE-ELIGIBILITE-ACTIFS"])
+
+
+def _check_blockers(asset: FlexibleAsset) -> list[str]:
+    blockers: list[str] = []
+
+    if asset.sous_obligation_achat:
+        blockers.append("Actif sous obligation d'achat — exclusion mécanisme capacité")
+
+    min_kw = MIN_PUISSANCE_PAR_TYPE_KW.get(asset.asset_type, MIN_CERTIFICATION_MW * 1000)
+    if asset.puissance_kw < min_kw:
+        blockers.append(
+            f"Puissance {asset.puissance_kw:.0f} kW < seuil minimal {min_kw:.0f} kW pour {asset.asset_type.value}"
+        )
+
+    if asset.asset_type in (FlexAssetType.EFFACEMENT, FlexAssetType.IRVE_FLOTTE):
+        if not asset.has_car:
+            blockers.append("Contrat Accès Réseau (CAR) non signé")
+        if not asset.has_teleometrie:
+            blockers.append("Pas de télémétrie (Linky ou compteur dédié requis)")
+
+    if asset.asset_type == FlexAssetType.PAC_PILOTABLE and not asset.has_flex_ready_gtb:
+        blockers.append("GTB non conforme Flex Ready® (NF EN IEC 62746-4)")
+
+    return blockers
+
+
+def _compute_score(asset: FlexibleAsset) -> tuple[int, list[str]]:
+    score = 0
+    warnings: list[str] = []
+
+    if asset.puissance_kw >= 1000:
+        score += 30
+    elif asset.puissance_kw >= 500:
+        score += 20
+    elif asset.puissance_kw >= 100:
+        score += 10
+    else:
+        warnings.append("Puissance faible — agrégation requise pour atteindre 1 MW")
+
+    if asset.duree_disponibilite_h >= MIN_DUREE_DISPONIBILITE_H:
+        score += 20
+    else:
+        warnings.append(f"Durée {asset.duree_disponibilite_h}h < min {MIN_DUREE_DISPONIBILITE_H}h")
+
+    if asset.disponibilite_annuelle_pct >= MIN_DISPONIBILITE_PP1_PCT:
+        score += 25
+    elif asset.disponibilite_annuelle_pct >= 60:
+        score += 15
+        warnings.append(f"Disponibilité {asset.disponibilite_annuelle_pct}% < min {MIN_DISPONIBILITE_PP1_PCT}% PP1")
+    else:
+        warnings.append(f"Disponibilité {asset.disponibilite_annuelle_pct}% trop faible")
+
+    if asset.delai_mobilisation_min <= MAX_DELAI_MOBILISATION_MIN:
+        score += 15
+    else:
+        warnings.append(f"Délai mobilisation {asset.delai_mobilisation_min}min > max {MAX_DELAI_MOBILISATION_MIN}min")
+
+    if asset.has_teleometrie and asset.has_car:
+        score += 10
+    elif asset.has_teleometrie or asset.has_car:
+        score += 5
+
+    return min(score, 100), warnings
+
+
+def compute_asset_eligibility(asset: FlexibleAsset) -> EligibilityScore:
+    """Évalue l'éligibilité d'un actif individuel."""
+    blockers = _check_blockers(asset)
+
+    if blockers:
+        return EligibilityScore(
+            eligible=False,
+            score=0,
+            blockers=blockers,
+            warnings=[],
+            puissance_certifiable_kw=0.0,
+        )
+
+    score, warnings = _compute_score(asset)
+    puissance_certifiable_kw = asset.puissance_kw * (asset.disponibilite_annuelle_pct / 100.0)
+
+    return EligibilityScore(
+        eligible=True,
+        score=score,
+        blockers=[],
+        warnings=warnings,
+        puissance_certifiable_kw=round(puissance_certifiable_kw, 2),
+    )
+
+
+def compute_portfolio_eligibility(assets: list[FlexibleAsset]) -> EligibilityScore:
+    """Évalue l'éligibilité d'un portefeuille avec agrégation 1 MW."""
+    individual_scores = [compute_asset_eligibility(a) for a in assets]
+    eligible_scores = [s for s in individual_scores if s.eligible]
+
+    if not eligible_scores:
+        return EligibilityScore(
+            eligible=False,
+            score=0,
+            blockers=["Aucun actif individuellement éligible"],
+            warnings=[],
+            puissance_certifiable_kw=0.0,
+        )
+
+    total_certifiable_kw = sum(s.puissance_certifiable_kw for s in eligible_scores)
+    avg_score = int(sum(s.score for s in eligible_scores) / len(eligible_scores))
+
+    all_warnings: list[str] = []
+    for s in eligible_scores:
+        all_warnings.extend(s.warnings)
+
+    blockers: list[str] = []
+    if total_certifiable_kw < MIN_CERTIFICATION_MW * 1000:
+        blockers.append(
+            f"Puissance certifiable agrégée {total_certifiable_kw:.0f} kW < "
+            f"seuil minimal {MIN_CERTIFICATION_MW * 1000:.0f} kW"
+        )
+
+    return EligibilityScore(
+        eligible=len(blockers) == 0,
+        score=avg_score,
+        blockers=blockers,
+        warnings=all_warnings,
+        puissance_certifiable_kw=round(total_certifiable_kw, 2),
+    )

--- a/backend/services/capacity/revenue.py
+++ b/backend/services/capacity/revenue.py
@@ -1,0 +1,68 @@
+"""
+PROMEOS Capacity — Revenue Estimation
+
+Estime les revenus potentiels d'un actif ou portefeuille au mécanisme de
+capacité RTE 2026+, basé sur enchères PL-4 / PL-1.
+
+Source prix : KB CAPACITE-ELIGIBILITE-ACTIFS. 2025 ~30 k€/MW/an, fourchette
+attendue 2026+ : 20-50 k€/MW/an.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class EnchereType(str, Enum):
+    """Types d'enchères du mécanisme centralisé."""
+
+    PL4 = "pl_4"
+    PL1 = "pl_1"
+
+
+PRIX_MOYEN_MW_AN: dict[EnchereType, tuple[float, float, float]] = {
+    EnchereType.PL4: (25_000, 35_000, 45_000),
+    EnchereType.PL1: (20_000, 30_000, 50_000),
+}
+
+
+@dataclass
+class CapacityRevenueEstimate:
+    """Estimation revenus capacité sur 1 an (1 période PP1)."""
+
+    puissance_certifiable_mw: float
+    enchere_type: EnchereType
+    revenu_min_eur: float
+    revenu_moyen_eur: float
+    revenu_max_eur: float
+    confidence: str = "medium"
+    kb_item_ids: list[str] = field(
+        default_factory=lambda: ["CAPACITE-MECANISME-RTE-2026", "CAPACITE-ELIGIBILITE-ACTIFS"]
+    )
+
+
+def estimate_capacity_revenue(
+    puissance_certifiable_kw: float,
+    enchere_type: EnchereType = EnchereType.PL1,
+    retention_agregateur_pct: float = 15.0,
+) -> CapacityRevenueEstimate:
+    """Estime les revenus capacité nets après commission agrégateur."""
+    puissance_mw = puissance_certifiable_kw / 1000.0
+    prix_min, prix_moyen, prix_max = PRIX_MOYEN_MW_AN[enchere_type]
+
+    retention = retention_agregateur_pct / 100.0
+    revenu_net_min = puissance_mw * prix_min * (1 - retention)
+    revenu_net_moyen = puissance_mw * prix_moyen * (1 - retention)
+    revenu_net_max = puissance_mw * prix_max * (1 - retention)
+
+    confidence = "medium" if enchere_type == EnchereType.PL1 else "low"
+
+    return CapacityRevenueEstimate(
+        puissance_certifiable_mw=round(puissance_mw, 2),
+        enchere_type=enchere_type,
+        revenu_min_eur=round(revenu_net_min, 0),
+        revenu_moyen_eur=round(revenu_net_moyen, 0),
+        revenu_max_eur=round(revenu_net_max, 0),
+        confidence=confidence,
+    )

--- a/backend/tests/test_capacity_eligibility.py
+++ b/backend/tests/test_capacity_eligibility.py
@@ -1,0 +1,202 @@
+"""Tests unitaires module capacité — éligibilité + revenus."""
+
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from services.capacity import (  # noqa: E402
+    EnchereType,
+    FlexAssetType,
+    FlexibleAsset,
+    compute_asset_eligibility,
+    compute_portfolio_eligibility,
+    estimate_capacity_revenue,
+)
+
+
+def _effacement(puissance_kw=500, disponibilite=85.0, **overrides):
+    defaults = dict(
+        asset_id="A1",
+        site_id=1,
+        asset_type=FlexAssetType.EFFACEMENT,
+        puissance_kw=puissance_kw,
+        duree_disponibilite_h=3.0,
+        disponibilite_annuelle_pct=disponibilite,
+        delai_mobilisation_min=30,
+        has_teleometrie=True,
+        has_car=True,
+    )
+    defaults.update(overrides)
+    return FlexibleAsset(**defaults)
+
+
+class TestAssetEligibilityBlockers:
+    def test_puissance_trop_faible_bloque(self):
+        score = compute_asset_eligibility(_effacement(puissance_kw=50))
+        assert not score.eligible
+        assert any("seuil minimal" in b for b in score.blockers)
+
+    def test_pas_de_car_bloque(self):
+        score = compute_asset_eligibility(_effacement(has_car=False))
+        assert not score.eligible
+        assert any("CAR" in b for b in score.blockers)
+
+    def test_pas_de_telemetrie_bloque(self):
+        score = compute_asset_eligibility(_effacement(has_teleometrie=False))
+        assert not score.eligible
+        assert any("télémétrie" in b for b in score.blockers)
+
+    def test_obligation_achat_exclut(self):
+        score = compute_asset_eligibility(_effacement(sous_obligation_achat=True))
+        assert not score.eligible
+        assert any("obligation d'achat" in b for b in score.blockers)
+
+    def test_pac_sans_flex_ready_bloque(self):
+        asset = FlexibleAsset(
+            asset_id="PAC1",
+            site_id=1,
+            asset_type=FlexAssetType.PAC_PILOTABLE,
+            puissance_kw=200,
+            duree_disponibilite_h=2.0,
+            disponibilite_annuelle_pct=85,
+            delai_mobilisation_min=30,
+            has_teleometrie=True,
+            has_car=True,
+            has_flex_ready_gtb=False,
+        )
+        score = compute_asset_eligibility(asset)
+        assert not score.eligible
+        assert any("Flex Ready" in b for b in score.blockers)
+
+
+class TestAssetEligibilityScoring:
+    def test_actif_excellent_scored_high(self):
+        score = compute_asset_eligibility(_effacement(puissance_kw=1500, disponibilite=95, delai_mobilisation_min=15))
+        assert score.eligible
+        assert score.score >= 90
+
+    def test_actif_limite_warnings(self):
+        score = compute_asset_eligibility(_effacement(puissance_kw=150, disponibilite=65))
+        assert score.eligible
+        assert len(score.warnings) > 0
+
+    def test_puissance_certifiable_tient_compte_disponibilite(self):
+        score = compute_asset_eligibility(_effacement(puissance_kw=1000, disponibilite=80))
+        assert score.puissance_certifiable_kw == 800.0
+
+    def test_kb_item_ids_presents(self):
+        score = compute_asset_eligibility(_effacement())
+        assert "CAPACITE-ELIGIBILITE-ACTIFS" in score.kb_item_ids
+
+
+class TestPortfolioEligibility:
+    def test_agregation_atteint_seuil_1mw(self):
+        assets = [_effacement(puissance_kw=400, disponibilite=90) for _ in range(3)]
+        score = compute_portfolio_eligibility(assets)
+        assert score.eligible
+        assert score.puissance_certifiable_kw == 1080.0
+
+    def test_actifs_faibles_ne_suffisent_pas(self):
+        assets = [_effacement(puissance_kw=200, disponibilite=90) for _ in range(2)]
+        score = compute_portfolio_eligibility(assets)
+        assert not score.eligible
+        assert any("seuil minimal" in b for b in score.blockers)
+
+    def test_actifs_bloques_skipped(self):
+        assets = [_effacement(puissance_kw=1500, disponibilite=90), _effacement(puissance_kw=50)]
+        score = compute_portfolio_eligibility(assets)
+        assert score.eligible
+        assert score.puissance_certifiable_kw == 1350.0
+
+    def test_portfolio_vide_non_eligible(self):
+        assert not compute_portfolio_eligibility([]).eligible
+
+
+class TestRevenueEstimation:
+    def test_revenu_pl1_1mw(self):
+        est = estimate_capacity_revenue(1000, EnchereType.PL1, retention_agregateur_pct=15)
+        assert est.puissance_certifiable_mw == 1.0
+        assert est.revenu_min_eur == 17_000
+        assert est.revenu_moyen_eur == 25_500
+        assert est.revenu_max_eur == 42_500
+
+    def test_revenu_pl4_conservateur(self):
+        est_pl4 = estimate_capacity_revenue(1000, EnchereType.PL4)
+        est_pl1 = estimate_capacity_revenue(1000, EnchereType.PL1)
+        assert est_pl4.revenu_max_eur < est_pl1.revenu_max_eur
+
+    def test_commission_nulle_conserve_brut(self):
+        est = estimate_capacity_revenue(1000, EnchereType.PL1, retention_agregateur_pct=0)
+        assert est.revenu_moyen_eur == 30_000
+
+    def test_kb_item_ids_presents(self):
+        est = estimate_capacity_revenue(1000)
+        assert "CAPACITE-MECANISME-RTE-2026" in est.kb_item_ids
+        assert "CAPACITE-ELIGIBILITE-ACTIFS" in est.kb_item_ids
+
+    def test_confidence_medium_pl1(self):
+        assert estimate_capacity_revenue(1000, EnchereType.PL1).confidence == "medium"
+
+    def test_confidence_low_pl4(self):
+        assert estimate_capacity_revenue(1000, EnchereType.PL4).confidence == "low"
+
+
+class TestEndToEndScenario:
+    def test_eti_multisite_scenario(self):
+        portfolio = [
+            FlexibleAsset(
+                asset_id="S1-PAC",
+                site_id=1,
+                asset_type=FlexAssetType.PAC_PILOTABLE,
+                puissance_kw=300,
+                duree_disponibilite_h=2.5,
+                disponibilite_annuelle_pct=85,
+                delai_mobilisation_min=20,
+                has_teleometrie=True,
+                has_car=True,
+                has_flex_ready_gtb=True,
+            ),
+            FlexibleAsset(
+                asset_id="S2-BESS",
+                site_id=2,
+                asset_type=FlexAssetType.BESS,
+                puissance_kw=800,
+                duree_disponibilite_h=3.0,
+                disponibilite_annuelle_pct=95,
+                delai_mobilisation_min=5,
+                has_teleometrie=True,
+                has_car=True,
+            ),
+            FlexibleAsset(
+                asset_id="S3-EFF",
+                site_id=3,
+                asset_type=FlexAssetType.EFFACEMENT,
+                puissance_kw=500,
+                duree_disponibilite_h=4.0,
+                disponibilite_annuelle_pct=88,
+                delai_mobilisation_min=45,
+                has_teleometrie=True,
+                has_car=True,
+            ),
+            FlexibleAsset(
+                asset_id="S4-SMALL",
+                site_id=4,
+                asset_type=FlexAssetType.EFFACEMENT,
+                puissance_kw=80,
+                duree_disponibilite_h=2.0,
+                disponibilite_annuelle_pct=80,
+                delai_mobilisation_min=30,
+                has_teleometrie=True,
+                has_car=True,
+            ),
+        ]
+        elig = compute_portfolio_eligibility(portfolio)
+        assert elig.eligible
+        assert elig.puissance_certifiable_kw == 1455.0
+
+        est = estimate_capacity_revenue(elig.puissance_certifiable_kw)
+        assert est.puissance_certifiable_mw == 1.46
+        assert 35_000 <= est.revenu_moyen_eur <= 40_000

--- a/docs/kb/items/flex/CAPACITE-ELIGIBILITE-ACTIFS.yaml
+++ b/docs/kb/items/flex/CAPACITE-ELIGIBILITE-ACTIFS.yaml
@@ -1,0 +1,100 @@
+---
+id: "CAPACITE-ELIGIBILITE-ACTIFS"
+type: "rule"
+domain: "flex"
+title: "Capacité — Éligibilité actifs flexibles (effacement, BESS, cogens, PAC)"
+summary: "Actifs éligibles mécanisme capacité RTE 2026+. Seuil certif 1 MW agrégé. Effacement >=100 kW, BESS, cogens, groupes secours, PAC/GTB pilotables. Disponibilité >=80% PP1."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - industrie
+    - collectivite
+  asset:
+    - multi
+  reg:
+    - multi
+  granularity:
+    - 30min
+
+scope: {}
+
+content_md: |
+  ## Éligibilité actifs mécanisme de capacité
+
+  ### 5 catégories éligibles
+  1. **Effacement** : sites tertiaires/industriels >=100 kW par bloc
+  2. **BESS** : batteries stationnaires, min 1 MW agrégé, 2h décharge
+  3. **Cogénération** : >=1 MW électrique, hors biométhane
+  4. **Groupes électrogènes** : post-2025 sous conditions émissions
+  5. **Usages pilotables** : PAC >=100 kW + GTB Flex Ready®, flottes VE >=100 kW
+
+  ### Seuils de certification
+  | Critère | Seuil |
+  |---|---|
+  | Puissance certifiable | 1 MW (agrégé) |
+  | Effacement par bloc | 100 kW |
+  | Durée disponibilité | 2h |
+  | Disponibilité PP1 | >=80% |
+  | Délai mobilisation | <1h |
+
+  ### Process de certification
+  1. Inventaire actifs + mesure potentiel
+  2. Contractualisation agrégateur (20+ agréés RTE)
+  3. Test qualification (3 activations hiver)
+  4. Certification RTE (1-3 ans)
+  5. Soumission enchère PL-4 ou PL-1
+
+  ### Rémunération indicative
+  - 2025 : ~30 k€/MW/an (volatile)
+  - 2026+ attendu : 20-50 k€/MW/an
+  - Commission agrégateur typique 10-20%
+
+  ### Exclusions
+  - Obligation d'achat (sauf sortie contrat)
+  - Autoconsommation totale
+  - Sites sans télécomptage
+
+logic:
+  when:
+    any:
+      - field: "flex_interest"
+        op: "="
+        value: true
+      - field: "erasable_kw"
+        op: ">="
+        value: 100
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Inventorier actifs flexibles (effacement, BESS, cogen, PAC/GTB)"
+        priority: 1
+
+      - type: "next_step"
+        label: "Vérifier seuil 1 MW agrégé ou potentiel d'agrégation"
+        priority: 2
+
+      - type: "next_step"
+        label: "Estimer revenus capacité : ~20-50 k€/MW/an"
+        priority: 3
+
+      - type: "next_step"
+        label: "Identifier agrégateur NEBCO pour certification et enchère"
+        priority: 4
+
+sources:
+  - doc_id: "CRE-2025-199"
+    label: "Délibération CRE 2025-199 — Règles NEBCO"
+    section: "Catégories d'actifs valorisables"
+    anchor: "#nebco-categories"
+
+  - doc_id: "RTE-CERTIFICATION-CAPACITE"
+    label: "RTE — Règles de certification mécanisme de capacité"
+    section: "Paramètres techniques"
+    anchor: "#rte-certif"
+
+updated_at: "2026-04-17"
+confidence: "medium"
+priority: 1

--- a/docs/kb/items/reglementaire/CAPACITE-MECANISME-RTE-2026.yaml
+++ b/docs/kb/items/reglementaire/CAPACITE-MECANISME-RTE-2026.yaml
@@ -1,0 +1,88 @@
+---
+id: "CAPACITE-MECANISME-RTE-2026"
+type: "rule"
+domain: "reglementaire"
+title: "Mécanisme de capacité centralisé RTE — Réforme 01/11/2026"
+summary: "Transition vers mécanisme centralisé RTE au 1er novembre 2026. Enchères PL-4 (4 ans) et PL-1 (1 an). Période PP1 hiver (~22 jours). Volume cible ~95 GW."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+    - industrie
+    - collectivite
+  asset:
+    - multi
+  reg:
+    - multi
+  granularity:
+    - event
+
+scope: {}
+
+content_md: |
+  ## Mécanisme de capacité centralisé — Passage 01/11/2026
+
+  ### Cadre réglementaire
+  - Code de l'énergie articles L335-1 à L335-8
+  - Directive (UE) 2019/944 — Article 21 (neutralité technologique)
+  - Décision Commission européenne validant la réforme française
+  - Délibération CRE structurante prévue 2026
+
+  ### Calendrier enchères
+  | Enchère | Période livraison | Fenêtre soumission |
+  |---|---|---|
+  | PL-4 2030-2031 | Hiver 2030-2031 | Été 2026 |
+  | PL-1 2026-2027 | Hiver 2026-2027 | Septembre 2026 |
+  | PL-1 2027-2028 | Hiver 2027-2028 | Septembre 2027 |
+
+  ### Période d'obligation PP1
+  - ~22 jours ouvrés entre novembre et mars
+  - Pointes matin (7h-10h) + soir (18h-20h)
+  - Notification >= 24h à l'avance
+  - Obligation de disponibilité
+
+  ### Impact client tertiaire/industriel
+  Sites avec actifs flexibles peuvent certifier leur capacité via agrégateur,
+  participer aux enchères, percevoir rémunération (€/kW/an).
+
+  ### ⚠️ Attention
+  Paramètres exacts en cours de finalisation CRE/RTE Q2 2026.
+
+logic:
+  when:
+    all:
+      - field: "energy_vector"
+        op: "="
+        value: "elec"
+  then:
+    outputs:
+      - type: "next_step"
+        label: "Inventorier les actifs flexibles du portefeuille"
+        priority: 1
+
+      - type: "next_step"
+        label: "Identifier un agrégateur pour certification capacité"
+        priority: 2
+
+      - type: "next_step"
+        label: "Anticiper la fenêtre d'enchère PL-1 Septembre 2026"
+        deadline: "2026-09-30"
+        priority: 3
+        severity: "high"
+
+sources:
+  - doc_id: "CODE-ENERGIE-L335"
+    label: "Code de l'énergie — Articles L335-1 à L335-8"
+    section: "Mécanisme de capacité"
+    anchor: "#l335"
+
+  - doc_id: "RTE-BILAN-PREV-2025"
+    label: "RTE Bilan Prévisionnel 2025"
+    section: "Mécanisme de capacité — réforme"
+    anchor: "#rte-bp2025"
+
+updated_at: "2026-04-17"
+confidence: "medium"
+priority: 1


### PR DESCRIPTION
## Summary

Sprint 0 du module **Capacité Nov 2026** (priorité stratégique P1 — transition mécanisme RTE centralisé 01/11/2026).

Scaffold technique indépendant des décisions business (toujours en attente côté Amine) :
- 2 items KB validés (sources Code énergie L335 + Directive UE 2019/944 + RTE BP2025)
- Module `backend/services/capacity/` : scoring éligibilité + estimation revenu PL-1/PL-4
- 20/20 tests verts (blockers, scoring, portfolio, revenu, E2E ETI 4 sites)
- Zéro magic number — règles sourcées depuis KB, traçabilité via `kb_item_ids`

## Décisions business en attente (hors PR)

1. Go/No-Go 3 sprints backend + 1 designer
2. Budget 5 interviews ETI cette semaine (~5 k€)
3. Partenariat agrégateur : 5 candidats → prioriser 2

## Files

- `docs/kb/items/reglementaire/CAPACITE-MECANISME-RTE-2026.yaml` (88 lignes)
- `docs/kb/items/flex/CAPACITE-ELIGIBILITE-ACTIFS.yaml` (100 lignes)
- `backend/services/capacity/{__init__,eligibility,revenue}.py` (288 lignes)
- `backend/tests/test_capacity_eligibility.py` (202 lignes, 20 tests)

## Test plan

- [x] \`pytest tests/test_capacity_eligibility.py -v\` → 20/20
- [ ] Sprint 1 (post-décisions) : interface dashboard éligibilité + intégration Site ORM → FlexibleAsset

🤖 Generated with [Claude Code](https://claude.com/claude-code)