### PR TITLE
refactor(parameter-store): dedup billing + pilotage via utils/parameter_store_base

### DIFF
--- a/backend/services/billing_engine/parameter_store.py
+++ b/backend/services/billing_engine/parameter_store.py
@@ -30,13 +30,23 @@ Compatibilité :
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Optional
 
+from utils.parameter_store_base import (
+    ParameterResolution,
+    coerce_date as _coerce_date,
+    load_yaml_section,
+    paris_today,
+    period_contains as _base_period_contains,
+    warn_unknown_once,
+)
+
 logger = logging.getLogger(__name__)
 
-# Codes déjà signalés comme inconnus — évite de spammer les logs à chaque lookup.
+# Codes déjà signalés comme inconnus — module-level set isolé du pilotage
+# (helper `warn_unknown_once` accepte le set en paramètre pour éviter qu'un
+# test pilotage pollue le cache billing — cf. audit Sprint 5b).
 _unknown_codes_seen: set[str] = set()
 
 # Codes connus du référentiel — documentés pour éviter les fautes de frappe.
@@ -101,28 +111,9 @@ KNOWN_CODES = frozenset(
 )
 
 
-@dataclass(frozen=True)
-class ParameterResolution:
-    """Résultat d'une résolution : valeur + trace d'audit."""
-
-    code: str
-    value: float
-    source: str  # "db" | "yaml" | "missing"
-    source_ref: Optional[str]  # référence réglementaire (arrêté, délibération CRE)
-    valid_from: Optional[date]
-    valid_to: Optional[date]
-    scope: dict[str, str]  # scope effectivement résolu
-
-    def to_trace(self) -> dict[str, Any]:
-        return {
-            "code": self.code,
-            "value": self.value,
-            "source": self.source,
-            "source_ref": self.source_ref,
-            "valid_from": self.valid_from.isoformat() if self.valid_from else None,
-            "valid_to": self.valid_to.isoformat() if self.valid_to else None,
-            "scope": self.scope,
-        }
+# `ParameterResolution` et `_coerce_date` proviennent désormais de
+# `utils.parameter_store_base` (Sprint 5b dedup). Rétro-compat totale :
+# importée sous le nom `ParameterResolution` depuis ce module.
 
 
 # ── YAML loader ────────────────────────────────────────────────────────────
@@ -132,6 +123,7 @@ class ParameterResolution:
 
 
 def _load_yaml() -> dict:
+    """Charge le YAML tarifs complet (dict vide si loader indispo)."""
     try:
         from config.tarif_loader import load_tarifs
 
@@ -151,31 +143,14 @@ def reload_yaml_cache() -> None:
         logger.debug("ParameterStore.reload_yaml_cache: %s", exc)
 
 
-# ── Helpers de normalisation ──────────────────────────────────────────────
-def _coerce_date(value: Any) -> Optional[date]:
-    """Normalise une date (str ISO, datetime, date) en date pure."""
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    if isinstance(value, str):
-        try:
-            return date.fromisoformat(value)
-        except ValueError:
-            logger.warning("ParameterStore: date invalide '%s'", value)
-            return None
-    return None
-
-
 def _period_contains(valid_from: Optional[date], valid_to: Optional[date], at: date) -> bool:
-    """True si `at` est dans [valid_from, valid_to] (bornes incluses)."""
-    if valid_from and at < valid_from:
-        return False
-    if valid_to and at > valid_to:
-        return False
-    return True
+    """True si `at` est dans [valid_from, valid_to] (bornes incluses).
+
+    Wrapper sur `utils.parameter_store_base.period_contains` avec l'ordre
+    d'arguments historique billing (valid_from, valid_to, at) pour éviter
+    de toucher les ~50 call sites internes.
+    """
+    return _base_period_contains(at, valid_from, valid_to)
 
 
 def _turpe_candidates(tarifs: dict, seg: str, value_key: str) -> list[tuple[dict, str]]:
@@ -423,12 +398,13 @@ class ParameterStore:
         Retourne toujours une ParameterResolution (jamais None).
         Pour une valeur manquante, source="missing" et value=0.0.
         """
-        if code not in KNOWN_CODES and code not in _unknown_codes_seen:
-            _unknown_codes_seen.add(code)
-            logger.warning("ParameterStore: code inconnu '%s'", code)
+        if code not in KNOWN_CODES:
+            warn_unknown_once(_unknown_codes_seen, logger, code, module_tag="ParameterStore")
 
         if at_date is None:
-            at_date = date.today()
+            # Sprint 5b fix : Europe/Paris forcé (évite J-1 sous Docker UTC
+            # au tournant d'année, cf. fix pilotage Sprint 2 remonté en base).
+            at_date = paris_today()
         if isinstance(at_date, datetime):
             at_date = at_date.date()
         scope = scope or {}

--- a/backend/services/pilotage/parameters.py
+++ b/backend/services/pilotage/parameters.py
@@ -6,9 +6,13 @@ constantes MVP du module Pilotage (ROI Flex Ready® + scoring portefeuille).
 
 Pattern : inspiré du `ParameterStore` billing V112 (résolution YAML versionnée
 par `valid_from` + scope), mais scopé sur les paramètres pilotage uniquement.
-Pas de duplication avec le ParameterStore billing : les paramètres pilotage
-vivent dans la section `pilotage_flex_ready:` du YAML `tarifs_reglementaires`,
-et ce module est la seule façade qui les lit.
+Les paramètres pilotage vivent dans la section `pilotage_flex_ready:` du YAML
+`tarifs_reglementaires`.
+
+Depuis Sprint 5b, la dataclass `ParameterResolution` + helpers (`coerce_date`,
+`warn_unknown_once`, `paris_today`, `load_yaml_section`) sont partagés avec
+billing via `utils.parameter_store_base`. La logique de résolution (scope
+scoring archetype, liste plate YAML) reste spécifique pilotage.
 
 Principes :
 - Une seule source de vérité : `config/tarifs_reglementaires.yaml`
@@ -22,15 +26,16 @@ Principes :
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from datetime import date, datetime
-from zoneinfo import ZoneInfo
+from typing import Optional, Union
 
-# Fuseau reference France : on veut la date "aujourd'hui" cote Paris, pas
-# la date UTC machine (qui peut etre J-1 au tournant d'annee dans les conteneurs
-# Docker UTC et rater un `valid_from: 2026-01-01`).
-_TZ_PARIS = ZoneInfo("Europe/Paris")
-from typing import Any, Optional, Union
+from utils.parameter_store_base import (
+    ParameterResolution,
+    coerce_date,
+    load_yaml_section,
+    paris_today,
+    warn_unknown_once,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,64 +54,21 @@ KNOWN_PILOTAGE_CODES = frozenset(
     }
 )
 
-# Cache des codes inconnus déjà loggés — évite le spam.
+# Cache des codes inconnus déjà loggés (module-level, isolé de billing) — évite spam.
 _unknown_codes_seen: set[str] = set()
 
-
-@dataclass(frozen=True)
-class PilotageParameterResolution:
-    """Résultat d'une résolution pilotage : valeur + trace d'audit."""
-
-    code: str
-    value: Union[float, int]
-    source: str  # "yaml" | "fallback" | "missing"
-    source_ref: Optional[str]  # citation réglementaire / baromètre
-    valid_from: Optional[date]
-    unite: Optional[str]
-    scope: dict[str, str]
-
-    def to_trace(self) -> dict[str, Any]:
-        return {
-            "code": self.code,
-            "value": self.value,
-            "source": self.source,
-            "source_ref": self.source_ref,
-            "valid_from": self.valid_from.isoformat() if self.valid_from else None,
-            "unite": self.unite,
-            "scope": self.scope,
-        }
-
-
-def _coerce_date(value: Any) -> Optional[date]:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    if isinstance(value, str):
-        try:
-            return date.fromisoformat(value)
-        except ValueError:
-            logger.warning("pilotage.parameters: date invalide '%s'", value)
-            return None
-    return None
+# Alias rétrocompat : code externe peut avoir importé `PilotageParameterResolution`.
+# La dataclass est maintenant `ParameterResolution` dans `utils.parameter_store_base`.
+PilotageParameterResolution = ParameterResolution
 
 
 def _load_pilotage_entries() -> list[dict]:
     """Charge la section `pilotage_flex_ready:` du YAML. [] si indisponible."""
-    try:
-        from config.tarif_loader import load_tarifs
-
-        tarifs = load_tarifs() or {}
-        entries = tarifs.get("pilotage_flex_ready") or []
-        if not isinstance(entries, list):
-            logger.warning("pilotage.parameters: section 'pilotage_flex_ready' malformée")
-            return []
-        return entries
-    except Exception as exc:  # pragma: no cover (défensif prod)
-        logger.warning("pilotage.parameters: YAML indisponible (%s)", exc)
+    entries = load_yaml_section("pilotage_flex_ready") or []
+    if not isinstance(entries, list):
+        logger.warning("pilotage.parameters: section 'pilotage_flex_ready' malformée")
         return []
+    return entries
 
 
 def _match_scope(entry_scope: dict, archetype: Optional[str]) -> Optional[int]:
@@ -129,7 +91,7 @@ def _resolve(
     code: str,
     at_date: date,
     archetype: Optional[str],
-) -> Optional[PilotageParameterResolution]:
+) -> Optional[ParameterResolution]:
     """Parcourt les entrées YAML et sélectionne la plus précise/récente."""
     entries = _load_pilotage_entries()
     if not entries:
@@ -146,7 +108,7 @@ def _resolve(
         scope_score = _match_scope(scope_dict, archetype)
         if scope_score is None:
             continue
-        vfrom = _coerce_date(entry.get("valid_from"))
+        vfrom = coerce_date(entry.get("valid_from"))
         if vfrom and vfrom > at_date:
             continue
         # Date default : "2000-01-01" si absente (applicable tout le temps)
@@ -164,12 +126,12 @@ def _resolve(
     if valeur is None:
         return None
 
-    return PilotageParameterResolution(
+    return ParameterResolution(
         code=code,
         value=valeur,
         source="yaml",
         source_ref=best_entry.get("source"),
-        valid_from=_coerce_date(best_entry.get("valid_from")),
+        valid_from=coerce_date(best_entry.get("valid_from")),
         unite=best_entry.get("unite"),
         scope=dict(best_entry.get("scope") or {}),
     )
@@ -180,7 +142,7 @@ def get_pilotage_param(
     at_date: Optional[date] = None,
     archetype: Optional[str] = None,
     default: Optional[Union[float, int]] = None,
-) -> PilotageParameterResolution:
+) -> ParameterResolution:
     """
     Résout un paramètre pilotage (YAML → fallback → missing).
 
