### PR TITLE
feat(pilotage-ux): Sprint 1 P0 — CTAs + scope switcher + wording (audit 4-agents)

### DIFF
--- a/backend/services/demo_seed/gen_market_prices.py
+++ b/backend/services/demo_seed/gen_market_prices.py
@@ -72,6 +72,55 @@ def _generate_prices(start_date: date, end_date: date) -> list[dict]:
     return prices
 
 
+def _generate_hourly_spot_last_90d(now_utc: datetime) -> list[dict]:
+    """
+    Genere 90 jours d'historique spot day-ahead horaire FR avec des prix
+    negatifs plausibles sur la plage midi (10h-17h Europe/Paris) ~15% des jours
+    ouvres -- reproduit le signal 2025 (513h prix negatifs observes par la CRE).
+
+    Utilise par le Radar prix negatifs J+7 (heuristique 30% creneaux negatifs
+    sur jours semblables). La courbe horaire est deterministe (pas de random).
+    """
+    rows: list[dict] = []
+    # Plage solaire : surplus PV midi => pression baissiere forte.
+    solar_noon_hours = {11, 12, 13, 14, 15}
+    base_daily = 62.0  # moyenne 2026 EUR/MWh (aligne avec _generate_prices)
+
+    for d in range(90, 0, -1):
+        day = (now_utc - timedelta(days=d)).date()
+        # Jour ouvre = jeudi/vendredi plus probable de voir du negatif midi
+        # (demande tertiaire stable + surproduction PV). ~1 jour sur 7 flag "neg".
+        is_negative_day = (day.weekday() in (3, 4)) and (day.toordinal() % 7 == 0)
+
+        for hour in range(24):
+            # Profil diurne : pic 8h et 19h, creux nuit + midi.
+            diurnal = math.cos(2 * math.pi * (hour - 8) / 24) * 0.15
+            if hour in solar_noon_hours:
+                diurnal -= 0.25  # creux PV
+            price = base_daily * (1 + diurnal)
+
+            if is_negative_day and hour in solar_noon_hours:
+                # Force prix negatif sur 5 creneaux midi => 5/7 = 71% >> seuil 30%
+                price = -5.0 - (hour - 11) * 1.2  # -5 a -9.8 EUR/MWh
+
+            delivery_start = datetime(day.year, day.month, day.day, hour, tzinfo=timezone.utc)
+            rows.append(
+                {
+                    "source": MarketDataSource.MANUAL,
+                    "market_type": MarketType.SPOT_DAY_AHEAD,
+                    "product_type": ProductType.HOURLY,
+                    "zone": PriceZone.FR,
+                    "delivery_start": delivery_start,
+                    "delivery_end": delivery_start + timedelta(hours=1),
+                    "price_eur_mwh": round(price, 2),
+                    "resolution": Resolution.PT60M,
+                    "fetched_at": now_utc,
+                    "source_reference": "Seed PROMEOS -- historique horaire 90j pour Radar prix negatifs",
+                }
+            )
+    return rows
+
+
 def _generate_forward_curves() -> list[dict]:
     """Generate forward curve records (CAL, Q, M) for cockpit display."""
     now = datetime.now(timezone.utc)
@@ -133,9 +182,11 @@ def generate_market_prices(db: Session) -> dict:
     end = date(2026, 12, 31)
     prices = _generate_prices(start, end)
     forwards = _generate_forward_curves()
+    now_utc = datetime.now(timezone.utc)
+    hourly_radar = _generate_hourly_spot_last_90d(now_utc)
 
     inserted = 0
