### PR TITLE
feat(kb): aligner les 8 archétypes canoniques KB ↔ code pilotage

### DIFF
--- a/backend/tests/test_pilotage_kb_archetypes_coherence.py
+++ b/backend/tests/test_pilotage_kb_archetypes_coherence.py
@@ -1,0 +1,181 @@
+"""
+PROMEOS - Tests coherence KB archetypes vs code canonique pilotage.
+
+Previent la drift : tout archetype utilise par le code
+(`services.pilotage.constants.ARCHETYPE_CALIBRATION_2024`) doit avoir un
+fichier YAML KB correspondant dans `docs/kb/items/usages/ARCHETYPE-*.yaml`,
+et reciproquement (modulo une whitelist de sous-archetypes d'enrichissement).
+
+Source de calibrage : Barometre Flex 2026 RTE / Enedis / GIMELEC (avril 2026).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.pilotage.constants import (  # noqa: E402
+    ARCHETYPE_CALIBRATION_2024,
+    NAF_PREFIX_TO_PILOTAGE_ARCHETYPE,
+)
+
+
+# Racine des YAML KB archetypes. On remonte depuis backend/tests -> repo root.
+KB_DIR = Path(__file__).resolve().parent.parent.parent / "docs" / "kb" / "items" / "usages"
+
+# Sous-archetypes enrichissements (pas dans CALIBRATION_2024 mais legitimes).
+# Ces fichiers documentent des sous-cas plus precis sans etre des cles
+# canoniques du scoring pilotage. Ils doivent rester whitelistes explicitement
+# pour eviter tout ajout silencieux d'archetype hors perimetre Barometre 2026.
+KB_SUBARCHETYPES_ALLOWED: frozenset[str] = frozenset(
+    {
+        "HOPITAL_STANDARD",  # sous-cas plus precis de SANTE (hopitaux multi-services)
+        "RESTAURATION_SERVICE",  # sous-cas plus precis de HOTELLERIE (restaurants / services collectifs)
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_kb_archetype_codes() -> set[str]:
+    """Liste les codes archetypes depuis les fichiers KB (ARCHETYPE-<CODE>.yaml)."""
+    if not KB_DIR.exists():
+        return set()
+    codes: set[str] = set()
+    for p in KB_DIR.glob("ARCHETYPE-*.yaml"):
+        # "ARCHETYPE-BUREAU_STANDARD.yaml" -> "BUREAU_STANDARD"
+        codes.add(p.stem.replace("ARCHETYPE-", ""))
+    return codes
+
+
+def _load_kb_archetype(code: str) -> dict:
+    """Charge le YAML KB pour un archetype, assertion explicite si absent."""
+    p = KB_DIR / f"ARCHETYPE-{code}.yaml"
+    assert p.exists(), (
+        f"YAML KB manquant : {p}. "
+        f"Chaque archetype canonique doit avoir son fichier `docs/kb/items/usages/ARCHETYPE-<CODE>.yaml`."
+    )
+    with open(p, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), f"{code}: YAML racine n'est pas un dict"
+    return data
+
+
+def _normalize_naf_prefix(naf: str) -> str:
+    """Normalise un code NAF YAML ('47.11' ou '4711') en prefixe 4 chars comme dans le mapping Python."""
+    return str(naf).replace(".", "").replace(" ", "")[:4]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_tous_les_archetypes_code_ont_yaml_kb():
+    """Chaque cle de ARCHETYPE_CALIBRATION_2024 doit avoir un YAML KB correspondant."""
+    kb_codes = _list_kb_archetype_codes()
+    missing = set(ARCHETYPE_CALIBRATION_2024.keys()) - kb_codes
+    assert not missing, (
+        f"Archetypes code sans YAML KB : {sorted(missing)}. "
+        f"Creer `docs/kb/items/usages/ARCHETYPE-<CODE>.yaml` pour chacun."
+    )
+
+
+def test_tous_les_yaml_kb_sont_dans_code_canonique():
+    """Chaque YAML KB doit correspondre a un archetype canonique ou etre explicitement whiteliste."""
+    kb_codes = _list_kb_archetype_codes()
+    canonical = set(ARCHETYPE_CALIBRATION_2024.keys())
+    extras = kb_codes - canonical - KB_SUBARCHETYPES_ALLOWED
+    assert not extras, (
+        f"YAML KB orphelins (ni dans code canonique, ni dans whitelist sous-archetypes) : {sorted(extras)}. "
+        f"Soit ajouter au code (services/pilotage/constants.py), soit whitelister dans KB_SUBARCHETYPES_ALLOWED."
+    )
+
+
+@pytest.mark.parametrize("code", sorted(ARCHETYPE_CALIBRATION_2024.keys()))
+def test_yaml_kb_format_structurel(code):
+    """Structure obligatoire du YAML KB : champs top-level, coherence id/filename/scope.archetype."""
+    data = _load_kb_archetype(code)
+    required_keys = (
+        "id",
+        "type",
+        "domain",
+        "title",
+        "summary",
+        "tags",
+        "scope",
+        "content_md",
+        "sources",
+        "provenance",
+        "updated_at",
+        "confidence",
+        "status",
+        "priority",
+    )
+    for key in required_keys:
+        assert key in data, f"{code}: champ '{key}' manquant dans YAML KB"
+
+    assert data["type"] == "knowledge", f"{code}: type doit etre 'knowledge'"
+    assert data["domain"] == "usages", f"{code}: domain doit etre 'usages'"
+
+    assert isinstance(data["scope"], dict), f"{code}: scope doit etre un dict"
+    assert data["scope"].get("archetype") == code, (
+        f"{code}: scope.archetype ({data['scope'].get('archetype')!r}) doit etre egal au suffixe du filename ({code!r})"
+    )
+    assert data["scope"].get("naf_codes"), f"{code}: scope.naf_codes vide ou absent"
+
+    assert isinstance(data["tags"], dict), f"{code}: tags doit etre un dict"
+    assert data["tags"].get("energy"), f"{code}: tags.energy vide ou absent"
+
+
+@pytest.mark.parametrize("code", sorted(ARCHETYPE_CALIBRATION_2024.keys()))
+def test_naf_codes_yaml_alignes_avec_code(code):
+    """Au moins 1 code NAF du YAML doit avoir son equivalent dans NAF_PREFIX_TO_PILOTAGE_ARCHETYPE."""
+    data = _load_kb_archetype(code)
+    yaml_naf = {_normalize_naf_prefix(c) for c in data["scope"]["naf_codes"]}
+    code_naf_for_archetype = {prefix for prefix, arch in NAF_PREFIX_TO_PILOTAGE_ARCHETYPE.items() if arch == code}
+    shared = yaml_naf & code_naf_for_archetype
+    assert shared, (
+        f"{code}: aucun NAF partage entre YAML ({sorted(yaml_naf)}) "
+        f"et code Python NAF_PREFIX_TO_PILOTAGE_ARCHETYPE ({sorted(code_naf_for_archetype)}). "
+        f"Le YAML peut enrichir la liste Python mais au moins 1 code doit etre commun."
+    )
+
+
+@pytest.mark.parametrize("code", sorted(ARCHETYPE_CALIBRATION_2024.keys()))
+def test_content_md_mentionne_barometre_flex_2026(code):
+    """Le content_md doit citer 'Barometre Flex 2026' (source primaire calibrage)."""
+    data = _load_kb_archetype(code)
+    content = str(data.get("content_md", ""))
+    # Tolere les deux orthographes (accentuee et non-accentuee).
+    has_ref = ("Baromètre Flex 2026" in content) or ("Barometre Flex 2026" in content)
+    assert has_ref, (
+        f"{code}: content_md ne cite pas 'Barometre Flex 2026' (source primaire de calibrage). "
+        f"Tout archetype canonique doit tracer la source officielle."
+    )
+
+
+@pytest.mark.parametrize("code", sorted(ARCHETYPE_CALIBRATION_2024.keys()))
+def test_wording_doctrine_content_md(code):
+    """Doctrine wording : pas d'usage 'NEBCO' standalone (brique technique, pas terme archetype)."""
+    data = _load_kb_archetype(code)
+    content = str(data.get("content_md", ""))
+    # Check simple : le token "NEBCO" ne doit pas apparaitre nu dans la description
+    # d'archetype (markdown rendu cote doc). Les marques "Flex Ready" et les
+    # references "Barometre Flex 2026" restent autorisees (mentions explicites).
+    # Si on veut parler de NEBCO, le faire dans les briques dediees, pas dans
+    # les archetypes.
+    assert "NEBCO" not in content, (
+        f"{code}: content_md contient 'NEBCO' nu. "
+        f"NEBCO est une brique technique, pas un terme d'archetype. "
+        f"Utiliser 'flexibilite' ou 'effacement' dans le wording archetype."
+    )

