### PR TITLE
fix(cx-2.5-bis): 6 P1 — FindingCard unit/TZ/memo + IAR cap + LRU cache + PII allowlist

### DIFF
--- a/backend/middleware/cx_logger.py
+++ b/backend/middleware/cx_logger.py
@@ -6,6 +6,7 @@ Fire-and-forget : les erreurs sont loggées mais ne bloquent pas la requête.
 
 import json
 import logging
+import time
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -13,6 +14,63 @@ from sqlalchemy.orm import Session
 from models.iam import AuditLog, UserOrgRole
 
 logger = logging.getLogger(__name__)
+
+# Sprint CX 2.5-bis (P2) : cache membership (user_id, org_id) → bool avec TTL.
+# Motivation : log_cx_event est sur le hot path (polling /api/cockpit toutes les 30s).
+# Le check UserOrgRole ajoute +1 query SQL par event. Avec un cache TTL 5 min, on
+# absorbe la majorité des appels répétés (même utilisateur sur la même org).
+#
+# Format entrée : _MEMBERSHIP_CACHE[(user_id, org_id)] = (is_member: bool, expires_at: float)
+# Simple dict module-level ; pas de lock car GIL + écritures idempotentes
+# (collision de race = re-query une fois, pas un problème de correctness).
+#
+# NOTE : l'invalidation explicite via invalidate_membership_cache() doit être appelée
+# quand une UserOrgRole est créée/supprimée/modifiée. HORS SCOPE de ce commit :
+# les endpoints admin mutant UserOrgRole devront invoquer cette helper dans un
+# sprint ultérieur (sans quoi le cache peut rester chaud jusqu'à 5 min après un
+# changement de rôle). Impact acceptable : un user qui perd accès à une org peut
+# voir ses events loggés pendant ≤ 5 min, mais la transaction est déjà isolée
+# côté route via require_platform_admin / get_current_user.
+_MEMBERSHIP_CACHE: dict[tuple[int, int], tuple[bool, float]] = {}
+_MEMBERSHIP_TTL_SEC = 300  # 5 minutes
+
+
+def _is_member_cached(db: Session, user_id: int, org_id: int, ttl_sec: int = _MEMBERSHIP_TTL_SEC) -> bool:
+    """Retourne True si user_id est membre de org_id (via UserOrgRole), avec cache TTL.
+
+    Cache miss → 1 query SELECT UserOrgRole.id. Cache hit → 0 query.
+    """
+    key = (user_id, org_id)
+    now = time.monotonic()
+    cached = _MEMBERSHIP_CACHE.get(key)
+    if cached is not None and cached[1] > now:
+        return cached[0]
+
+    is_member = (
+        db.query(UserOrgRole.id).filter(UserOrgRole.user_id == user_id, UserOrgRole.org_id == org_id).first()
+    ) is not None
+    _MEMBERSHIP_CACHE[key] = (is_member, now + ttl_sec)
+    return is_member
+
+
+def invalidate_membership_cache(user_id: Optional[int] = None, org_id: Optional[int] = None) -> None:
+    """Invalide le cache membership.
+
+    - Sans argument : vide tout le cache (utile en tests).
+    - Avec (user_id, org_id) : invalide cette paire.
+    - Avec user_id seul : invalide toutes les paires pour cet utilisateur.
+    - Avec org_id seul : invalide toutes les paires pour cette org.
+    """
+    if user_id is None and org_id is None:
+        _MEMBERSHIP_CACHE.clear()
+        return
+    to_delete = [
+        key
+        for key in _MEMBERSHIP_CACHE
+        if (user_id is None or key[0] == user_id) and (org_id is None or key[1] == org_id)
+    ]
+    for key in to_delete:
+        _MEMBERSHIP_CACHE.pop(key, None)
 
 # Event type constants — utiliser ces constantes plutôt que des strings hardcodés
 # pour éviter drift silencieux (la validation log_cx_event return si event_type