@@ -189,7 +151,7 @@ def get_pilotage_param(
     code : str
         Code canonique (ex. "HEURES_FENETRES_FAVORABLES_AN").
     at_date : date | None
-        Date d'effet à considérer. Default = aujourd'hui.
+        Date d'effet à considérer. Default = aujourd'hui Europe/Paris.
     archetype : str | None
         Archetype canonique (ex. "COMMERCE_ALIMENTAIRE"). Si None, seul le
         scope wildcard "*" est considéré.
@@ -199,15 +161,14 @@ def get_pilotage_param(
 
     Returns
     -------
-    PilotageParameterResolution (jamais None) : value + trace.
+    ParameterResolution (jamais None) : value + trace.
     Si code inconnu et pas de default → value=0, source="missing" (+ warning).
     """
-    if code not in KNOWN_PILOTAGE_CODES and code not in _unknown_codes_seen:
-        _unknown_codes_seen.add(code)
-        logger.warning("pilotage.parameters: code inconnu '%s'", code)
+    if code not in KNOWN_PILOTAGE_CODES:
+        warn_unknown_once(_unknown_codes_seen, logger, code, module_tag="pilotage.parameters")
 
     if at_date is None:
-        at_date = datetime.now(_TZ_PARIS).date()
+        at_date = paris_today()
     if isinstance(at_date, datetime):
         at_date = at_date.date()
 
@@ -229,13 +190,11 @@ def get_pilotage_param(
             code,
             default,
         )
-        return PilotageParameterResolution(
+        return ParameterResolution(
             code=code,
             value=default,
             source="fallback",
             source_ref="hardcoded fallback (YAML indisponible ou code absent)",
-            valid_from=None,
-            unite=None,
             scope={"archetype": archetype or "*"},
         )
 
@@ -245,13 +204,10 @@ def get_pilotage_param(
         archetype,
         at_date,
     )
-    return PilotageParameterResolution(
+    return ParameterResolution(
         code=code,
         value=0,
         source="missing",
-        source_ref=None,
-        valid_from=None,
-        unite=None,
         scope={"archetype": archetype or "*"},
     )
 

--- a/backend/tests/test_parameter_store_base.py
+++ b/backend/tests/test_parameter_store_base.py
@@ -1,0 +1,208 @@
+"""
+PROMEOS - Tests du module commun utils/parameter_store_base.
+
+Fige le contrat (fields + defaults + to_trace) partagé entre ParameterStore
+(billing) et parameters (pilotage). Toute évolution de `ParameterResolution`
+doit passer par ce test — en particulier : pas d'ajout de champ requis sans
+default (sinon breaking change cross-module).
+
+Couvre aussi :
+    - `coerce_date` (ISO, date, datetime, None, invalid)
+    - `period_contains` (bornes ouvertes et inclusives)
+    - `warn_unknown_once` (anti-spam, sets isolés)
+    - `load_yaml_section` (délégation tarif_loader)
+    - `paris_today` (fuseau Europe/Paris)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import date, datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from utils.parameter_store_base import (
+    ParameterResolution,
+    coerce_date,
+    load_yaml_section,
+    paris_today,
+    period_contains,
+    warn_unknown_once,
+)
+
+
+# ---------------------------------------------------------------------------
+# Contract test : ParameterResolution — garanti entre billing et pilotage
+# ---------------------------------------------------------------------------
+def test_parameter_resolution_contract_fields():
+    """
+    Fige les champs publics. Ajouter un champ non-optional casse billing
+    et pilotage simultanément — ce test doit tirer la sonnette d'alarme.
+    """
+    res = ParameterResolution(code="X", value=1.0, source="yaml")
+    # Les 3 requis
+    assert res.code == "X"
+    assert res.value == 1.0
+    assert res.source == "yaml"
+    # Les 5 optionnels (défauts)
+    assert res.source_ref is None
+    assert res.valid_from is None
+    assert res.valid_to is None
+    assert res.unite is None
+    assert res.scope == {}
+
+
+def test_parameter_resolution_frozen():
+    """Immuable : un set direct lève FrozenInstanceError."""
+    res = ParameterResolution(code="X", value=1.0, source="yaml")
+    with pytest.raises(Exception):
+        res.code = "Y"  # type: ignore[misc]
+
+
+def test_parameter_resolution_kw_only():
+    """kw_only=True : arguments positionnels refusés (protège extensions futures)."""
+    with pytest.raises(TypeError):
+        ParameterResolution("X", 1.0, "yaml")  # type: ignore[misc]
+
+
+def test_to_trace_expose_tous_les_champs():
+    """`to_trace()` doit exposer les 8 champs (contrat audit regops/cfo)."""
+    res = ParameterResolution(
+        code="CEE_BACS_EUR_M2",
+        value=3.5,
+        source="yaml",
+        source_ref="fiche CEE BAT-TH-116",
+        valid_from=date(2026, 1, 1),
+        valid_to=date(2026, 12, 31),
+        unite="EUR/m2",
+        scope={"archetype": "BUREAU_STANDARD"},
+    )
+    trace = res.to_trace()
+    assert trace == {
+        "code": "CEE_BACS_EUR_M2",
+        "value": 3.5,
+        "source": "yaml",
+        "source_ref": "fiche CEE BAT-TH-116",
+        "valid_from": "2026-01-01",
+        "valid_to": "2026-12-31",
+        "unite": "EUR/m2",
+        "scope": {"archetype": "BUREAU_STANDARD"},
+    }
+
+
+def test_to_trace_nones_serializes_correctement():
+    """Bornes ouvertes : isoformat() n'est pas appelé sur None."""
+    res = ParameterResolution(code="X", value=1.0, source="yaml")
+    trace = res.to_trace()
+    assert trace["valid_from"] is None
+    assert trace["valid_to"] is None
+    assert trace["unite"] is None
+
+
+# ---------------------------------------------------------------------------
+# coerce_date
+# ---------------------------------------------------------------------------
+def test_coerce_date_iso_str():
+    assert coerce_date("2026-01-01") == date(2026, 1, 1)
+
+
+def test_coerce_date_datetime_to_date():
+    assert coerce_date(datetime(2026, 1, 1, 12, 30)) == date(2026, 1, 1)
+
+
+def test_coerce_date_date_passthrough():
+    d = date(2026, 6, 15)
+    assert coerce_date(d) == d
+
+
+def test_coerce_date_none_returns_none():
+    assert coerce_date(None) is None
+
+
+def test_coerce_date_invalid_str_returns_none():
+    """Str non parseable → None silent (ne raise pas, fail-safe batch)."""
+    assert coerce_date("pas une date") is None
+    assert coerce_date("2026-13-99") is None
+
+
+# ---------------------------------------------------------------------------
+# period_contains
+# ---------------------------------------------------------------------------
+def test_period_contains_bornes_inclusives():
+    """valid_from ≤ at ≤ valid_to avec bornes comprises."""
+    at = date(2026, 6, 15)
+    assert period_contains(at, date(2026, 1, 1), date(2026, 12, 31)) is True
+    assert period_contains(at, date(2026, 6, 15), date(2026, 6, 15)) is True  # 1 jour
+
+
+def test_period_contains_avant_valid_from():
+    assert period_contains(date(2025, 12, 31), date(2026, 1, 1), None) is False
+
+
+def test_period_contains_apres_valid_to():
+    assert period_contains(date(2027, 1, 1), None, date(2026, 12, 31)) is False
+
+
+def test_period_contains_bornes_ouvertes():
+    """None des deux côtés → applicable à toute l'histoire."""
+    assert period_contains(date(2020, 1, 1), None, None) is True
+    assert period_contains(date(2050, 6, 15), None, None) is True
+
+
+# ---------------------------------------------------------------------------
+# warn_unknown_once — set isolé, pas de double log
+# ---------------------------------------------------------------------------
+def test_warn_unknown_once_no_double_warning(caplog):
+    """Le même code ne logue qu'une fois par set."""
+    seen: set[str] = set()
+    lg = logging.getLogger("test.warn")
+    with caplog.at_level(logging.WARNING, logger="test.warn"):
+        warn_unknown_once(seen, lg, "CODE_X")
+        warn_unknown_once(seen, lg, "CODE_X")
+        warn_unknown_once(seen, lg, "CODE_X")
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "CODE_X" in warnings[0].message
+
+
+def test_warn_unknown_once_sets_isoles():
+    """Deux sets distincts = 2 logs (billing n'empoisonne pas pilotage)."""
+    set_a: set[str] = set()
+    set_b: set[str] = set()
+    lg = logging.getLogger("test.isole")
+    warn_unknown_once(set_a, lg, "CODE_Y")
+    warn_unknown_once(set_b, lg, "CODE_Y")
+    # Chaque set a enregistré, indépendamment
+    assert "CODE_Y" in set_a
+    assert "CODE_Y" in set_b
+
+
+# ---------------------------------------------------------------------------
+# load_yaml_section + paris_today
+# ---------------------------------------------------------------------------
+def test_load_yaml_section_existe():
+    """Une section connue du YAML doit être lisible."""
+    entries = load_yaml_section("pilotage_flex_ready")
+    assert entries is not None
+    assert isinstance(entries, list)
+    assert len(entries) > 0
+
+
+def test_load_yaml_section_absente_retourne_none():
+    """Section inexistante → None (le caller décide du fallback)."""
+    assert load_yaml_section("section_bidon_inexistante") is None
+
+
+def test_paris_today_dans_fuseau_paris():
+    """`paris_today()` doit retourner une date Europe/Paris, pas UTC."""
+    from zoneinfo import ZoneInfo
+
+    today_paris = paris_today()
+    expected = datetime.now(ZoneInfo("Europe/Paris")).date()
+    # Très tolérant : on accepte une seconde de drift sur le tournant minuit
+    # (si le test tourne à 23:59:59 Paris, paris_today() peut être J et expected J+1)
+    assert abs((today_paris - expected).days) <= 1

--- a/backend/utils/parameter_store_base.py
+++ b/backend/utils/parameter_store_base.py
@@ -1,0 +1,174 @@
+"""
+PROMEOS — Base partagée entre les ParameterStore (billing) et parameters (pilotage).
+
+Consolide ~100 LOC strictement identiques entre `services/billing_engine/
+parameter_store.py` (V112) et `services/pilotage/parameters.py` (V115 Sprint 2) :
+
+    - `ParameterResolution` : dataclass frozen `kw_only=True` avec trace d'audit
+      (7 champs dont `unite` et `valid_to` tous deux `Optional`, extensibles
+      sans breaking via default None).
+    - `coerce_date(value)` : accepte str ISO / date / datetime / None.
+    - `period_contains(at_date, valid_from, valid_to)` : test d'inclusion
+      inclusive (valid_from ≤ at_date ≤ valid_to, bornes None = ouvertes).
+    - `warn_unknown_once(seen_set, logger, code)` : anti-spam. Le set est
+      passé en paramètre pour que billing et pilotage gardent leurs propres
+      scopes isolés (évite pollution cross-module en tests parallèles).
+    - `load_yaml_section(key)` : délégation `config.tarif_loader.load_tarifs()`
+      (cache unique partagé, `reload_tarifs()` propagé).
+    - `paris_today()` : date "aujourd'hui" forcée Europe/Paris (évite le
+      bug latent UTC-vs-Paris sous Docker au tournant d'année).
+
+Architecture : chaque ParameterStore applicatif (billing, pilotage) garde
+sa propre logique de résolution (dispatch YAML par section vs liste plate +
+scope scoring), son propre `KNOWN_CODES` frozenset, et sa propre façade
+publique. Seul l'échafaudage commun vit ici.
+
+Référence : review indépendant PR #231 Sprint 2 + audit pré-refactor Sprint 5b.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+_TZ_PARIS = ZoneInfo("Europe/Paris")
+
+
+@dataclass(frozen=True, kw_only=True)
+class ParameterResolution:
+    """
+    Résultat d'une résolution : valeur + trace d'audit réglementaire.
+
+    Partagé entre billing et pilotage. `kw_only=True` + tous les champs
+    extensibles `Optional = None` pour permettre l'ajout de champs futurs
+    (ex. `confidence`) sans casser l'instanciation existante.
+
+    Attributs
+    ---------
+    code        Code canonique du paramètre (ex. "TVA_RATE_TURPE", "CEE_BACS_EUR_M2")
+    value       Valeur numérique résolue (int ou float)
+    source      "db" | "yaml" | "fallback" | "missing" — origine machine-readable
+    source_ref  Citation réglementaire (arrêté, CRE, Baromètre) — optionnelle
+    valid_from  Date d'effet — ouverte (None) si applicable à toute l'histoire
+    valid_to    Date de fin — ouverte (None) si paramètre encore en vigueur
+    unite       Unité métier ("EUR/kWh", "h/an", etc.) — optionnelle pour billing
+    scope       Dict scope effectivement résolu (ex. {"archetype": "BUREAU_STANDARD"})
+    """
+
+    code: str
+    value: float
+    source: str
+    source_ref: Optional[str] = None
+    valid_from: Optional[date] = None
+    valid_to: Optional[date] = None
+    unite: Optional[str] = None
+    scope: dict[str, str] = field(default_factory=dict)
+
+    def to_trace(self) -> dict[str, Any]:
+        """Export dict pour injection dans payload hypotheses.parametres_sources."""
+        return {
+            "code": self.code,
+            "value": self.value,
+            "source": self.source,
+            "source_ref": self.source_ref,
+            "valid_from": self.valid_from.isoformat() if self.valid_from else None,
+            "valid_to": self.valid_to.isoformat() if self.valid_to else None,
+            "unite": self.unite,
+            "scope": self.scope,
+        }
+
+
+def coerce_date(value: Any) -> Optional[date]:
+    """
+    Normalise en `date` depuis str ISO ("2026-01-01"), date, datetime, None.
+
+    Retourne None si valeur vide ou non parseable (plutôt que raise —
+    évite d'interrompre un batch de résolution sur une entrée YAML corrompue).
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def period_contains(
+    at_date: date,
+    valid_from: Optional[date],
+    valid_to: Optional[date],
+) -> bool:
+    """
+    True si `at_date ∈ [valid_from, valid_to]` (bornes inclusives).
+
+    Bornes None = ouvertes (paramètre applicable à toute l'histoire côté
+    début ou encore en vigueur côté fin). Utilisé par les 2 moteurs de
+    résolution pour filtrer les candidats avant ranking.
+    """
+    if valid_from is not None and at_date < valid_from:
+        return False
+    if valid_to is not None and at_date > valid_to:
+        return False
+    return True
+
+
+def warn_unknown_once(
+    seen_set: set[str],
+    logger: logging.Logger,
+    code: str,
+    module_tag: str = "parameter_store",
+) -> None:
+    """
+    Log `warning` une seule fois par code inconnu (anti-spam).
+
+    Le `seen_set` est passé en paramètre — billing et pilotage gardent
+    chacun leur propre set module-level pour éviter qu'un test pilotage
+    pollue silencieusement le cache billing (et inversement).
+
+    Args
+    ----
+    seen_set   Set module-level du caller (append-only, thread-safe suffisant
+               pour FastAPI sync)
+    logger     Logger du caller (pour propagation du contexte "billing" ou
+               "pilotage" dans les logs structurés)
+    code       Code inconnu observé
+    module_tag Label ajouté au message de log pour traçabilité
+    """
+    if code in seen_set:
+        return
+    seen_set.add(code)
+    logger.warning("%s: code inconnu '%s'", module_tag, code)
+
+
+def load_yaml_section(key: str) -> Any:
+    """
+    Charge une section du YAML `tarifs_reglementaires.yaml` via le loader
+    unique `config.tarif_loader.load_tarifs` (cache `@lru_cache` partagé).
+
+    Le test `reload_tarifs()` (côté billing) purge automatiquement les 2
+    consommateurs (billing + pilotage). Retourne la valeur par défaut
+    `None` si la section est absente — le caller décide du fallback.
+    """
+    from config.tarif_loader import load_tarifs
+
+    return load_tarifs().get(key)
+
+
+def paris_today() -> date:
+    """
+    Date "aujourd'hui" forcée Europe/Paris (pas UTC naïf).
+
+    Fix le bug latent sous Docker UTC : à 01h Paris un 1er janvier,
+    `date.today()` retourne J-1 UTC et rate un `valid_from: AAAA-01-01`.
+    Doit être utilisé par tous les callers qui résolvent `at_date=None`.
+    """
+    return datetime.now(_TZ_PARIS).date()


### PR DESCRIPTION
## Contexte

Dette finale Sprint 5 suite review indépendant PR #231 Sprint 2 : ~200 LOC duplicité entre `services/billing_engine/parameter_store.py` (V112) et `services/pilotage/parameters.py` (Sprint 2).

**Audit préalable** par agent SDK a retenu le **Scenario B (extraction module commun)** sur Scenario A (full merge, risque facturation trop élevé sur 478 tests billing) et Scenario C (status quo, drift inévitable).

## utils/parameter_store_base.py NEW

Module partagé (~180 LOC) exposant uniquement ce qui est strictement identique :
- `ParameterResolution` dataclass `frozen=True, kw_only=True` avec 3 champs requis + 5 `Optional = None` (extensibilité sans breaking cross-module)
- `coerce_date` + `period_contains`
- `warn_unknown_once(seen_set, logger, code, module_tag)` : **set en paramètre** — billing et pilotage gardent leurs sets isolés (évite pollution cross-module en tests)
- `load_yaml_section` : délégation tarif_loader
- `paris_today()` : Europe/Paris forcé (vs `date.today()` UTC naïf)

## Refactor des 2 consommateurs

- **pilotage/parameters.py** (-52 LOC) : import depuis base, alias rétro-compat `PilotageParameterResolution = ParameterResolution`, logique scope archetype intacte.
- **billing/parameter_store.py** (-50 LOC) : import depuis base, `_period_contains` conservé en wrapper pour préserver l'ordre d'args historique (évite de toucher ~50 call sites internes).
- **BONUS** : `date.today()` → `paris_today()` dans `ParameterStore.get()` — fix bug latent UTC-vs-Paris sous Docker au tournant d'année (même fix que pilotage Sprint 2, remonté au billing).

## Ce qui reste séparé (décision)

- Dispatch YAML : billing = sections typées / pilotage = liste plate → incompatibles
- `KNOWN_CODES` : namespaces disjoints
- Sets `_unknown_codes_seen` : module-level isolés (anti-pollution)
- Façades publiques : `ParameterStore().get()` vs `get_pilotage_param()`

## Test contract

`test_parameter_store_base.py` NEW (19 tests) fige l'interface : `kw_only`, `frozen`, `to_trace` 8 champs, `warn_unknown_once` anti-spam + sets isolés, `period_contains` bornes, `paris_today` TZ.

## Résultats

- **478/478 billing** verts (shadow billing V112/V113/V114 intact)
- **84/84 pilotage** verts
- **19/19 contract** NEW
- Ruff lint clean

## Follow-up Vague 3 billing

Quand le scope DB billing sera activé, helper `score_scope()` pourra remonter en base (ADR si fusion naturelle à ce moment).

## Source doctrine

Review indépendant PR #231 + audit pré-refactor Sprint 5b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)