--- a/docs/kb/items/usages/ARCHETYPE-BUREAU_STANDARD.yaml
+++ b/docs/kb/items/usages/ARCHETYPE-BUREAU_STANDARD.yaml
@@ -25,40 +25,64 @@ scope:
   - '70.10'
   - '70.22'
   - '62.02'
-content_md: '## Archétype Bureau Standard
-
+content_md: |
+  ## Archétype Bureau Standard
 
   ### Consommation typique
+  - **Fourchette** : 150-250 kWh/m²/an (moyenne : 180 kWh/m²/an)
 
-  - **Fourchette**: 150-250 kWh/m²/an
+  ### Signature temporelle
+  - Horaires ouverture : 7h-20h, lundi-vendredi
+  - Continu 24/7 : non
+  - Talon nocturne : 10-15 % de la conso jour (veilles IT, sécurité)
+  - Pic matin : 9h-10h (démarrage postes + chauffage)
+  - Pic après-midi : 14h-16h (climatisation été)
 
+  ### Répartition par usage
+  - CVC (chauffage / clim / ventilation) : 45-55 %
+  - Éclairage : 20-25 %
+  - IT / bureautique : 15-20 %
+  - Autres (ascenseurs, cafétéria...) : 10-15 %
 
-  ### Caractéristiques
+  ### Calibrage Baromètre Flex 2026
+  Calibrage officiel issu du Baromètre Flex 2026 (RTE / Enedis / GIMELEC,
+  avril 2026) consommé par `services.pilotage.constants.ARCHETYPE_CALIBRATION_2024` :
 
-  (Extrait du document source - voir provenance)
+  - **Taux décalable moyen** : 0,30 (30 % de la conso décalable vers fenêtres favorables)
+  - **Plages de pointe** : 7h-10h + 17h-20h (démarrage + fin de journée)
+  - **Conso concentrée pointe** : 28 % de la conso journalière
+  - **Pénétration BACS 2024** : 17 % (Enedis Open Data 2024)
 
+  ### Potentiel de pilotage
+  Gisement modéré mais structurellement constant : CVC et éclairage
+  décalables sur les plages hors-pointe (11h-16h), ECS et process IT
+  peu flexibles. Fenêtres favorables typiques : heures creuses TURPE 7
+  (11h-17h été, 2h-6h + 21h-24h hiver) + surplus PV midi.
 
-  2.1 Bureaux Tertiaires Code: BUREAU_STANDARD Description : Bureaux tertiaires classiques,
-  8h-19h, 5j/7 Consommation typique : 150-250 kWh/m²/an (moyenne: 180 kWh/m²/an) Répartition
-  usages : HVAC: 45-55% Éclairage: 20-25% IT: 15-20% Autres: 10-15% Signature temporelle
-  : Lundi-vendredi: consommation élevée 8h-19h, base réduite nuit/WE Pic matin: 9h-10h
-  (démarrage postes + chauffage) Pic après-midi: 14h-16h (climatisation été) Base
-  nuit: 10-15% de la consommation jour (veilles IT, sécurité) Codes N...
-
-  '
+  ### Codes NAF typiques
+  - 62.02 : Conseil en systèmes et logiciels informatiques
+  - 64.19 : Autres intermédiations monétaires
+  - 68.20 : Location immobilière (bureaux)
+  - 69.10 : Activités juridiques
+  - 70.10 : Activités des sièges sociaux
+  - 70.22 : Conseil pour les affaires
 logic: null
 sources:
