### PR TITLE
feat(cx-ux): migrate UsageAnomaliesCard to FindingCard (3/66 backlog)

### DIFF
--- a/frontend/src/components/analytics/UsageAnomaliesCard.jsx
+++ b/frontend/src/components/analytics/UsageAnomaliesCard.jsx
@@ -3,33 +3,14 @@
  *
  * Display-only. Donnees de GET /api/analytics/sites/{id}/usage-anomalies.
  * Chaque anomalie = un usage concerne + gain estime + action recommandee.
+ *
+ * Sprint CX UX migration (3/66) : rendu des anomalies unifié via <FindingCard>.
  */
 
 import { useState, useEffect } from 'react';
-import { AlertTriangle, TrendingDown, Zap } from 'lucide-react';
+import { AlertTriangle, TrendingDown } from 'lucide-react';
+import { FindingCard } from '../../ui';
 import { getUsageAnomalies } from '../../services/api';
-
-const SEVERITY_STYLE = {
-  critical: {
-    bg: 'bg-red-50',
-    border: 'border-red-200',
-    icon: 'text-red-600',
-    text: 'text-red-800',
-  },
-  high: { bg: 'bg-red-50', border: 'border-red-200', icon: 'text-red-500', text: 'text-red-700' },
-  medium: {
-    bg: 'bg-amber-50',
-    border: 'border-amber-200',
-    icon: 'text-amber-500',
-    text: 'text-amber-700',
-  },
-  low: {
-    bg: 'bg-blue-50',
-    border: 'border-blue-200',
-    icon: 'text-blue-500',
-    text: 'text-blue-700',
-  },
-};
 
 export default function UsageAnomaliesCard({ siteId, preloadedData }) {
   const [data, setData] = useState(preloadedData || null);
@@ -89,40 +70,22 @@ export default function UsageAnomaliesCard({ siteId, preloadedData }) {
         )}
       </div>
 
-      {/* Liste des anomalies */}
+      {/* Liste des anomalies via FindingCard unifié */}
       <div className="space-y-3">
-        {data.anomalies.map((a, i) => {
-          const style = SEVERITY_STYLE[a.severity] || SEVERITY_STYLE.medium;
-          return (
-            <div
-              key={`${a.usage_code}-${a.anomaly_type}-${i}`}
-              className={`rounded-lg border p-3 ${style.bg} ${style.border}`}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <Zap size={12} className={style.icon} />
-                    <span className={`text-sm font-medium ${style.text}`}>{a.message}</span>
-                  </div>
-                  <p className="text-xs text-gray-600 mt-1">{a.detail}</p>
-                  <p className="text-xs text-gray-500 mt-1.5 italic">{a.action}</p>
-                </div>
-                {a.gain_eur_an > 0 && (
-                  <div className="shrink-0 text-right">
-                    <div className="text-sm font-bold text-green-700">
-                      {Math.round(a.gain_eur_an).toLocaleString('fr-FR')} &euro;/an
-                    </div>
-                    {a.gain_kwh_an > 0 && (
-                      <div className="text-[10px] text-gray-500">
-                        {Math.round(a.gain_kwh_an).toLocaleString('fr-FR')} kWh
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          );
-        })}
+        {data.anomalies.map((a, i) => (
+          <FindingCard
+            key={`${a.usage_code}-${a.anomaly_type}-${i}`}
+            compact
+            severity={a.severity || 'medium'}
+            category="consumption"
+            title={a.message}
+            description={a.action ? `${a.detail} — ${a.action}` : a.detail}
+            impact={{
+              eur: a.gain_eur_an,
+              kwh: a.gain_kwh_an,
+            }}
+          />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
Sprint CX UX dette progressive — 3ème migration.

## Scope
Rendu custom des anomalies (div + severity style + Zap icon per row + layout flex) remplacé par `<FindingCard compact>` unifié.

## Mapping
| Champ anomalie | Prop FindingCard |
|---|---|
| `severity` | severity (direct match) |
| `message` | title |
| `detail` + `action` | description concat ("detail — action") |
| `gain_eur_an` | impact.eur |
| `gain_kwh_an` | impact.kwh |

## Supprimé
- SEVERITY_STYLE dict local (24 lignes)
- Rendering custom per anomalie (~30 lignes)
- -56 lignes / +19 lignes

## Conservé
- Header card (titre + badge n_anomalies + total_gain recuperables) — pattern spécifique
- Loading skeleton

## Progression backlog UX dette
**3/66 cards migrées** :
1. AlertesPrioritaires (sprint CX 2)
2. RecommendationsCard (PR #243)
3. UsageAnomaliesCard (ce sprint)

## Tests
- FindingCard 40/40 verts
- Prettier clean

## Prochains candidats
AuditSmeCard (compliance), PriorityActions (cockpit), InsightDrawer header (billing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)