### PR TITLE
feat(pilotage-v1): Innovation V1 — 3 endpoints + 3 cartes cockpit (Radar J+7 · ROI Flex Ready® · Portefeuille)

### DIFF
--- a/backend/routes/pilotage.py
+++ b/backend/routes/pilotage.py
@@ -1,17 +1,22 @@
 """
 PROMEOS - Routes Pilotage des usages.
 
-Endpoint Flex Ready (R) -- expose les 5 donnees standardisees (NF EN IEC 62746-4)
-pour un site de demonstration.
+Endpoints :
+    - /flex-ready-signals/{site_id} : 5 donnees standardisees NF EN IEC 62746-4
+      (conformite technique, cf. flex_ready.py).
+    - /roi-flex-ready/{site_id}     : gain annuel estime EUR (business case CFO,
+      cf. roi_flex_ready.py).
+    - /radar-prix-negatifs          : fenetres probables prix negatifs J+7.
 
 Reference : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from database import get_db
@@ -20,6 +25,9 @@ from services.pilotage.flex_ready import (
     FlexReadySignalsResponse,
     build_flex_ready_signals,
 )
+from services.pilotage.portefeuille_scoring import compute_portefeuille_scoring
+from services.pilotage.radar_prix_negatifs import predict_negative_windows
+from services.pilotage.roi_flex_ready import compute_roi_flex_ready
 
 
 router = APIRouter(prefix="/api/pilotage", tags=["Pilotage"])
@@ -39,6 +47,9 @@ DEMO_SITES: dict[str, dict[str, Any]] = {
         "prix_eur_kwh": 0.185,
         "puissance_souscrite_kva": 250,
         "energy_vector": "ELEC",
+        "archetype_code": "COMMERCE_ALIMENTAIRE",
+        "puissance_pilotable_kw": 220.0,
+        "surface_m2": 2500.0,
     },
     "bureau-001": {
         "nom": "Bureau Haussmann",
@@ -46,6 +57,9 @@ DEMO_SITES: dict[str, dict[str, Any]] = {
         "prix_eur_kwh": 0.172,
         "puissance_souscrite_kva": 144,
         "energy_vector": "ELEC",
+        "archetype_code": "BUREAU_STANDARD",
+        "puissance_pilotable_kw": 120.0,
+        "surface_m2": 1800.0,
     },
     "entrepot-001": {
         "nom": "Entrepot Rungis",
@@ -53,8 +67,34 @@ DEMO_SITES: dict[str, dict[str, Any]] = {
         "prix_eur_kwh": 0.158,
         "puissance_souscrite_kva": 400,
         "energy_vector": "ELEC",
+        "archetype_code": "LOGISTIQUE_FRIGO",
+        "puissance_pilotable_kw": 85.0,
+        "surface_m2": 6000.0,
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# ROI Flex Ready (R) -- schemas de reponse (Piste 2 V1 innovation).
+# ---------------------------------------------------------------------------
+class RoiFlexReadyComposantes(BaseModel):
+    """Les 3 composantes additives du gain annuel Flex Ready (R)."""
+
+    evitement_pointe_eur: float = Field(..., description="Gain evitement pointe EUR/an")
+    decalage_nebco_eur: float = Field(..., description="Valorisation decalage NEBCO EUR/an")
+    cee_bacs_eur: float = Field(..., description="CEE BAT-TH-116 (GTB/BACS) EUR")
+
+
+class RoiFlexReadyResponse(BaseModel):
+    """Payload ROI Flex Ready (R) : gain annuel estime + hypotheses explicites."""
+
+    site_id: str = Field(..., description="Identifiant canonique du site")
+    archetype: str = Field(..., description="Archetype finalement utilise (fallback si inconnu)")
+    gain_annuel_total_eur: float = Field(..., description="Gain annuel total estime (EUR)")
+    composantes: RoiFlexReadyComposantes = Field(..., description="Detail des 3 composantes")
+    hypotheses: dict = Field(..., description="Parametres MVP utilises (explainability)")
+    confiance: str = Field(..., description="Niveau de confiance : 'indicative' en MVP")
+    source: str = Field(..., description="Citation courte des sources de calibrage")
 
 
 def _build_demo_site_ctx(site_id: str) -> dict[str, Any]:
@@ -69,6 +109,173 @@ def _build_demo_site_ctx(site_id: str) -> dict[str, Any]:
             detail=f"Site demo inconnu : '{site_id}'. Sites disponibles : {sorted(DEMO_SITES.keys())}",
         )
     return ctx
+
+
+# ---------------------------------------------------------------------------
+# Radar prix negatifs J+7 -- schemas de reponse.
+# ---------------------------------------------------------------------------
+class FenetrePrediteModel(BaseModel):
+    """Fenetre favorable probable predite (cote client : wording doctrine)."""
+
+    datetime_debut: str = Field(..., description="ISO 8601 Europe/Paris aware")
+    datetime_fin: str = Field(..., description="ISO 8601 Europe/Paris aware")
+    probabilite: float = Field(..., ge=0.0, le=1.0, description="Probabilite [0,1]")
+    prix_estime_min_eur_mwh: float = Field(..., description="Mediane des prix negatifs observes sur jours semblables")
+    usages_recommandes: List[str] = Field(
+        ..., description="Usages flexibles conseilles (ecs, ve_recharge, pre_charge_froid)"
+    )
+    base_historique_jours: int = Field(
+        ..., ge=0, description="Nb de jours historiques semblables ayant servi a la prediction"
+    )
+
+
+class RadarPrixNegatifsResponse(BaseModel):
+    """Reponse endpoint /radar-prix-negatifs (wording cote client = 'favorable probable')."""
+
+    fenetres_predites: List[FenetrePrediteModel]
+    horizon_jours: int = Field(..., ge=1, le=14)
+    source: str = Field("historique_entsoe_90j", description="Source des donnees d'entree")
+    confiance: str = Field("indicative", description="Niveau de confiance du signal")
+
+
+@router.get("/radar-prix-negatifs", response_model=RadarPrixNegatifsResponse)
+def radar_prix_negatifs(
+    horizon_days: int = Query(7, ge=1, le=14, description="Horizon de prediction (1..14 jours)"),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+) -> RadarPrixNegatifsResponse:
+    """
+    Radar prix negatifs J+7 (Piste 1 V1 innovation).
+
+    Predit les fenetres probables de prix spot negatifs pour les jours a venir,
+    a partir de l'historique MktPrice day-ahead FR (90 derniers jours).
+    Approche MVP heuristique -- pas de ML :
+        1. Analyse creneaux 10h-17h des 90 derniers jours.
+        2. Pour chaque jour cible J+1..J+horizon, on compare aux jours de semaine
+           semblables du meme mois.
+        3. Si > 30 % des creneaux semblables ont ete negatifs => fenetre predite.
+
+    Fallback gracieux :
+        - < 30 jours d'historique => liste vide.
+        - Aucune recurrence detectee => liste vide.
+
+    Wording doctrine : cote front, ces fenetres sont presentees comme
+    "Fenetres favorables probables" (pas "prix negatifs").
+    """
+    fenetres = predict_negative_windows(horizon_days=horizon_days, db=db)
+    return RadarPrixNegatifsResponse(
+        fenetres_predites=fenetres,
+        horizon_jours=horizon_days,
+        source="historique_entsoe_90j",
+        confiance="indicative",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scoring portefeuille multi-sites -- schemas de reponse (Piste 3 V1)
+# ---------------------------------------------------------------------------
+class PortefeuilleSiteRanked(BaseModel):
+    """Ligne de classement Top-N d'un site dans le portefeuille."""
+
+    site_id: str = Field(..., description="Identifiant canonique du site")
+    archetype: Optional[str] = Field(None, description="Code archetype ou None si inconnu")
+    score: float = Field(..., ge=0.0, le=100.0, description="Score potentiel pilotable 0-100")
+    gain_annuel_eur: float = Field(..., ge=0.0, description="Gain annuel estime (EUR)")
+    rang: int = Field(..., ge=1, description="Rang dans le classement (1 = meilleur)")
+
+
+class PortefeuilleHeatmapEntry(BaseModel):
+    """Agregat par archetype : nb_sites, gain total, score moyen."""
+
+    nb_sites: int = Field(..., ge=0)
+    gain_total_eur: float = Field(..., ge=0.0)
+    score_moyen: float = Field(..., ge=0.0, le=100.0)
+
+
+class PortefeuilleScoringResponse(BaseModel):
+    """Reponse endpoint /portefeuille-scoring (Piste 3 V1)."""
+
+    nb_sites_total: int = Field(..., ge=0)
+    gain_annuel_portefeuille_eur: float = Field(..., ge=0.0)
+    top_10: List[PortefeuilleSiteRanked]
+    heatmap_archetype: dict[str, PortefeuilleHeatmapEntry]
+    source: str = Field(..., description="Source du calibrage")
+
+
+def _demo_sites_as_portfolio() -> list[dict[str, Any]]:
+    """Transforme DEMO_SITES en liste prete pour compute_portefeuille_scoring."""
+    return [
+        {
+            "site_id": site_id,
+            "archetype_code": ctx.get("archetype_code"),
+            "puissance_pilotable_kw": ctx.get("puissance_pilotable_kw", 0.0),
+        }
+        for site_id, ctx in DEMO_SITES.items()
+    ]
+
+
+def _org_sites_as_portfolio(db: Session, auth: AuthContext) -> list[dict[str, Any]]:
+    """
+    Liste les sites actifs scopes par AuthContext.site_ids pour le scoring.
+
+    Note : le modele Site ne porte pas encore `archetype_code` ni
+    `puissance_pilotable_kw`. On retombe sur des valeurs sentinelles
+    (archetype None -> fallback score 50, puissance_pilotable 0 -> gain 0).
+    Ce wiring servira quand ces champs seront ajoutes au modele (backlog).
+    """
+    from models import Site
+
+    site_ids = getattr(auth, "site_ids", None) or []
+    if not site_ids:
+        return []
+    rows = (
+        db.query(Site)
+        .filter(Site.id.in_(site_ids))
+        .filter(Site.actif == True)  # noqa: E712
+        .all()
+    )
+    return [
+        {
+            "site_id": str(site.id),
+            "archetype_code": getattr(site, "archetype_code", None),
+            "puissance_pilotable_kw": float(getattr(site, "puissance_pilotable_kw", 0.0) or 0.0),
+        }
+        for site in rows
+    ]
+
+
+@router.get("/portefeuille-scoring", response_model=PortefeuilleScoringResponse)
+def portefeuille_scoring(
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+) -> PortefeuilleScoringResponse:
+    """
+    Classement par potentiel de pilotage d'un portefeuille multi-sites.
+
+    Retourne :
+        - nb_sites_total                : cardinal du portefeuille
+        - gain_annuel_portefeuille_eur  : somme des gains annuels estimes
+        - top_10                        : Top-10 trie par score decroissant
+        - heatmap_archetype             : agregat par archetype (nb, gain, score moyen)
+
+    En DEMO_MODE (auth absent ou sans org_id), utilise les 3 sites de DEMO_SITES.
+    En prod (auth.org_id present), iterer sur les sites actifs de l'organisation
+    courante -- avec fallback sentinel tant que les champs archetype /
+    puissance_pilotable_kw ne sont pas encore portes par le modele Site.
+
+    Source : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
+    """
+    if auth is not None and getattr(auth, "org_id", None):
+        sites = _org_sites_as_portfolio(db, auth)
+        # Si l'org n'a aucun site utile (cas pilote pre-seed), on retombe
+        # sur la demo pour garantir un payload non-vide exploitable par le front.
+        if not sites:
+            sites = _demo_sites_as_portfolio()
+    else:
+        sites = _demo_sites_as_portfolio()
+
+    result = compute_portefeuille_scoring(sites)
+    return PortefeuilleScoringResponse(**result)
 
 
 @router.get("/flex-ready-signals/{site_id}", response_model=FlexReadySignalsResponse)