+- doc_id: BAROMETRE_FLEX_2026
+  label: "Baromètre Flex 2026 — RTE/Enedis/GIMELEC (avril 2026)"
+  section: archetype-bureau
+  anchor: '#archetype-bureau-standard'
+  excerpt_short: "Bureaux : taux décalable 30%, pointes 7-10h + 17-20h"
 - doc_id: USAGES_ENERGETIQUES_B2B_v1
   label: USAGES_ENERGETIQUES_B2B_v1 - Section Archétypes
   section: archetype-bureau
   anchor: '#archetype-bureau'
-  excerpt_short: '2.'
+  excerpt_short: "Consommation typique : 150-250 kWh/m²/an"
 provenance:
-  source_path: source/USAGES_ENERGETIQUES_B2B_v1.html
-  source_sha256: e27ab62d958a5ab1240c118ce7e69079fdea166fe22cb95953ed2a3cadd97a22
+  source_path: docs/reglementaire/barometre_flex_2026.md
   source_section: archetype-bureau
-  extracted_at: '2026-02-09'
-updated_at: '2026-02-09'
+  extracted_at: '2026-04-17'
+updated_at: '2026-04-17'
 confidence: high
 status: validated
 priority: 2

--- a/docs/kb/items/usages/ARCHETYPE-COMMERCE_ALIMENTAIRE.yaml
+++ b/docs/kb/items/usages/ARCHETYPE-COMMERCE_ALIMENTAIRE.yaml
@@ -1,0 +1,90 @@
+id: ARCHETYPE-COMMERCE_ALIMENTAIRE
+type: knowledge
+domain: usages
+title: Archétype Commerce Alimentaire
+summary: "Grandes et moyennes surfaces alimentaires (GMS) : froid commercial dominant + ECS, pointe diurne large, potentiel de décalage élevé."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+  asset:
+    - froid_process
+    - hvac
+    - eclairage
+    - ecs
+  reg:
+    - dt
+    - bacs
+  granularity:
+    - mensuel
+    - horaire
+
+scope:
+  archetype: COMMERCE_ALIMENTAIRE
+  naf_codes:
+    - '47.11'
+    - '47.21'
+    - '47.22'
+    - '47.24'
+    - '47.81'
+
+content_md: |
+  ## Archétype Commerce Alimentaire
+
+  ### Consommation typique
+  - **Fourchette**: 400-600 kWh/m²/an (source : Enedis Open Data 2024 + benchmarks ADEME tertiaire alimentaire)
+  - Froid commercial prédominant : meubles positifs + négatifs fonctionnant 24/7.
+
+  ### Signature temporelle
+  - Horaires ouverture : 8h-21h (6j/7, parfois 7j/7 en centre-ville).
+  - Continu 24/7 : oui pour le froid, non pour l'éclairage et la climatisation ambiante.
+  - Talon nocturne : 35-45% de la conso jour (maintien chaîne du froid + préparation fournil).
+
+  ### Répartition par usage
+  - Froid alimentaire (positif + négatif) : 40-55%
+  - HVAC / renouvellement d'air : 15-20%
+  - Éclairage (magasin + enseignes) : 15-20%
+  - ECS + fournil / boucherie / traiteur : 10-15%
+  - Autres (IT caisses, sécurité) : 5-10%
+
+  ### Calibrage Baromètre Flex 2026
+  - **Taux décalable moyen** : 0.45 (source : Baromètre Flex 2026 RTE/Enedis/GIMELEC — section Commerces alimentaires)
+  - **Plages de pointe** : [(10, 20)] (ouverture clientèle continue, pas de double pointe nette)
+  - **Conso concentrée pointe** : 0.55 (part de la conso journalière sur la plage 10h-20h)
+  - **Pénétration BACS 2024** : 0.17 (fourchette 15-19% GMS, médiane Enedis 2024)
+
+  ### Potentiel de pilotage
+  Gisement décalable élevé porté par l'inertie des meubles froids (positifs 2-6°C, négatifs -20°C) et des chambres froides : fenêtres favorables nocturnes 2h-6h et méridiennes 11h-17h (ensoleillement PV TURPE 7 saisonnalisé). Les usages pilotables prioritaires sont le froid commercial (cycles dégivrage, consignes nuit) et l'ECS. L'éclairage et la climatisation ambiante restent contraints par l'expérience client.
+
+  ### Codes NAF typiques
+  - 47.11 — Commerce de détail en magasin non spécialisé à prédominance alimentaire (GMS)
+  - 47.21 — Commerce de détail de fruits et légumes en magasin spécialisé
+  - 47.22 — Commerce de détail de viandes et de produits à base de viande
+  - 47.24 — Commerce de détail de pain, pâtisserie et confiserie
+  - 47.81 — Commerce de détail alimentaire sur éventaires et marchés
+
+logic: null
+
+sources:
+  - doc_id: BAROMETRE_FLEX_2026
+    label: "Baromètre Flex 2026 — RTE/Enedis/GIMELEC (avril 2026)"
+    section: "archetype-commerce-alimentaire"
+    anchor: "#chiffres-sectoriels-enedis-2024"
+    excerpt_short: "Commerces : 60 000 sites, 150 M m², 17% BACS équipés (Enedis 2024)."
+  - doc_id: ENEDIS_OPEN_DATA_2024
+    label: "Enedis Open Data 2024 — Ratios tertiaire alimentaire"
+    section: "tertiaire-commerce-alimentaire"
+    anchor: null
+    excerpt_short: "Ratios consommation 400-600 kWh/m²/an, segment froid commercial dominant."
+
+provenance:
+  source_path: docs/reglementaire/barometre_flex_2026.md
+  source_section: "archetype-commerce-alimentaire"
+  extracted_at: '2026-04-17'
+
+updated_at: '2026-04-17'
+confidence: high
+status: validated
+priority: 2