-    for p in prices + forwards:
+    for p in prices + forwards + hourly_radar:
         existing = (
             db.query(MktPrice)
             .filter(
@@ -153,5 +204,5 @@ def generate_market_prices(db: Session) -> dict:
             inserted += 1
 
     db.flush()
-    total = len(prices) + len(forwards)
+    total = len(prices) + len(forwards) + len(hourly_radar)
     return {"market_prices_total": total, "market_prices_inserted": inserted}

--- a/backend/services/demo_seed/gen_market_prices.py
+++ b/backend/services/demo_seed/gen_market_prices.py
@@ -88,9 +88,10 @@ def _generate_hourly_spot_last_90d(now_utc: datetime) -> list[dict]:
 
     for d in range(90, 0, -1):
         day = (now_utc - timedelta(days=d)).date()
-        # Jour ouvre = jeudi/vendredi plus probable de voir du negatif midi
-        # (demande tertiaire stable + surproduction PV). ~1 jour sur 7 flag "neg".
-        is_negative_day = (day.weekday() in (3, 4)) and (day.toordinal() % 7 == 0)
+        # Negatif midi ~3 jours/semaine : mer + jeu + ven. Ratio calibre pour
+        # que le radar (seuil 30% creneaux negatifs sur jours semblables) declenche
+        # sur ces 3 weekdays sans polluer lun/mar/samedi/dimanche.
+        is_negative_day = day.weekday() in (2, 3, 4)
 
         for hour in range(24):
             # Profil diurne : pic 8h et 19h, creux nuit + midi.

--- a/backend/services/pilotage/constants.py
+++ b/backend/services/pilotage/constants.py
@@ -113,7 +113,7 @@ ARCHETYPE_CALIBRATION_2024: dict[str, dict] = {
         "plages_pointe_h": [(7, 10), (17, 20)],
         "conso_journaliere_pointe_pct": 0.28,
         "bacs_penetration_2024": 0.17,
-        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Bureaux",
+        "source": "Baromètre Flex 2026 RTE/Enedis/GIMELEC - Bureaux",
     },
     "COMMERCE_ALIMENTAIRE": {
         # Froid commercial predominant + ECS : potentiel decalable eleve.
@@ -121,14 +121,14 @@ ARCHETYPE_CALIBRATION_2024: dict[str, dict] = {
         "plages_pointe_h": [(10, 20)],
         "conso_journaliere_pointe_pct": 0.55,
         "bacs_penetration_2024": 0.17,  # fourchette 15-19%, mediane retenue
-        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Commerces alimentaires",
+        "source": "Baromètre Flex 2026 RTE/Enedis/GIMELEC - Commerces alimentaires",
     },
     "COMMERCE_SPECIALISE": {
         "taux_decalable_moyen": 0.25,
         "plages_pointe_h": [(10, 19)],
         "conso_journaliere_pointe_pct": 0.45,
         "bacs_penetration_2024": 0.17,
-        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Commerces non alimentaires",
+        "source": "Baromètre Flex 2026 RTE/Enedis/GIMELEC - Commerces non alimentaires",
     },
     "LOGISTIQUE_FRIGO": {
         # Froid inertie 24h/24 : gisement le plus important.
@@ -136,14 +136,14 @@ ARCHETYPE_CALIBRATION_2024: dict[str, dict] = {
         "plages_pointe_h": [(0, 24)],
         "conso_journaliere_pointe_pct": 1.0,
         "bacs_penetration_2024": 0.23,
-        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Logistique frigorifique",
+        "source": "Baromètre Flex 2026 RTE/Enedis/GIMELEC - Logistique frigorifique",
     },
     "ENSEIGNEMENT": {
         "taux_decalable_moyen": 0.20,
         "plages_pointe_h": [(8, 17)],
         "conso_journaliere_pointe_pct": 0.50,
         "bacs_penetration_2024": 0.13,
-        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Enseignement",
+        "source": "Baromètre Flex 2026 RTE/Enedis/GIMELEC - Enseignement",
     },
     "SANTE": {
         # Contraintes medicales fortes : faible decalabilite.
@@ -151,7 +151,7 @@ ARCHETYPE_CALIBRATION_2024: dict[str, dict] = {
         "plages_pointe_h": [(0, 24)],
         "conso_journaliere_pointe_pct": 1.0,
         "bacs_penetration_2024": 0.40,
-        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Sante",
+        "source": "Baromètre Flex 2026 RTE/Enedis/GIMELEC - Sante",
     },
     "HOTELLERIE": {
         # Clim + ECS : double pointe matin/soir.
@@ -159,14 +159,14 @@ ARCHETYPE_CALIBRATION_2024: dict[str, dict] = {
         "plages_pointe_h": [(6, 10), (18, 23)],
         "conso_journaliere_pointe_pct": 0.48,
         "bacs_penetration_2024": 0.11,
-        "source": "Barometre Flex 2026 RTE/Enedis/GIMELEC - Hotellerie",
+        "source": "Baromètre Flex 2026 RTE/Enedis/GIMELEC - Hotellerie",
     },
     "INDUSTRIE_LEGERE": {
         "taux_decalable_moyen": 0.35,
         "plages_pointe_h": [(6, 18)],
         "conso_journaliere_pointe_pct": 0.60,
         "bacs_penetration_2024": 0.20,  # estimation GIMELEC (non publie par Enedis)
-        "source": "Barometre Flex 2026 GIMELEC - Industrie legere (estimation)",
+        "source": "Baromètre Flex 2026 GIMELEC - Industrie legere (estimation)",
     },
 }
 

--- a/backend/services/pilotage/roi_flex_ready.py
+++ b/backend/services/pilotage/roi_flex_ready.py
@@ -191,5 +191,5 @@ def compute_roi_flex_ready(
             "puissance_max_kw": p_max_kw,
         },
         "confiance": "indicative",
-        "source": "Barometre Flex 2026 RTE/Enedis + fiche CEE BAT-TH-116",
+        "source": "Baromètre Flex 2026 RTE/Enedis + fiche CEE BAT-TH-116",
     }

--- a/backend/tests/test_pilotage_archetype_calibration.py
+++ b/backend/tests/test_pilotage_archetype_calibration.py
@@ -47,7 +47,7 @@ def test_all_8_archetypes_calibrated():
     for code in EXPECTED_ARCHETYPES:
         entry = ARCHETYPE_CALIBRATION_2024[code]
         assert required_fields <= entry.keys(), f"{code} : champs manquants {required_fields - entry.keys()}"
-        assert "Barometre Flex 2026" in entry["source"] or "GIMELEC" in entry["source"], (
+        assert "Baromètre Flex 2026" in entry["source"] or "GIMELEC" in entry["source"], (
             f"{code} : source doit citer le Barometre Flex 2026 / GIMELEC (got {entry['source']!r})"
         )
 
@@ -87,7 +87,7 @@ def test_compute_potential_score_uses_calibration_when_present():
     assert result["used_calibration"] is True
     assert result["taux_decalable"] == pytest.approx(0.55)
     assert result["conso_pointe_pct"] == pytest.approx(1.0)
-    assert "Barometre Flex 2026" in result["source"]
+    assert "Baromètre Flex 2026" in result["source"]
     # Score doit etre plus eleve que celui d'un bureau standard (logique metier)
     result_bureau = compute_potential_score("BUREAU_STANDARD")
     assert result_bureau["used_calibration"] is True

--- a/backend/tests/test_pilotage_roi_flex_ready.py
+++ b/backend/tests/test_pilotage_roi_flex_ready.py
@@ -155,7 +155,7 @@ def test_roi_endpoint_schema_pydantic_valide(client):
     assert parsed.archetype == "COMMERCE_ALIMENTAIRE"
     assert parsed.gain_annuel_total_eur > 0
     assert parsed.confiance == "indicative"
-    assert "Barometre Flex 2026" in parsed.source
+    assert "Baromètre Flex 2026" in parsed.source
     # Les 3 composantes doivent etre presentes
     assert parsed.composantes.evitement_pointe_eur >= 0
     assert parsed.composantes.decalage_nebco_eur >= 0

--- a/frontend/src/__tests__/pilotage_archetype_labels.test.js
+++ b/frontend/src/__tests__/pilotage_archetype_labels.test.js
@@ -1,0 +1,75 @@
+/**
+ * PROMEOS — Pilotage archetypeLabels helpers — runtime unit tests.
+ *
+ * Couvre le comportement reel des helpers humanise* (pas juste source-guard).
+ * Fix audit 17/04/2026 : helpers non testes runtime pouvaient driver sans
+ * signal (ex : un nouveau code backend `DATA_CENTER` afficherait le SCREAMING
+ * brut au lieu d'un label humain).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ARCHETYPE_LABELS,
+  DEMO_SITE_LABELS,
+  humaniseArchetype,
+  humaniseSiteId,
+} from '../components/pilotage/archetypeLabels';
+
+describe('humaniseArchetype', () => {
+  it('humanise les 8 archetypes canoniques du Baromètre Flex 2026', () => {
+    expect(humaniseArchetype('BUREAU_STANDARD')).toBe('Bureau standard');
+    expect(humaniseArchetype('COMMERCE_ALIMENTAIRE')).toBe('Commerce alimentaire');
+    expect(humaniseArchetype('COMMERCE_SPECIALISE')).toBe('Commerce spécialisé');
+    expect(humaniseArchetype('LOGISTIQUE_FRIGO')).toBe('Logistique frigorifique');
+    expect(humaniseArchetype('ENSEIGNEMENT')).toBe('Enseignement');
+    expect(humaniseArchetype('SANTE')).toBe('Santé');
+    expect(humaniseArchetype('HOTELLERIE')).toBe('Hôtellerie');
+    expect(humaniseArchetype('INDUSTRIE_LEGERE')).toBe('Industrie légère');
+  });
+
+  it('retourne "Indéterminé" quand le code est null/undefined/""', () => {
+    expect(humaniseArchetype(null)).toBe('Indéterminé');
+    expect(humaniseArchetype(undefined)).toBe('Indéterminé');
+    expect(humaniseArchetype('')).toBe('Indéterminé');
+  });
+
+  it("fallback au code brut si l'archetype est inconnu (drift doctrine)", () => {
+    // Un code backend non encore mappe cote front reste visible tel quel --
+    // c'est preferable a un "indetermine" silencieux qui masquerait le drift.
+    expect(humaniseArchetype('DATA_CENTER')).toBe('DATA_CENTER');
+    expect(humaniseArchetype('FUTUR_CODE')).toBe('FUTUR_CODE');
+  });
+
+  it('ARCHETYPE_LABELS expose les 8 cles canoniques attendues', () => {
+    expect(Object.keys(ARCHETYPE_LABELS).sort()).toEqual([
+      'BUREAU_STANDARD',
+      'COMMERCE_ALIMENTAIRE',
+      'COMMERCE_SPECIALISE',
+      'ENSEIGNEMENT',
+      'HOTELLERIE',
+      'INDUSTRIE_LEGERE',
+      'LOGISTIQUE_FRIGO',
+      'SANTE',
+    ]);
+  });
+});
+
+describe('humaniseSiteId', () => {
+  it('humanise les 3 cles DEMO_SITES canoniques', () => {
+    expect(humaniseSiteId('retail-001')).toBe('Hypermarché Montreuil');
+    expect(humaniseSiteId('bureau-001')).toBe('Bureau Haussmann');
+    expect(humaniseSiteId('entrepot-001')).toBe('Entrepôt Rungis');
+  });
+
+  it('retourne "" quand le siteId est absent', () => {
+    expect(humaniseSiteId(null)).toBe('');
+    expect(humaniseSiteId(undefined)).toBe('');
+    expect(humaniseSiteId('')).toBe('');
+  });
+
+  it('fallback au siteId brut pour un Site.id reel (numerique) ou cle inconnue', () => {
+    // Un Site.id reel de prod (ex: "42") passe tel quel -- le caller
+    // RoiFlexReadyCard resoud le nom humain via scopedSites.find() separement.
+    expect(humaniseSiteId('42')).toBe('42');
+    expect(humaniseSiteId('unknown-key')).toBe('unknown-key');
+  });
+});

--- a/frontend/src/__tests__/pilotage_cards_sprint1.test.js
+++ b/frontend/src/__tests__/pilotage_cards_sprint1.test.js
@@ -95,6 +95,32 @@ describe('RadarPrixNegatifsCard — timezone Europe/Paris force', () => {
   });
 });
 
+// ── Wording fixes Sprint 1b (audit visuel agents SDK) ───────────────
+describe('Pilotage cards — Sprint 1b wording FAIL corriges', () => {
+  it('Radar sous-titre utilise "Fenetres favorables probables" (pas "cout efface")', () => {
+    expect(radarSrc).toMatch(/Fenêtres favorables probables/);
+    const codeOnly = radarSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    expect(codeOnly).not.toMatch(/coût effacé/);
+  });
+
+  it('Radar badge confiance affiche "confiance indicative" (pas "INDICATIVE" majuscules)', () => {
+    expect(radarSrc).toMatch(/confiance \{data\?\.confiance/);
+    const codeOnly = radarSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    expect(codeOnly).not.toMatch(/uppercase tracking-wide[^}]*confiance/);
+  });
+
+  it('RoiFlexReadyCard humanise archetype + site_id (plus de codes SCREAMING_SNAKE cote UI)', () => {
+    expect(roiSrc).toMatch(/humaniseArchetype/);
+    expect(roiSrc).toMatch(/humaniseSiteId/);
+  });
+
+  it('PortefeuilleScoringCard humanise archetype + mappe "INCONNU" en "A qualifier"', () => {
+    expect(portefeuilleSrc).toMatch(/humaniseArchetype/);
+    expect(portefeuilleSrc).toMatch(/HEATMAP_INCONNU_LABEL/);
+    expect(portefeuilleSrc).toMatch(/À qualifier/);
+  });
+});
+
 // ── Data-testid stability (audit robustesse) ─────────────────────────
 describe('Pilotage cards — data-testid stable pour Playwright', () => {
   it('chaque carte porte son data-testid racine', () => {

--- a/frontend/src/__tests__/pilotage_cards_sprint1.test.js
+++ b/frontend/src/__tests__/pilotage_cards_sprint1.test.js
@@ -1,0 +1,105 @@
+/**
+ * PROMEOS — Pilotage V1 Sprint 1 P0 UX — Source Guards.
+ *
+ * Couvre :
+ *   - Wording doctrine : zero "NEBCO" cote client
+ *   - Scope switcher : useScope() cable sur les 2 cartes concernees
+ *   - CTA present sur les 3 cartes
+ *   - RadarPrixNegatifsCard utilise Intl.DateTimeFormat avec timeZone Europe/Paris
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cardsDir = join(__dirname, '..', 'components', 'pilotage');
+
+const radarSrc = readFileSync(join(cardsDir, 'RadarPrixNegatifsCard.jsx'), 'utf-8');
+const roiSrc = readFileSync(join(cardsDir, 'RoiFlexReadyCard.jsx'), 'utf-8');
+const portefeuilleSrc = readFileSync(join(cardsDir, 'PortefeuilleScoringCard.jsx'), 'utf-8');
+
+// ── Doctrine wording (fix #3 audit) ──────────────────────────────────
+describe('Pilotage cards — wording doctrine', () => {
+  it('RoiFlexReadyCard ne doit pas afficher "NEBCO" cote client', () => {
+    // Le terme peut rester dans les commentaires/docstrings (reference
+    // technique interne), mais pas dans les JSX rendus.
+    const codeOnly = roiSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    expect(codeOnly).not.toMatch(/>[^<]*NEBCO[^<]*</);
+    expect(codeOnly).not.toMatch(/label=["'][^"']*NEBCO[^"']*["']/);
+  });
+
+  it('RoiFlexReadyCard utilise "Effacement rémunéré" pour la composante decalage', () => {
+    expect(roiSrc).toMatch(/Effacement rémunéré/);
+  });
+
+  it('RadarPrixNegatifsCard ne doit pas dire "prix negatif" cote client', () => {
+    const codeOnly = radarSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    expect(codeOnly).not.toMatch(/>[^<]*prix négatif[^<]*</i);
+  });
+});
+
+// ── Scope switcher (fix #1 audit) ────────────────────────────────────
+describe('Pilotage cards — scope switcher', () => {
+  it('RoiFlexReadyCard utilise useScope (plus de hardcode site)', () => {
+    expect(roiSrc).toMatch(/from\s+['"]\.\.\/\.\.\/contexts\/ScopeContext['"]/);
+    expect(roiSrc).toMatch(/useScope\(\)/);
+    // scope.siteId prioritaire sur le fallback demo
+    expect(roiSrc).toMatch(/scope\?\.siteId/);
+  });
+
+  it('PortefeuilleScoringCard re-fetch au changement de scope', () => {
+    expect(portefeuilleSrc).toMatch(/useScope\(\)/);
+    // useEffect doit avoir une dependance qui change au switch d'org/portefeuille
+    expect(portefeuilleSrc).toMatch(/scopeKey/);
+  });
+});
+
+// ── CTAs (fix #2 audit) ──────────────────────────────────────────────
+describe('Pilotage cards — CTAs actionnables', () => {
+  it('RadarPrixNegatifsCard propose un CTA "Planifier" via ActionDrawer, desactive si pas de site scope', () => {
+    expect(radarSrc).toMatch(/useActionDrawer/);
+    expect(radarSrc).toMatch(/openActionDrawer\(/);
+    expect(radarSrc).toMatch(/pilotage_radar/);
+    expect(radarSrc).toMatch(/Planifier/);
+    // Bouton disabled si scope.siteId absent (evite actions sans rattachement)
+    expect(radarSrc).toMatch(/disabled=\{!hasSite\}/);
+    // sourceId fallback si datetime absent (clef idempotence drawer)
+    expect(radarSrc).toMatch(/datetime \|\| `radar-\$\{idx\}`/);
+  });
+
+  it('RoiFlexReadyCard expose un CTA navigation vers la fiche site (via toSite)', () => {
+    expect(roiSrc).toMatch(/useNavigate/);
+    expect(roiSrc).toMatch(/navigate\(ctaTarget\)/);
+    expect(roiSrc).toMatch(/toSite\(scope\.siteId\)/);
+    expect(roiSrc).toMatch(/data-testid=["']pilotage-roi-cta["']/);
+  });
+
+  it('PortefeuilleScoringCard rend les lignes top-5 cliquables via <Link> vers /sites/:id', () => {
+    expect(portefeuilleSrc).toMatch(/from ['"]react-router-dom['"]/);
+    expect(portefeuilleSrc).toMatch(/<Link\b/);
+    expect(portefeuilleSrc).toMatch(/toSite\(/);
+    // Seules les lignes avec Site.id numerique doivent etre cliquables
+    expect(portefeuilleSrc).toMatch(/NUMERIC_ID_RE/);
+  });
+});
+
+// ── Timezone Europe/Paris (audit utilisation #6) ─────────────────────
+describe('RadarPrixNegatifsCard — timezone Europe/Paris force', () => {
+  it('utilise Intl.DateTimeFormat avec timeZone Europe/Paris (pas new Date().getHours())', () => {
+    expect(radarSrc).toMatch(/new Intl\.DateTimeFormat/);
+    expect(radarSrc).toMatch(/timeZone:\s*['"]Europe\/Paris['"]/);
+    // Plus de getHours() direct sur new Date(iso) pour affichage
+    const codeOnly = radarSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    expect(codeOnly).not.toMatch(/new Date\([^)]+\)\.getHours\(\)/);
+  });
+});
+
+// ── Data-testid stability (audit robustesse) ─────────────────────────
+describe('Pilotage cards — data-testid stable pour Playwright', () => {
+  it('chaque carte porte son data-testid racine', () => {
+    expect(radarSrc).toMatch(/data-testid=["']pilotage-radar-card["']/);
+    expect(roiSrc).toMatch(/data-testid=["']pilotage-roi-card["']/);
+    expect(portefeuilleSrc).toMatch(/data-testid=["']pilotage-portefeuille-card["']/);
+  });
+});

--- a/frontend/src/__tests__/pilotage_cards_sprint1.test.js
+++ b/frontend/src/__tests__/pilotage_cards_sprint1.test.js
@@ -60,12 +60,14 @@ describe('Pilotage cards — CTAs actionnables', () => {
   it('RadarPrixNegatifsCard propose un CTA "Planifier" via ActionDrawer, desactive si pas de site scope', () => {
     expect(radarSrc).toMatch(/useActionDrawer/);
     expect(radarSrc).toMatch(/openActionDrawer\(/);
-    expect(radarSrc).toMatch(/pilotage_radar/);
+    // Le backend actions n'accepte que "manual" ou "insight" comme source_type.
+    // On utilise donc sourceType: 'insight' + sourceId prefixe `pilotage_radar:`
+    // pour conserver la tracabilite sans casser la validation enum.
+    expect(radarSrc).toMatch(/sourceType:\s*['"]insight['"]/);
+    expect(radarSrc).toMatch(/sourceId:\s*`pilotage_radar:/);
     expect(radarSrc).toMatch(/Planifier/);
     // Bouton disabled si scope.siteId absent (evite actions sans rattachement)
     expect(radarSrc).toMatch(/disabled=\{!hasSite\}/);
-    // sourceId fallback si datetime absent (clef idempotence drawer)
-    expect(radarSrc).toMatch(/datetime \|\| `radar-\$\{idx\}`/);
   });
 
   it('RoiFlexReadyCard expose un CTA navigation vers la fiche site (via toSite)', () => {

--- a/frontend/src/components/pilotage/PortefeuilleScoringCard.jsx
+++ b/frontend/src/components/pilotage/PortefeuilleScoringCard.jsx
@@ -6,18 +6,13 @@
  *
  * Source : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { getPortefeuilleScoring } from '../../services/api/pilotage';
+import { useScope } from '../../contexts/ScopeContext';
+import { toSite } from '../../services/routes';
+import { fmtEur } from '../../utils/format';
 import { Skeleton, InfoTip } from '../../ui';
-
-function fmtEuro(n) {
-  if (n == null) return '—';
-  return Number(n).toLocaleString('fr-FR', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: 0,
-  });
-}
 
 function scoreBand(s) {
   if (s >= 75) return 'bg-emerald-500';
@@ -34,10 +29,17 @@ function heatIntensity(gainTotal, maxGain) {
   return 'bg-indigo-100 text-indigo-800';
 }
 
+const NUMERIC_ID_RE = /^\d+$/;
+
 export default function PortefeuilleScoringCard() {
+  const { scope, scopedSites } = useScope();
+
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  // Re-fetch au switch d'org ou portefeuille -- scoring recalcule cote backend.
+  const scopeKey = `${scope?.orgId ?? 'none'}:${scope?.portefeuilleId ?? 'none'}`;
 
   useEffect(() => {
     let cancel = false;
@@ -55,7 +57,13 @@ export default function PortefeuilleScoringCard() {
     return () => {
       cancel = true;
     };
-  }, []);
+  }, [scopeKey]);
+
+  const siteLabel = useMemo(() => {
+    const byId = new Map();
+    (scopedSites || []).forEach((s) => byId.set(String(s.id), s.nom));
+    return (siteIdRaw) => byId.get(String(siteIdRaw)) || siteIdRaw;
+  }, [scopedSites]);
 
   if (loading) {
     return (
@@ -107,9 +115,9 @@ export default function PortefeuilleScoringCard() {
           </p>
         </div>
         <div className="text-right">
-          <div className="text-[10px] text-gray-400 uppercase tracking-wide">Budget flex</div>
+          <div className="text-[10px] text-gray-400 uppercase tracking-wide">Gain portefeuille</div>
           <div className="text-sm font-bold text-gray-900 whitespace-nowrap">
-            {fmtEuro(gain_annuel_portefeuille_eur)}/an
+            {fmtEur(gain_annuel_portefeuille_eur)}/an
           </div>
         </div>
       </div>
@@ -118,28 +126,50 @@ export default function PortefeuilleScoringCard() {
         <p className="text-xs text-gray-500">Aucun site scopé pour l'instant.</p>
       ) : (
         <ol className="space-y-1.5">
-          {top5.map((site) => (
-            <li
-              key={site.site_id}
-              className="flex items-center gap-2 text-xs"
-              data-testid={`portefeuille-row-${site.site_id}`}
-            >
-              <span className="w-5 text-[10px] text-gray-400 font-medium">#{site.rang}</span>
-              <span className="flex-1 min-w-0 truncate text-gray-800">{site.site_id}</span>
-              <span className="text-[10px] text-gray-500 truncate max-w-[90px]">
-                {site.archetype || '—'}
-              </span>
-              <div className="w-20 h-1.5 bg-gray-100 rounded-full overflow-hidden">
-                <div
-                  className={`h-full ${scoreBand(site.score)} rounded-full`}
-                  style={{ width: `${Math.max(2, Math.round(site.score))}%` }}
-                />
-              </div>
-              <span className="w-16 text-right text-gray-900 font-medium whitespace-nowrap">
-                {fmtEuro(site.gain_annuel_eur)}
-              </span>
-            </li>
-          ))}
+          {top5.map((site) => {
+            const siteIdStr = String(site.site_id);
+            const isNumeric = NUMERIC_ID_RE.test(siteIdStr);
+            const rowInner = (
+              <>
+                <span className="w-5 text-[10px] text-gray-400 font-medium">#{site.rang}</span>
+                <span className="flex-1 min-w-0 truncate text-gray-800">
+                  {siteLabel(site.site_id)}
+                </span>
+                <span className="text-[10px] text-gray-500 truncate max-w-[90px]">
+                  {site.archetype || '—'}
+                </span>
+                <div className="w-20 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                  <div
+                    className={`h-full ${scoreBand(site.score)} rounded-full`}
+                    style={{ width: `${Math.max(2, Math.round(site.score))}%` }}
+                  />
+                </div>
+                <span className="w-16 text-right text-gray-900 font-medium whitespace-nowrap">
+                  {fmtEur(site.gain_annuel_eur)}
+                </span>
+              </>
+            );
+            return (
+              <li key={siteIdStr} data-testid={`portefeuille-row-${siteIdStr}`}>
+                {isNumeric ? (
+                  <Link
+                    to={toSite(siteIdStr)}
+                    className="flex items-center gap-2 text-xs rounded px-1 py-0.5 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none focus:ring-1 focus:ring-indigo-400 no-underline"
+                  >
+                    {rowInner}
+                  </Link>
+                ) : (
+                  <div
+                    className="flex items-center gap-2 text-xs rounded px-1 py-0.5"
+                    title="Disponible en production uniquement"
+                    aria-disabled="true"
+                  >
+                    {rowInner}
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ol>
       )}
 
@@ -160,7 +190,7 @@ export default function PortefeuilleScoringCard() {
                   agg?.score_moyen || 0
                 )}`}
               >
-                {code} · {fmtEuro(agg?.gain_total_eur)}
+                {code} · {fmtEur(agg?.gain_total_eur)}
               </span>
             ))}
           </div>

--- a/frontend/src/components/pilotage/PortefeuilleScoringCard.jsx
+++ b/frontend/src/components/pilotage/PortefeuilleScoringCard.jsx
@@ -13,6 +13,9 @@ import { useScope } from '../../contexts/ScopeContext';
 import { toSite } from '../../services/routes';
 import { fmtEur } from '../../utils/format';
 import { Skeleton, InfoTip } from '../../ui';
+import { humaniseArchetype } from './archetypeLabels';
+
+const HEATMAP_INCONNU_LABEL = 'À qualifier';
 
 function scoreBand(s) {
   if (s >= 75) return 'bg-emerald-500';
@@ -135,8 +138,8 @@ export default function PortefeuilleScoringCard() {
                 <span className="flex-1 min-w-0 truncate text-gray-800">
                   {siteLabel(site.site_id)}
                 </span>
-                <span className="text-[10px] text-gray-500 truncate max-w-[90px]">
-                  {site.archetype || '—'}
+                <span className="text-[10px] text-gray-500 truncate max-w-[110px]">
+                  {humaniseArchetype(site.archetype)}
                 </span>
                 <div className="w-20 h-1.5 bg-gray-100 rounded-full overflow-hidden">
                   <div
@@ -179,20 +182,23 @@ export default function PortefeuilleScoringCard() {
             Heatmap archétype <InfoTip content="Intensité = gain annuel total par archétype" />
           </div>
           <div className="flex flex-wrap gap-1">
-            {archetypes.map(([code, agg]) => (
-              <span
-                key={code}
-                className={`text-[10px] px-2 py-0.5 rounded ${heatIntensity(
-                  agg?.gain_total_eur || 0,
-                  maxArchGain
-                )}`}
-                title={`${agg?.nb_sites || 0} site(s) · score moyen ${Math.round(
-                  agg?.score_moyen || 0
-                )}`}
-              >
-                {code} · {fmtEur(agg?.gain_total_eur)}
-              </span>
-            ))}
+            {archetypes.map(([code, agg]) => {
+              const label = code === 'INCONNU' ? HEATMAP_INCONNU_LABEL : humaniseArchetype(code);
+              return (
+                <span
+                  key={code}
+                  className={`text-[10px] px-2 py-0.5 rounded ${heatIntensity(
+                    agg?.gain_total_eur || 0,
+                    maxArchGain
+                  )}`}
+                  title={`${agg?.nb_sites || 0} site(s) · score moyen ${Math.round(
+                    agg?.score_moyen || 0
+                  )}`}
+                >
+                  {label} · {fmtEur(agg?.gain_total_eur)}
+                </span>
+              );
+            })}
           </div>
         </div>
       )}

--- a/frontend/src/components/pilotage/RadarPrixNegatifsCard.jsx
+++ b/frontend/src/components/pilotage/RadarPrixNegatifsCard.jsx
@@ -6,35 +6,35 @@
  *
  * Source : Barometre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026).
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { CalendarPlus } from 'lucide-react';
 import { getRadarPrixNegatifs } from '../../services/api/pilotage';
+import { useActionDrawer } from '../../contexts/ActionDrawerContext';
+import { useScope } from '../../contexts/ScopeContext';
 import { Skeleton, InfoTip } from '../../ui';
 
-const WEEKDAY = ['dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam'];
+// Formatteurs Intl forces sur Europe/Paris -- independant du fuseau navigateur.
+// Les backends renvoient des ISO aware Europe/Paris (ex. 2026-04-22T10:00+02:00),
+// mais new Date().getHours() rend l'heure locale du navigateur -- pas la bonne.
+const RANGE_FMT = new Intl.DateTimeFormat('fr-FR', {
+  timeZone: 'Europe/Paris',
+  weekday: 'short',
+  day: '2-digit',
+  month: '2-digit',
+  hour: '2-digit',
+  hour12: false,
+});
 
-function formatDateTime(iso) {
-  if (!iso) return '—';
-  try {
-    const d = new Date(iso);
-    return `${WEEKDAY[d.getDay()]} ${String(d.getDate()).padStart(2, '0')}/${String(
-      d.getMonth() + 1
-    ).padStart(2, '0')} · ${String(d.getHours()).padStart(2, '0')}h`;
-  } catch {
-    return iso;
-  }
-}
+const HOUR_FMT = new Intl.DateTimeFormat('fr-FR', {
+  timeZone: 'Europe/Paris',
+  hour: '2-digit',
+  hour12: false,
+});
 
 function formatRange(debut, fin) {
   if (!debut || !fin) return '—';
   try {
-    const a = new Date(debut);
-    const b = new Date(fin);
-    return `${WEEKDAY[a.getDay()]} ${String(a.getDate()).padStart(2, '0')}/${String(
-      a.getMonth() + 1
-    ).padStart(2, '0')} · ${String(a.getHours()).padStart(2, '0')}h–${String(b.getHours()).padStart(
-      2,
-      '0'
-    )}h`;
+    return `${RANGE_FMT.format(new Date(debut))}–${HOUR_FMT.format(new Date(fin))}`;
   } catch {
     return `${debut} → ${fin}`;
   }
@@ -47,9 +47,17 @@ const USAGE_LABEL = {
 };
 
 export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
+  const { openActionDrawer } = useActionDrawer();
+  const { scope } = useScope();
+
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  // Radar signal est national (ENTSO-E FR) mais on re-fetch au switch d'org
+  // pour invalider tout cache stale au niveau du client. Cf. ScopeContext
+  // clearApiCache() qui flush les GET lors du changement de scope.
+  const scopeKey = `${scope?.orgId ?? 'none'}:${horizonDays}`;
 
   useEffect(() => {
     let cancel = false;
@@ -67,7 +75,32 @@ export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
     return () => {
       cancel = true;
     };
-  }, [horizonDays]);
+  }, [scopeKey, horizonDays]);
+
+  const hasSite = Boolean(scope?.siteId);
+
+  const handlePlanifier = (fenetre, idx) => {
+    if (!hasSite) return;
+    const datetime = fenetre?.datetime_debut;
+    const usages = (fenetre?.usages_recommandes || []).map((u) => USAGE_LABEL[u] || u).join(' · ');
+    openActionDrawer({
+      siteId: scope.siteId,
+      sourceType: 'pilotage_radar',
+      sourceId: datetime || `radar-${idx}`,
+      prefill: {
+        titre: `Décaler usages flexibles — ${formatRange(
+          fenetre?.datetime_debut,
+          fenetre?.datetime_fin
+        )}`,
+        description:
+          `Fenêtre favorable probable détectée (${Math.round((fenetre?.probabilite || 0) * 100)}%).` +
+          (usages ? ` Usages conseillés : ${usages}.` : ''),
+        date_cible: datetime ? datetime.split('T')[0] : null,
+      },
+    });
+  };
+
+  const topFenetres = useMemo(() => (data?.fenetres_predites || []).slice(0, 4), [data]);
 
   if (loading) {
     return (
@@ -93,9 +126,11 @@ export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
     );
   }
 
-  const fenetres = data?.fenetres_predites || [];
   const emptyMsg =
     'Historique insuffisant ou aucune récurrence détectée sur l’horizon demandé. Revenez demain.';
+  const ctaTitle = hasSite
+    ? 'Créer une action planifiée pour cette fenêtre'
+    : 'Sélectionnez un site pour planifier un décalage';
 
   return (
     <div
@@ -106,8 +141,7 @@ export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
         <div>
           <h3 className="text-sm font-semibold text-gray-800">Radar fenêtres favorables</h3>
           <p className="text-[11px] text-gray-500 mt-0.5">
-            Probabilité de créneaux à prix effondrés dans les {data?.horizon_jours ?? horizonDays}{' '}
-            jours.
+            Créneaux probables à coût effacé dans les {data?.horizon_jours ?? horizonDays} jours.
           </p>
         </div>
         <span className="inline-flex items-center gap-1 bg-emerald-50 text-emerald-700 text-[10px] font-medium px-2 py-0.5 rounded-full whitespace-nowrap">
@@ -115,14 +149,15 @@ export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
         </span>
       </div>
 
-      {fenetres.length === 0 ? (
+      {topFenetres.length === 0 ? (
         <p className="text-xs text-gray-500">{emptyMsg}</p>
       ) : (
         <ul className="space-y-2">
-          {fenetres.slice(0, 4).map((f, idx) => (
+          {topFenetres.map((f, idx) => (
             <li
               key={`${f.datetime_debut}-${idx}`}
               className="flex items-center justify-between gap-3 text-xs border border-gray-100 rounded-lg px-2.5 py-2"
+              data-testid={`pilotage-radar-row-${idx}`}
             >
               <div className="flex-1 min-w-0">
                 <div className="font-medium text-gray-900">
@@ -133,11 +168,24 @@ export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
                     'Décaler les usages flexibles'}
                 </div>
               </div>
-              <div className="text-right whitespace-nowrap">
-                <div className="text-sm font-semibold text-emerald-700">
-                  {Math.round((f.probabilite || 0) * 100)}%
+              <div className="flex items-center gap-3 shrink-0 text-right whitespace-nowrap">
+                <div>
+                  <div className="text-sm font-semibold text-emerald-700">
+                    {Math.round((f.probabilite || 0) * 100)}%
+                  </div>
+                  <div className="text-[10px] text-gray-400">probable</div>
                 </div>
-                <div className="text-[10px] text-gray-400">probable</div>
+                <button
+                  type="button"
+                  onClick={() => handlePlanifier(f, idx)}
+                  disabled={!hasSite}
+                  className="inline-flex items-center gap-1 text-[10px] font-medium text-indigo-700 hover:text-indigo-900 hover:underline disabled:text-gray-400 disabled:cursor-not-allowed disabled:hover:no-underline"
+                  title={ctaTitle}
+                  data-testid={`pilotage-radar-cta-${idx}`}
+                >
+                  <CalendarPlus size={12} />
+                  Planifier
+                </button>
               </div>
             </li>
           ))}

--- a/frontend/src/components/pilotage/RadarPrixNegatifsCard.jsx
+++ b/frontend/src/components/pilotage/RadarPrixNegatifsCard.jsx
@@ -141,7 +141,7 @@ export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
         <div>
           <h3 className="text-sm font-semibold text-gray-800">Radar fenêtres favorables</h3>
           <p className="text-[11px] text-gray-500 mt-0.5">
-            Créneaux probables à coût effacé dans les {data?.horizon_jours ?? horizonDays} jours.
+            Fenêtres favorables probables dans les {data?.horizon_jours ?? horizonDays} jours.
           </p>
         </div>
         <span className="inline-flex items-center gap-1 bg-emerald-50 text-emerald-700 text-[10px] font-medium px-2 py-0.5 rounded-full whitespace-nowrap">
@@ -197,7 +197,7 @@ export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
           Source : historique marché 90 j{' '}
           <InfoTip content="Baromètre Flex 2026 RTE/Enedis/GIMELEC" />
         </span>
-        <span className="uppercase tracking-wide">{data?.confiance || 'indicative'}</span>
+        <span>confiance {data?.confiance || 'indicative'}</span>
       </div>
     </div>
   );

--- a/frontend/src/components/pilotage/RadarPrixNegatifsCard.jsx
+++ b/frontend/src/components/pilotage/RadarPrixNegatifsCard.jsx
@@ -83,10 +83,13 @@ export default function RadarPrixNegatifsCard({ horizonDays = 7 }) {
     if (!hasSite) return;
     const datetime = fenetre?.datetime_debut;
     const usages = (fenetre?.usages_recommandes || []).map((u) => USAGE_LABEL[u] || u).join(' · ');
+    // Le backend actions n'accepte que `manual` ou `insight` comme source_type
+    // (cf. backend/routes/actions.py:263 + ActionSourceType enum). On prefixe
+    // donc le sourceId avec `pilotage_radar:` pour conserver la tracabilite.
     openActionDrawer({
       siteId: scope.siteId,
-      sourceType: 'pilotage_radar',
-      sourceId: datetime || `radar-${idx}`,
+      sourceType: 'insight',
+      sourceId: `pilotage_radar:${datetime || `idx-${idx}`}`,
       prefill: {
         titre: `Décaler usages flexibles — ${formatRange(
           fenetre?.datetime_debut,

--- a/frontend/src/components/pilotage/RoiFlexReadyCard.jsx
+++ b/frontend/src/components/pilotage/RoiFlexReadyCard.jsx
@@ -2,24 +2,20 @@
  * RoiFlexReadyCard - Pilotage V1.
  *
  * Gain annuel estime Flex Ready(R) pour le site courant.
- * 3 composantes : evitement pointe + decalage NEBCO + CEE BAT-TH-116.
+ * 3 composantes : evitement pointe + effacement remunere + CEE BAT-TH-116.
  *
  * Sources : Barometre Flex 2026 (RTE/Enedis/GIMELEC), fiche CEE BAT-TH-116.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
 import { getRoiFlexReady } from '../../services/api/pilotage';
+import { useScope } from '../../contexts/ScopeContext';
+import { toSite } from '../../services/routes';
+import { fmtEur } from '../../utils/format';
 import { Skeleton, InfoTip } from '../../ui';
 
-const DEFAULT_DEMO_SITE = 'retail-001';
-
-function fmtEuro(n) {
-  if (n == null) return '—';
-  return Number(n).toLocaleString('fr-FR', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: 0,
-  });
-}
+const DEMO_FALLBACK_SITE = 'retail-001';
 
 function ComposanteBar({ label, value, total, color, tooltip }) {
   const pct = total > 0 ? Math.max(2, Math.round((value / total) * 100)) : 0;
@@ -30,7 +26,7 @@ function ComposanteBar({ label, value, total, color, tooltip }) {
           {label}
           {tooltip ? <InfoTip content={tooltip} /> : null}
         </span>
-        <span className="font-medium text-gray-900">{fmtEuro(value)}</span>
+        <span className="font-medium text-gray-900">{fmtEur(value)}</span>
       </div>
       <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
         <div className={`h-full ${color} rounded-full`} style={{ width: `${pct}%` }} />
@@ -39,8 +35,17 @@ function ComposanteBar({ label, value, total, color, tooltip }) {
   );
 }
 
-export default function RoiFlexReadyCard({ siteId }) {
-  const resolvedSiteId = siteId || DEFAULT_DEMO_SITE;
+export default function RoiFlexReadyCard({ siteId: siteIdProp }) {
+  const navigate = useNavigate();
+  const { scope, scopedSites } = useScope();
+
+  const resolvedSiteId = String(siteIdProp || scope?.siteId || DEMO_FALLBACK_SITE);
+
+  const siteNom = useMemo(() => {
+    if (!scope?.siteId) return null;
+    const found = scopedSites?.find((s) => String(s.id) === resolvedSiteId);
+    return found?.nom || null;
+  }, [scope?.siteId, scopedSites, resolvedSiteId]);
 
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -86,7 +91,7 @@ export default function RoiFlexReadyCard({ siteId }) {
       >
         <h3 className="text-sm font-semibold text-gray-800 mb-2">Gain annuel Flex Ready®</h3>
         <p className="text-xs text-gray-500">
-          Site sans données Flex Ready® — sélectionnez un site démo ou terminer le seed.
+          Site pas encore qualifié Flex Ready® — contactez votre CSM pour activer le diagnostic.
         </p>
       </div>
     );
@@ -94,6 +99,8 @@ export default function RoiFlexReadyCard({ siteId }) {
 
   const { gain_annuel_total_eur, composantes = {}, archetype } = data;
   const total = Number(gain_annuel_total_eur || 0);
+  const ctaLabel = scope?.siteId ? 'Voir la fiche site' : 'Explorer un site démo';
+  const ctaTarget = scope?.siteId ? toSite(scope.siteId) : '/sites';
 
   return (
     <div
@@ -104,7 +111,7 @@ export default function RoiFlexReadyCard({ siteId }) {
         <div>
           <h3 className="text-sm font-semibold text-gray-800">Gain annuel Flex Ready®</h3>
           <p className="text-[11px] text-gray-500 mt-0.5">
-            Valorisation cumulée — site {resolvedSiteId}
+            Valorisation cumulée — {siteNom || resolvedSiteId}
           </p>
         </div>
         <span
@@ -116,7 +123,7 @@ export default function RoiFlexReadyCard({ siteId }) {
       </div>
 
       <div>
-        <div className="text-3xl font-bold text-gray-900 leading-none">{fmtEuro(total)}</div>
+        <div className="text-3xl font-bold text-gray-900 leading-none">{fmtEur(total)}</div>
         <div className="text-[11px] text-gray-500 mt-1">
           Archétype : {archetype || 'indéterminé'} · confiance {data.confiance || 'indicative'}
         </div>
@@ -128,23 +135,33 @@ export default function RoiFlexReadyCard({ siteId }) {
           value={composantes.evitement_pointe_eur || 0}
           total={total}
           color="bg-amber-500"
-          tooltip="kW pilotable × heures pointe évitées × spread €/MWh"
+          tooltip="kW pilotable × heures pointe évitées × écart prix pointe vs creux"
         />
         <ComposanteBar
-          label="Décalage NEBCO"
+          label="Effacement rémunéré"
           value={composantes.decalage_nebco_eur || 0}
           total={total}
           color="bg-emerald-500"
-          tooltip="kW décalable × ~200 h/an × 60 €/MWh spread"
+          tooltip="Décalage volontaire de consommation vers les fenêtres favorables (~200 h/an × 60 €/MWh)"
         />
         <ComposanteBar
           label="CEE BAT-TH-116"
           value={composantes.cee_bacs_eur || 0}
           total={total}
           color="bg-sky-500"
-          tooltip="3,5 €/m² × surface — fiche GTB/BACS"
+          tooltip="3,5 €/m² × surface — fiche CEE pilotage bâtiment"
         />
       </div>
+
+      <button
+        type="button"
+        onClick={() => navigate(ctaTarget)}
+        className="mt-1 inline-flex items-center justify-between gap-1 text-xs font-medium text-indigo-700 hover:text-indigo-900 hover:underline"
+        data-testid="pilotage-roi-cta"
+      >
+        <span>{ctaLabel}</span>
+        <ArrowRight size={12} />
+      </button>
 
       <div className="text-[10px] text-gray-400 mt-auto pt-1 border-t border-gray-100">
         Source : {data.source || 'Baromètre Flex 2026 + fiche CEE'}

--- a/frontend/src/components/pilotage/RoiFlexReadyCard.jsx
+++ b/frontend/src/components/pilotage/RoiFlexReadyCard.jsx
@@ -14,6 +14,7 @@ import { useScope } from '../../contexts/ScopeContext';
 import { toSite } from '../../services/routes';
 import { fmtEur } from '../../utils/format';
 import { Skeleton, InfoTip } from '../../ui';
+import { humaniseArchetype, humaniseSiteId } from './archetypeLabels';
 
 const DEMO_FALLBACK_SITE = 'retail-001';
 
@@ -111,7 +112,7 @@ export default function RoiFlexReadyCard({ siteId: siteIdProp }) {
         <div>
           <h3 className="text-sm font-semibold text-gray-800">Gain annuel Flex Ready®</h3>
           <p className="text-[11px] text-gray-500 mt-0.5">
-            Valorisation cumulée — {siteNom || resolvedSiteId}
+            Valorisation cumulée — {siteNom || humaniseSiteId(resolvedSiteId)}
           </p>
         </div>
         <span
@@ -125,7 +126,7 @@ export default function RoiFlexReadyCard({ siteId: siteIdProp }) {
       <div>
         <div className="text-3xl font-bold text-gray-900 leading-none">{fmtEur(total)}</div>
         <div className="text-[11px] text-gray-500 mt-1">
-          Archétype : {archetype || 'indéterminé'} · confiance {data.confiance || 'indicative'}
+          Archétype : {humaniseArchetype(archetype)} · confiance {data.confiance || 'indicative'}
         </div>
       </div>
 

--- a/frontend/src/components/pilotage/archetypeLabels.js
+++ b/frontend/src/components/pilotage/archetypeLabels.js
@@ -1,0 +1,41 @@
+/**
+ * PROMEOS - Labels humains des archetypes Pilotage.
+ *
+ * Mapping des codes canoniques backend (`ARCHETYPE_CALIBRATION_2024`) vers
+ * leurs libelles humains FR affiches cote client. Source : Barometre Flex 2026
+ * + GLOSSAIRE Pilotage `docs/pilotage-usages/GLOSSAIRE.md` §4.
+ *
+ * Regle doctrine : les codes SCREAMING_SNAKE (BUREAU_STANDARD, COMMERCE_
+ * ALIMENTAIRE...) ne doivent PAS etre exposes brut cote UI (audit wording
+ * 17/04/2026 a flag 4 FAIL sur ce point).
+ */
+export const ARCHETYPE_LABELS = {
+  BUREAU_STANDARD: 'Bureau standard',
+  COMMERCE_ALIMENTAIRE: 'Commerce alimentaire',
+  COMMERCE_SPECIALISE: 'Commerce spécialisé',
+  LOGISTIQUE_FRIGO: 'Logistique frigorifique',
+  ENSEIGNEMENT: 'Enseignement',
+  SANTE: 'Santé',
+  HOTELLERIE: 'Hôtellerie',
+  INDUSTRIE_LEGERE: 'Industrie légère',
+};
+
+/**
+ * Labels humains des cles DEMO_SITES (fallback quand scope = "Tous les sites").
+ * Source : `backend/routes/pilotage.py` DEMO_SITES (clef `nom`).
+ */
+export const DEMO_SITE_LABELS = {
+  'retail-001': 'Hypermarché Montreuil',
+  'bureau-001': 'Bureau Haussmann',
+  'entrepot-001': 'Entrepôt Rungis',
+};
+
+export function humaniseArchetype(code) {
+  if (!code) return 'Indéterminé';
+  return ARCHETYPE_LABELS[code] || code;
+}
+
+export function humaniseSiteId(siteId) {
+  if (!siteId) return '';
+  return DEMO_SITE_LABELS[siteId] || siteId;
+}


### PR DESCRIPTION
## Contexte

Audit 4 agents parallèles a identifié que les 3 cartes Pilotage V1 (PR #222 mergée) restaient **cosmétiques** : pas de CTA, scope non branché (hardcode `retail-001`), "NEBCO" visible côté client. Sprint 1 P0 règle les 3 bloquants UX avant d'attaquer la Vague 2 innovation roadmap.

## Fixes P0

**#1 Scope switcher** — `RoiFlexReadyCard` consomme `useScope().scope.siteId` prioritaire sur le fallback DEMO. `PortefeuilleScoringCard` re-fetch au switch org/portefeuille via `scopeKey` dans `useEffect` deps. Nom humain du site affiché à la place de l'id brut.

**#2 CTAs actionnables sur les 3 cartes**
- Radar → bouton "Planifier" par fenêtre → `openActionDrawer({ sourceType: 'pilotage_radar', prefill })`. **Désactivé si pas de site scope** (évite action orpheline).
- ROI → bouton "Voir la fiche site" → `navigate(toSite(scope.siteId))`.
- Portefeuille → top-5 en `<Link to={toSite(id)}>` (sémantique native vs `role=button` inventé).

**#3 Wording "NEBCO" → "Effacement rémunéré"** — label composante + tooltip. Regex de test garantit zéro "NEBCO" JSX client-side.

## Findings simplify/review appliqués avant commit

4 agents parallèles (simplify reuse + simplify quality + simplify efficiency + code-review) :

- **Reuse** : `fmtEur` de `utils/format.js` au lieu de `fmtEuro` local ×2 ; `toSite(id)` au lieu de `/sites/${id}` hardcodé.
- **Quality** : suppression `useMemo` sur ternaire trivial ; `<Link>` remplace `<li role=button>` ; `NUMERIC_ID_RE` extrait constant.
- **Efficiency** : `HOUR_FMT` hoisté au module scope (allocation par call évitée).
- **Bugs** : `sourceId: datetime || \`radar-${idx}\`` (fallback idempotency drawer) ; Planifier disabled si `!scope.siteId`.
- **Robustesse** : `Intl.DateTimeFormat({ timeZone: 'Europe/Paris' })` force le fuseau (plus `new Date().getHours()` qui rend l'heure navigateur).

## Dégradation gracieuse

Base `main` (sans Option C PR #227). Pour un site numérique réel, le backend `/roi-flex-ready/{numeric_id}` retourne 404 → empty state "Site pas encore qualifié Flex Ready®". Brille au merge de #227.

## Test plan

- [x] `cd frontend && npx vitest run src/__tests__/pilotage_cards_sprint1.test.js` → 10/10 ✅
- [x] `cd frontend && npx vite build` → 38s ✅
- [ ] Manual DEMO : cockpit `/cockpit`, voir 3 cartes avec CTAs, bouton Planifier ouvre ActionDrawer prefilé
- [ ] Manual scope : sélectionner un site réel → RoiFlexReadyCard affiche ce site (nom humain)
- [ ] Manual wording : inspecter DOM → zéro "NEBCO"

## Dépendances / ordre de merge

- PR #222 (V1 Pilotage) : ✅ mergée
- PR #227 (Option C Site model) : en review — pas bloquant mais améliore l'expérience (`/roi-flex-ready/{Site.id}` numérique).
- PR #227 + #228 (cette PR) peuvent merger dans n'importe quel ordre.

## Source doctrine

Baromètre Flex 2026 (RTE/Enedis/GIMELEC, avril 2026) + `docs/ux/cx-amelioration-continue-2026.md` (Top 20 actions CX, pyramide inversée, Action Center).

🤖 Generated with [Claude Code](https://claude.com/claude-code)