### PR TITLE
feat(pilotage): Option C — wire Site.archetype_code + puissance_pilotable_kw (follow-up #222)

### DIFF
--- a/backend/migrations/add_pilotage_fields_to_site.py
+++ b/backend/migrations/add_pilotage_fields_to_site.py
@@ -1,0 +1,68 @@
+"""
+Migration: 2 colonnes Flex Ready (R) sur sites.
+
+New columns on sites :
+  - archetype_code (VARCHAR(50)) — archetype Barometre Flex 2026
+  - puissance_pilotable_kw (FLOAT) — puissance decalable estimee (kW)
+
+Source : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
+Safe to re-run : uses column existence checks.
+Backward-compatible : toutes nullable, pas de contrainte NOT NULL.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent.parent / "data" / "promeos.db"
+
+
+def column_exists(cursor, table: str, column: str) -> bool:
+    cursor.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def add_column_if_missing(cursor, table: str, column: str, col_type: str) -> bool:
+    if column_exists(cursor, table, column):
+        return False
+    cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {col_type}")
+    return True
+
+
+PILOTAGE_COLUMNS = [
+    ("archetype_code", "VARCHAR(50)"),
+    ("puissance_pilotable_kw", "FLOAT"),
+]
+
+
+def run_migration(db_path: Path = DB_PATH) -> dict:
+    if not db_path.exists():
+        raise FileNotFoundError(f"DB not found at {db_path}")
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    summary: dict = {"columns_added": []}
+
+    for col, col_type in PILOTAGE_COLUMNS:
+        if add_column_if_missing(cursor, "sites", col, col_type):
+            summary["columns_added"].append(col)
+
+    # Index sur archetype_code pour accelerer les agregations heatmap par archetype
+    cursor.execute("CREATE INDEX IF NOT EXISTS ix_sites_archetype_code ON sites(archetype_code)")
+
+    conn.commit()
+    conn.close()
+    return summary
+
+
+if __name__ == "__main__":
+    result = run_migration()
+    added = result["columns_added"]
+    if not added:
+        print("Schema was already up to date.")
+    else:
+        print(f"Added {len(added)} columns: {', '.join(added)}")
+    sys.exit(0)

--- a/backend/models/site.py
+++ b/backend/models/site.py
@@ -75,6 +75,19 @@ class Site(Base, TimestampMixin, SoftDeleteMixin):
     annual_kwh_total = Column(Float, nullable=True, comment="Consommation annuelle totale (kWh)")
     last_energy_update_at = Column(DateTime, nullable=True, comment="Derniere MAJ donnees energie")
 
+    # Pilotage des usages (Flex Ready® NF EN IEC 62746-4, Baromètre Flex 2026)
+    archetype_code = Column(
+        String(50),
+        nullable=True,
+        index=True,
+        comment="Archétype Baromètre Flex 2026 (BUREAU_STANDARD, COMMERCE_ALIMENTAIRE, LOGISTIQUE_FRIGO...)",
+    )
+    puissance_pilotable_kw = Column(
+        Float,
+        nullable=True,
+        comment="Puissance pilotable/décalable estimée (kW), pour scoring portefeuille",
+    )
+
     @property
     def conso_kwh_an(self):
         """Alias for annual_kwh_total — used by frontend dashboards."""

--- a/backend/routes/pilotage.py
+++ b/backend/routes/pilotage.py
@@ -119,6 +119,63 @@ def _build_demo_site_ctx(site_id: str) -> dict[str, Any]:
     return ctx
 
 
+def _scoped_site_query(db: Session, auth: Optional[AuthContext]):
+    """
+    Query de base `Site actif` + defense-in-depth org_id si auth present.
+
+    Hors auth (DEMO_MODE), aucune restriction -- le filtre d'actif suffit.
+    Retourne un Query[Site] que les callers affinent avec `.filter(Site.id == ...)`
+    ou `.filter(Site.id.in_(...))`.
+
+    Le 404 retourne sur lookup vide evite de distinguer "site inexistant" et
+    "site hors scope" -- choix delibere anti-enumeration (vs monitoring.py 403).
+    """
+    from models import EntiteJuridique, Portefeuille, Site
+
+    query = db.query(Site).filter(Site.actif == True)  # noqa: E712
+    if auth is not None and getattr(auth, "org_id", None):
+        query = (
+            query.join(Portefeuille, Site.portefeuille_id == Portefeuille.id)
+            .join(EntiteJuridique, Portefeuille.entite_juridique_id == EntiteJuridique.id)
+            .filter(EntiteJuridique.organisation_id == auth.org_id)
+        )
+    return query
+
+
+def _load_site_ctx(
+    db: Session,
+    site_id: str,
+    auth: Optional[AuthContext],
+) -> dict[str, Any]:
+    """
+    Resout `site_id` en fiche pour `compute_roi_flex_ready` :
+        - Si `site_id` est numerique -> lookup Site.id en DB (scope via auth.org_id).
+        - Sinon -> fallback DEMO_SITES (404 si cle inconnue).
+
+    Un site sans `archetype_code` renseigne tombe sur le fallback
+    BUREAU_STANDARD cote compute_roi_flex_ready (explainability preservee).
+    """
+    if not site_id.isdigit():
+        return _build_demo_site_ctx(site_id)
+
+    from models import Site
+
+    site_pk = int(site_id)
+    site = _scoped_site_query(db, auth).filter(Site.id == site_pk).first()
+    if site is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Site introuvable ou hors scope : id={site_pk}",
+        )
+
+    return {
+        "nom": site.nom,
+        "puissance_max_instantanee_kw": float(site.puissance_pilotable_kw or 0.0),
+        "surface_m2": float(site.surface_m2 or 0.0),
+        "archetype_code": site.archetype_code,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Radar prix negatifs J+7 -- schemas de reponse.
 # ---------------------------------------------------------------------------
@@ -224,37 +281,23 @@ def _demo_sites_as_portfolio() -> list[dict[str, Any]]:
 
 def _org_sites_as_portfolio(db: Session, auth: AuthContext) -> list[dict[str, Any]]:
     """
-    Liste les sites actifs scopes par AuthContext.site_ids pour le scoring.
+    Liste les sites actifs scopes par AuthContext.site_ids + org pour le scoring.
 
-    Defense-in-depth : en plus du filtre `Site.id IN auth.site_ids` (deja
-    scope par l'IAM dans `get_scoped_site_ids`), on recroise la hierarchie
-    Portefeuille -> EntiteJuridique pour garantir `organisation_id == auth.org_id`.
-    Si l'auth layer leakait un site_id cross-org, on ne servirait rien.
-
-    Note : le modele Site ne porte pas encore `archetype_code` ni
-    `puissance_pilotable_kw`. On retombe sur des valeurs sentinelles
-    (archetype None -> fallback score 50, puissance_pilotable 0 -> gain 0).
-    Ce wiring servira quand ces champs seront ajoutes au modele (backlog Option C).
+    Defense-in-depth via `_scoped_site_query` (join Portefeuille -> EntiteJuridique).
+    Lit `archetype_code` + `puissance_pilotable_kw` directement depuis Site.
+    Sites non seedes -> None/0, scoring retombe sur fallback 50 + gain 0.
     """
-    from models import EntiteJuridique, Portefeuille, Site
+    from models import Site
 
     site_ids = getattr(auth, "site_ids", None) or []
     if not site_ids:
         return []
-    rows = (
-        db.query(Site)
-        .join(Portefeuille, Site.portefeuille_id == Portefeuille.id)
-        .join(EntiteJuridique, Portefeuille.entite_juridique_id == EntiteJuridique.id)
-        .filter(Site.id.in_(site_ids))
-        .filter(EntiteJuridique.organisation_id == auth.org_id)
-        .filter(Site.actif == True)  # noqa: E712
-        .all()
-    )
+    rows = _scoped_site_query(db, auth).filter(Site.id.in_(site_ids)).all()
     return [
         {
             "site_id": str(site.id),
-            "archetype_code": getattr(site, "archetype_code", None),
-            "puissance_pilotable_kw": float(getattr(site, "puissance_pilotable_kw", 0.0) or 0.0),
+            "archetype_code": site.archetype_code,
+            "puissance_pilotable_kw": float(site.puissance_pilotable_kw or 0.0),
         }
         for site in rows
     ]
@@ -349,15 +392,18 @@ def roi_flex_ready(
         - Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026)
         - Fiche CEE BAT-TH-116 (systeme GTB / BACS)
 
-    Scope MVP : `site_id` doit correspondre a une cle du catalogue DEMO_SITES
-    (`retail-001`, `bureau-001`, `entrepot-001`). Le wiring sur Site.id reel
-    (archetype_code + puissance_pilotable_kw + surface_m2 portes par le modele
-    Site) fera l'objet d'une PR follow-up (Option C). 404 hors DEMO_SITES.
+    Accepte deux formes de `site_id` :
+        - Numerique (ex. `42`) : Site.id reel, lookup DB avec scope org via
+          la chaine Portefeuille -> EntiteJuridique -> Organisation.
+        - Alphanumerique (ex. `retail-001`) : cle DEMO_SITES (catalogue demo).
 
-    Auth optionnelle (DEMO_MODE tolere). La session `db` est en place pour le
-    futur wiring Site.id mais n'est pas utilisee en MVP.
+    404 si le site est introuvable ou hors scope.
+    Archetype non renseigne cote prod -> fallback BUREAU_STANDARD (cf.
+    compute_roi_flex_ready), avec hypotheses exposees dans la payload.
+
+    Auth optionnelle (DEMO_MODE tolere).
     """
-    ctx = _build_demo_site_ctx(site_id)
+    ctx = _load_site_ctx(db=db, site_id=site_id, auth=auth)
     return compute_roi_flex_ready(
         site_id=site_id,
         demo_site=ctx,

--- a/backend/services/demo_seed/gen_pilotage_fields.py
+++ b/backend/services/demo_seed/gen_pilotage_fields.py
@@ -1,0 +1,84 @@
+"""
+PROMEOS - Seed des champs Pilotage Flex Ready (R) sur les sites existants.
+
+Populise `archetype_code` et `puissance_pilotable_kw` sur les sites du pack
+demo courant. Priorite :
+    1. Nom canonique connu (Carrefour Montreuil, Tour Haussmann, Entrepot Rungis)
+    2. Fallback `TypeSite` -> archetype Barometre Flex 2026
+
+Idempotent : n'ecrase pas les valeurs deja renseignees manuellement.
+
+Source calibration : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
+Les dicts canoniques et fallback vivent dans services/pilotage/constants.py
+(co-localises avec ARCHETYPE_CALIBRATION_2024).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from models import Site
+from services.pilotage.constants import (
+    CANONICAL_SITE_PILOTAGE,
+    TYPESITE_ARCHETYPE_FALLBACK,
+)
+
+
+def _normalise_nom(nom: Optional[str]) -> str:
+    """Normalise un nom de site pour matching canonique (casse + accents)."""
+    if not nom:
+        return ""
+    # NFKD decompose les accents, puis on drop les marques non-ASCII.
+    stripped = unicodedata.normalize("NFKD", nom).encode("ascii", "ignore").decode("ascii")
+    return stripped.lower().strip()
+
+
+def _resolve(site: Site) -> Optional[tuple[str, float]]:
+    """Retourne (archetype_code, puissance_pilotable_kw) pour un site, ou None."""
+    canonical = CANONICAL_SITE_PILOTAGE.get(_normalise_nom(site.nom))
+    if canonical is not None:
+        return canonical
+    type_value = getattr(site.type, "value", None)
+    if type_value:
+        return TYPESITE_ARCHETYPE_FALLBACK.get(type_value)
+    return None
+
+
+def seed_pilotage_fields(db: Session, sites: list[Site]) -> dict:
+    """
+    Populise archetype_code + puissance_pilotable_kw sur une liste de sites.
+
+    Idempotent : ne touche pas les sites ou les deux champs sont deja renseignes.
+    Si un seul des deux champs est renseigne, on complete l'autre seulement.
+
+    Returns:
+        {"updated": N, "skipped_full": M, "unresolved": K}
+    """
+    stats = {"updated": 0, "skipped_full": 0, "unresolved": 0}
+
+    for site in sites:
+        has_arch = bool(site.archetype_code)
+        has_kw = site.puissance_pilotable_kw is not None
+
+        if has_arch and has_kw:
+            stats["skipped_full"] += 1
+            continue
+
+        resolution = _resolve(site)
+        if resolution is None:
+            stats["unresolved"] += 1
+            continue
+
+        archetype, kw = resolution
+        if not has_arch:
+            site.archetype_code = archetype
+        if not has_kw:
+            site.puissance_pilotable_kw = kw
+        stats["updated"] += 1
+
+    if stats["updated"]:
+        db.flush()
+    return stats

--- a/backend/services/demo_seed/orchestrator.py
+++ b/backend/services/demo_seed/orchestrator.py
@@ -72,6 +72,13 @@ class SeedOrchestrator:
         self.db.flush()
         result["delivery_points_created"] = dp_total
 
+        # Populate archetype_code + puissance_pilotable_kw (Baromètre Flex 2026)
+        # pour que portefeuille-scoring et roi-flex-ready travaillent sur des
+        # sites réels plutôt que sur le catalogue DEMO_SITES hardcodé.
+        from .gen_pilotage_fields import seed_pilotage_fields
+
+        result["pilotage_fields"] = seed_pilotage_fields(self.db, master["sites"])
+
         # V107: build site_meta for surface-normalized consumption
         site_meta = {}
         for s in master["sites"]:

--- a/backend/services/pilotage/constants.py
+++ b/backend/services/pilotage/constants.py
@@ -216,3 +216,37 @@ SAISON_BASSE_MOIS: set[int] = {4, 5, 6, 7, 8, 9, 10}  # avril-octobre
 def get_calibration(archetype_code: str) -> dict | None:
     """Retourne le calibrage 2024 pour un archetype, ou None si absent."""
     return ARCHETYPE_CALIBRATION_2024.get(archetype_code)
+
+
+# --- 4. Mapping TypeSite -> archetype + puissance pilotable median ----------
+#
+# Utilise par le seed et le wiring automatique quand un Site n'a ni archetype
+# renseigne manuellement ni correspondance canonique sur le nom. Les valeurs
+# kW sont des medianes calibrees Barometre Flex 2026 par segment tertiaire.
+#
+# Garder en sync avec ARCHETYPE_CALIBRATION_2024 : toutes les cles de droite
+# doivent exister dans ARCHETYPE_CALIBRATION_2024 (ou fallback BUREAU_STANDARD).
+TYPESITE_ARCHETYPE_FALLBACK: dict[str, tuple[str, float]] = {
+    # TypeSite.value -> (archetype_code, puissance_pilotable_kw_median)
+    "magasin": ("COMMERCE_ALIMENTAIRE", 80.0),
+    "commerce": ("COMMERCE_SPECIALISE", 40.0),
+    "bureau": ("BUREAU_STANDARD", 50.0),
+    "entrepot": ("LOGISTIQUE_FRIGO", 60.0),
+    "usine": ("INDUSTRIE_LEGERE", 150.0),
+    "hotel": ("HOTELLERIE", 45.0),
+    "sante": ("SANTE", 70.0),
+    "enseignement": ("ENSEIGNEMENT", 35.0),
+}
+
+
+# Sites canoniques de la demo -- donnees exactes recommandees par l'equipe
+# produit (Hypermarche Montreuil, Tour Haussmann, Entrepot Rungis). Utilise
+# par le seed pour forcer le match sur les 3 sites vedettes.
+CANONICAL_SITE_PILOTAGE: dict[str, tuple[str, float]] = {
+    # Nom normalise (lowercase + accents strippes) -> (archetype, kw)
+    "carrefour montreuil": ("COMMERCE_ALIMENTAIRE", 220.0),
+    "hypermarche montreuil": ("COMMERCE_ALIMENTAIRE", 220.0),
+    "tour haussmann": ("BUREAU_STANDARD", 120.0),
+    "bureau haussmann": ("BUREAU_STANDARD", 120.0),
+    "entrepot rungis": ("LOGISTIQUE_FRIGO", 85.0),
+}

--- a/backend/tests/test_pilotage_option_c.py
+++ b/backend/tests/test_pilotage_option_c.py
@@ -1,0 +1,241 @@
+"""
+PROMEOS - Tests wiring Site model reel pour Pilotage Flex Ready (R).
+
+Couvre :
+    1. Colonnes Site.archetype_code + Site.puissance_pilotable_kw presentes.
+    2. Seed pilotage fields : canonique (Carrefour -> COMMERCE_ALIMENTAIRE),
+       fallback TypeSite, idempotence.
+    3. /roi-flex-ready/{Site.id} : lookup DB avec scope org + 404 hors scope.
+    4. /portefeuille-scoring : lit archetype_code + puissance_pilotable_kw
+       directement depuis Site.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from database import get_db
+from main import app
+from middleware.auth import AuthContext, get_optional_auth
+from models import (
+    Base,
+    EntiteJuridique,
+    Organisation,
+    Portefeuille,
+    Site,
+)
+from models.enums import TypeSite
+from services.demo_seed.gen_pilotage_fields import seed_pilotage_fields
+
+
+@pytest.fixture
+def db_session():
+    """Session DB SQLite in-memory, isolation totale."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def org_with_site(db_session):
+    """Cree une Org + EntiteJuridique + Portefeuille + Site canonique."""
+    org = Organisation(nom="Test Org", siren="123456789")
+    db_session.add(org)
+    db_session.flush()
+
+    entite = EntiteJuridique(
+        nom="Test Entite",
+        siren="123456789",
+        organisation_id=org.id,
+    )
+    db_session.add(entite)
+    db_session.flush()
+
+    ptf = Portefeuille(
+        nom="Test Portefeuille",
+        entite_juridique_id=entite.id,
+    )
+    db_session.add(ptf)
+    db_session.flush()
+
+    site = Site(
+        nom="Hypermarche Montreuil",
+        type=TypeSite.MAGASIN,
+        portefeuille_id=ptf.id,
+        surface_m2=2500.0,
+        actif=True,
+    )
+    db_session.add(site)
+    db_session.flush()
+    return {"org": org, "entite": entite, "ptf": ptf, "site": site}
+
+
+# ---------------------------------------------------------------------------
+# Test 1 : colonnes Site presentes (Site model a jour)
+# ---------------------------------------------------------------------------
+def test_site_model_porte_les_colonnes_pilotage():
+    """Le modele Site doit porter `archetype_code` + `puissance_pilotable_kw`."""
+    assert hasattr(Site, "archetype_code"), "Site.archetype_code manquant"
+    assert hasattr(Site, "puissance_pilotable_kw"), "Site.puissance_pilotable_kw manquant"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 : seed canonique matche sur le nom (Carrefour -> COMMERCE_ALIMENTAIRE)
+# ---------------------------------------------------------------------------
+def test_seed_canonique_matche_par_nom(db_session, org_with_site):
+    """Un site nomme 'Hypermarche Montreuil' doit recevoir COMMERCE_ALIMENTAIRE."""
+    site = org_with_site["site"]
+    stats = seed_pilotage_fields(db_session, [site])
+    db_session.flush()
+
+    assert stats["updated"] == 1
+    assert site.archetype_code == "COMMERCE_ALIMENTAIRE"
+    assert site.puissance_pilotable_kw == 220.0
+
+
+# ---------------------------------------------------------------------------
+# Test 3 : fallback TypeSite pour un nom inconnu
+# ---------------------------------------------------------------------------
+def test_seed_fallback_typesite(db_session, org_with_site):
+    """Un site inconnu doit retomber sur l'archetype du TypeSite."""
+    site = org_with_site["site"]
+    site.nom = "Site Inconnu 42"
+    db_session.flush()
+
+    stats = seed_pilotage_fields(db_session, [site])
+    db_session.flush()
+
+    assert stats["updated"] == 1
+    # TypeSite.MAGASIN -> COMMERCE_ALIMENTAIRE (80.0 kW)
+    assert site.archetype_code == "COMMERCE_ALIMENTAIRE"
+    assert site.puissance_pilotable_kw == 80.0
+
+
+# ---------------------------------------------------------------------------
+# Test 4 : seed idempotent (ne reecrase pas les valeurs existantes)
+# ---------------------------------------------------------------------------
+def test_seed_idempotent(db_session, org_with_site):
+    """Un second run ne doit pas ecraser les valeurs deja renseignees."""
+    site = org_with_site["site"]
+    site.archetype_code = "SANTE"
+    site.puissance_pilotable_kw = 999.0
+    db_session.flush()
+
+    stats = seed_pilotage_fields(db_session, [site])
+
+    assert stats["skipped_full"] == 1
+    assert site.archetype_code == "SANTE", "valeur existante ecrasee"
+    assert site.puissance_pilotable_kw == 999.0
+
+
+# ---------------------------------------------------------------------------
+# Test 5 : /roi-flex-ready/{Site.id} accepte Site.id reel (numerique)
+# ---------------------------------------------------------------------------
+def test_roi_flex_ready_accepte_site_id_reel(db_session, org_with_site):
+    """L'endpoint resout un Site.id numerique en DB et construit le ctx."""
+    site = org_with_site["site"]
+    # Seed des champs pilotage pour que l'archetype soit deterministe.
+    seed_pilotage_fields(db_session, [site])
+    db_session.flush()
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        r = client.get(f"/api/pilotage/roi-flex-ready/{site.id}")
+        assert r.status_code == 200, f"HTTP {r.status_code}: {r.text}"
+        data = r.json()
+        assert data["site_id"] == str(site.id)
+        assert data["archetype"] == "COMMERCE_ALIMENTAIRE"
+        assert data["gain_annuel_total_eur"] > 0
+        # CEE = surface_m2 * 3.5
+        assert data["composantes"]["cee_bacs_eur"] == pytest.approx(2500.0 * 3.5)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 6 : /roi-flex-ready/{Site.id} 404 si hors scope org (defense-in-depth)
+# ---------------------------------------------------------------------------
+def test_roi_flex_ready_404_hors_scope_org(db_session, org_with_site):
+    """Un Site.id qui n'appartient pas a l'org de l'utilisateur -> 404."""
+    site = org_with_site["site"]
+
+    def _override_db():
+        yield db_session
+
+    # Auth avec org_id DIFFERENT de celui du site
+    fake_auth = AuthContext(
+        user=None,
+        user_org_role=None,
+        org_id=999,  # pas l'org du site
+        role=None,
+        site_ids=[site.id],
+    )
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_optional_auth] = lambda: fake_auth
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        r = client.get(f"/api/pilotage/roi-flex-ready/{site.id}")
+        assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 7 : /portefeuille-scoring lit archetype + puissance depuis Site
+# ---------------------------------------------------------------------------
+def test_portefeuille_scoring_lit_archetype_depuis_site(db_session, org_with_site):
+    """Le scoring portefeuille en prod lit les vrais champs Site, pas DEMO."""
+    site = org_with_site["site"]
+    seed_pilotage_fields(db_session, [site])
+    db_session.flush()
+
+    def _override_db():
+        yield db_session
+
+    fake_auth = AuthContext(
+        user=None,
+        user_org_role=None,
+        org_id=org_with_site["org"].id,
+        role=None,
+        site_ids=[site.id],
+    )
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_optional_auth] = lambda: fake_auth
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        r = client.get("/api/pilotage/portefeuille-scoring")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["nb_sites_total"] == 1
+        top = data["top_10"]
+        assert len(top) == 1
+        # site_id format : str(Site.id) (cf. _org_sites_as_portfolio)
+        assert top[0]["site_id"] == str(site.id)
+        assert top[0]["archetype"] == "COMMERCE_ALIMENTAIRE"
+        assert top[0]["gain_annuel_eur"] > 0
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

Follow-up PR #222 (Pilotage V1 mergée) : wiring côté prod des endpoints `/roi-flex-ready` et `/portefeuille-scoring` sur le modèle Site réel (plus seulement DEMO_SITES hardcodé).

- **Site model** : 2 colonnes Flex Ready® (`archetype_code` indexé + `puissance_pilotable_kw`)
- **Migration idempotente** : `add_pilotage_fields_to_site.py` (PRAGMA + CREATE INDEX IF NOT EXISTS)
- **Seed** : `gen_pilotage_fields.py` hooké dans `orchestrator.py`, canonique par nom (Carrefour Montreuil / Tour Haussmann / Entrepôt Rungis) puis fallback TypeSite
- **Routes** :
  - Helper `_scoped_site_query(db, auth)` partagé (defense-in-depth join Portefeuille → EntiteJuridique → organisation_id)
  - `/roi-flex-ready/{site_id}` accepte maintenant **Site.id numérique** (ex. `/roi-flex-ready/42`) **ET** clés DEMO_SITES alphanum (rétrocompat)
  - `/portefeuille-scoring` lit `archetype_code` + `puissance_pilotable_kw` directement depuis Site
- **Calibration centralisée** : `TYPESITE_ARCHETYPE_FALLBACK` + `CANONICAL_SITE_PILOTAGE` déplacés dans `services/pilotage/constants.py` (co-localisés avec `ARCHETYPE_CALIBRATION_2024`)

## Audit `/simplify` 3 agents avant commit

- Dedup `_scoped_site_query` helper (vs 2× join pattern duplicate)
- Calibration déplacée dans constants.py (data vs logic)
- `unicodedata.normalize('NFKD')` remplace 5× `.replace(...)` chainés
- Drop `db.flush()` redondant orchestrator
- Suppression labels "Option C" dans docstrings (rot-prone)

Findings déférés (follow-up PR) : StrEnum ArchetypeCode (blast radius), réutilisation `archetype_resolver` NAF-based, caching serveur `/portefeuille-scoring`.

## Test plan

- [x] Backend : `cd backend && python -m pytest tests/test_pilotage_*.py -q` → 32 passed (25 existants + 7 nouveaux)
- [x] Migration idempotente : re-run sur DB existante → "Schema was already up to date"
- [ ] Manual : seed DEMO pack → vérifier 3 sites canoniques ont `archetype_code` + `puissance_pilotable_kw` renseignés
- [ ] Manual : `/api/pilotage/roi-flex-ready/{site_id_réel}` → payload ROI calculé depuis Site.archetype_code
- [ ] Manual : `/api/pilotage/portefeuille-scoring` auth org réelle → top-10 issu des Sites (plus DEMO_SITES)

## Tests ajoutés (7)

1. Colonnes Site.archetype_code + Site.puissance_pilotable_kw présentes
2. Seed canonique matche par nom (Hypermarché Montreuil → COMMERCE_ALIMENTAIRE, 220 kW)
3. Seed fallback TypeSite (MAGASIN → COMMERCE_ALIMENTAIRE, 80 kW)
4. Seed idempotent (n'écrase pas valeurs manuelles)
5. /roi-flex-ready/{Site.id} accepte Site.id numérique réel
6. /roi-flex-ready 404 si hors scope org (defense-in-depth)
7. /portefeuille-scoring lit archetype + puissance depuis Site

## Source doctrine

Baromètre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)