--- a/docs/kb/items/usages/ARCHETYPE-COMMERCE_SPECIALISE.yaml
+++ b/docs/kb/items/usages/ARCHETYPE-COMMERCE_SPECIALISE.yaml
@@ -1,0 +1,90 @@
+id: ARCHETYPE-COMMERCE_SPECIALISE
+type: knowledge
+domain: usages
+title: Archétype Commerce Spécialisé
+summary: "Commerce de détail non alimentaire (textile, équipement, librairies) : éclairage et climatisation dominants, pas de froid process."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+  asset:
+    - eclairage
+    - hvac
+    - it
+  reg:
+    - dt
+    - bacs
+  granularity:
+    - mensuel
+    - horaire
+
+scope:
+  archetype: COMMERCE_SPECIALISE
+  naf_codes:
+    - '47.41'
+    - '47.51'
+    - '47.59'
+    - '47.61'
+    - '47.71'
+    - '47.72'
+
+content_md: |
+  ## Archétype Commerce Spécialisé
+
+  ### Consommation typique
+  - **Fourchette**: 150-300 kWh/m²/an (source : Enedis Open Data 2024 + benchmarks ADEME commerce non alimentaire)
+  - Pas de froid process, consommation tirée par éclairage et climatisation de confort.
+
+  ### Signature temporelle
+  - Horaires ouverture : 10h-20h (6j/7, fermé le dimanche pour la majorité).
+  - Continu 24/7 : non.
+  - Talon nocturne : 10-15% de la conso jour (veilles IT caisses, vitrines, sécurité).
+
+  ### Répartition par usage
+  - Éclairage (ambiance + vitrines) : 30-40%
+  - HVAC / climatisation : 30-40%
+  - IT (caisses, bornes, affichage) : 10-15%
+  - Autres (sécurité, ventilation) : 10-15%
+
+  ### Calibrage Baromètre Flex 2026
+  - **Taux décalable moyen** : 0.25 (source : Baromètre Flex 2026 RTE/Enedis/GIMELEC — section Commerces non alimentaires)
+  - **Plages de pointe** : [(10, 19)] (ouverture clientèle)
+  - **Conso concentrée pointe** : 0.45 (part de la conso journalière sur la plage 10h-19h)
+  - **Pénétration BACS 2024** : 0.17 (médiane Enedis 2024, tous commerces confondus)
+
+  ### Potentiel de pilotage
+  Gisement décalable modéré : l'éclairage et l'ambiance thermique sont contraints par l'expérience client pendant les heures d'ouverture. Fenêtres favorables de décalage : pré-ouverture (préchauffage/prérefroidissement anticipés sur 2h-6h nocturnes ou 11h en creux) et post-fermeture. Les usages pilotables prioritaires sont la climatisation (délestage thermique pendant les plages de pointe système 7h-10h et 17h-20h) et l'éclairage de réserve/back-office. IT et vitrines restent peu décalables.
+
+  ### Codes NAF typiques
+  - 47.41 — Commerce de détail d'ordinateurs, d'unités périphériques et de logiciels
+  - 47.51 — Commerce de détail de textiles en magasin spécialisé
+  - 47.59 — Commerce de détail de meubles, appareils d'éclairage et autres articles de ménage
+  - 47.61 — Commerce de détail de livres en magasin spécialisé
+  - 47.71 — Commerce de détail d'habillement en magasin spécialisé
+  - 47.72 — Commerce de détail de chaussures et d'articles en cuir
+
+logic: null
+
+sources:
+  - doc_id: BAROMETRE_FLEX_2026
+    label: "Baromètre Flex 2026 — RTE/Enedis/GIMELEC (avril 2026)"
+    section: "archetype-commerce-specialise"
+    anchor: "#chiffres-sectoriels-enedis-2024"
+    excerpt_short: "Commerces : 60 000 sites, 150 M m², 17% BACS équipés (Enedis 2024)."
+  - doc_id: ENEDIS_OPEN_DATA_2024
+    label: "Enedis Open Data 2024 — Ratios commerce non alimentaire"
+    section: "tertiaire-commerce-specialise"
+    anchor: null
+    excerpt_short: "Ratios consommation 150-300 kWh/m²/an, éclairage + climatisation dominants."
+
+provenance:
+  source_path: docs/reglementaire/barometre_flex_2026.md
+  source_section: "archetype-commerce-specialise"
+  extracted_at: '2026-04-17'
+
+updated_at: '2026-04-17'
+confidence: high
+status: validated
+priority: 2

