### PR TITLE
polish(cx-sprint1): 3 fixes code review — perf T2V + error catalog test + percentile bounds

### DIFF
--- a/backend/routes/cx_dashboard.py
+++ b/backend/routes/cx_dashboard.py
@@ -117,6 +117,11 @@ def get_t2v(
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
+    # Limite à 10 000 (user, org) pairs pour garder le calcul percentile en mémoire
+    # borné. À réécrire en SQL natif (percentile_cont) si volume dépasse cette limite
+    # de façon récurrente — cf followup IAR refinement.
+    MAX_SAMPLE = 10_000
+
     first_action = (
         db.query(
             AuditLog.user_id.label("user_id"),
@@ -130,6 +135,7 @@ def get_t2v(
             AuditLog.created_at >= cutoff,
         )
         .group_by(AuditLog.user_id, AuditLog.resource_id)
+        .limit(MAX_SAMPLE)
         .subquery()
     )
 

--- a/backend/tests/test_cx_dashboard_drivers.py
+++ b/backend/tests/test_cx_dashboard_drivers.py
@@ -14,6 +14,38 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+# ─── Helper _percentile (unit tests) ────────────────────────────────────────
+from routes.cx_dashboard import _percentile  # noqa: E402
+
+
+class TestPercentile:
+    def test_empty_returns_none(self):
+        assert _percentile([], 0.5) is None
+
+    def test_single_value_any_p(self):
+        assert _percentile([42.0], 0.0) == 42.0
+        assert _percentile([42.0], 0.5) == 42.0
+        assert _percentile([42.0], 1.0) == 42.0
+
+    def test_p_zero_returns_min(self):
+        assert _percentile([1.0, 2.0, 3.0, 10.0], 0.0) == 1.0
+
+    def test_p_one_returns_max(self):
+        assert _percentile([1.0, 2.0, 3.0, 10.0], 1.0) == 10.0
+
+    def test_p50_interpolation(self):
+        # Avec 4 valeurs, p50 interpole entre index 1 (=2) et 2 (=3) avec k=1.5
+        # Résultat : 2 + (3 - 2) * 0.5 = 2.5
+        assert _percentile([1.0, 2.0, 3.0, 4.0], 0.5) == 2.5
+
+    def test_p95_on_large_sample(self):
+        values = list(range(101))  # 0..100
+        values.sort()
+        p95 = _percentile(values, 0.95)
+        # k = 100 * 0.95 = 95, donc valeur exacte à l'index 95
+        assert p95 == 95.0
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine

--- a/backend/tests/test_error_catalog.py
+++ b/backend/tests/test_error_catalog.py
@@ -72,6 +72,21 @@ def test_business_error_with_context():
     assert kwargs["detail"]["context"] == {"action_id": 42, "org_id": 7}
 
 
+def test_business_error_context_is_json_serializable():
+    """Le champ context doit toujours être JSON-serializable (évite crash FastAPI)."""
+    import json
+
+    kwargs = business_error(
+        "ACTION_NOT_FOUND",
+        action_id=42,
+        nested={"site": "paris", "value": 1234.5},
+        items=[1, 2, 3],
+    )
+    serialized = json.dumps(kwargs["detail"])
+    assert "action_id" in serialized
+    assert "paris" in serialized
+
+
 def test_business_error_raises_on_unknown_code():
     with pytest.raises(KeyError):
         business_error("NOPE_NOT_A_REAL_CODE")


### PR DESCRIPTION
## Contexte

Suite au code review de PR #220 (Sprint CX 1), 3 suggestions polish implémentées. La 4ᵉ suggestion (IAR refinement) fera l'objet d'une issue séparée pour sprint CX v2 car elle nécessite un arbitrage métier.

## Fixes

### Fix #1 — T2V endpoint : LIMIT 10 000 pairs

`backend/routes/cx_dashboard.py` : ajout `.limit(10_000)` sur subquery `first_action`.

- Garde le calcul percentile en mémoire borné (avant : chargement tous utilisateurs × orgs)
- Commentaire explicite sur la réécriture SQL natif (`percentile_cont`) si le volume dépasse cette limite récurrent
- Impact : échantillon tronqué si > 10k, mais l'endpoint admin reste réactif

### Fix #3 — error_catalog : test sérialisation JSON du context

`backend/tests/test_error_catalog.py` : nouveau test `test_business_error_context_is_json_serializable`.

- Vérifie que le `context` (dict libre) passé à `business_error()` produit un detail JSON-serializable
- Évite crash FastAPI silencieux si l'appelant passe un objet non sérialisable

### Fix #4 — _percentile : 6 tests unitaires aux bornes

`backend/tests/test_cx_dashboard_drivers.py` : nouvelle classe `TestPercentile` avec 6 tests :
- empty → None
- single value → la valeur (quelle que soit p)
- p=0 → min
- p=1 → max
- p50 avec 4 valeurs → interpolation correcte (2.5)
- p95 sur 101 valeurs → valeur exacte à l'index 95

## Test plan

- [x] 33 tests verts (26 existants + 6 _percentile + 1 context serialization)
- [x] ruff check clean
- [x] Aucune régression (même base que PR #220 mergée)

## Suggestion #2 (IAR refinement) — pas traitée ici

Suggestion #2 du review : `CX_ACTION_FROM_INSIGHT` fire sur toutes les actions DONE, incluant `source_type=manual`. Sémantiquement ambigu pour le driver IAR.

→ Nécessite arbitrage métier (définition exacte de "action issue d'insight" pour IAR). **Sera tracké dans une issue séparée pour sprint CX v2**, avec discussion de la granularité souhaitée (filtrer par source_type ? par flag `linked_to_insight` ? définir un whitelist ?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)