### PR TITLE
fix(cx-iar): Issue #225 — whitelist source_type pour CX_ACTION_FROM_INSIGHT

### DIFF
--- a/backend/services/action_status_service.py
+++ b/backend/services/action_status_service.py
@@ -22,7 +22,29 @@ from typing import Optional
 from sqlalchemy.orm import Session
 
 from middleware.cx_logger import CX_ACTION_FROM_INSIGHT, log_cx_event
-from models import ActionItem, ActionStatus
+from models import ActionItem, ActionSourceType, ActionStatus
+
+# Issue #225 IAR refinement (Option A whitelist source_type) :
+# CX_ACTION_FROM_INSIGHT doit fire UNIQUEMENT pour les actions issues d'un
+# insight/recommandation système PROMEOS, pas pour les actions manuelles
+# créées par l'utilisateur (qui ne mesurent pas la capacité du système à
+# convertir un insight en action).
+#
+# Exclus : MANUAL (l'user tape son propre titre, pas tracé côté CX_INSIGHT_CONSULTED)
+# Inclus : tous les autres source_types qui correspondent à une détection
+# ou une recommandation générée par le système.
+INSIGHT_DRIVEN_SOURCE_TYPES: frozenset[ActionSourceType] = frozenset(
+    {
+        ActionSourceType.COMPLIANCE,
+        ActionSourceType.CONSUMPTION,
+        ActionSourceType.BILLING,
+        ActionSourceType.PURCHASE,
+        ActionSourceType.INSIGHT,
+        ActionSourceType.SEGMENTATION,
+        ActionSourceType.COPILOT,
+        ActionSourceType.PILOTAGE,
+    }
+)
 
 
 def mark_action_done(
@@ -35,6 +57,9 @@ def mark_action_done(
     """
     Marque une action DONE + set closed_at (si None) + fire CX_ACTION_FROM_INSIGHT.
 
+    Issue #225 (IAR refinement) : fire l'event UNIQUEMENT si le source_type
+    appartient à INSIGHT_DRIVEN_SOURCE_TYPES (exclut MANUAL qui pollue IAR).
+
     Args:
         db: Session SQLAlchemy (le caller doit commit/flush après).
         action: L'ActionItem à clôturer.
@@ -46,15 +71,21 @@ def mark_action_done(
     if action.closed_at is None:
         action.closed_at = datetime.now(timezone.utc)
 
-    if emit_event and action.org_id is not None:
-        log_cx_event(
-            db,
-            action.org_id,
-            user_id,
-            CX_ACTION_FROM_INSIGHT,
-            {
-                "action_id": action.id,
-                "source_type": action.source_type.value if action.source_type else None,
-                "reason": reason or "mark_done",
-            },
-        )
+    if not emit_event or action.org_id is None:
+        return
+
+    # Issue #225 : filtre whitelist source_type pour sémantique IAR propre
+    if action.source_type not in INSIGHT_DRIVEN_SOURCE_TYPES:
+        return
+
+    log_cx_event(
+        db,
+        action.org_id,
+        user_id,
+        CX_ACTION_FROM_INSIGHT,
+        {
+            "action_id": action.id,
+            "source_type": action.source_type.value if action.source_type else None,
+            "reason": reason or "mark_done",
+        },
+    )

--- a/backend/tests/test_action_status_service.py
+++ b/backend/tests/test_action_status_service.py
@@ -136,3 +136,77 @@ def test_mark_action_done_without_user_id(db_session):
     events = db_session.query(AuditLog).filter(AuditLog.action == "CX_ACTION_FROM_INSIGHT").all()
     assert len(events) == 1
     assert events[0].user_id is None
+
+
+# ─── Issue #225 — IAR refinement : whitelist source_type ───────────────────
+
+
+def test_issue225_manual_action_does_not_fire_event(db_session):
+    """Issue #225 : action MANUAL → status DONE OK, mais PAS d'event CX.
+
+    MANUAL = action créée par user (pas d'insight/reco système détecté),
+    donc ne doit pas compter dans le numérateur IAR.
+    """
+    _seed_org_and_member(db_session)
+    action = ActionItem(
+        id=700,
+        org_id=1,
+        source_type=ActionSourceType.MANUAL,
+        source_id="user-created",
+        source_key="manual-700",
+        title="Action créée par user",
+        status=ActionStatus.OPEN,
+    )
+    db_session.add(action)
+    db_session.flush()
+
+    mark_action_done(db_session, action, user_id=1, reason="user_manual")
+    db_session.commit()
+
+    # Status OK
+    assert action.status == ActionStatus.DONE
+    assert action.closed_at is not None
+    # Mais AUCUN event CX car MANUAL exclu du whitelist
+    events = db_session.query(AuditLog).filter(AuditLog.action == "CX_ACTION_FROM_INSIGHT").count()
+    assert events == 0
+
+
+def test_issue225_insight_driven_sources_fire_event(db_session):
+    """Issue #225 : les 8 source_types insight-driven fire l'event IAR."""
+    _seed_org_and_member(db_session)
+
+    expected_sources = [
+        ActionSourceType.COMPLIANCE,
+        ActionSourceType.CONSUMPTION,
+        ActionSourceType.BILLING,
+        ActionSourceType.PURCHASE,
+        ActionSourceType.INSIGHT,
+        ActionSourceType.SEGMENTATION,
+        ActionSourceType.COPILOT,
+        ActionSourceType.PILOTAGE,
+    ]
+
+    for idx, src in enumerate(expected_sources):
+        action = ActionItem(
+            id=800 + idx,
+            org_id=1,
+            source_type=src,
+            source_id=f"test-{src.value}",
+            source_key=f"key-{src.value}",
+            title=f"Action {src.value}",
+            status=ActionStatus.OPEN,
+        )
+        db_session.add(action)
+        db_session.flush()
+        mark_action_done(db_session, action, user_id=1, reason=f"test_{src.value}")
+
+    db_session.commit()
+
+    events = db_session.query(AuditLog).filter(AuditLog.action == "CX_ACTION_FROM_INSIGHT").all()
+    assert len(events) == 8
+    # Vérifier qu'on a bien 1 event par source insight-driven
+    logged_sources = set()
+    for e in events:
+        detail = json.loads(e.detail_json)
+        logged_sources.add(detail["source_type"])
+    assert logged_sources == {src.value for src in expected_sources}


### PR DESCRIPTION
Closes #225.

## Problème
`CX_ACTION_FROM_INSIGHT` firait sur toute action DONE, incluant MANUAL. Numérateur IAR surestimé par des actions qui ne mesurent pas la conversion insight→action.

## Fix — Option A whitelist
- `INSIGHT_DRIVEN_SOURCE_TYPES` : 8 sources whitelistées (COMPLIANCE, CONSUMPTION, BILLING, PURCHASE, INSIGHT, SEGMENTATION, COPILOT, PILOTAGE)
- Exclut MANUAL
- Dans `mark_action_done`, si source ∉ whitelist → status DONE OK mais pas d'event

## Tests
7 verts (5 existants inchangés + 2 Issue #225 : MANUAL exclu + 8 sources fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)