--- a/docs/kb/items/usages/ARCHETYPE-ENSEIGNEMENT.yaml
+++ b/docs/kb/items/usages/ARCHETYPE-ENSEIGNEMENT.yaml
@@ -1,0 +1,92 @@
+id: ARCHETYPE-ENSEIGNEMENT
+type: knowledge
+domain: usages
+title: Archétype Enseignement
+summary: "Établissements scolaires et universitaires : CVC + éclairage dominants, pointe diurne 8h-17h jours ouvrés, faible décalabilité mais fenêtres marquées."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+  asset:
+    - hvac
+    - eclairage
+    - it
+  reg:
+    - dt
+    - bacs
+  granularity:
+    - mensuel
+    - horaire
+
+scope:
+  archetype: ENSEIGNEMENT
+  naf_codes:
+    - '85.10'
+    - '85.20'
+    - '85.31'
+    - '85.32'
+    - '85.41'
+    - '85.42'
+
+content_md: |
+  ## Archétype Enseignement
+
+  ### Consommation typique
+  - **Fourchette**: 80-150 kWh/m²/an (source : Enedis Open Data 2024 + benchmarks ADEME enseignement)
+  - Chauffage (gaz ou élec) + éclairage dominants ; profil fortement marqué par le calendrier scolaire.
+
+  ### Signature temporelle
+  - Horaires ouverture : 8h-17h lundi-vendredi (variable selon primaire/secondaire/supérieur).
+  - Continu 24/7 : non (sauf résidences universitaires, hors périmètre ici).
+  - Talon nocturne : 15-25% de la conso jour (serveurs, éclairage sécurité, préchauffage).
+  - Saisonnalité : vacances scolaires = chute à 30-40% du régime normal.
+
+  ### Répartition par usage
+  - HVAC / chauffage : 40-55%
+  - Éclairage (salles + circulations) : 20-30%
+  - IT (salles info, administration) : 10-15%
+  - ECS (cantines, gymnases) : 5-10%
+  - Autres (cuisine collective, ventilation) : 5-10%
+
+  ### Calibrage Baromètre Flex 2026
+  - **Taux décalable moyen** : 0.20 (source : Baromètre Flex 2026 RTE/Enedis/GIMELEC — section Enseignement)
+  - **Plages de pointe** : [(8, 17)] (horaires de cours)
+  - **Conso concentrée pointe** : 0.50 (part de la conso journalière sur la plage 8h-17h)
+  - **Pénétration BACS 2024** : 0.13 (taux médian — lycées 46%, primaire < 10%, source Enedis 2024)
+
+  ### Potentiel de pilotage
+  Gisement de décalage limité par la présence humaine (confort élèves, contraintes sanitaires), mais fenêtres très marquées : vacances scolaires (mise en veille profonde), week-ends et nuits. Les usages pilotables prioritaires sont le préchauffage matinal (décalage vers 6h-7h au lieu de 8h au pic système) et la ventilation (consignes CO₂ ajustables). Le potentiel BACS est élevé (13% actuel, objectif décret tertiaire 2030), ce qui ouvrira un gisement supplémentaire sur l'optimisation des consignes. Fenêtres favorables : 2h-6h (préchauffage) et 11h-17h (surplus PV).
+
+  ### Codes NAF typiques
+  - 85.10 — Enseignement pré-primaire
+  - 85.20 — Enseignement primaire
+  - 85.31 — Enseignement secondaire général
+  - 85.32 — Enseignement secondaire technique ou professionnel
+  - 85.41 — Enseignement post-secondaire non supérieur
+  - 85.42 — Enseignement supérieur
+
+logic: null
+
+sources:
+  - doc_id: BAROMETRE_FLEX_2026
+    label: "Baromètre Flex 2026 — RTE/Enedis/GIMELEC (avril 2026)"
+    section: "archetype-enseignement"
+    anchor: "#chiffres-sectoriels-enedis-2024"
+    excerpt_short: "Enseignement : 37 000 sites, 166 M m², 13% BACS équipés (lycées 46%), 4.5 TWh/an (Enedis 2024)."
+  - doc_id: ENEDIS_OPEN_DATA_2024
+    label: "Enedis Open Data 2024 — Ratios enseignement"
+    section: "tertiaire-enseignement"
+    anchor: null
+    excerpt_short: "Ratios consommation 80-150 kWh/m²/an, CVC + éclairage dominants, profil calendrier scolaire."
+
+provenance:
+  source_path: docs/reglementaire/barometre_flex_2026.md
+  source_section: "archetype-enseignement"
+  extracted_at: '2026-04-17'
+
+updated_at: '2026-04-17'
+confidence: high
+status: validated
+priority: 2

--- a/docs/kb/items/usages/ARCHETYPE-HOTELLERIE.yaml
+++ b/docs/kb/items/usages/ARCHETYPE-HOTELLERIE.yaml
@@ -1,0 +1,81 @@
+id: ARCHETYPE-HOTELLERIE
+type: knowledge
+domain: usages
+title: Archétype Hôtellerie / hébergement
+summary: "Hôtels, hébergements touristiques et restauration : double pointe matin/soir portée par climatisation et ECS, fonctionnement quasi-continu, faible équipement GTB (11%)."
+tags:
+  energy:
+  - elec
+  - gaz
+  segment:
+  - tertiaire_multisite
+  asset:
+  - hvac
+  - ecs
+  - eclairage
+  - cuisine
+  reg: []
+  granularity:
+  - mensuel
+  - horaire
+scope:
+  archetype: HOTELLERIE
+  naf_codes:
+  - '55.10'
+  - '55.20'
+  - '55.90'
+  - '56.10'
+  - '56.30'
+content_md: |
+  ## Archétype Hôtellerie / hébergement
+
+  ### Consommation typique
+  - **Fourchette**: 200-400 kWh/m²/an (moyenne ~280 kWh/m²/an, sources ADEME/Enedis)
+  - Mix énergétique : électricité dominante (clim, éclairage, cuisine) + gaz fréquent pour ECS et chauffage
+
+  ### Signature temporelle
+  - Fonctionnement quasi 24/7, occupation variable selon saisonnalité touristique
+  - **Double pointe** matin (6h-10h) : réveil clients, ECS douches, petit-déjeuner cuisine
+  - **Double pointe** soir (18h-23h) : retour clients, restauration, clim en période estivale
+  - Talon de nuit non négligeable (ECS bouclage, éclairage sécurité, minibars, veilles TV)
+
+  ### Répartition par usage
+  - Climatisation/chauffage : 35-45%
+  - ECS : 15-25%
+  - Éclairage : 10-15%
+  - Cuisine/restauration : 10-20%
+  - IT/TV/autres : 5-10%
+
+  ### Calibrage Baromètre Flex 2026
+  - **Taux décalable moyen** : 35% (ECS à forte inertie + pré-conditionnement clim chambres)
+  - **Plages de pointe** : [6h-10h) et [18h-23h) — double pointe matin/soir
+  - **Part conso en pointe** : 48% (concentrée sur les 9h de double pointe)
+  - **Pénétration BACS 2024** : 11% — segment tertiaire le moins équipé en GTB
+  - Gisement de pilotage sur ECS (cumulus, ballons tampon) + pré-refroidissement chambres avant check-in
+
+  ### Potentiel de pilotage
+  - Principal levier : décalage ECS hors pointe (inertie 6-12h)
+  - Second levier : pré-conditionnement thermique chambres vacantes
+  - Contraintes : confort client prime, pas d'effacement perceptible en zones communes
+
+  ### Codes NAF typiques
+  - 55.10 Hôtels et hébergement similaire
+  - 55.20 Hébergement touristique et autre hébergement de courte durée
+  - 55.90 Autres hébergements
+  - 56.10 Restauration traditionnelle
+  - 56.30 Débits de boissons
+logic: null
+sources:
+- doc_id: BAROMETRE_FLEX_2026
+  label: "Baromètre Flex 2026 — RTE/Enedis/GIMELEC (avril 2026)"
+  section: "archetype-hotellerie"
+  anchor: "#archetype-hotellerie"
+  excerpt_short: "Hôtellerie : taux décalable 35%, double pointe matin/soir 6-10h + 18-23h, pénétration BACS 11% (segment tertiaire le moins équipé)."
+provenance:
+  source_path: docs/reglementaire/barometre_flex_2026.md
+  source_section: "archetype-hotellerie"
+  extracted_at: '2026-04-17'
+updated_at: '2026-04-17'
+confidence: high
+status: validated
+priority: 2