@@ -59,11 +117,10 @@ def log_cx_event(
         return
 
     # S1 hardening : validation membership user → org
+    # P2 hardening : membership check mis en cache (TTL 5 min) pour absorber le hot path
+    # (polling /api/cockpit 30s). Voir _is_member_cached + invalidate_membership_cache.
     if user_id is not None and org_id is not None:
-        is_member = (
-            db.query(UserOrgRole.id).filter(UserOrgRole.user_id == user_id, UserOrgRole.org_id == org_id).first()
-        )
-        if not is_member:
+        if not _is_member_cached(db, user_id, org_id):
             logger.warning(
                 "CX event rejeté : user_id=%s pas membre de org_id=%s (event=%s)",
                 user_id,

--- a/backend/middleware/cx_logger.py
+++ b/backend/middleware/cx_logger.py
@@ -72,6 +72,7 @@ def invalidate_membership_cache(user_id: Optional[int] = None, org_id: Optional[
     for key in to_delete:
         _MEMBERSHIP_CACHE.pop(key, None)
 
+
 # Event type constants — utiliser ces constantes plutôt que des strings hardcodés
 # pour éviter drift silencieux (la validation log_cx_event return si event_type
 # n'est pas dans CX_EVENT_TYPES, sans trace).

--- a/backend/routes/cx_dashboard.py
+++ b/backend/routes/cx_dashboard.py
@@ -199,6 +199,13 @@ def get_iar(
 
     Retourne le ratio global + décomposition par org.
     Ratio "null" si dénominateur=0 (pas assez de signal).
+
+    Sprint CX 2.5-bis (F10) : le ratio peut dépasser 1.0 dans le cas légitime
+    « 1 insight → N actions » (une même recommandation générant plusieurs actions).
+    Pour garder une sémantique « taux » interprétable côté UI, on expose :
+    - `iar_raw` : le ratio brut (peut être > 1.0)
+    - `iar` : le ratio cappé à 1.0 (interprétable comme pourcentage)
+    - `is_capped` : true si iar_raw > 1.0 (signale au front d'afficher une nuance)
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
@@ -225,10 +232,17 @@ def get_iar(
         else:
             org["actions"] = row.n
 
-    def _ratio(actions: int, insights: int) -> Optional[float]:
+    def _ratio_triplet(actions: int, insights: int) -> dict[str, Optional[float] | bool]:
+        """Calcule iar_raw, iar (cappé à 1.0) et is_capped."""
         if insights <= 0:
-            return None
-        return round(actions / insights, 4)
+            return {"iar": None, "iar_raw": None, "is_capped": False}
+        raw = round(actions / insights, 4)
+        capped = raw > 1.0
+        return {
+            "iar": round(min(raw, 1.0), 4),
+            "iar_raw": raw,
+            "is_capped": capped,
+        }
 
     global_insights = sum(d["insights"] for d in by_org.values())
     global_actions = sum(d["actions"] for d in by_org.values())
@@ -238,13 +252,13 @@ def get_iar(
         "global": {
             "insights_consulted": global_insights,
             "actions_validated": global_actions,
-            "iar": _ratio(global_actions, global_insights),
+            **_ratio_triplet(global_actions, global_insights),
         },
         "by_org": {
             oid: {
                 "insights_consulted": d["insights"],
                 "actions_validated": d["actions"],
-                "iar": _ratio(d["actions"], d["insights"]),
+                **_ratio_triplet(d["actions"], d["insights"]),
             }
             for oid, d in by_org.items()
         },

--- a/backend/services/error_catalog.py
+++ b/backend/services/error_catalog.py
@@ -19,7 +19,71 @@ Le helper retourne un kwargs prêt pour HTTPException :
     { "status_code": 404, "detail": {"code": "...", "message": "...", "suggestion": "..."} }
 """
 
+import logging
+import re
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Sprint CX 2.5-bis (S3) : anti-PII guard sur le context sérialisé au client.
+#
+# Contexte : business_error(**context) sérialise le dict `context` directement
+# dans detail.context. Un dev pressé peut passer `user_email=u.email` ou
+# `action=action_orm_obj` → leak PII ou objet SQLAlchemy au client.
+#
+# Stratégie :
+#   1. Allowlist de clés neutres (IDs, codes fiscaux, champs techniques).
+#   2. Regex de blocklist pour les clés "dangereuses" (email, token, nom…) —
+#      filet de sécurité si un dev ajoute une nouvelle clé sans maj l'allowlist.
+#   3. Warning log si une clé est strippée (pour détecter les usages à
+#      corriger côté caller).
+_SAFE_CONTEXT_KEYS: frozenset[str] = frozenset(
+    {
+        "action_id",
+        "site_id",
+        "org_id",
+        "siren",
+        "siret",
+        "module",
+        "field",
+        "value_reçue",
+        "limite",
+        "period_start",
+        "period_end",
+        "count",
+    }
+)
+
+# Regex case-insensitive : toute clé matchant ce pattern est strippée même
+# si elle finit dans l'allowlist un jour par erreur (defense in depth).
+_PII_KEY_PATTERN = re.compile(r"email|phone|token|password|_at$|name$|nom", re.IGNORECASE)
+
+
+def _sanitize_context(code: str, context: dict[str, Any]) -> dict[str, Any]:
+    """Filtre un dict de context pour ne garder que les clés safe.
+
+    - Garde uniquement les clés dans _SAFE_CONTEXT_KEYS.
+    - Strippe aussi toute clé matchant _PII_KEY_PATTERN (même si dans l'allowlist).
+    - Log un warning par clé strippée avec le code d'erreur pour traçabilité.
+    """
+    safe: dict[str, Any] = {}
+    for key, value in context.items():
+        if _PII_KEY_PATTERN.search(key):
+            logger.warning(
+                "business_error[%s] : clé context '%s' strippée (match PII pattern)",
+                code,
+                key,
+            )
+            continue
+        if key not in _SAFE_CONTEXT_KEYS:
+            logger.warning(
+                "business_error[%s] : clé context '%s' strippée (pas dans allowlist)",
+                code,
+                key,
+            )
+            continue
+        safe[key] = value
+    return safe
 
 
 ERROR_CATALOG: dict[str, dict[str, Any]] = {
@@ -137,7 +201,11 @@ def business_error(code: str, **context: Any) -> dict[str, Any]:
 
     Args:
         code: Clé du catalogue (ex. "ACTION_NOT_FOUND")
-        **context: Champs additionnels à ajouter dans `detail` (ex. action_id=42)
+        **context: Champs additionnels à ajouter dans `detail` (ex. action_id=42).
+            Sprint CX 2.5-bis (S3) : les clés sont filtrées par _SAFE_CONTEXT_KEYS
+            avant sérialisation. Toute clé hors allowlist ou matchant le pattern
+            PII (email/phone/token/password/*_at/*name/nom) est strippée avec
+            un warning log. Passer `user_email=x` ne leak RIEN au client.
 
     Returns:
         dict avec status_code et detail, utilisable comme :
@@ -147,11 +215,13 @@ def business_error(code: str, **context: Any) -> dict[str, Any]:
         KeyError: si le code n'existe pas dans le catalogue.
     """
     entry = ERROR_CATALOG[code]
-    detail = {
+    detail: dict[str, Any] = {
         "code": code,
         "message": entry["message"],
         "suggestion": entry["suggestion"],
     }
     if context:
-        detail["context"] = context
+        safe_context = _sanitize_context(code, context)
+        if safe_context:
+            detail["context"] = safe_context
     return {"status_code": entry["http_status"], "detail": detail}

--- a/backend/tests/test_cx_dashboard_drivers.py
+++ b/backend/tests/test_cx_dashboard_drivers.py
@@ -153,8 +153,31 @@ class TestIAR:
 
         r = client.get("/api/admin/cx-dashboard/iar")
         body = r.json()
+        # F10 : iar (cappé) == iar_raw (brut) quand actions <= insights
         assert body["global"]["iar"] == 0.3
+        assert body["global"]["iar_raw"] == 0.3
+        assert body["global"]["is_capped"] is False
         assert body["by_org"]["1"]["iar"] == 0.3
+        assert body["by_org"]["1"]["iar_raw"] == 0.3
+        assert body["by_org"]["1"]["is_capped"] is False
+
+    def test_iar_capped_when_actions_exceed_insights(self, isolated_client):
+        """F10 : cas '1 insight → N actions' → iar_raw > 1.0, iar cappé à 1.0."""
+        client, db = isolated_client
+        # 10 insights, 50 actions → raw = 5.0, capped = 1.0
+        for _ in range(10):
+            _seed_event(db, 1, 1, "CX_INSIGHT_CONSULTED", 2)
+        for _ in range(50):
+            _seed_event(db, 1, 1, "CX_ACTION_FROM_INSIGHT", 1)
+
+        r = client.get("/api/admin/cx-dashboard/iar")
+        body = r.json()
+        assert body["global"]["iar"] == 1.0  # cappé
+        assert body["global"]["iar_raw"] == 5.0  # valeur brute exposée
+        assert body["global"]["is_capped"] is True
+        assert body["by_org"]["1"]["iar"] == 1.0
+        assert body["by_org"]["1"]["iar_raw"] == 5.0
+        assert body["by_org"]["1"]["is_capped"] is True
 
     def test_excludes_events_outside_window(self, isolated_client):
         client, db = isolated_client
@@ -165,6 +188,8 @@ class TestIAR:
         body = r.json()
         assert body["global"]["insights_consulted"] == 0
         assert body["global"]["iar"] is None  # dénominateur=0
+        assert body["global"]["iar_raw"] is None
+        assert body["global"]["is_capped"] is False
 
 
 # ─── WAU/MAU ────────────────────────────────────────────────────────────────

--- a/backend/tests/test_cx_logger.py
+++ b/backend/tests/test_cx_logger.py
@@ -10,7 +10,13 @@ from sqlalchemy.pool import StaticPool
 from models import Base
 from models.iam import AuditLog, User, UserOrgRole, UserRole
 from models import Organisation
-from middleware.cx_logger import log_cx_event, CX_EVENT_TYPES
+from middleware.cx_logger import (
+    log_cx_event,
+    CX_EVENT_TYPES,
+    _is_member_cached,
+    invalidate_membership_cache,
+    _MEMBERSHIP_CACHE,
+)
 
 
 @pytest.fixture
@@ -24,7 +30,10 @@ def db_session():
     Base.metadata.create_all(bind=engine)
     Session = sessionmaker(bind=engine)
     session = Session()
+    # P2 : isole le cache membership entre tests (module-level global)
+    invalidate_membership_cache()
     yield session
+    invalidate_membership_cache()
     session.close()
 
 
@@ -161,3 +170,56 @@ def test_s1_event_with_null_user_id_bypasses_membership_check(db_session):
         db_session.query(AuditLog).filter(AuditLog.action == "CX_DASHBOARD_OPENED", AuditLog.resource_id == "5").count()
     )
     assert count == 1
+
+
+# ─── Sprint CX 2.5-bis P2 : membership cache (TTL 5 min) ────────────────────
+
+
+def test_membership_check_cached_within_ttl(db_session):
+    """P2 : le 2e appel avec même (user_id, org_id) ne re-query pas la DB.
+
+    Stratégie : on seed membership, on fait 1 check (miss → query DB → cache),
+    on supprime UserOrgRole en DB, puis 2e check → doit retourner True car
+    le cache TTL est chaud. Prouve que le cache est bien consulté avant DB.
+    """
+    _seed_member(db_session, user_id=1, org_id=1)
+
+    # 1er check : miss → query DB → cache miss et fill
+    assert _is_member_cached(db_session, 1, 1) is True
+    assert (1, 1) in _MEMBERSHIP_CACHE
+
+    # On supprime la ligne en DB pour prouver que le 2e check
+    # ne re-query pas : si la DB était re-hittée, le résultat basculerait à False.
+    db_session.query(UserOrgRole).filter_by(user_id=1, org_id=1).delete()
+    db_session.flush()
+
+    # 2e check : doit encore retourner True (cache hit, pas de query DB)
+    assert _is_member_cached(db_session, 1, 1) is True
+
+
+def test_membership_cache_invalidated_explicitly(db_session):
+    """P2 : invalidate_membership_cache() purge la paire → re-query DB au prochain appel."""
+    _seed_member(db_session, user_id=2, org_id=2)
+    assert _is_member_cached(db_session, 2, 2) is True
+
+    # Supprime la ligne en DB + invalide explicitement le cache
+    db_session.query(UserOrgRole).filter_by(user_id=2, org_id=2).delete()
+    db_session.flush()
+    invalidate_membership_cache(user_id=2, org_id=2)
+
+    # Prochain check → cache miss → query DB → False
+    assert _is_member_cached(db_session, 2, 2) is False
+
+
+def test_membership_cache_ttl_expires(db_session):
+    """P2 : au-delà du TTL, le cache re-query la DB."""
+    _seed_member(db_session, user_id=3, org_id=3)
+
+    # ttl_sec=0 → l'entrée expire immédiatement
+    assert _is_member_cached(db_session, 3, 3, ttl_sec=0) is True
+
+    # On supprime en DB et on re-check avec TTL normal : comme l'entrée précédente
+    # est expirée (expires_at = now + 0), le check re-query → False.
+    db_session.query(UserOrgRole).filter_by(user_id=3, org_id=3).delete()
+    db_session.flush()
+    assert _is_member_cached(db_session, 3, 3) is False

--- a/backend/tests/test_error_catalog.py
+++ b/backend/tests/test_error_catalog.py
@@ -3,6 +3,7 @@ Tests for business error catalog (Sprint CX item #3).
 Guarantees: 20 codes, FR messages, suggestions, valid HTTP status.
 """
 
+import logging
 import sys
 import os
 
@@ -10,7 +11,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
 
-from services.error_catalog import ERROR_CATALOG, business_error
+from services.error_catalog import ERROR_CATALOG, business_error, _SAFE_CONTEXT_KEYS
 
 
 VALID_HTTP_STATUS = {400, 404, 409, 422, 500}
@@ -75,6 +76,83 @@ def test_business_error_with_context():
 def test_business_error_raises_on_unknown_code():
     with pytest.raises(KeyError):
         business_error("NOPE_NOT_A_REAL_CODE")
+
+
+# ─── Sprint CX 2.5-bis S3 : anti-PII allowlist sur context ───────────────
+
+
+def test_safe_context_allowlisted():
+    """S3 : les clés de l'allowlist passent inchangées."""
+    kwargs = business_error(
+        "ACTION_NOT_FOUND",
+        action_id=42,
+        site_id=7,
+        org_id=1,
+        siren="123456789",
+        siret="12345678900012",
+        module="billing",
+        field="puissance_souscrite",
+        value_reçue=99,
+        limite=36,
+        period_start="2026-01-01",
+        period_end="2026-12-31",
+        count=5,
+    )
+    ctx = kwargs["detail"]["context"]
+    for key in _SAFE_CONTEXT_KEYS:
+        assert key in ctx, f"clé safe {key} manquante dans le context retourné"
+
+
+def test_pii_keys_stripped_email():
+    """S3 : `user_email` strippé même si dev insiste."""
+    kwargs = business_error("USER_NOT_FOUND", user_email="leak@example.com", action_id=42)
+    ctx = kwargs["detail"].get("context", {})
+    assert "user_email" not in ctx
+    assert "email" not in ctx
+    assert ctx == {"action_id": 42}
+
+
+def test_pii_keys_stripped_common_patterns():
+    """S3 : patterns email/phone/token/password/*_at/*name/nom tous strippés."""
+    kwargs = business_error(
+        "USER_NOT_FOUND",
+        user_email="x@y.z",
+        phone="0102030405",
+        access_token="secret",
+        password="hunter2",
+        created_at="2026-01-01T00:00:00",
+        last_name="Dupont",
+        nom="Dupont",
+        action_id=42,  # seul survivant
+    )
+    ctx = kwargs["detail"].get("context", {})
+    assert ctx == {"action_id": 42}
+
+
+def test_non_allowlisted_key_stripped():
+    """S3 : clé inconnue (hors allowlist ET hors pattern PII) → strippée quand même."""
+    kwargs = business_error("ACTION_NOT_FOUND", action_id=42, random_debug_field="whatever")
+    ctx = kwargs["detail"].get("context", {})
+    assert "random_debug_field" not in ctx
+    assert ctx == {"action_id": 42}
+
+
+def test_warning_logged_on_strip(caplog):
+    """S3 : chaque clé strippée émet un warning traçable."""
+    with caplog.at_level(logging.WARNING, logger="services.error_catalog"):
+        business_error("ACTION_NOT_FOUND", user_email="leak@x.io", action_id=42)
+
+    # Un warning contenant le code d'erreur et la clé strippée
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("user_email" in r.getMessage() and "ACTION_NOT_FOUND" in r.getMessage() for r in warnings), (
+        f"warning strip attendu, records={[r.getMessage() for r in warnings]}"
+    )
+
+
+def test_empty_context_after_strip_omits_field():
+    """S3 : si toutes les clés sont strippées, detail.context est absent (pas {})."""
+    kwargs = business_error("USER_NOT_FOUND", user_email="x@y.z", password="hunter2")
+    assert "context" not in kwargs["detail"]
 
 
 def test_required_codes_present():

--- a/frontend/src/__tests__/FindingCard.test.js
+++ b/frontend/src/__tests__/FindingCard.test.js
@@ -149,9 +149,12 @@ describe('E. FindingCard — a11y & interactivity', () => {
 describe('H. FindingCard — fixes post-code-review PR #228', () => {
   const src = readSrc('ui/FindingCard.jsx');
 
-  it('Fix #1 : daysUntil wrappé avec useMemo (perf liste)', () => {
-    expect(src).toContain('import { useMemo }');
-    expect(src).toMatch(/useMemo\(\(\)\s*=>\s*daysUntil\(deadline\)/);
+  it('Sprint CX 2.5-bis F5 : daysUntil sans useMemo (évite staleness à minuit)', () => {
+    // useMemo retiré car daysUntil() fait new Date() et la memo ne se rerun pas
+    // à minuit → "J-1" restait figé. Calcul trivial donc recompute à chaque render.
+    expect(src).not.toContain('import { useMemo }');
+    expect(src).not.toMatch(/useMemo\(\(\)\s*=>\s*daysUntil\(deadline\)/);
+    expect(src).toMatch(/const\s+days\s*=\s*daysUntil\(deadline\)/);
   });
 
   it('Fix #2 : dev warning si impact fourni mais tous champs vides', () => {
@@ -164,6 +167,14 @@ describe('H. FindingCard — fixes post-code-review PR #228', () => {
     expect(src).toContain('data-category={category || undefined}');
     expect(src).not.toContain("data-category={category || 'generic'}");
   });
+
+  it('Sprint CX 2.5-bis F6 : daysUntil parse date-only en local TZ (pas UTC)', () => {
+    // Fix timezone bug : new Date('2026-04-20') = UTC midnight, à Paris 1h du matin
+    // la soustraction avec now local donnait négatif → "Dépassé" affiché à tort.
+    // Fix : split('T')[0] + new Date(y, m-1, d) pour local midnight.
+    expect(src).toContain("split('T')[0]");
+    expect(src).toMatch(/new Date\(y,\s*m\s*-\s*1,\s*d\)/);
+  });
 });
 
 // ── F. Impact display unifié ───────────────────────────────────────────────
@@ -171,10 +182,16 @@ describe('H. FindingCard — fixes post-code-review PR #228', () => {
 describe('F. FindingCard — impact (EUR/kWh/CO₂)', () => {
   const src = readSrc('ui/FindingCard.jsx');
 
-  it('supporte eur, kwh, co2_kg dans impact', () => {
+  it('supporte eur, kwh, co2e_kg dans impact (F4 : unité ADEME co2e)', () => {
     expect(src).toContain('eur');
     expect(src).toContain('kwh');
-    expect(src).toContain('co2_kg');
+    expect(src).toContain('co2e_kg');
+    // Sprint CX 2.5-bis F4 : l'ancien nom co2_kg ne doit plus apparaître
+    expect(src).not.toMatch(/\bco2_kg\b/);
+  });
+
+  it("affiche l'unité kgCO₂e/an (équivalent carbone ADEME)", () => {
+    expect(src).toContain('kgCO₂e/an');
   });
 
   it('utilise fmtEur pour formatage EUR (localisation FR)', () => {

--- a/frontend/src/ui/FindingCard.jsx
+++ b/frontend/src/ui/FindingCard.jsx
@@ -19,7 +19,6 @@
  * Convention category : 'compliance' | 'billing' | 'consumption' | 'purchase' | 'flex' | 'audit' | 'insight'
  */
 
-import { useMemo } from 'react';
 import {
   ChevronRight,
   AlertTriangle,
@@ -76,9 +75,26 @@ const CATEGORY_ICONS = {
 };
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Calcule le nombre de jours jusqu'à deadline (local TZ).
+ *
+ * Sprint CX 2.5-bis F6 : fix timezone bug. `new Date('2026-04-20')` est
+ * parsé UTC minuit alors que `new Date()` est local now. À Paris à 1h du
+ * matin le 20/04, la différence donnait négatif → "Dépassé" affiché pour
+ * une échéance "aujourd'hui". Fix : normaliser les 2 dates en local
+ * midnight avant soustraction.
+ */
 function daysUntil(dateStr) {
   if (!dateStr) return null;
-  return Math.ceil((new Date(dateStr) - new Date()) / (1000 * 60 * 60 * 24));
+  // Support ISO date-only (YYYY-MM-DD) et ISO datetime
+  const datePart = String(dateStr).split('T')[0];
+  const [y, m, d] = datePart.split('-').map(Number);
+  if (!y || !m || !d) return null;
+  const deadlineLocal = new Date(y, m - 1, d); // local midnight
+  const today = new Date();
+  const todayLocal = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  return Math.round((deadlineLocal - todayLocal) / (1000 * 60 * 60 * 24));
 }
 
 function DeadlineBadge({ days }) {
@@ -123,8 +139,8 @@ function ConfidenceBadge({ score }) {
 
 function ImpactRow({ impact }) {
   if (!impact) return null;
-  const { eur, kwh, co2_kg } = impact;
-  if (eur == null && kwh == null && co2_kg == null) return null;
+  const { eur, kwh, co2e_kg } = impact;
+  if (eur == null && kwh == null && co2e_kg == null) return null;
   return (
     <div className="mt-2 flex items-center gap-3 text-xs flex-wrap" data-testid="finding-impact">
       {eur != null && eur !== 0 && (
@@ -137,8 +153,10 @@ function ImpactRow({ impact }) {
       {kwh != null && kwh > 0 && (
         <span className="text-gray-500">{Math.round(kwh).toLocaleString('fr-FR')} kWh/an</span>
       )}
-      {co2_kg != null && co2_kg > 0 && (
-        <span className="text-gray-500">{Math.round(co2_kg).toLocaleString('fr-FR')} kgCO₂/an</span>
+      {co2e_kg != null && co2e_kg > 0 && (
+        <span className="text-gray-500">
+          {Math.round(co2e_kg).toLocaleString('fr-FR')} kgCO₂e/an
+        </span>
       )}
     </div>
   );
@@ -153,7 +171,7 @@ function ImpactRow({ impact }) {
  * @param {'compliance'|'billing'|'consumption'|'purchase'|'flex'|'audit'|'insight'} [props.category]
  * @param {string} props.title
  * @param {string} [props.description]
- * @param {{eur?:number, kwh?:number, co2_kg?:number}} [props.impact]
+ * @param {{eur?:number, kwh?:number, co2e_kg?:number}} [props.impact]
  * @param {string} [props.deadline] - ISO date string
  * @param {number} [props.confidence] - 0..1
  * @param {string} [props.actionLabel]
@@ -180,16 +198,19 @@ export default function FindingCard({
   const cfg = SEVERITY_CONFIG[severity] || SEVERITY_CONFIG.medium;
   const Icon = category && CATEGORY_ICONS[category];
 
-  // Fix #1 (code review PR #228) : useMemo pour éviter recompute de `new Date()`
-  // à chaque render, important quand FindingCard est rendu dans une liste de N items.
-  const days = useMemo(() => daysUntil(deadline), [deadline]);
+  // Sprint CX 2.5-bis F5 : retrait de useMemo — daysUntil() fait `new Date()` (now),
+  // la memo ne se rerun pas à minuit donc "J-1" restait figé. Calcul trivial (<1µs),
+  // recompute à chaque render est correct et bon marché.
+  const days = daysUntil(deadline);
 
   // Fix #2 (code review) : dev warning si `impact` fourni mais tous champs vides/nuls
   // Aide à détecter un backend qui renvoie un payload vide silencieusement.
   if (import.meta.env?.DEV && impact) {
-    const { eur, kwh, co2_kg } = impact;
+    const { eur, kwh, co2e_kg } = impact;
     const allEmpty =
-      (eur == null || eur === 0) && (kwh == null || kwh === 0) && (co2_kg == null || co2_kg === 0);
+      (eur == null || eur === 0) &&
+      (kwh == null || kwh === 0) &&
+      (co2e_kg == null || co2e_kg === 0);
     if (allEmpty) {
       // eslint-disable-next-line no-console
       console.warn(


### PR DESCRIPTION
## Sprint CX 2.5-bis — 6 P1 fixes suite audit SDK

Complète le Sprint 2.5 Hardening (PR #237 mergée). Livre les P1 restants du backlog `project_sprint_cx25_hardening_backlog_2026_04_17.md`.

## 4 commits atomiques

| Commit | P1 | Description |
|--------|-----|-------------|
| `4a462d5f` | **F4+F5+F6** | FindingCard : co2e_kg (ADEME) + useMemo retiré (staleness) + TZ fix (local midnight) |
| `0520961a` | **F10** | IAR cap 1.0 + expose iar_raw + is_capped (sémantique taux) |
| `c76c82e3` | **P2** | LRU cache TTL 5min membership check (hot-path cockpit polling) |
| `51f3d2d6` | **S3** | business_error context allowlist anti-PII (12 clés safe + regex fallback) |

## Process — 2 agents SDK parallèles

- **Agent A** (frontend) : F4 + F5 + F6 + tests source-guard
- **Agent B** (backend) : F10 + P2 + S3 + tests isolés
- Plans livrés en ~90s, puis exécution directe des edits par chaque agent
- Scope chirurgical : 8 fichiers modifiés, +375/-31

## Tests

- **129 tests verts** :
  - Backend : 89 (cx_logger + drivers + security + error_catalog + action_status + actions + cx_dashboard_drivers)
  - Frontend : 40 (FindingCard source-guard)
- Ruff clean backend, prettier OK frontend

## Détail fix

### F4 — unité ADEME
- `impact.co2_kg` → `impact.co2e_kg` (aligné backend `co2e_savings_est_kg`)
- Label UI `kgCO₂/an` → `kgCO₂e/an`

### F5 — useMemo staleness
- `daysUntil` recomputait via `new Date()` (now) sans trigger memo invalidation à minuit
- Retiré le useMemo (calcul <1µs)

### F6 — timezone bug
- `new Date('YYYY-MM-DD')` = UTC minuit vs `new Date()` = local now
- Fix : `split('T')[0]` + `new Date(y, m-1, d)` pour local midnight des 2 côtés

### F10 — IAR > 1
- Cas légitime "1 insight → N actions" → ratio > 1
- Expose `iar_raw` (brut) + `iar` (cappé 1.0) + `is_capped` (flag UI)

### P2 — hot-path LRU cache
- Dict module-level `_MEMBERSHIP_CACHE[(user_id, org_id)]` + TTL 5min
- Helper `invalidate_membership_cache()` pour purge explicite
- Câblage CRUD UserOrgRole hors scope (noté dans code)

### S3 — anti-PII
- `_SAFE_CONTEXT_KEYS` : 12 clés neutres explicites
- `_PII_KEY_PATTERN` regex filet de sécurité
- Warning log par clé strippée pour traçabilité

## Reste post-merge

- **UX dette** : 1/67 cards migrées vers FindingCard (progressive)
- **S3 hardening** : câbler `invalidate_membership_cache` sur UserOrgRole CRUD
- **Issue #225** : IAR refinement arbitrage métier (sprint CX v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)