@@ -92,3 +299,37 @@ def flex_ready_signals(
     """
     ctx = _build_demo_site_ctx(site_id)
     return build_flex_ready_signals(site_id=site_id, demo_site=ctx, db=db)
+
+
+@router.get("/roi-flex-ready/{site_id}", response_model=RoiFlexReadyResponse)
+def roi_flex_ready(
+    site_id: str,
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+) -> RoiFlexReadyResponse:
+    """
+    Expose le business case chiffre Flex Ready (R) : gain annuel estime (EUR).
+
+    Complete la conformite technique NF EN IEC 62746-4 (voir
+    /flex-ready-signals) avec la seule question que les CFOs lisent :
+    "Combien ce site gagne-t-il par an a etre Flex Ready (R) + pilote ?"
+
+    Trois composantes additives :
+        1. Gain evitement pointe        -- kW pilotable x h pointe evitees x spread
+        2. Valorisation decalage NEBCO  -- kW decalable x 200 h/an x 60 EUR/MWh
+        3. CEE BAT-TH-116 (GTB/BACS)    -- surface m2 x 3,5 EUR/m2
+
+    Wording doctrine : "gain annuel estime" cote client. Confiance "indicative"
+    en MVP. Hypotheses toujours exposees dans la payload (explainability).
+
+    Sources :
+        - Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026)
+        - Fiche CEE BAT-TH-116 (systeme GTB / BACS)
+
+    Auth optionnelle (DEMO_MODE tolere). 404 si site absent du catalogue de demo.
+    """
+    ctx = _build_demo_site_ctx(site_id)
+    return compute_roi_flex_ready(
+        site_id=site_id,
+        demo_site=ctx,
+        archetype_code=ctx.get("archetype_code"),
+    )

--- a/backend/routes/pilotage.py
+++ b/backend/routes/pilotage.py
@@ -13,6 +13,7 @@ Reference : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
 
 from __future__ import annotations
 
+import os
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -21,6 +22,13 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from middleware.auth import AuthContext, get_optional_auth
+
+
+def _is_demo_mode() -> bool:
+    """Vrai si `PROMEOS_DEMO_MODE=true` — gate explicite pour fallback DEMO."""
+    return os.environ.get("PROMEOS_DEMO_MODE", "false").lower() == "true"
+
+
 from services.pilotage.flex_ready import (
     FlexReadySignalsResponse,
     build_flex_ready_signals,
@@ -218,19 +226,27 @@ def _org_sites_as_portfolio(db: Session, auth: AuthContext) -> list[dict[str, An
     """
     Liste les sites actifs scopes par AuthContext.site_ids pour le scoring.
 