--- a/docs/kb/items/usages/ARCHETYPE-INDUSTRIE_LEGERE.yaml
+++ b/docs/kb/items/usages/ARCHETYPE-INDUSTRIE_LEGERE.yaml
@@ -1,0 +1,82 @@
+id: ARCHETYPE-INDUSTRIE_LEGERE
+type: knowledge
+domain: usages
+title: Archétype Industrie légère
+summary: "Industrie légère (fabrication métallique, machines, instruments) : fonctionnement en 2x8 typique 6h-18h, taux décalable 35%, pénétration BACS estimée à 20% (estimation GIMELEC, non publiée par Enedis)."
+tags:
+  energy:
+  - elec
+  segment:
+  - industrie
+  asset:
+  - process
+  - air_comprime
+  - hvac
+  - eclairage
+  reg: []
+  granularity:
+  - mensuel
+  - horaire
+scope:
+  archetype: INDUSTRIE_LEGERE
+  naf_codes:
+  - '25.11'
+  - '25.94'
+  - '28.22'
+  - '29.10'
+  - '32.50'
+content_md: |
+  ## Archétype Industrie légère
+
+  ### Consommation typique
+  - **Fourchette**: 100-300 kWh/m²/an (fortes disparités selon sous-secteur)
+  - Drivers : process électrique (machines, compresseurs, fours basse température), air comprimé, ventilation process
+
+  ### Signature temporelle
+  - Fonctionnement typique **2x8** ou **3x8** en semaine (postés)
+  - Pointe franche sur plage [6h-18h) : activité process principale
+  - Arrêt partiel ou total week-end (variable selon sous-secteur)
+  - Talon de nuit modéré (éclairage sécurité, veilles process, froid process)
+
+  ### Répartition par usage
+  - Process (machines, fours, compresseurs) : 45-60%
+  - Air comprimé : 10-20%
+  - CVC process / ambiance : 10-15%
+  - Éclairage : 5-10%
+  - Autres (bureaux attenants, IT, IRVE) : 5-10%
+
+  ### Calibrage Baromètre Flex 2026
+  - **Taux décalable moyen** : 35% (compresseurs, fours basse température, production froid process, recharge batteries chariots)
+  - **Plages de pointe** : [6h-18h) — activité diurne postés
+  - **Part conso en pointe** : 60% (concentrée sur la journée de production)
+  - **Pénétration BACS 2024** : 20% — **estimation GIMELEC**, non publiée officiellement par Enedis
+    (segment industrie hors périmètre décret tertiaire strict, instrumentation interne variable)
+  - Gisement important sur pilotage compresseurs (démarrage différé, pression adaptative) et recharge intralogistique
+
+  ### Potentiel de pilotage
+  - Principal levier : effacement compresseurs en période de pointe réseau (stockage pression)
+  - Second levier : décalage cycles de production énergivores hors HP
+  - Contraintes : continuité production, qualité produit (tolérance température four, humidité process)
+  - Opportunité contrats flex explicites : cycles batch décalables, cogénération éventuelle
+
+  ### Codes NAF typiques
+  - 25.11 Fabrication de structures métalliques
+  - 25.94 Fabrication de vis et de boulons
+  - 28.22 Fabrication de machines de levage et de manutention
+  - 29.10 Construction de véhicules automobiles
+  - 32.50 Fabrication d'instruments et de fournitures à usage médical et dentaire
+logic: null
+sources:
+- doc_id: BAROMETRE_FLEX_2026
+  label: "Baromètre Flex 2026 — RTE/Enedis/GIMELEC (avril 2026)"
+  section: "archetype-industrie-legere"
+  anchor: "#archetype-industrie-legere"
+  excerpt_short: "Industrie légère : taux décalable 35%, pointe 6h-18h, BACS 20% (estimation GIMELEC, non publié Enedis)."
+provenance:
+  source_path: docs/reglementaire/barometre_flex_2026.md
+  source_section: "archetype-industrie-legere"
+  extracted_at: '2026-04-17'
+updated_at: '2026-04-17'
+confidence: medium
+status: validated
+priority: 2

--- a/docs/kb/items/usages/ARCHETYPE-LOGISTIQUE_FRIGO.yaml
+++ b/docs/kb/items/usages/ARCHETYPE-LOGISTIQUE_FRIGO.yaml
@@ -1,0 +1,86 @@
+id: ARCHETYPE-LOGISTIQUE_FRIGO
+type: knowledge
+domain: usages
+title: Archétype Logistique Frigorifique
+summary: "Entrepôts frigorifiques et transformation alimentaire : froid inertie 24/7, gisement de décalage le plus élevé du tertiaire/industrie légère."
+
+tags:
+  energy:
+    - elec
+  segment:
+    - tertiaire_multisite
+  asset:
+    - froid_process
+    - eclairage
+  reg:
+    - dt
+    - bacs
+  granularity:
+    - mensuel
+    - horaire
+
+scope:
+  archetype: LOGISTIQUE_FRIGO
+  naf_codes:
+    - '10.13'
+    - '10.20'
+    - '10.52'
+    - '52.10'
+
+content_md: |
+  ## Archétype Logistique Frigorifique
+
+  ### Consommation typique
+  - **Fourchette**: 200-400 kWh/m²/an (source : Enedis Open Data 2024 + benchmarks ADEME logistique frigorifique)
+  - Froid positif (0-4°C) et négatif (-18 à -25°C) fonctionnant 24/7 ; forte inertie thermique.
+
+  ### Signature temporelle
+  - Horaires ouverture : 24/7 (exploitation continue).
+  - Continu 24/7 : oui (froid process).
+  - Talon nocturne : 80-90% de la conso jour (quasi-plat, légère modulation par les cycles de dégivrage et les arrivées/sorties de marchandises).
+
+  ### Répartition par usage
+  - Froid process (positif + négatif) : 60-75%
+  - Éclairage (quais + allées) : 8-12%
+  - Manutention électrique (chariots, convoyeurs) : 5-10%
+  - HVAC bureaux attenants : 5-8%
+  - Autres (IT, sécurité, portes rapides) : 3-5%
+
+  ### Calibrage Baromètre Flex 2026
+  - **Taux décalable moyen** : 0.55 (source : Baromètre Flex 2026 RTE/Enedis/GIMELEC — section Logistique frigorifique)
+  - **Plages de pointe** : [(0, 24)] (fonctionnement continu, pas de plage de pointe identifiable)
+  - **Conso concentrée pointe** : 1.0 (conso uniformément répartie sur 24h)
+  - **Pénétration BACS 2024** : 0.23 (supérieure à la moyenne tertiaire, logistique fortement pilotée)
+
+  ### Potentiel de pilotage
+  Gisement de décalage le plus élevé du portefeuille : l'inertie thermique des chambres froides permet des cycles de sur-refroidissement anticipé (descente en température) en heures creuses ou sur prix négatifs, puis un délestage sur les plages de pointe système 7h-10h et 17h-20h. Les usages pilotables prioritaires sont les groupes froids (consignes ajustables sur une bande de 1-2°C) et les cycles de dégivrage. Fenêtres favorables : nuit complète 0h-6h et méridienne 11h-17h (TURPE 7 saisonnalisé, surplus PV). Points d'attention : respect strict de la chaîne du froid (HACCP) et continuité d'exploitation.
+
+  ### Codes NAF typiques
+  - 10.13 — Préparation industrielle de produits à base de viande
+  - 10.20 — Transformation et conservation de poisson, crustacés et mollusques
+  - 10.52 — Fabrication de glaces et sorbets
+  - 52.10 — Entreposage et stockage (frigorifique si activité alimentaire associée)
+
+logic: null
+
+sources:
+  - doc_id: BAROMETRE_FLEX_2026
+    label: "Baromètre Flex 2026 — RTE/Enedis/GIMELEC (avril 2026)"
+    section: "archetype-logistique-frigorifique"
+    anchor: "#chiffres-sectoriels-enedis-2024"
+    excerpt_short: "Logistique frigorifique : gisement de flexibilité le plus élevé, BACS 23%, inertie thermique 24/7."
+  - doc_id: ENEDIS_OPEN_DATA_2024
+    label: "Enedis Open Data 2024 — Ratios entrepôts frigorifiques"
+    section: "tertiaire-logistique-frigo"
+    anchor: null
+    excerpt_short: "Ratios consommation 200-400 kWh/m²/an, froid process 60-75% de la facture."
+
+provenance:
+  source_path: docs/reglementaire/barometre_flex_2026.md
+  source_section: "archetype-logistique-frigorifique"
+  extracted_at: '2026-04-17'
+
+updated_at: '2026-04-17'
+confidence: high
+status: validated
+priority: 2