+    Defense-in-depth : en plus du filtre `Site.id IN auth.site_ids` (deja
+    scope par l'IAM dans `get_scoped_site_ids`), on recroise la hierarchie
+    Portefeuille -> EntiteJuridique pour garantir `organisation_id == auth.org_id`.
+    Si l'auth layer leakait un site_id cross-org, on ne servirait rien.
+
     Note : le modele Site ne porte pas encore `archetype_code` ni
     `puissance_pilotable_kw`. On retombe sur des valeurs sentinelles
     (archetype None -> fallback score 50, puissance_pilotable 0 -> gain 0).
-    Ce wiring servira quand ces champs seront ajoutes au modele (backlog).
+    Ce wiring servira quand ces champs seront ajoutes au modele (backlog Option C).
     """
-    from models import Site
+    from models import EntiteJuridique, Portefeuille, Site
 
     site_ids = getattr(auth, "site_ids", None) or []
     if not site_ids:
         return []
     rows = (
         db.query(Site)
+        .join(Portefeuille, Site.portefeuille_id == Portefeuille.id)
+        .join(EntiteJuridique, Portefeuille.entite_juridique_id == EntiteJuridique.id)
         .filter(Site.id.in_(site_ids))
+        .filter(EntiteJuridique.organisation_id == auth.org_id)
         .filter(Site.actif == True)  # noqa: E712
         .all()
     )
@@ -258,20 +274,27 @@ def portefeuille_scoring(
         - top_10                        : Top-10 trie par score decroissant
         - heatmap_archetype             : agregat par archetype (nb, gain, score moyen)
 
-    En DEMO_MODE (auth absent ou sans org_id), utilise les 3 sites de DEMO_SITES.
     En prod (auth.org_id present), iterer sur les sites actifs de l'organisation
     courante -- avec fallback sentinel tant que les champs archetype /
     puissance_pilotable_kw ne sont pas encore portes par le modele Site.
+    Si l'org ne porte aucun site (pilote pre-seed), le payload est vide --
+    on ne pollue pas l'ecran d'un utilisateur authentifie avec des donnees DEMO.
+
+    En DEMO_MODE uniquement (PROMEOS_DEMO_MODE=true ou auth absent), retombe sur
+    les 3 sites de DEMO_SITES pour garantir un payload non-vide exploitable
+    par le front de demonstration.
 
     Source : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
     """
     if auth is not None and getattr(auth, "org_id", None):
         sites = _org_sites_as_portfolio(db, auth)
-        # Si l'org n'a aucun site utile (cas pilote pre-seed), on retombe
-        # sur la demo pour garantir un payload non-vide exploitable par le front.
-        if not sites:
+        # Org authentifiee sans site utile : retourner payload vide plutot
+        # que polluer l'ecran avec des donnees DEMO. Fallback DEMO reserve
+        # au mode demonstration explicite.
+        if not sites and _is_demo_mode():
             sites = _demo_sites_as_portfolio()
     else:
+        # Pas d'auth : mode DEMO (front public ou dev local)
         sites = _demo_sites_as_portfolio()
 
     result = compute_portefeuille_scoring(sites)
@@ -304,6 +327,7 @@ def flex_ready_signals(
 @router.get("/roi-flex-ready/{site_id}", response_model=RoiFlexReadyResponse)
 def roi_flex_ready(
     site_id: str,
+    db: Session = Depends(get_db),
     auth: Optional[AuthContext] = Depends(get_optional_auth),
 ) -> RoiFlexReadyResponse:
     """
@@ -325,7 +349,13 @@ def roi_flex_ready(
         - Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026)
         - Fiche CEE BAT-TH-116 (systeme GTB / BACS)
 
-    Auth optionnelle (DEMO_MODE tolere). 404 si site absent du catalogue de demo.
+    Scope MVP : `site_id` doit correspondre a une cle du catalogue DEMO_SITES
+    (`retail-001`, `bureau-001`, `entrepot-001`). Le wiring sur Site.id reel
+    (archetype_code + puissance_pilotable_kw + surface_m2 portes par le modele
+    Site) fera l'objet d'une PR follow-up (Option C). 404 hors DEMO_SITES.
+
+    Auth optionnelle (DEMO_MODE tolere). La session `db` est en place pour le
+    futur wiring Site.id mais n'est pas utilisee en MVP.
     """
     ctx = _build_demo_site_ctx(site_id)
     return compute_roi_flex_ready(

--- a/backend/services/pilotage/portefeuille_scoring.py
+++ b/backend/services/pilotage/portefeuille_scoring.py
@@ -1,0 +1,176 @@
+"""
+PROMEOS - Scoring portefeuille multi-sites : classement par potentiel de pilotage.
+
+`compute_portefeuille_scoring` agrège le score de potentiel pilotable (S22)
+sur N sites et produit :
+
+    1. Un classement Top-10 par score décroissant
+    2. Une heatmap par archétype (nb_sites, gain total EUR, score moyen)
+    3. Le gain annuel portefeuille (somme des gains estimés par site)
+
+Le gain annuel par site est une estimation :
+
+    gain_annuel_eur = puissance_pilotable_kw
+                    × heures_favorables_annuelles_par_archetype
+                    × spread_eur_par_kwh
+
+Calibrage Baromètre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026) :
+    - heures_favorables : nombre d'heures/an où un site de cet archétype peut
+      valoriser de la flexibilité (effacement HP, décalage HC, MA NEBEF...)
+    - spread : écart moyen HP/HC + MA + capacité par kWh pilotable
+
+Doctrine : "classement par potentiel de pilotage" (jamais "classement flex",
+ce dernier étant réservé au scoring mono-site S22).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from services.pilotage.score_potential import compute_potential_score
+
+
+# --- Paramètres calibrage gain annuel ---------------------------------------
+
+# Heures favorables annuelles par archétype (calibrage Baromètre Flex 2026).
+# Couvre : pointes HP hiver (~500h), plages MA NEBEF (~250h), réserve capacité
+# (~100h), décalages HC (~150h). Les archétypes 24/7 (logistique frigo, santé)
+# cumulent davantage de fenêtres activables.
+_HEURES_FAVORABLES_PAR_ARCHETYPE: dict[str, int] = {
+    "BUREAU_STANDARD": 900,
+    "COMMERCE_ALIMENTAIRE": 1400,  # froid 24/7 -> plus de fenêtres MA
+    "COMMERCE_SPECIALISE": 800,
+    "LOGISTIQUE_FRIGO": 1600,  # froid inertie -> gisement le plus large
+    "ENSEIGNEMENT": 700,
+    "SANTE": 600,  # contraintes médicales -> moins d'heures utilisables
+    "HOTELLERIE": 1100,
+    "INDUSTRIE_LEGERE": 1000,
+}
+
+# Spread moyen valorisable (EUR/kWh pilotable). Calibrage Baromètre Flex 2026 :
+# moyenne des gains constatés (HP-HC + rémunération NEBEF + capacité) sur les
+# sites tertiaires 2024. Valeur conservative, cohérente avec observatoire CRE.
+_SPREAD_EUR_PAR_KWH_DEFAULT = 0.08
+
+# Fallback si archétype inconnu : heures favorables médianes tertiaires.
+_FALLBACK_HEURES_FAVORABLES = 800
+
+# Fallback score quand archétype inconnu et compute_potential_score ne donne
+# pas de signal exploitable (sécurisation : cap à 50 pour éviter de prioriser
+# à tort des sites non qualifiés).
+_FALLBACK_SCORE = 50.0
+
+
+def _estimate_gain_annuel_eur(
+    archetype_code: Optional[str],
+    puissance_pilotable_kw: float,
+) -> float:
+    """
+    Estime le gain annuel valorisable pour un site donné.
+
+    Formule : kW × heures_favorables × spread EUR/kWh.
+
+    Args:
+        archetype_code : code canonique d'archétype (ex: "BUREAU_STANDARD").
+        puissance_pilotable_kw : puissance mobilisable en kW.
+
+    Returns:
+        Gain annuel estimé en EUR (arrondi à l'entier).
+    """
+    if puissance_pilotable_kw <= 0:
+        return 0.0
+    heures = _HEURES_FAVORABLES_PAR_ARCHETYPE.get(
+        archetype_code or "",
+        _FALLBACK_HEURES_FAVORABLES,
+    )
+    gain = puissance_pilotable_kw * heures * _SPREAD_EUR_PAR_KWH_DEFAULT
+    return round(gain)
+
+
+def _score_site(archetype_code: Optional[str]) -> float:
+    """
+    Calcule le score mono-site via compute_potential_score ; fallback 50 si
+    aucun signal calibré n'est exploitable.
+    """
+    result = compute_potential_score(archetype_code)
+    # Si l'archétype n'est pas calibré ET qu'on ne dispose d'aucun override,
+    # on garde le fallback 50 plutôt que la valeur heuristique (évite de
+    # prioriser à tort des sites mal qualifiés).
+    if not result.get("used_calibration") and not archetype_code:
+        return _FALLBACK_SCORE
+    return float(result["score"])
+
+
+def compute_portefeuille_scoring(sites: list[dict]) -> dict:
+    """
+    Classe un portefeuille de sites par potentiel de pilotage.
+
+    Args:
+        sites : liste de fiches site. Chaque fiche doit porter :
+            - site_id               : str
+            - archetype_code        : str ou None
+            - puissance_pilotable_kw: float (>= 0)
+
+    Returns:
+        dict avec :
+            - nb_sites_total                : int
+            - gain_annuel_portefeuille_eur  : int (somme des gains)
+            - top_10                        : list[dict] (site_id, archetype,
+                                               score, gain_annuel_eur, rang)
+            - heatmap_archetype             : dict archétype -> stats
+            - source                        : citation source
+    """
+    enriched: list[dict] = []
+    for site in sites:
+        site_id = site.get("site_id")
+        archetype = site.get("archetype_code")
+        puissance = float(site.get("puissance_pilotable_kw") or 0.0)
+
+        score = _score_site(archetype)
+        gain = _estimate_gain_annuel_eur(archetype, puissance)
+        enriched.append(
+            {
+                "site_id": site_id,
+                "archetype": archetype,
+                "score": score,
+                "gain_annuel_eur": gain,
+            }
+        )
+
+    # Classement décroissant par score, départage par gain puis site_id (stable).
+    enriched.sort(
+        key=lambda s: (-s["score"], -s["gain_annuel_eur"], s["site_id"] or ""),
+    )
+
+    # Top-10 avec rang séquentiel (1, 2, 3, ...)
+    top_10: list[dict] = []
+    for idx, row in enumerate(enriched[:10], start=1):
+        top_10.append({**row, "rang": idx})
+
+    # Heatmap par archétype : nb_sites, gain_total, score_moyen.
+    heatmap: dict[str, dict] = {}
+    for row in enriched:
+        key = row["archetype"] or "INCONNU"
+        bucket = heatmap.setdefault(
+            key,
+            {"nb_sites": 0, "gain_total_eur": 0, "score_sum": 0.0},
+        )
+        bucket["nb_sites"] += 1
+        bucket["gain_total_eur"] += row["gain_annuel_eur"]
+        bucket["score_sum"] += row["score"]
+
+    for bucket in heatmap.values():
+        nb = max(bucket["nb_sites"], 1)
+        bucket["score_moyen"] = round(bucket["score_sum"] / nb, 1)
+        bucket["gain_total_eur"] = round(bucket["gain_total_eur"])
+        del bucket["score_sum"]
+
+    gain_portefeuille = round(sum(row["gain_annuel_eur"] for row in enriched))
+
+    return {
+        "nb_sites_total": len(enriched),
+        "gain_annuel_portefeuille_eur": gain_portefeuille,
+        "top_10": top_10,
+        "heatmap_archetype": heatmap,
+        "source": "PROMEOS Pilotage Score — Baromètre Flex 2026 Enedis",
+    }

--- a/backend/services/pilotage/radar_prix_negatifs.py
+++ b/backend/services/pilotage/radar_prix_negatifs.py
@@ -1,0 +1,203 @@
+"""
+PROMEOS - Radar prix negatifs J+7 (Piste 1 V1 innovation).
+
+Contexte (Barometre Flex 2026) : 513h de prix spot negatifs en 2025 (+46% vs 2024).
+Les agregateurs voient H-1, PROMEOS doit voir J+7 grace a une prediction simple
+sur historique day-ahead FR.
+
+Approche MVP (sans ML) :
+    - Fenetre d'analyse : 90 derniers jours de MktPrice day-ahead zone FR.
+    - Pour chaque jour cible (J+1 a J+horizon), on regarde les memes jours de
+      la semaine (lun/mar/...) du meme mois dans l'historique.
+    - Si > 30 % des creneaux 10h-17h ont ete a prix negatif ce jour-semaine
+      la, on emet une fenetre "favorable probable".
+    - Probabilite = moyenne observee (part de creneaux negatifs dans la plage
+      10h-17h des jours semblables).
+    - Prix estime min = mediane des valeurs negatives observees (EUR/MWh).
+    - Usages recommandes = liste fixe (ecs, ve_recharge, pre_charge_froid)
+      calibree sur le Barometre Flex 2026.
+
+Fallback gracieux :
+    - < 30 jours d'historique => liste vide.
+    - Aucun creneau negatif historique => liste vide.
+
+Wording doctrine (cf. docs_ux_demo_strategy) : cote client on parle de
+"fenetre favorable probable" (pas "prix negatif") -- cette couche renvoie les
+donnees brutes, le front se charge du wording.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, time, timedelta, timezone
+from statistics import median
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from models.market_models import MarketType, MktPrice, PriceZone
+
+
+# Fuseau reference France (timestamps Europe/Paris aware cote sortie)
+_TZ_PARIS = ZoneInfo("Europe/Paris")
+
+# Fenetre historique analysee
+_HISTORY_DAYS = 90
+
+# Seuil minimum d'historique pour produire une prediction (fallback si < 30j)
+_MIN_HISTORY_DAYS = 30
+
+# Plage horaire etudiee (surplus PV midi -> debut apres-midi)
+_WINDOW_START_H = 10
+_WINDOW_END_H = 17  # exclusif cote hours 10..16 => 7 creneaux horaires
+
+# Seuil de recurrence : % creneaux negatifs parmi jours semblables pour emettre
+_NEG_SHARE_THRESHOLD = 0.30
+
+# Usages recommandes lorsqu'une fenetre favorable probable est detectee.
+# Calibre sur Barometre Flex 2026 (flex diffuse residentielle/tertiaire).
+_USAGES_RECOMMANDES = ["ecs", "ve_recharge", "pre_charge_froid"]
+
+
+def _to_paris(dt: datetime) -> datetime:
+    """Normalise un datetime en Europe/Paris (assume UTC si naif)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_TZ_PARIS)
+
+
+def predict_negative_windows(
+    horizon_days: int = 7,
+    db: Optional[Session] = None,
+    now: Optional[datetime] = None,
+) -> list[dict[str, Any]]:
+    """
+    Predit les fenetres J+1..J+horizon probables en prix negatif.
+
+    Parametres
+    ----------
+    horizon_days : int
+        Nombre de jours a projeter (1..14). Defaut 7.
+    db : Session
+        Session SQLAlchemy (requis pour lire MktPrice). Si None, retourne [].
+    now : datetime, optionnel
+        Injection d'horloge pour tests. Defaut : datetime.now(Europe/Paris).
+
+    Retour
+    ------
+    Liste de fenetres predites (dict) :
+        - datetime_debut : ISO 8601 Europe/Paris aware
+        - datetime_fin   : ISO 8601 Europe/Paris aware
+        - probabilite    : float dans [0, 1]
+        - prix_estime_min_eur_mwh : float (median des valeurs negatives)
+        - usages_recommandes : list[str]
+        - base_historique_jours  : int (nb de jours semblables observes)
+    """
+    if db is None:
+        return []
+
+    # Borne horizon de facon robuste (1..14)
+    horizon_days = max(1, min(int(horizon_days), 14))
+
+    now_paris = _to_paris(now) if now is not None else datetime.now(_TZ_PARIS)
+    today_paris = now_paris.date()
+    history_start_utc = (now_paris - timedelta(days=_HISTORY_DAYS)).astimezone(timezone.utc)
+
+    # -----------------------------------------------------------------
+    # 1) Chargement historique day-ahead FR sur 90 jours glissants.
+    # -----------------------------------------------------------------
+    rows = (
+        db.query(MktPrice)
+        .filter(
+            MktPrice.zone == PriceZone.FR,
+            MktPrice.market_type == MarketType.SPOT_DAY_AHEAD,
+            MktPrice.delivery_start >= history_start_utc,
+            MktPrice.delivery_start < now_paris.astimezone(timezone.utc),
+        )
+        .all()
+    )
+
+    if not rows:
+        return []
+
+    # -----------------------------------------------------------------
+    # 2) Regroupement par (weekday, month). Pour chaque paire on agrege :
+    #      - jours distincts observes (pour gate _MIN_HISTORY_DAYS),
+    #      - total de creneaux 10h-17h et nb negatifs,
+    #      - prix negatifs observes (pour mediane).
+    # -----------------------------------------------------------------
+    stats: dict[tuple[int, int], dict[str, Any]] = defaultdict(
+        lambda: {
+            "days": set(),
+            "slots_total": 0,
+            "slots_negative": 0,
+            "neg_prices": [],
+        }
+    )
+
+    for row in rows:
+        start_paris = _to_paris(row.delivery_start)
+        hour = start_paris.hour
+        if not (_WINDOW_START_H <= hour < _WINDOW_END_H):
+            continue
+        key = (start_paris.weekday(), start_paris.month)
+        bucket = stats[key]
+        bucket["days"].add(start_paris.date())
+        bucket["slots_total"] += 1
+        price = float(row.price_eur_mwh)
+        if price < 0:
+            bucket["slots_negative"] += 1
+            bucket["neg_prices"].append(price)
+
+    # Gate global : si l'historique couvre < 30 jours distincts => fallback vide
+    all_days: set = set()
+    for bucket in stats.values():
+        all_days.update(bucket["days"])
+    if len(all_days) < _MIN_HISTORY_DAYS:
+        return []
+
+    # -----------------------------------------------------------------
+    # 3) Projection J+1..J+horizon.
+    # -----------------------------------------------------------------
+    predictions: list[dict[str, Any]] = []
+    for offset in range(1, horizon_days + 1):
+        target_date = today_paris + timedelta(days=offset)
+        key = (target_date.weekday(), target_date.month)
+        bucket = stats.get(key)
+        if not bucket or bucket["slots_total"] == 0:
+            continue
+        neg_share = bucket["slots_negative"] / bucket["slots_total"]
+        if neg_share < _NEG_SHARE_THRESHOLD:
+            continue
+
+        # Prix estime : mediane des valeurs negatives (fallback -5 EUR/MWh)
+        if bucket["neg_prices"]:
+            prix_min = float(median(bucket["neg_prices"]))
+        else:
+            prix_min = -5.0
+
+        # Bornes fenetre prediction (Europe/Paris aware)
+        dt_debut = datetime.combine(
+            target_date,
+            time(hour=_WINDOW_START_H, minute=0),
+            tzinfo=_TZ_PARIS,
+        )
+        dt_fin = datetime.combine(
+            target_date,
+            time(hour=_WINDOW_END_H, minute=0),
+            tzinfo=_TZ_PARIS,
+        )
+
+        predictions.append(
+            {
+                "datetime_debut": dt_debut.isoformat(),
+                "datetime_fin": dt_fin.isoformat(),
+                "probabilite": round(min(max(neg_share, 0.0), 1.0), 3),
+                "prix_estime_min_eur_mwh": round(prix_min, 2),
+                "usages_recommandes": list(_USAGES_RECOMMANDES),
+                "base_historique_jours": len(bucket["days"]),
+            }
+        )
+
+    return predictions

--- a/backend/services/pilotage/roi_flex_ready.py
+++ b/backend/services/pilotage/roi_flex_ready.py
@@ -1,0 +1,195 @@
+"""
+PROMEOS - ROI Flex Ready (R) : business case chiffre par site.
+
+Cette brique complete `flex_ready.py` (conformite technique NF EN IEC 62746-4)
+en exposant le gain financier annuel estime pour un site Flex Ready (R) pilote.
+
+Elle repond a la seule question que les CFOs lisent :
+    "Combien ce site gagne-t-il par an a etre Flex Ready (R) + pilote ?"
+
+Trois composantes additives :
+
+    1. Gain evitement pointe
+        = (kW pilotable) x (heures pointe evitees / an) x (spread pointe EUR/MWh)
+        Les heures pointe evitees sont la somme des largeurs des plages
+        `plages_pointe_h` du calibrage Barometre Flex 2026, multipliees par
+        un facteur d'effacement realiste (% de jours ouvrables ou l'effacement
+        est reellement active).
+
+    2. Valorisation decalage NEBCO
+        = (kW decalable) x (heures fenetres favorables / an) x (spread moyen)
+        Hypothese : 200 h/an de fenetres favorables (surplus PV, prix negatifs
+        marginaux) avec spread moyen 60 EUR/MWh (Baro Flex 2026 + observatoire
+        CRE T4 2025 : 513 h negatives en 2025).
+
+    3. CEE BACS
+        = (surface m2) x (forfait CEE BAT-TH-116 EUR/m2)
+        Forfait 3,5 EUR/m2 (fiche CEE BAT-TH-116 "Systeme GTB" valorisation
+        moyenne 2025-2026, hypothese conservatrice au milieu de la fourchette
+        observee 2-5 EUR/m2 selon volume et cours du kWhc).
+
+Confiance : "indicative" — les 3 composantes sont des ordres de grandeur
+MVP, pas des engagements commerciaux. Les hypotheses sont toujours exposees
+dans la payload (explainability).
+
+Sources :
+    - Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026)
+    - Fiche CEE BAT-TH-116 (systeme GTB / BACS)
+    - Observatoire CRE T4 2025 (513 h prix negatifs France 2025)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from services.pilotage.constants import ARCHETYPE_CALIBRATION_2024
+
+
+# --- Hypotheses MVP (exposees dans la payload) -------------------------------
+
+# Fenetres annuelles favorables au decalage NEBCO (surplus PV, prix negatifs
+# marginaux, creux TURPE 7 favorables). Source : Barometre Flex 2026 + CRE T4 2025.
+HEURES_FENETRES_FAVORABLES_AN: int = 200
+
+# Spread moyen sur ces fenetres (EUR/MWh). Delta entre prix moyen et prix
+# bas lors des fenetres favorables. Hypothese MVP conservatrice.
+SPREAD_MOYEN_EUR_MWH: float = 60.0
+
+# Spread pointe vs plage creuse (EUR/MWh). Ordre de grandeur 2025-2026 : les
+# pointes hiver haute saison atteignent regulierement +120 EUR/MWh vs plage
+# de base (Observatoire CRE, Bulletin marches gros T4 2025). Hypothese MVP.
+SPREAD_POINTE_EUR_MWH: float = 120.0
+
+# Nombre de jours effectifs par an ou l'effacement pointe est realisable
+# (hors week-ends, jours feries, pannes GTB). ~200 jours ouvres typiques.
+JOURS_EFFACEMENT_PAR_AN: int = 200
+
+# Forfait CEE BAT-TH-116 (systeme GTB / BACS) en EUR/m2 de surface chauffee.
+# Fiche CEE standardisee, valorisation moyenne 2025-2026.
+CEE_BACS_EUR_M2: float = 3.5
+
+# Archetype par defaut quand l'archetype fourni est inconnu du calibrage.
+# BUREAU_STANDARD est le segment mediane / fallback le plus representatif.
+_DEFAULT_ARCHETYPE: str = "BUREAU_STANDARD"
+
+
+def _heures_pointe_par_jour(plages_pointe_h: list[tuple[int, int]]) -> int:
+    """
+    Somme des largeurs (en heures) des plages de pointe d'un archetype.
+
+    Convention `plages_pointe_h` : liste de tuples (h_debut, h_fin) avec
+    intervalle [h_debut, h_fin), donc largeur = h_fin - h_debut.
+    """
+    total = 0
+    for h_debut, h_fin in plages_pointe_h:
+        # Defense : si tuple inverse ou vide, contribution = 0 (pas d'erreur)
+        if h_fin > h_debut:
+            total += h_fin - h_debut
+    return total
+
+
+def compute_roi_flex_ready(
+    site_id: str,
+    demo_site: dict[str, Any],
+    archetype_code: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Calcule le gain annuel estime (EUR) pour un site Flex Ready (R) pilote.
+
+    Parametres
+    ----------
+    site_id : str
+        Identifiant canonique du site (ex. "retail-001").
+    demo_site : dict
+        Fiche site (DEMO_SITES) avec au minimum :
+            - puissance_max_instantanee_kw : float  (kW)
+            - surface_m2                   : float  (m2, default 0 si absent)
+            - archetype_code               : str    (optionnel, surcharge arg)
+    archetype_code : str | None
+        Code canonique d'archetype. Si None ou inconnu de
+        `ARCHETYPE_CALIBRATION_2024`, fallback sur BUREAU_STANDARD.
+
+    Retour
+    ------
+    dict avec :
+      - site_id                    : str
+      - archetype                  : str (archetype finalement utilise)
+      - gain_annuel_total_eur      : float (somme des 3 composantes, arrondie)
+      - composantes :
+          - evitement_pointe_eur   : float
+          - decalage_nebco_eur     : float
+          - cee_bacs_eur           : float
+      - hypotheses : dict (parametres MVP utilises, pour explainability)
+      - confiance  : "indicative"
+      - source     : citation courte Barometre Flex 2026 + fiche CEE
+    """
+    # 1. Resoudre l'archetype : priorite argument > fiche site > defaut.
+    resolved_code = archetype_code or demo_site.get("archetype_code") or _DEFAULT_ARCHETYPE
+    calib = ARCHETYPE_CALIBRATION_2024.get(resolved_code)
+    if calib is None:
+        # Archetype inconnu -> fallback BUREAU_STANDARD (toujours present)
+        resolved_code = _DEFAULT_ARCHETYPE
+        calib = ARCHETYPE_CALIBRATION_2024[_DEFAULT_ARCHETYPE]
+
+    p_max_kw = float(demo_site.get("puissance_max_instantanee_kw", 0.0))
+    surface_m2 = float(demo_site.get("surface_m2", 0.0))
+    taux_decalable = float(calib["taux_decalable_moyen"])
+    plages_pointe = calib["plages_pointe_h"]
+
+    # --- Composante 1 : evitement pointe --------------------------------
+    # kW pilotable = P max x taux decalable archetype
+    # Heures pointe / an = somme largeurs plages x jours effaces par an
+    # Gain EUR = kW pilotable x heures / an x spread EUR/MWh / 1000 (MWh->kWh)
+    kw_pilotable = p_max_kw * taux_decalable
+    heures_pointe_par_jour = _heures_pointe_par_jour(plages_pointe)
+    heures_pointe_evitees_an = heures_pointe_par_jour * JOURS_EFFACEMENT_PAR_AN
+    # Facteur d'effacement realiste : on ne peut effacer qu'une fraction des
+    # heures pointe (GTB active, contraintes metier). On prend 10% de la
+    # fenetre totale pointe x jours ouvres -- hypothese conservatrice MVP.
+    # Formule finale : kWh decales = kw_pilotable x (heures_pointe_evitees_an x 0.1)
+    #                 gain = kWh x spread / 1000
+    #
+    # NB : on garde la multiplication par 0.1 implicite dans le facteur
+    # "heures pointe evitees" pour la lisibilite de la formule cible du spec.
+    kwh_evites_an = kw_pilotable * heures_pointe_evitees_an * 0.1
+    evitement_pointe_eur = kwh_evites_an * SPREAD_POINTE_EUR_MWH / 1000.0
+
+    # --- Composante 2 : decalage NEBCO ----------------------------------
+    # kW decalable = P max x taux decalable archetype (meme hypothese)
+    # Heures fenetres favorables = 200 h/an (hypothese MVP)
+    # Gain EUR = kW decalable x heures x spread / 1000
+    kw_decalable = kw_pilotable  # meme assiette que le pilotable pointe
+    kwh_decales_an = kw_decalable * HEURES_FENETRES_FAVORABLES_AN
+    decalage_nebco_eur = kwh_decales_an * SPREAD_MOYEN_EUR_MWH / 1000.0
+
+    # --- Composante 3 : CEE BACS ----------------------------------------
+    # Forfait CEE BAT-TH-116 x surface m2. Si surface_m2 = 0 (non renseignee),
+    # composante = 0 (pas de gain estime), pas une erreur.
+    cee_bacs_eur = max(0.0, surface_m2) * CEE_BACS_EUR_M2
+
+    # --- Total ---------------------------------------------------------
+    gain_total = evitement_pointe_eur + decalage_nebco_eur + cee_bacs_eur
+
+    return {
+        "site_id": site_id,
+        "archetype": resolved_code,
+        "gain_annuel_total_eur": round(gain_total, 2),
+        "composantes": {
+            "evitement_pointe_eur": round(evitement_pointe_eur, 2),
+            "decalage_nebco_eur": round(decalage_nebco_eur, 2),
+            "cee_bacs_eur": round(cee_bacs_eur, 2),
+        },
+        "hypotheses": {
+            "heures_fenetres_favorables_an": HEURES_FENETRES_FAVORABLES_AN,
+            "spread_moyen_eur_mwh": SPREAD_MOYEN_EUR_MWH,
+            "spread_pointe_eur_mwh": SPREAD_POINTE_EUR_MWH,
+            "jours_effacement_par_an": JOURS_EFFACEMENT_PAR_AN,
+            "cee_bacs_eur_m2": CEE_BACS_EUR_M2,
+            "taux_decalable_archetype": taux_decalable,
+            "heures_pointe_par_jour_archetype": heures_pointe_par_jour,
+            "surface_m2": surface_m2,
+            "puissance_max_kw": p_max_kw,
+        },
+        "confiance": "indicative",
+        "source": "Barometre Flex 2026 RTE/Enedis + fiche CEE BAT-TH-116",
+    }

--- a/backend/tests/test_pilotage_portefeuille_scoring.py
+++ b/backend/tests/test_pilotage_portefeuille_scoring.py
@@ -25,6 +25,7 @@ from sqlalchemy.pool import StaticPool
 
 from database import get_db
 from main import app
+from middleware.auth import AuthContext, get_optional_auth
 from models import Base
 from services.pilotage.portefeuille_scoring import compute_portefeuille_scoring
 
@@ -225,3 +226,57 @@ def test_rangs_sequentiels():
         f"archetype None -> fallback score 50, obtenu {result_unknown['top_10'][0]['score']}"
     )
     assert result_unknown["top_10"][0]["rang"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 7 : auth avec org_id mais aucun site -> payload vide (pas DEMO)
+# ---------------------------------------------------------------------------
+def test_authenticated_user_without_sites_returns_empty(monkeypatch):
+    """
+    Fix P1 #2 audit PR #222 : un utilisateur authentifie avec org_id mais
+    site_ids vide ne doit PAS voir les donnees DEMO_SITES. Payload vide.
+
+    On s'assure aussi que PROMEOS_DEMO_MODE n'est pas "true" pour ce test
+    (sinon le fallback DEMO est autorise explicitement).
+    """
+    monkeypatch.delenv("PROMEOS_DEMO_MODE", raising=False)
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    def _override_db():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _fake_auth():
+        # Auth authentique avec org_id set mais site_ids vide (pilote pre-seed).
+        # user/user_org_role/role ne sont pas utilises par l'endpoint.
+        return AuthContext(
+            user=None,
+            user_org_role=None,
+            org_id=42,
+            role=None,
+            site_ids=[],
+        )
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_optional_auth] = _fake_auth
+    try:
+        c = TestClient(app, raise_server_exceptions=False)
+        r = c.get("/api/pilotage/portefeuille-scoring")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["nb_sites_total"] == 0
+        assert data["gain_annuel_portefeuille_eur"] == 0
+        assert data["top_10"] == []
+        assert data["heatmap_archetype"] == {}
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_pilotage_portefeuille_scoring.py
+++ b/backend/tests/test_pilotage_portefeuille_scoring.py
@@ -1,0 +1,227 @@
+"""
+PROMEOS - Tests scoring portefeuille multi-sites (Piste 3 V1).
+
+Couvre :
+    1. Top-10 trie par score decroissant
+    2. Heatmap archetype : nb_sites + gain_total coherents
+    3. Gain portefeuille = somme des gains top_10 (portefeuille <= 10 sites)
+    4. Endpoint /portefeuille-scoring : 200 + schema Pydantic valide
+    5. Portefeuille vide -> nb=0, gain=0, top_10=[]
+    6. Rangs sequentiels (1, 2, 3, ...)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from database import get_db
+from main import app
+from models import Base
+from services.pilotage.portefeuille_scoring import compute_portefeuille_scoring
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def client():
+    """TestClient avec DB SQLite in-memory — isolation totale."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    def _override():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    os.environ["PROMEOS_DEMO_MODE"] = "true"
+    app.dependency_overrides[get_db] = _override
+    c = TestClient(app, raise_server_exceptions=False)
+    yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def sample_portfolio() -> list[dict]:
+    """Portefeuille test de 3 sites, archetypes calibrés Baromètre Flex 2026."""
+    return [
+        {
+            "site_id": "retail-001",
+            "archetype_code": "COMMERCE_ALIMENTAIRE",
+            "puissance_pilotable_kw": 220.0,
+        },
+        {
+            "site_id": "bureau-001",
+            "archetype_code": "BUREAU_STANDARD",
+            "puissance_pilotable_kw": 120.0,
+        },
+        {
+            "site_id": "entrepot-001",
+            "archetype_code": "LOGISTIQUE_FRIGO",
+            "puissance_pilotable_kw": 85.0,
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test 1 : Top-10 trie par score decroissant
+# ---------------------------------------------------------------------------
+def test_top10_trie_score_decroissant(sample_portfolio):
+    result = compute_portefeuille_scoring(sample_portfolio)
+    top = result["top_10"]
+    assert len(top) == 3, "portefeuille 3 sites -> top_10 contient 3 lignes"
+    scores = [row["score"] for row in top]
+    assert scores == sorted(scores, reverse=True), f"top_10 doit etre trie par score DESC, obtenu {scores}"
+    # Sanity check calibrage : COMMERCE_ALIMENTAIRE et LOGISTIQUE_FRIGO ont
+    # les plus hauts taux_decalable (0.45 / 0.55) donc scorent > BUREAU_STANDARD.
+    archetypes_order = [row["archetype"] for row in top]
+    assert archetypes_order[-1] == "BUREAU_STANDARD", f"BUREAU_STANDARD doit etre dernier, ordre : {archetypes_order}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 : Heatmap archetype agrege correctement
+# ---------------------------------------------------------------------------
+def test_heatmap_agregation(sample_portfolio):
+    result = compute_portefeuille_scoring(sample_portfolio)
+    heatmap = result["heatmap_archetype"]
+
+    assert set(heatmap.keys()) == {
+        "COMMERCE_ALIMENTAIRE",
+        "BUREAU_STANDARD",
+        "LOGISTIQUE_FRIGO",
+    }
+
+    for archetype, bucket in heatmap.items():
+        assert bucket["nb_sites"] == 1, f"{archetype}: 1 site attendu, obtenu {bucket['nb_sites']}"
+        assert bucket["gain_total_eur"] > 0
+        assert 0.0 <= bucket["score_moyen"] <= 100.0
+
+    # Portefeuille dupliqué → aggregation cumulative
+    doubled = sample_portfolio + [
+        {
+            "site_id": "bureau-002",
+            "archetype_code": "BUREAU_STANDARD",
+            "puissance_pilotable_kw": 60.0,
+        }
+    ]
+    result2 = compute_portefeuille_scoring(doubled)
+    assert result2["heatmap_archetype"]["BUREAU_STANDARD"]["nb_sites"] == 2
+    # gain cumulé = gain 120 kW + gain 60 kW, mêmes heures/spread
+    gain_cumulatif = result2["heatmap_archetype"]["BUREAU_STANDARD"]["gain_total_eur"]
+    assert gain_cumulatif == pytest.approx(
+        result["heatmap_archetype"]["BUREAU_STANDARD"]["gain_total_eur"] + round(60.0 * 900 * 0.08)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 : Gain portefeuille = somme des gains top_10
+# ---------------------------------------------------------------------------
+def test_gain_portefeuille_somme_top10(sample_portfolio):
+    """Pour un portefeuille <= 10 sites, gain_portefeuille == sum(top_10)."""
+    result = compute_portefeuille_scoring(sample_portfolio)
+    somme_top = sum(row["gain_annuel_eur"] for row in result["top_10"])
+    assert result["gain_annuel_portefeuille_eur"] == pytest.approx(somme_top)
+    # Somme > 0 puisque les 3 sites ont puissance_pilotable > 0
+    assert result["gain_annuel_portefeuille_eur"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Test 4 : Endpoint retourne 200 + schema Pydantic
+# ---------------------------------------------------------------------------
+def test_endpoint_retourne_200_et_schema_valide(client):
+    r = client.get("/api/pilotage/portefeuille-scoring")
+    assert r.status_code == 200, f"HTTP {r.status_code}: {r.text}"
+    data = r.json()
+
+    # Schema top-level
+    assert data["nb_sites_total"] == 3
+    assert data["gain_annuel_portefeuille_eur"] > 0
+    assert isinstance(data["top_10"], list)
+    assert len(data["top_10"]) == 3
+    assert "Baromètre Flex 2026" in data["source"]
+
+    # Chaque ligne top_10 a les bons champs + bornes
+    for row in data["top_10"]:
+        assert set(row.keys()) >= {
+            "site_id",
+            "archetype",
+            "score",
+            "gain_annuel_eur",
+            "rang",
+        }
+        assert 0.0 <= row["score"] <= 100.0
+        assert row["gain_annuel_eur"] >= 0.0
+        assert row["rang"] >= 1
+
+    # Heatmap : 1 entree par archetype demo
+    assert set(data["heatmap_archetype"].keys()) == {
+        "COMMERCE_ALIMENTAIRE",
+        "BUREAU_STANDARD",
+        "LOGISTIQUE_FRIGO",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 5 : Portefeuille vide -> payload zero-consistent
+# ---------------------------------------------------------------------------
+def test_portefeuille_vide():
+    result = compute_portefeuille_scoring([])
+    assert result["nb_sites_total"] == 0
+    assert result["gain_annuel_portefeuille_eur"] == 0
+    assert result["top_10"] == []
+    assert result["heatmap_archetype"] == {}
+    assert "Baromètre Flex 2026" in result["source"]
+
+
+# ---------------------------------------------------------------------------
+# Test 6 : Rangs sequentiels (1, 2, 3, ...)
+# ---------------------------------------------------------------------------
+def test_rangs_sequentiels():
+    """top_10 doit porter des rangs 1..N sans trou."""
+    # 12 sites pour vérifier qu'on capte bien seulement les 10 premiers
+    sites = [
+        {
+            "site_id": f"s-{i:03d}",
+            "archetype_code": "BUREAU_STANDARD",
+            "puissance_pilotable_kw": 50.0 + i,  # gain croissant par site_id
+        }
+        for i in range(12)
+    ]
+    result = compute_portefeuille_scoring(sites)
+    top = result["top_10"]
+    assert len(top) == 10, "top_10 plafonne à 10 lignes"
+    rangs = [row["rang"] for row in top]
+    assert rangs == list(range(1, 11)), f"rangs doivent etre 1..10, obtenu {rangs}"
+
+    # nb_sites_total = tous (12), pas seulement le top_10
+    assert result["nb_sites_total"] == 12
+
+    # Fallback archetype INCONNU = pas d'archetype -> fallback 50
+    sites_inconnu = [
+        {
+            "site_id": "s-unknown",
+            "archetype_code": None,
+            "puissance_pilotable_kw": 100.0,
+        }
+    ]
+    result_unknown = compute_portefeuille_scoring(sites_inconnu)
+    assert result_unknown["top_10"][0]["score"] == pytest.approx(50.0), (
+        f"archetype None -> fallback score 50, obtenu {result_unknown['top_10'][0]['score']}"
+    )
+    assert result_unknown["top_10"][0]["rang"] == 1

--- a/backend/tests/test_pilotage_radar_prix_negatifs.py
+++ b/backend/tests/test_pilotage_radar_prix_negatifs.py
@@ -1,0 +1,242 @@
+"""
+PROMEOS - Tests Radar prix negatifs J+7 (Piste 1 V1 innovation).
+
+Couvre :
+    1. Endpoint horizon par defaut = 7 jours.
+    2. Fallback gracieux : aucune donnee historique => liste vide.
+    3. Probabilite toujours dans [0, 1].
+    4. Timestamps ISO 8601 aware Europe/Paris.
+    5. Endpoint repond 200 et le payload respecte le schema Pydantic.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from database import get_db
+from main import app
+from models import Base
+from models.market_models import (
+    MarketDataSource,
+    MarketType,
+    MktPrice,
+    PriceZone,
+    ProductType,
+    Resolution,
+)
+from services.pilotage.radar_prix_negatifs import predict_negative_windows
+
+
+_TZ_PARIS = ZoneInfo("Europe/Paris")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def isolated_session():
+    """Session DB SQLite in-memory isolee (sans override FastAPI)."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def client():
+    """TestClient FastAPI + DB in-memory dediee."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    def _override():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    c = TestClient(app, raise_server_exceptions=False)
+    # Expose la factory pour que les tests puissent seeder la meme DB.
+    c.session_factory = SessionLocal  # type: ignore[attr-defined]
+    yield c
+    app.dependency_overrides.clear()
+
+
+def _seed_history(
+    db,
+    *,
+    now: datetime,
+    days: int = 60,
+    neg_share_in_window: float = 0.7,
+) -> None:
+    """
+    Seed `days` jours d'historique day-ahead FR : pour chaque jour, 24 points
+    horaires dont une fraction `neg_share_in_window` est negative dans la
+    fenetre 10h-17h (les autres heures sont neutres positives).
+    """
+    rows: list[MktPrice] = []
+    for d in range(1, days + 1):
+        day = now - timedelta(days=d)
+        for h in range(24):
+            delivery_start = datetime(day.year, day.month, day.day, h, 0, tzinfo=timezone.utc)
+            delivery_end = delivery_start + timedelta(hours=1)
+            if 10 <= h < 17:
+                # On force une part negative dans la fenetre etudiee
+                price = -20.0 if (h - 10) / 7.0 < neg_share_in_window else 45.0
+            else:
+                price = 60.0
+            rows.append(
+                MktPrice(
+                    source=MarketDataSource.ENTSOE,
+                    market_type=MarketType.SPOT_DAY_AHEAD,
+                    product_type=ProductType.HOURLY,
+                    zone=PriceZone.FR,
+                    delivery_start=delivery_start,
+                    delivery_end=delivery_end,
+                    price_eur_mwh=price,
+                    resolution=Resolution.PT60M,
+                    fetched_at=datetime.now(timezone.utc),
+                )
+            )
+    db.add_all(rows)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Test 1 : endpoint horizon par defaut = 7 jours
+# ---------------------------------------------------------------------------
+def test_radar_horizon_default_7j(client):
+    """L'endpoint sans parametre doit utiliser horizon_jours = 7."""
+    r = client.get("/api/pilotage/radar-prix-negatifs")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["horizon_jours"] == 7
+    assert "fenetres_predites" in data
+    assert isinstance(data["fenetres_predites"], list)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 : pas de crash si aucune donnee historique => liste vide
+# ---------------------------------------------------------------------------
+def test_radar_no_history_returns_empty(isolated_session):
+    """Sans donnees MktPrice en DB, la prediction doit etre vide (pas de crash)."""
+    result = predict_negative_windows(horizon_days=7, db=isolated_session)
+    assert result == []
+
+
+def test_radar_history_too_short_returns_empty(isolated_session):
+    """Avec < 30 jours d'historique, fallback gracieux = liste vide."""
+    now_utc = datetime.now(timezone.utc)
+    _seed_history(isolated_session, now=now_utc, days=10, neg_share_in_window=0.9)
+    result = predict_negative_windows(horizon_days=7, db=isolated_session)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Test 3 : probabilite dans [0, 1]
+# ---------------------------------------------------------------------------
+def test_radar_probabilite_entre_0_et_1(isolated_session):
+    """Toute fenetre retournee a une probabilite dans [0, 1]."""
+    now_utc = datetime.now(timezone.utc)
+    _seed_history(isolated_session, now=now_utc, days=60, neg_share_in_window=0.8)
+    windows = predict_negative_windows(horizon_days=7, db=isolated_session)
+    assert len(windows) > 0, "Avec 60j d'historique fortement negatif on attend des fenetres"
+    for w in windows:
+        assert 0.0 <= w["probabilite"] <= 1.0
+        assert isinstance(w["base_historique_jours"], int)
+        assert w["base_historique_jours"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test 4 : timestamps ISO 8601 aware Europe/Paris
+# ---------------------------------------------------------------------------
+def test_radar_timestamps_iso_europe_paris(isolated_session):
+    """Les datetime retournes doivent etre ISO 8601 avec offset Europe/Paris."""
+    now_utc = datetime.now(timezone.utc)
+    _seed_history(isolated_session, now=now_utc, days=60, neg_share_in_window=0.8)
+    windows = predict_negative_windows(horizon_days=7, db=isolated_session)
+    assert windows, "Prerequis : au moins une fenetre predite"
+    for w in windows:
+        # Parse strict des ISO 8601
+        dt_debut = datetime.fromisoformat(w["datetime_debut"])
+        dt_fin = datetime.fromisoformat(w["datetime_fin"])
+        # Doivent etre tz-aware
+        assert dt_debut.tzinfo is not None
+        assert dt_fin.tzinfo is not None
+        # Offset Europe/Paris : +01:00 (hiver) ou +02:00 (ete)
+        offset_h = dt_debut.utcoffset().total_seconds() / 3600.0
+        assert offset_h in (1.0, 2.0), f"Offset inattendu : {offset_h}"
+        # Debut avant fin
+        assert dt_debut < dt_fin
+        # Plage 10h-17h Europe/Paris
+        assert dt_debut.astimezone(_TZ_PARIS).hour == 10
+        assert dt_fin.astimezone(_TZ_PARIS).hour == 17
+
+
+# ---------------------------------------------------------------------------
+# Test 5 : endpoint 200 + schema Pydantic conforme
+# ---------------------------------------------------------------------------
+def test_radar_endpoint_200_et_schema(client):
+    """L'endpoint repond 200 et le payload matche RadarPrixNegatifsResponse."""
+    # Seed historique dans la meme DB que celle bindee au client
+    SessionLocal = client.session_factory  # type: ignore[attr-defined]
+    db = SessionLocal()
+    try:
+        _seed_history(db, now=datetime.now(timezone.utc), days=60, neg_share_in_window=0.8)
+    finally:
+        db.close()
+
+    r = client.get("/api/pilotage/radar-prix-negatifs?horizon_days=7")
+    assert r.status_code == 200
+    data = r.json()
+
+    # Schema racine
+    assert set(data.keys()) >= {
+        "fenetres_predites",
+        "horizon_jours",
+        "source",
+        "confiance",
+    }
+    assert data["horizon_jours"] == 7
+    assert data["source"] == "historique_entsoe_90j"
+    assert data["confiance"] == "indicative"
+
+    # Schema fenetre (si non-vide)
+    for w in data["fenetres_predites"]:
+        assert set(w.keys()) >= {
+            "datetime_debut",
+            "datetime_fin",
+            "probabilite",
+            "prix_estime_min_eur_mwh",
+            "usages_recommandes",
+            "base_historique_jours",
+        }
+        assert 0.0 <= w["probabilite"] <= 1.0
+        assert isinstance(w["usages_recommandes"], list)
+        assert w["usages_recommandes"], "usages_recommandes ne doit pas etre vide"

--- a/backend/tests/test_pilotage_roi_flex_ready.py
+++ b/backend/tests/test_pilotage_roi_flex_ready.py
@@ -1,0 +1,166 @@
+"""
+PROMEOS - Tests endpoint ROI Flex Ready (R) (Piste 2 V1 innovation).
+
+Couvre :
+    1. Gain total = somme des 3 composantes
+    2. Composantes toutes >= 0 (pas de gain negatif)
+    3. 404 si site absent de DEMO_SITES
+    4. Archetype inconnu -> fallback BUREAU_STANDARD
+    5. CEE = surface_m2 x 3,5 EUR/m2
+    6. Endpoint retourne un schema Pydantic valide (RoiFlexReadyResponse)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from database import get_db
+from main import app
+from models import Base
+from routes.pilotage import DEMO_SITES, RoiFlexReadyResponse
+from services.pilotage.roi_flex_ready import (
+    CEE_BACS_EUR_M2,
+    compute_roi_flex_ready,
+)
+
+
+@pytest.fixture
+def client():
+    """TestClient avec DB SQLite in-memory -- isolation totale."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    def _override():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    c = TestClient(app, raise_server_exceptions=False)
+    yield c
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 1 : gain total = somme des 3 composantes
+# ---------------------------------------------------------------------------
+def test_roi_gain_total_est_somme_composantes():
+    """Le gain annuel total doit etre la somme exacte des 3 composantes."""
+    ctx = DEMO_SITES["retail-001"]
+    result = compute_roi_flex_ready(
+        site_id="retail-001",
+        demo_site=ctx,
+        archetype_code="COMMERCE_ALIMENTAIRE",
+    )
+    composantes = result["composantes"]
+    somme = composantes["evitement_pointe_eur"] + composantes["decalage_nebco_eur"] + composantes["cee_bacs_eur"]
+    # Les 3 composantes et le total sont arrondis a 2 decimales.
+    # L'egalite peut porter une erreur d'arrondi < 0.01 ; on tolere ce delta.
+    assert abs(result["gain_annuel_total_eur"] - round(somme, 2)) < 0.02
+
+
+# ---------------------------------------------------------------------------
+# Test 2 : toutes les composantes sont >= 0
+# ---------------------------------------------------------------------------
+def test_roi_composantes_toutes_positives_ou_zero():
+    """Aucune composante ne peut etre negative (garde-fou sanity)."""
+    for site_id, ctx in DEMO_SITES.items():
+        result = compute_roi_flex_ready(
+            site_id=site_id,
+            demo_site=ctx,
+            archetype_code=ctx.get("archetype_code"),
+        )
+        for name, value in result["composantes"].items():
+            assert value >= 0, f"{site_id}/{name} negatif : {value}"
+        assert result["gain_annuel_total_eur"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Test 3 : site inconnu -> 404
+# ---------------------------------------------------------------------------
+def test_roi_site_inconnu_retourne_404(client):
+    """Un site_id absent de DEMO_SITES doit renvoyer 404 avec message explicite."""
+    r = client.get("/api/pilotage/roi-flex-ready/inexistant-999")
+    assert r.status_code == 404
+    payload = r.json()
+    # Tolerance sur le format d'erreur (APIError vs detail brut).
+    msg = payload.get("detail") or payload.get("message") or ""
+    assert "inexistant-999" in msg, f"Payload 404 inattendu : {payload!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 : archetype inconnu -> fallback BUREAU_STANDARD
+# ---------------------------------------------------------------------------
+def test_roi_archetype_inconnu_fallback_bureau_standard():
+    """Un archetype_code inconnu doit retomber sur BUREAU_STANDARD, pas crasher."""
+    ctx = dict(DEMO_SITES["bureau-001"])
+    result = compute_roi_flex_ready(
+        site_id="bureau-001",
+        demo_site=ctx,
+        archetype_code="ARCHETYPE_FANTAISISTE_XYZ",
+    )
+    assert result["archetype"] == "BUREAU_STANDARD"
+    # Les 3 composantes doivent etre calculees avec le calibrage BUREAU_STANDARD
+    assert result["composantes"]["evitement_pointe_eur"] > 0
+    assert result["composantes"]["decalage_nebco_eur"] > 0
+    assert result["composantes"]["cee_bacs_eur"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5 : CEE = m2 x 3,5
+# ---------------------------------------------------------------------------
+def test_roi_cee_bacs_formule():
+    """La composante CEE doit valoir surface_m2 x CEE_BACS_EUR_M2 (3,5)."""
+    ctx = DEMO_SITES["retail-001"]
+    result = compute_roi_flex_ready(
+        site_id="retail-001",
+        demo_site=ctx,
+        archetype_code="COMMERCE_ALIMENTAIRE",
+    )
+    surface = float(ctx["surface_m2"])
+    attendu = round(surface * CEE_BACS_EUR_M2, 2)
+    assert result["composantes"]["cee_bacs_eur"] == attendu
+    # Sanity : retail-001 = 2500 m2 * 3,5 = 8750 EUR
+    assert result["composantes"]["cee_bacs_eur"] == 8750.0
+
+
+# ---------------------------------------------------------------------------
+# Test 6 : endpoint retourne un schema Pydantic valide
+# ---------------------------------------------------------------------------
+def test_roi_endpoint_schema_pydantic_valide(client):
+    """L'endpoint doit retourner un payload conforme a RoiFlexReadyResponse."""
+    r = client.get("/api/pilotage/roi-flex-ready/retail-001")
+    assert r.status_code == 200, f"Status inattendu : {r.status_code} -- {r.text}"
+    data = r.json()
+
+    # Validation Pydantic explicite : erreur d'assertion claire en cas de derive schema.
+    parsed = RoiFlexReadyResponse.model_validate(data)
+    assert parsed.site_id == "retail-001"
+    assert parsed.archetype == "COMMERCE_ALIMENTAIRE"
+    assert parsed.gain_annuel_total_eur > 0
+    assert parsed.confiance == "indicative"
+    assert "Barometre Flex 2026" in parsed.source
+    # Les 3 composantes doivent etre presentes
+    assert parsed.composantes.evitement_pointe_eur >= 0
+    assert parsed.composantes.decalage_nebco_eur >= 0
+    assert parsed.composantes.cee_bacs_eur >= 0
+    # Hypotheses doivent exposer les parametres MVP attendus
+    assert parsed.hypotheses["cee_bacs_eur_m2"] == CEE_BACS_EUR_M2
+    assert parsed.hypotheses["heures_fenetres_favorables_an"] == 200
+    assert parsed.hypotheses["spread_moyen_eur_mwh"] == 60

--- a/frontend/src/components/pilotage/PortefeuilleScoringCard.jsx
+++ b/frontend/src/components/pilotage/PortefeuilleScoringCard.jsx
@@ -1,0 +1,175 @@
+/**
+ * PortefeuilleScoringCard - Pilotage V1.
+ *
+ * Classement portefeuille multi-sites par potentiel de pilotage.
+ * Top-5 + mini-heatmap agregee par archetype.
+ *
+ * Source : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
+ */
+import { useEffect, useState } from 'react';
+import { getPortefeuilleScoring } from '../../services/api/pilotage';
+import { Skeleton, InfoTip } from '../../ui';
+
+function fmtEuro(n) {
+  if (n == null) return '—';
+  return Number(n).toLocaleString('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  });
+}
+
+function scoreBand(s) {
+  if (s >= 75) return 'bg-emerald-500';
+  if (s >= 55) return 'bg-amber-500';
+  if (s >= 35) return 'bg-orange-500';
+  return 'bg-gray-300';
+}
+
+function heatIntensity(gainTotal, maxGain) {
+  if (!maxGain || maxGain <= 0) return 'bg-gray-50';
+  const r = gainTotal / maxGain;
+  if (r > 0.66) return 'bg-indigo-500 text-white';
+  if (r > 0.33) return 'bg-indigo-300 text-indigo-900';
+  return 'bg-indigo-100 text-indigo-800';
+}
+
+export default function PortefeuilleScoringCard() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    getPortefeuilleScoring()
+      .then((d) => {
+        if (!cancel) setData(d);
+      })
+      .catch(() => {
+        if (!cancel) setError(true);
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div
+        className="bg-white border border-gray-200 rounded-xl p-4"
+        data-testid="pilotage-portefeuille-card"
+      >
+        <Skeleton className="h-5 w-48 mb-3" />
+        <Skeleton className="h-24 rounded mb-3" />
+        <Skeleton className="h-12 rounded" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div
+        className="bg-white border border-gray-200 rounded-xl p-4"
+        data-testid="pilotage-portefeuille-card"
+      >
+        <h3 className="text-sm font-semibold text-gray-800 mb-2">Classement portefeuille</h3>
+        <p className="text-xs text-gray-500">Scoring portefeuille temporairement indisponible.</p>
+      </div>
+    );
+  }
+
+  const {
+    nb_sites_total,
+    gain_annuel_portefeuille_eur,
+    top_10 = [],
+    heatmap_archetype = {},
+  } = data;
+  const top5 = top_10.slice(0, 5);
+  const archetypes = Object.entries(heatmap_archetype).sort(
+    (a, b) => (b[1]?.gain_total_eur || 0) - (a[1]?.gain_total_eur || 0)
+  );
+  const maxArchGain = archetypes.reduce((acc, [, v]) => Math.max(acc, v?.gain_total_eur || 0), 0);
+
+  return (
+    <div
+      className="bg-white border border-gray-200 rounded-xl p-4 flex flex-col gap-3"
+      data-testid="pilotage-portefeuille-card"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-800">Classement portefeuille</h3>
+          <p className="text-[11px] text-gray-500 mt-0.5">
+            Sites à prioriser par potentiel de pilotage
+          </p>
+        </div>
+        <div className="text-right">
+          <div className="text-[10px] text-gray-400 uppercase tracking-wide">Budget flex</div>
+          <div className="text-sm font-bold text-gray-900 whitespace-nowrap">
+            {fmtEuro(gain_annuel_portefeuille_eur)}/an
+          </div>
+        </div>
+      </div>
+
+      {top5.length === 0 ? (
+        <p className="text-xs text-gray-500">Aucun site scopé pour l'instant.</p>
+      ) : (
+        <ol className="space-y-1.5">
+          {top5.map((site) => (
+            <li
+              key={site.site_id}
+              className="flex items-center gap-2 text-xs"
+              data-testid={`portefeuille-row-${site.site_id}`}
+            >
+              <span className="w-5 text-[10px] text-gray-400 font-medium">#{site.rang}</span>
+              <span className="flex-1 min-w-0 truncate text-gray-800">{site.site_id}</span>
+              <span className="text-[10px] text-gray-500 truncate max-w-[90px]">
+                {site.archetype || '—'}
+              </span>
+              <div className="w-20 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                <div
+                  className={`h-full ${scoreBand(site.score)} rounded-full`}
+                  style={{ width: `${Math.max(2, Math.round(site.score))}%` }}
+                />
+              </div>
+              <span className="w-16 text-right text-gray-900 font-medium whitespace-nowrap">
+                {fmtEuro(site.gain_annuel_eur)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {archetypes.length > 0 && (
+        <div>
+          <div className="text-[10px] text-gray-500 uppercase tracking-wide mb-1 flex items-center gap-1">
+            Heatmap archétype <InfoTip content="Intensité = gain annuel total par archétype" />
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {archetypes.map(([code, agg]) => (
+              <span
+                key={code}
+                className={`text-[10px] px-2 py-0.5 rounded ${heatIntensity(
+                  agg?.gain_total_eur || 0,
+                  maxArchGain
+                )}`}
+                title={`${agg?.nb_sites || 0} site(s) · score moyen ${Math.round(
+                  agg?.score_moyen || 0
+                )}`}
+              >
+                {code} · {fmtEuro(agg?.gain_total_eur)}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="text-[10px] text-gray-400 mt-auto pt-1 border-t border-gray-100">
+        {nb_sites_total} site(s) · {data.source || 'Baromètre Flex 2026'}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/pilotage/RadarPrixNegatifsCard.jsx
+++ b/frontend/src/components/pilotage/RadarPrixNegatifsCard.jsx
@@ -1,0 +1,156 @@
+/**
+ * RadarPrixNegatifsCard - Pilotage V1.
+ *
+ * Fenetres favorables probables a J+7. Wording doctrine cote client :
+ * "fenetre favorable probable" (pas "prix negatif").
+ *
+ * Source : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
+ */
+import { useEffect, useState } from 'react';
+import { getRadarPrixNegatifs } from '../../services/api/pilotage';
+import { Skeleton, InfoTip } from '../../ui';
+
+const WEEKDAY = ['dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam'];
+
+function formatDateTime(iso) {
+  if (!iso) return '—';
+  try {
+    const d = new Date(iso);
+    return `${WEEKDAY[d.getDay()]} ${String(d.getDate()).padStart(2, '0')}/${String(
+      d.getMonth() + 1
+    ).padStart(2, '0')} · ${String(d.getHours()).padStart(2, '0')}h`;
+  } catch {
+    return iso;
+  }
+}
+
+function formatRange(debut, fin) {
+  if (!debut || !fin) return '—';
+  try {
+    const a = new Date(debut);
+    const b = new Date(fin);
+    return `${WEEKDAY[a.getDay()]} ${String(a.getDate()).padStart(2, '0')}/${String(
+      a.getMonth() + 1
+    ).padStart(2, '0')} · ${String(a.getHours()).padStart(2, '0')}h–${String(b.getHours()).padStart(
+      2,
+      '0'
+    )}h`;
+  } catch {
+    return `${debut} → ${fin}`;
+  }
+}
+
+const USAGE_LABEL = {
+  ecs: 'ECS',
+  ve_recharge: 'Recharge VE',
+  pre_charge_froid: 'Pré-charge froid',
+};
+
+export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    getRadarPrixNegatifs(horizonDays)
+      .then((d) => {
+        if (!cancel) setData(d);
+      })
+      .catch(() => {
+        if (!cancel) setError(true);
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [horizonDays]);
+
+  if (loading) {
+    return (
+      <div
+        className="bg-white border border-gray-200 rounded-xl p-4"
+        data-testid="pilotage-radar-card"
+      >
+        <Skeleton className="h-5 w-56 mb-3" />
+        <Skeleton className="h-20 rounded" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className="bg-white border border-gray-200 rounded-xl p-4"
+        data-testid="pilotage-radar-card"
+      >
+        <h3 className="text-sm font-semibold text-gray-800 mb-2">Radar fenêtres favorables</h3>
+        <p className="text-xs text-gray-500">Signal temporairement indisponible.</p>
+      </div>
+    );
+  }
+
+  const fenetres = data?.fenetres_predites || [];
+  const emptyMsg =
+    'Historique insuffisant ou aucune récurrence détectée sur l’horizon demandé. Revenez demain.';
+
+  return (
+    <div
+      className="bg-white border border-gray-200 rounded-xl p-4 flex flex-col gap-3"
+      data-testid="pilotage-radar-card"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-800">Radar fenêtres favorables</h3>
+          <p className="text-[11px] text-gray-500 mt-0.5">
+            Probabilité de créneaux à prix effondrés dans les {data?.horizon_jours ?? horizonDays}{' '}
+            jours.
+          </p>
+        </div>
+        <span className="inline-flex items-center gap-1 bg-emerald-50 text-emerald-700 text-[10px] font-medium px-2 py-0.5 rounded-full whitespace-nowrap">
+          Anticipation J+{data?.horizon_jours ?? horizonDays}
+        </span>
+      </div>
+
+      {fenetres.length === 0 ? (
+        <p className="text-xs text-gray-500">{emptyMsg}</p>
+      ) : (
+        <ul className="space-y-2">
+          {fenetres.slice(0, 4).map((f, idx) => (
+            <li
+              key={`${f.datetime_debut}-${idx}`}
+              className="flex items-center justify-between gap-3 text-xs border border-gray-100 rounded-lg px-2.5 py-2"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="font-medium text-gray-900">
+                  {formatRange(f.datetime_debut, f.datetime_fin)}
+                </div>
+                <div className="text-[10px] text-gray-500 mt-0.5">
+                  {(f.usages_recommandes || []).map((u) => USAGE_LABEL[u] || u).join(' · ') ||
+                    'Décaler les usages flexibles'}
+                </div>
+              </div>
+              <div className="text-right whitespace-nowrap">
+                <div className="text-sm font-semibold text-emerald-700">
+                  {Math.round((f.probabilite || 0) * 100)}%
+                </div>
+                <div className="text-[10px] text-gray-400">probable</div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex items-center justify-between text-[10px] text-gray-400 mt-auto pt-1 border-t border-gray-100">
+        <span>
+          Source : historique marché 90 j{' '}
+          <InfoTip content="Baromètre Flex 2026 RTE/Enedis/GIMELEC" />
+        </span>
+        <span className="uppercase tracking-wide">{data?.confiance || 'indicative'}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/pilotage/RoiFlexReadyCard.jsx
+++ b/frontend/src/components/pilotage/RoiFlexReadyCard.jsx
@@ -1,0 +1,154 @@
+/**
+ * RoiFlexReadyCard - Pilotage V1.
+ *
+ * Gain annuel estime Flex Ready(R) pour le site courant.
+ * 3 composantes : evitement pointe + decalage NEBCO + CEE BAT-TH-116.
+ *
+ * Sources : Barometre Flex 2026 (RTE/Enedis/GIMELEC), fiche CEE BAT-TH-116.
+ */
+import { useEffect, useState } from 'react';
+import { getRoiFlexReady } from '../../services/api/pilotage';
+import { Skeleton, InfoTip } from '../../ui';
+
+const DEFAULT_DEMO_SITE = 'retail-001';
+
+function fmtEuro(n) {
+  if (n == null) return '—';
+  return Number(n).toLocaleString('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  });
+}
+
+function ComposanteBar({ label, value, total, color, tooltip }) {
+  const pct = total > 0 ? Math.max(2, Math.round((value / total) * 100)) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-[11px]">
+        <span className="text-gray-700 flex items-center gap-1">
+          {label}
+          {tooltip ? <InfoTip content={tooltip} /> : null}
+        </span>
+        <span className="font-medium text-gray-900">{fmtEuro(value)}</span>
+      </div>
+      <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+        <div className={`h-full ${color} rounded-full`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function RoiFlexReadyCard({ siteId }) {
+  const resolvedSiteId = siteId || DEFAULT_DEMO_SITE;
+
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    setError(null);
+    getRoiFlexReady(resolvedSiteId)
+      .then((d) => {
+        if (!cancel) setData(d);
+      })
+      .catch(() => {
+        if (!cancel) setError(true);
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [resolvedSiteId]);
+
+  if (loading) {
+    return (
+      <div
+        className="bg-white border border-gray-200 rounded-xl p-4"
+        data-testid="pilotage-roi-card"
+      >
+        <Skeleton className="h-5 w-40 mb-3" />
+        <Skeleton className="h-10 w-32 mb-4" />
+        <Skeleton className="h-20 rounded" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div
+        className="bg-white border border-gray-200 rounded-xl p-4"
+        data-testid="pilotage-roi-card"
+      >
+        <h3 className="text-sm font-semibold text-gray-800 mb-2">Gain annuel Flex Ready®</h3>
+        <p className="text-xs text-gray-500">
+          Site sans données Flex Ready® — sélectionnez un site démo ou terminer le seed.
+        </p>
+      </div>
+    );
+  }
+
+  const { gain_annuel_total_eur, composantes = {}, archetype } = data;
+  const total = Number(gain_annuel_total_eur || 0);
+
+  return (
+    <div
+      className="bg-white border border-gray-200 rounded-xl p-4 flex flex-col gap-3"
+      data-testid="pilotage-roi-card"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-800">Gain annuel Flex Ready®</h3>
+          <p className="text-[11px] text-gray-500 mt-0.5">
+            Valorisation cumulée — site {resolvedSiteId}
+          </p>
+        </div>
+        <span
+          className="inline-flex items-center bg-indigo-50 text-indigo-700 text-[10px] font-medium px-2 py-0.5 rounded-full whitespace-nowrap"
+          title="Standard NF EN IEC 62746-4"
+        >
+          Flex Ready® 62746-4
+        </span>
+      </div>
+
+      <div>
+        <div className="text-3xl font-bold text-gray-900 leading-none">{fmtEuro(total)}</div>
+        <div className="text-[11px] text-gray-500 mt-1">
+          Archétype : {archetype || 'indéterminé'} · confiance {data.confiance || 'indicative'}
+        </div>
+      </div>
+
+      <div className="space-y-2.5">
+        <ComposanteBar
+          label="Évitement pointe"
+          value={composantes.evitement_pointe_eur || 0}
+          total={total}
+          color="bg-amber-500"
+          tooltip="kW pilotable × heures pointe évitées × spread €/MWh"
+        />
+        <ComposanteBar
+          label="Décalage NEBCO"
+          value={composantes.decalage_nebco_eur || 0}
+          total={total}
+          color="bg-emerald-500"
+          tooltip="kW décalable × ~200 h/an × 60 €/MWh spread"
+        />
+        <ComposanteBar
+          label="CEE BAT-TH-116"
+          value={composantes.cee_bacs_eur || 0}
+          total={total}
+          color="bg-sky-500"
+          tooltip="3,5 €/m² × surface — fiche GTB/BACS"
+        />
+      </div>
+
+      <div className="text-[10px] text-gray-400 mt-auto pt-1 border-t border-gray-100">
+        Source : {data.source || 'Baromètre Flex 2026 + fiche CEE'}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Cockpit.jsx
+++ b/frontend/src/pages/Cockpit.jsx
@@ -63,6 +63,9 @@ import CockpitHero from './cockpit/CockpitHero';
 import ScoreBreakdownPanel from '../components/ScoreBreakdownPanel';
 import TrajectorySection from './cockpit/TrajectorySection';
 import ActionsImpact from './cockpit/ActionsImpact';
+import RadarPrixNegatifsCard from '../components/pilotage/RadarPrixNegatifsCard';
+import RoiFlexReadyCard from '../components/pilotage/RoiFlexReadyCard';
+import PortefeuilleScoringCard from '../components/pilotage/PortefeuilleScoringCard';
 import PerformanceSitesCard from './cockpit/PerformanceSitesCard';
 import VecteurEnergetiqueCard from './cockpit/VecteurEnergetiqueCard';
 import AlertesPrioritaires from './cockpit/AlertesPrioritaires';
@@ -728,6 +731,23 @@ const Cockpit = () => {
       </div>
 
       <ActionsImpact actions={cockpitActions} loading={cockpitLoading} />
+
+      {/* ═══════════ PILOTAGE DES USAGES — insights V1 (Baromètre Flex 2026) ═══════════ */}
+      <section className="space-y-3" data-testid="cockpit-pilotage-v1">
+        <div className="flex items-baseline justify-between">
+          <h2 className="text-sm font-semibold text-gray-800 uppercase tracking-wide">
+            Pilotage des usages
+          </h2>
+          <span className="text-[10px] text-gray-400">
+            Baromètre Flex 2026 · RTE / Enedis / GIMELEC
+          </span>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <RadarPrixNegatifsCard horizonDays={7} />
+          <RoiFlexReadyCard />
+          <PortefeuilleScoringCard />
+        </div>
+      </section>
 
       {/* ═══════════ ZONE 2 : KPI DÉCIDEUR — déplacé dans ZONE 4 (détail) ═══════════ */}
 

--- a/frontend/src/services/api/index.js
+++ b/frontend/src/services/api/index.js
@@ -28,3 +28,4 @@ export * from './cockpit';
 export * from './admin';
 export * from './market';
 export * from './contractsV2';
+export * from './pilotage';

--- a/frontend/src/services/api/pilotage.js
+++ b/frontend/src/services/api/pilotage.js
@@ -1,0 +1,20 @@
+/**
+ * PROMEOS - API Pilotage des usages.
+ * Endpoints V1 innovation : Radar J+7, ROI Flex Ready®, Scoring portefeuille.
+ * Ref : Baromètre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
+ */
+import { cachedGet } from './core';
+
+export const getRadarPrixNegatifs = (horizonDays = 7) =>
+  cachedGet('/pilotage/radar-prix-negatifs', { params: { horizon_days: horizonDays } }).then(
+    (r) => r.data
+  );
+
+export const getRoiFlexReady = (siteId) =>
+  cachedGet(`/pilotage/roi-flex-ready/${siteId}`).then((r) => r.data);
+
+export const getPortefeuilleScoring = () =>
+  cachedGet('/pilotage/portefeuille-scoring').then((r) => r.data);
+
+export const getFlexReadySignals = (siteId) =>
+  cachedGet(`/pilotage/flex-ready-signals/${siteId}`).then((r) => r.data);


### PR DESCRIPTION
## Summary

V1 innovation roadmap post-S22 — 3 pistes livrées en backend + frontend, consommables directement dans le Cockpit.

- **Backend (commit 7300ffc7)** : 3 endpoints + services pilotage (24/24 tests verts)
  - `GET /api/pilotage/radar-prix-negatifs?horizon_days=7` — prédiction heuristique MVP sur historique MktPrice 90j, regroupement (weekday, month), seuil récurrence 30 %. Fallback gracieux si historique < 30j.
  - `GET /api/pilotage/roi-flex-ready/{site_id}` — gain annuel EUR chiffré, 3 composantes additives (évitement pointe · décalage NEBCO · CEE BAT-TH-116), hypothèses explicites dans le payload.
  - `GET /api/pilotage/portefeuille-scoring` — classement Top-10 + heatmap archétype + budget flex portefeuille. DB-first si `auth.org_id`, fallback DEMO_SITES.
- **Frontend (commit cce6546a)** : section « Pilotage des usages » insérée dans Cockpit après `ActionsImpact`
  - `RadarPrixNegatifsCard` — wording doctrine « fenêtre favorable probable » (jamais « prix négatif » côté client), badge « Anticipation J+7 », probabilité % + usages recommandés.
  - `RoiFlexReadyCard` — gros chiffre EUR/an + 3 mini-bars composantes, badge « Flex Ready® 62746-4 », tooltips expliquant chaque formule.
  - `PortefeuilleScoringCard` — Top-5 avec rang/score/gain, heatmap agrégée par archétype, budget flex total.
- **Zéro régression** : 24/24 tests pilotage verts, `npm run build` OK.

## Différenciants

- **Wedge unique** J+7 vs agrégateurs qui ne voient que H-1.
- **Business case CFO** chiffré (aucun concurrent ne chiffre le gain annuel par site).
- **Portefeuille multi-sites** (Voltalis mono-site, PROMEOS classe).

## Source doctrine

Baromètre Flex 2026 (RTE / Enedis / GIMELEC / Think Smartgrids / IGNES / ACTEE / IFPEB / SBA, avril 2026).

## Test plan

- [x] Backend : `cd backend && python -m pytest tests/test_pilotage_*.py -q` → 24 passed
- [x] Frontend : `cd frontend && npx vite build` → built in 43.52s, zéro warning bloquant
- [ ] Manual : démarrer backend (8001) + frontend (5173), aller sur /cockpit, vérifier les 3 cartes V1 dans la section « Pilotage des usages »
- [ ] Manual : DEMO_MODE=true doit afficher 3 sites DEMO (retail-001, bureau-001, entrepot-001) dans le classement portefeuille
- [ ] Option C (wiring `archetype_code` + `puissance_pilotable_kw` sur le modèle Site) à traiter dans une PR dédiée

## Backlog V1 restant (follow-up PR)

- Ajouter `archetype_code` + `puissance_pilotable_kw` au modèle Site (migration idempotente + seed démo + backfill hook orchestrator).
- Wiring scoring portefeuille multi-org réel (actuellement fallback DEMO si pas de sites scopés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)