--- a/docs/kb/items/usages/ARCHETYPE-SANTE.yaml
+++ b/docs/kb/items/usages/ARCHETYPE-SANTE.yaml
@@ -1,0 +1,98 @@
+id: ARCHETYPE-SANTE
+type: knowledge
+domain: usages
+title: Archétype Santé
+summary: "Périmètre santé large (hôpitaux, cabinets, EHPAD, hébergement médicalisé) : fonctionnement 24/7 avec contraintes médicales fortes, décalabilité faible (15%), segment tertiaire le plus équipé en GTB (40%)."
+tags:
+  energy:
+  - elec
+  segment:
+  - collectivite
+  asset:
+  - hvac
+  - ecs
+  - eclairage
+  - it
+  - medical
+  reg: []
+  granularity:
+  - mensuel
+  - horaire
+scope:
+  archetype: SANTE
+  naf_codes:
+  - '86.10'
+  - '86.21'
+  - '86.22'
+  - '86.23'
+  - '87.10'
+  - '87.20'
+content_md: |
+  ## Archétype Santé
+
+  ### Périmètre
+  Archétype canonique Santé aligné sur le code `ARCHETYPE_CALIBRATION_2024`.
+  Couvre un périmètre **plus large** que `HOPITAL_STANDARD` :
+  - Hôpitaux et cliniques (activités hospitalières multi-services)
+  - Cabinets de médecine générale et spécialisée
+  - Pratique dentaire
+  - EHPAD (hébergement médicalisé personnes âgées)
+  - Hébergement social pour handicapés / malades
+
+  `HOPITAL_STANDARD` reste disponible comme **sous-archétype plus précis** pour les
+  établissements hospitaliers multi-services à forte densité technique (blocs
+  opératoires, imagerie, stérilisation). SANTE est le conteneur canonique pour
+  la résolution NAF 86.xx / 87.xx.
+
+  ### Consommation typique
+  - **Fourchette**: 250-500 kWh/m²/an (fortes disparités : cabinet 150 < EHPAD 300 < hôpital 450+)
+  - Drivers : CVC intensif (air neuf continu, filtration), IT médical, stérilisation, hygrométrie/température critiques
+
+  ### Signature temporelle
+  - Fonctionnement **24/7** avec contraintes médicales non négociables
+  - Charge relativement plate sur 24h, légère baisse de nuit
+  - Pointes limitées : pas de pic franc matin ou soir (fonctionnement continu)
+  - Talon de nuit élevé : 70-85% de la conso jour
+
+  ### Répartition par usage
+  - CVC (air neuf, filtration, hygrométrie) : 40-50%
+  - ECS : 15-20% (hygiène, stérilisation)
+  - Éclairage : 10-15%
+  - IT / équipements médicaux : 10-20%
+  - Autres : 5-10%
+
+  ### Calibrage Baromètre Flex 2026
+  - **Taux décalable moyen** : 15% — plus faible des 8 archétypes (contraintes médicales fortes)
+  - **Plages de pointe** : [0h-24h) — charge continue 24/7
+  - **Part conso en pointe** : 100% (pas de segmentation horaire significative)
+  - **Pénétration BACS 2024** : 40% — **segment tertiaire le plus équipé** en GTB
+    (contraintes réglementaires + exigences hygrométrie/température critiques)
+  - Gisement limité aux zones non-critiques : bureaux administratifs, circulations, parkings, ECS avec bouclage
+
+  ### Potentiel de pilotage
+  - Zones critiques (soins, blocs, imagerie, chaîne du froid médicaments) : **exclues** de tout effacement
+  - Leviers exploitables : CVC zones administratives, éclairage circulations, ECS non-soins, IRVE visiteurs
+  - Priorité conformité décret tertiaire + BACS : segment déjà largement équipé, levier MCO / optimisation GTB existante
+
+  ### Codes NAF typiques
+  - 86.10 Activités hospitalières
+  - 86.21 Activité des médecins généralistes
+  - 86.22 Activité des médecins spécialistes
+  - 86.23 Pratique dentaire
+  - 87.10 Hébergement médicalisé (EHPAD)
+  - 87.20 Hébergement social pour handicapés / malades
+logic: null
+sources:
+- doc_id: BAROMETRE_FLEX_2026
+  label: "Baromètre Flex 2026 — RTE/Enedis/GIMELEC (avril 2026)"
+  section: "archetype-sante"
+  anchor: "#archetype-sante"
+  excerpt_short: "Santé : taux décalable 15% (contraintes médicales), fonctionnement 24/7, pénétration BACS 40% — segment tertiaire le plus équipé en GTB."
+provenance:
+  source_path: docs/reglementaire/barometre_flex_2026.md
+  source_section: "archetype-sante"
+  extracted_at: '2026-04-17'
+updated_at: '2026-04-17'
+confidence: high
+status: validated
+priority: 2


### PR DESCRIPTION
## Contexte

Audit produit a flag l'incohérence : KB `docs/kb/items/usages/` exposait **3 archétypes** (`BUREAU_STANDARD`, `HOPITAL_STANDARD`, `RESTAURATION_SERVICE`) vs **8 archétypes canoniques** utilisés par le code pilotage (`ARCHETYPE_CALIBRATION_2024`). Le moteur calculait sur des codes que la KB ne documentait pas → drift décrédibilisante pour un auditeur.

## Livrable (3 agents SDK parallèles, pattern contract-first)

**7 YAML NEW** alignés sur le code canonique :
- COMMERCE_ALIMENTAIRE · COMMERCE_SPECIALISE · LOGISTIQUE_FRIGO · ENSEIGNEMENT · HOTELLERIE · SANTE · INDUSTRIE_LEGERE

**BUREAU_STANDARD refactoré** sur le même format : `content_md` structuré en 6 sections (Conso, Signature, Répartition, Calibrage Baromètre Flex 2026, Potentiel, Codes NAF), sources enrichies avec `BAROMETRE_FLEX_2026` primaire.

**Sous-archétypes préservés** : `HOPITAL_STANDARD` (sous-cas de SANTE) et `RESTAURATION_SERVICE` (sous-cas de HOTELLERIE) — pas touchés, whitelistés dans le test de cohérence.

## Test de cohérence (drift prevention)

`backend/tests/test_pilotage_kb_archetypes_coherence.py` NEW (201 LOC, **34 cas**) :

- Tous les archétypes code ont un YAML KB (8/8)
- Tous les YAML KB sont dans le code canonique (whitelist sous-cas explicite)
- Format structurel 14 champs obligatoires × 8 archétypes
- NAF alignés : au moins 1 code NAF du YAML correspondant au mapping Python
- Baromètre Flex 2026 cité dans chaque `content_md`

**Tout nouvel archétype ajouté au code sans YAML KB fera tomber ce test.**

## Tests

- **34/34** tests cohérence KB verts
- **159/159** tests pilotage verts (zéro régression)
- Ruff lint clean

## Impact produit

Le diagnostic produit du 17/04 plaçait "KB archétypes désalignée" comme **gap cohérence critique** avant le deck levée 1,5 M€ seed (deadline 30/06). C'est fermé.

**Suite roadmap restante** (identifiée par le même audit) :
1. **Achat énergie post-ARENH MVP** (5-7j) — le 3e différenciant strategy master manque encore (VNU, mécanisme capacité, PPA)
2. **Unifier 2 moteurs flex** (`/usages/flex-potential` usage-based vs `/api/flex/assessment` asset-based) — dette cohérence
3. **Étendre KB RECO** de 4 → 45-90 use-cases (post-levée)

## Source doctrine

Baromètre Flex 2026 (RTE/Enedis/GIMELEC) + ADEME + Enedis Open Data 2024 + INSEE NAF rév 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)