### PR TITLE
feat(achat-hardening): Pydantic extra=forbid + constantes MVP en YAML versionné

### DIFF
--- a/backend/config/tarifs_reglementaires.yaml
+++ b/backend/config/tarifs_reglementaires.yaml
@@ -467,8 +467,9 @@ tva:
 vnu:
   seuil_1_eur_mwh: 78.0
   seuil_2_eur_mwh: 110.0
+  impact_upside_mvp_eur_mwh: 2.0
   statut: "EN VIGUEUR — DORMANT (prix marché ~60 €/MWh < seuil 78)"
-  source: "Loi de souveraineté énergétique — VNU au 01/01/2026"
+  source: "Loi de souveraineté énergétique — VNU au 01/01/2026 (Décret 2026-55, CRE 2026-52)"
   valid_from: "2026-01-01"
   revision_triennale: "~2028 (CRE)"
   note: "L'ancien ARENH (42 EUR/MWh) n'est plus applicable. Ne plus utiliser comme référence de prix."
@@ -478,6 +479,18 @@ prix_reference:
   elec_eur_kwh: 0.068
   gaz_eur_kwh: 0.045
   source: "PROMEOS POC fallback (EPEX Spot 30j moyen)"
+
+# ── Cost Simulator post-ARENH MVP — constantes versionnées ─────────────────
+# Utilisées par `services/purchase/cost_simulator_2026.py`. Migration depuis
+# constantes hardcodées vers YAML pour traçabilité + versioning par date
+# d'effet (cohérent avec le reste du référentiel CRE).
+cost_simulator_2026:
+  baseline_eur_mwh: 80.0  # ARENH 42 × 50% + complément spot 2024 (~120 × 50%)
+  fallback_forward_eur_mwh: 68.0  # Si mkt_prices vide (= prix_reference.elec_eur_kwh × 1000)
+  peak_premium_ratio: 0.15  # Majoration HP/HC baseload, calibrée Observatoire CRE T4 2025
+  source: "PROMEOS MVP post-ARENH — calibration Observatoire CRE T4 2025 + baromètre CRE bulletin marchés de gros 2025"
+  valid_from: "2026-01-01"
+  valid_to: null
 
 # ── Pilotage Flex Ready® — paramètres MVP ROI + scoring portefeuille ───────
 # Constantes indicatives (pas des engagements commerciaux) utilisées par :

--- a/backend/routes/purchase_cost_simulation.py
+++ b/backend/routes/purchase_cost_simulation.py
@@ -23,7 +23,7 @@ import logging
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from database import get_db
@@ -40,6 +40,8 @@ router = APIRouter(prefix="/api/purchase/cost-simulation", tags=["Achat Energie 
 class CostComposantes(BaseModel):
     """Décomposition des 6 composantes de la facture prévisionnelle post-ARENH."""
 
+    model_config = ConfigDict(extra="forbid")
+
     fourniture_eur: float = Field(..., description="Fourniture énergie (forward baseload × CDC annuel)")
     turpe_eur: float = Field(..., description="TURPE 7 (part fixe + variable)")
     vnu_eur: float = Field(
@@ -53,6 +55,8 @@ class CostComposantes(BaseModel):
 
 class CostHypotheses(BaseModel):
     """Hypothèses MVP documentées (contrat stable côté frontend)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     prix_forward_y1_eur_mwh: float
     facteur_forme: float
@@ -85,6 +89,8 @@ class CostHypotheses(BaseModel):
 
 class Baseline2024(BaseModel):
     """Estimation facture historique ARENH 2024 HT pour delta comparable."""
+
+    model_config = ConfigDict(extra="forbid")
 
     fourniture_ht_eur: float
     prix_moyen_pondere_eur_mwh: float

--- a/backend/services/purchase/cost_simulator_2026.py
+++ b/backend/services/purchase/cost_simulator_2026.py
@@ -269,11 +269,11 @@ def _resolve_accise_code(site) -> str:
     return _accise_code_for_category("elec", tp)
 
 
-def _resolve_vnu_seuil(store: ParameterStore) -> tuple[float, Optional[str], float]:
+def _resolve_vnu_seuil() -> tuple[float, Optional[str], float]:
     """Extrait seuil + impact upside VNU depuis `tarifs_reglementaires.yaml::vnu`.
 
     Retourne `(seuil_eur_mwh, source_ref, impact_upside_eur_mwh)`. Fallback
-    hardcodé si YAML absent.
+    hardcodé si YAML absent — warning loggé pour visibilité prod.
     """
     try:
         vnu = load_yaml_section("vnu") or {}
@@ -281,7 +281,7 @@ def _resolve_vnu_seuil(store: ParameterStore) -> tuple[float, Optional[str], flo
         impact = float(vnu.get("impact_upside_mvp_eur_mwh", VNU_IMPACT_MVP_EUR_MWH_FALLBACK))
         return seuil, vnu.get("source"), impact
     except Exception as exc:
-        logger.debug("cost_simulator_2026: vnu lookup failed: %s", exc)
+        logger.warning("cost_simulator_2026: vnu lookup failed (fallback hardcoded): %s", exc)
     return VNU_SEUIL_DEFAUT_EUR_MWH, None, VNU_IMPACT_MVP_EUR_MWH_FALLBACK
 
 
@@ -300,7 +300,7 @@ def _load_simulator_params() -> dict[str, float]:
             "peak_premium_ratio": float(section.get("peak_premium_ratio", PEAK_PREMIUM_RATIO_FALLBACK)),
         }
     except Exception as exc:
-        logger.debug("cost_simulator_2026: simulator params lookup failed: %s", exc)
+        logger.warning("cost_simulator_2026: simulator params lookup failed (fallback hardcoded): %s", exc)
     return {
         "baseline_eur_mwh": BASELINE_2024_EUR_MWH_FALLBACK,
         "fallback_forward_eur_mwh": FALLBACK_FORWARD_EUR_MWH,
@@ -402,7 +402,7 @@ def simulate_annual_cost_2026(
     # consommateur final. L'additionner à la facture client comme auparavant
     # gonflait artificiellement le total de ~2 EUR/MWh quand "actif". On expose
     # désormais le statut + risque upside dans `hypotheses`, facture toujours = 0.
-    vnu_seuil, vnu_source_ref, vnu_impact = _resolve_vnu_seuil(store)
+    vnu_seuil, vnu_source_ref, vnu_impact = _resolve_vnu_seuil()
     vnu_statut = "dormant" if forward_y1 < vnu_seuil else "actif"
     vnu_eur = 0.0
     vnu_risque_upside_eur_mwh = vnu_impact if vnu_statut == "actif" else 0.0

--- a/backend/services/purchase/cost_simulator_2026.py
+++ b/backend/services/purchase/cost_simulator_2026.py
@@ -42,7 +42,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from services.billing_engine.parameter_store import ParameterStore
-from utils.parameter_store_base import paris_today
+from utils.parameter_store_base import load_yaml_section, paris_today
 
 logger = logging.getLogger(__name__)
 
@@ -54,10 +54,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_ANNUAL_KWH = 100_000.0  # Fallback si site sans conso
 DEFAULT_ARCHETYPE = "BUREAU_STANDARD"
 
-# Prix de référence fallback (EUR/MWh) si forward absent de mkt_prices.
-# YAML `prix_reference.elec_eur_kwh = 0.068` → 68 EUR/MWh.
-FALLBACK_FORWARD_EUR_MWH = 68.0
-
 # Mécanisme capacité RTE — aligné sur `billing_engine/catalog.py::CAPACITE_ELEC`
 # (enchère 06/03/2025 : 3.15 EUR/MW × coeff obligation 1.2 / 8760h ≈ 0.43 EUR/MWh).
 # Le mécanisme centralisé acheteur unique nov. 2026 conserve la même valeur
@@ -65,10 +61,18 @@ FALLBACK_FORWARD_EUR_MWH = 68.0
 # Source unique de vérité : `billing_engine/catalog.py` ligne 879.
 CAPACITE_UNITAIRE_EUR_MWH = 0.43
 
-# VNU redistributif MVP : si seuil 1 atteint, impact estimé 2 EUR/MWh
-# (hypothèse produit, à documenter dans hypotheses payload).
-VNU_IMPACT_MVP_EUR_MWH = 2.0
+# Seuil VNU par défaut (fallback hardcodé si YAML indisponible).
+# Valeur canonique dans `tarifs_reglementaires.yaml::vnu.seuil_1_eur_mwh`.
 VNU_SEUIL_DEFAUT_EUR_MWH = 78.0
+
+# Fallbacks hardcodés — constantes YAML canoniques dans `cost_simulator_2026`
+# section de `tarifs_reglementaires.yaml`. Valeurs ici uniquement pour tenir
+# les tests en mode stand-alone (YAML manquant) + exposer une cible de
+# compatibilité stable à la BC.
+FALLBACK_FORWARD_EUR_MWH = 68.0  # YAML: cost_simulator_2026.fallback_forward_eur_mwh
+BASELINE_2024_EUR_MWH_FALLBACK = 80.0  # YAML: cost_simulator_2026.baseline_eur_mwh
+VNU_IMPACT_MVP_EUR_MWH_FALLBACK = 2.0  # YAML: vnu.impact_upside_mvp_eur_mwh
+PEAK_PREMIUM_RATIO_FALLBACK = 0.15  # YAML: cost_simulator_2026.peak_premium_ratio
 
 # Facteur de forme typique par archétype (E_an / (P_max × 8760h)).
 # Aligné sur les 8 archétypes canoniques `ARCHETYPE_CALIBRATION_2024`
@@ -86,15 +90,11 @@ ARCHETYPE_FACTEUR_FORME = {
     "DEFAULT": 0.40,
 }
 
-# Baseline 2024 : pondération ARENH 42 EUR/MWh (50% quota) + complément spot
-# ~120 EUR/MWh moyenne 2024 → ~80 EUR/MWh pondéré HT énergie brute.
-# Hypothèse produit simplificatrice MVP, à préciser si besoin futur.
-BASELINE_2024_EUR_MWH = 80.0
-
-# Peak premium MVP : majoration baseload pour modéliser le prix pondéré HP/HC.
-# Calibré sur spread HP/HC tertiaire moyen 2024 (Observatoire CRE T4 2025).
-# Appliqué proportionnellement à `(1 - facteur_forme)` — site flat → 0 premium.
-PEAK_PREMIUM_RATIO = 0.15
+# Ces constantes sont conservées comme alias pour imports rétro-compatibles.
+# Les valeurs effectives proviennent de YAML (cf. `_load_simulator_params`).
+BASELINE_2024_EUR_MWH = BASELINE_2024_EUR_MWH_FALLBACK
+PEAK_PREMIUM_RATIO = PEAK_PREMIUM_RATIO_FALLBACK
+VNU_IMPACT_MVP_EUR_MWH = VNU_IMPACT_MVP_EUR_MWH_FALLBACK
 
 # Segment TURPE par défaut (C4_BT = tertiaire moyen, majoritaire dans portefeuille PME).
 # Si `Meter.tariff_type` renseigne C5 / C3, on bascule.
@@ -133,12 +133,12 @@ TURPE_FIXE_PROFILES = {
 # ── Helpers internes ─────────────────────────────────────────────────────────
 
 
-def _resolve_forward_y1(db: Session, year: int) -> tuple[float, str]:
+def _resolve_forward_y1(db: Session, year: int, fallback_eur_mwh: float) -> tuple[float, str]:
     """
     Cherche un forward baseload FR année `year` dans `mkt_prices`.
 
     Retourne (prix_eur_mwh, trace). La trace est la clé à ajouter dans
-    `source_calibration` si on a dû tomber sur le fallback.
+    `source_calibration` si on a dû tomber sur le fallback YAML-versionné.
     """
     try:
         from models.market_models import (
@@ -166,7 +166,7 @@ def _resolve_forward_y1(db: Session, year: int) -> tuple[float, str]:
     except Exception as exc:
         logger.debug("cost_simulator_2026: forward lookup failed: %s", exc)
 
-    return FALLBACK_FORWARD_EUR_MWH, "forward_indisponible_fallback_reference_price"
+    return fallback_eur_mwh, "forward_indisponible_fallback_reference_price"
 
 
 def _resolve_archetype_safe(db: Session, site) -> tuple[str, Optional[str]]:
@@ -269,23 +269,43 @@ def _resolve_accise_code(site) -> str:
     return _accise_code_for_category("elec", tp)
 
 
-def _resolve_vnu_seuil(store: ParameterStore) -> tuple[float, Optional[str]]:
-    """
-    Extrait le seuil d'activation VNU depuis le YAML `vnu.seuil_1_eur_mwh`.
+def _resolve_vnu_seuil(store: ParameterStore) -> tuple[float, Optional[str], float]:
+    """Extrait seuil + impact upside VNU depuis `tarifs_reglementaires.yaml::vnu`.
 
-    VNU n'est pas versionné via ParameterStore (pas de code canonique)
-    — on lit directement la section YAML via le loader partagé.
+    Retourne `(seuil_eur_mwh, source_ref, impact_upside_eur_mwh)`. Fallback
+    hardcodé si YAML absent.
     """
     try:
-        from utils.parameter_store_base import load_yaml_section
-
         vnu = load_yaml_section("vnu") or {}
-        seuil = vnu.get("seuil_1_eur_mwh")
-        if seuil is not None:
-            return float(seuil), vnu.get("source")
+        seuil = float(vnu.get("seuil_1_eur_mwh", VNU_SEUIL_DEFAUT_EUR_MWH))
+        impact = float(vnu.get("impact_upside_mvp_eur_mwh", VNU_IMPACT_MVP_EUR_MWH_FALLBACK))
+        return seuil, vnu.get("source"), impact
     except Exception as exc:
         logger.debug("cost_simulator_2026: vnu lookup failed: %s", exc)
-    return VNU_SEUIL_DEFAUT_EUR_MWH, None
+    return VNU_SEUIL_DEFAUT_EUR_MWH, None, VNU_IMPACT_MVP_EUR_MWH_FALLBACK
+
+
+def _load_simulator_params() -> dict[str, float]:
+    """Charge les paramètres MVP versionnés depuis YAML.
+
+    `tarifs_reglementaires.yaml::cost_simulator_2026` fournit `baseline_eur_mwh`,
+    `fallback_forward_eur_mwh`, `peak_premium_ratio`. Fallback hardcodé en cas
+    d'indisponibilité (test en mémoire sans fichier YAML).
+    """
+    try:
+        section = load_yaml_section("cost_simulator_2026") or {}
+        return {
+            "baseline_eur_mwh": float(section.get("baseline_eur_mwh", BASELINE_2024_EUR_MWH_FALLBACK)),
+            "fallback_forward_eur_mwh": float(section.get("fallback_forward_eur_mwh", FALLBACK_FORWARD_EUR_MWH)),
+            "peak_premium_ratio": float(section.get("peak_premium_ratio", PEAK_PREMIUM_RATIO_FALLBACK)),
+        }
+    except Exception as exc:
+        logger.debug("cost_simulator_2026: simulator params lookup failed: %s", exc)
+    return {
+        "baseline_eur_mwh": BASELINE_2024_EUR_MWH_FALLBACK,
+        "fallback_forward_eur_mwh": FALLBACK_FORWARD_EUR_MWH,
+        "peak_premium_ratio": PEAK_PREMIUM_RATIO_FALLBACK,
+    }
 
 
 # ── Interface publique ──────────────────────────────────────────────────────
@@ -314,6 +334,12 @@ def simulate_annual_cost_2026(
     """
     at_date = (now.date() if isinstance(now, datetime) else None) or paris_today()
 
+    # 0. Chargement des constantes MVP versionnées (YAML).
+    sim_params = _load_simulator_params()
+    baseline_eur_mwh = sim_params["baseline_eur_mwh"]
+    peak_premium_ratio = sim_params["peak_premium_ratio"]
+    fallback_forward = sim_params["fallback_forward_eur_mwh"]
+
     # 1. Normalisation inputs site
     annual_kwh, trace_kwh = _resolve_annual_kwh(site)
     annual_mwh = annual_kwh / 1000.0
@@ -336,10 +362,10 @@ def simulate_annual_cost_2026(
     # site flat (facteur 0.65+, logistique frigo) reste proche du baseload.
     # Multiplicateur MVP : `1 + peak_premium × (1 - facteur_forme)` avec
     # `peak_premium = 0.15` calibré sur spread HP/HC tertiaire 2024 (CRE T4).
-    forward_y1, trace_fwd = _resolve_forward_y1(db, year)
+    forward_y1, trace_fwd = _resolve_forward_y1(db, year, fallback_forward)
     if trace_fwd:
         traces.append(trace_fwd)
-    peakload_multiplier = 1.0 + PEAK_PREMIUM_RATIO * (1.0 - facteur_forme)
+    peakload_multiplier = 1.0 + peak_premium_ratio * (1.0 - facteur_forme)
     fourniture_eur = annual_mwh * forward_y1 * peakload_multiplier
 
     # 4. TURPE 7 (part fixe + variable)
@@ -376,10 +402,10 @@ def simulate_annual_cost_2026(
     # consommateur final. L'additionner à la facture client comme auparavant
     # gonflait artificiellement le total de ~2 EUR/MWh quand "actif". On expose
     # désormais le statut + risque upside dans `hypotheses`, facture toujours = 0.
-    vnu_seuil, vnu_source_ref = _resolve_vnu_seuil(store)
+    vnu_seuil, vnu_source_ref, vnu_impact = _resolve_vnu_seuil(store)
     vnu_statut = "dormant" if forward_y1 < vnu_seuil else "actif"
     vnu_eur = 0.0
-    vnu_risque_upside_eur_mwh = VNU_IMPACT_MVP_EUR_MWH if vnu_statut == "actif" else 0.0
+    vnu_risque_upside_eur_mwh = vnu_impact if vnu_statut == "actif" else 0.0
 
     # 6. Mécanisme capacité RTE — plein exercice annuel.
     # Cohérence avec `billing_engine/catalog.py` : le basculement mécanisme
@@ -439,7 +465,7 @@ def simulate_annual_cost_2026(
     # donc comparer fourniture 2026 (profilée) à baseline 2024 flat donnerait
     # un delta archetype-biaisé trompeur. Avec le multiplier commun, le delta
     # isole le shift Post-ARENH (ARENH 42 × 50% + spot → forward 100%).
-    baseline_2024_fourniture_eur = round(annual_mwh * BASELINE_2024_EUR_MWH * peakload_multiplier, 2)
+    baseline_2024_fourniture_eur = round(annual_mwh * baseline_eur_mwh * peakload_multiplier, 2)
     delta_fourniture_ht_pct = (
         round(
             (fourniture_eur - baseline_2024_fourniture_eur) / baseline_2024_fourniture_eur * 100.0,
@@ -456,7 +482,7 @@ def simulate_annual_cost_2026(
         "prix_forward_y1_eur_mwh": round(forward_y1, 2),
         "facteur_forme": facteur_forme,
         "peakload_multiplier": round(peakload_multiplier, 4),
-        "peak_premium_ratio": PEAK_PREMIUM_RATIO,
+        "peak_premium_ratio": peak_premium_ratio,
         "capacite_unitaire_eur_mwh": CAPACITE_UNITAIRE_EUR_MWH,
         "capacite_source_ref": "billing_engine/catalog.py::CAPACITE_ELEC (0.43 EUR/MWh)",
         "vnu_statut": vnu_statut,
@@ -478,7 +504,7 @@ def simulate_annual_cost_2026(
         "accise_eur_kwh": round(accise_eur_kwh, 5),
         "cta_rate": cta_rate,
         "tva_rate": tva_rate,
-        "baseline_2024_eur_mwh": BASELINE_2024_EUR_MWH,
+        "baseline_2024_eur_mwh": baseline_eur_mwh,
         "comparabilite_baseline": (
             "delta_vs_2024_pct cadré HT énergie pure (fourniture uniquement), "
             "même peakload_multiplier appliqué aux deux côtés pour isoler le "
@@ -492,7 +518,7 @@ def simulate_annual_cost_2026(
 
     baseline_2024 = {
         "fourniture_ht_eur": baseline_2024_fourniture_eur,
-        "prix_moyen_pondere_eur_mwh": BASELINE_2024_EUR_MWH,
+        "prix_moyen_pondere_eur_mwh": baseline_eur_mwh,
         "methode": (
             "ARENH 42 EUR/MWh × 50 % + complément spot moyen 2024 pondéré "
             "par peakload_multiplier de l'archétype (simplification MVP). "

--- a/backend/tests/test_achat_cost_simulator_2026.py
+++ b/backend/tests/test_achat_cost_simulator_2026.py
@@ -355,6 +355,23 @@ class TestSimulateFacture2026:
         # entre archétypes, isolant le shift Post-ARENH (baseline 80 → forward 62).
         assert r_bureau["delta_vs_2024_pct"] == pytest.approx(r_log["delta_vs_2024_pct"], abs=0.1)
 
+    def test_simulate_params_lus_depuis_yaml(self, db_session):
+        """Les constantes MVP (baseline, fallback forward, peak_premium) viennent du YAML."""
+        from services.purchase.cost_simulator_2026 import _load_simulator_params
+
+        params = _load_simulator_params()
+        # Valeurs actuelles dans tarifs_reglementaires.yaml::cost_simulator_2026
+        assert params["baseline_eur_mwh"] == pytest.approx(80.0, rel=1e-3)
+        assert params["fallback_forward_eur_mwh"] == pytest.approx(68.0, rel=1e-3)
+        assert params["peak_premium_ratio"] == pytest.approx(0.15, rel=1e-3)
+
+        # Le service les expose dans hypotheses (traçabilité auditeur)
+        _, site = _make_org_site(db_session, annual_kwh=500_000.0)
+        _seed_forward(db_session, year=2026, price_eur_mwh=62.0)
+        result = simulate_annual_cost_2026(site, db_session, year=2026)
+        assert result["hypotheses"]["baseline_2024_eur_mwh"] == pytest.approx(80.0, rel=1e-3)
+        assert result["hypotheses"]["peak_premium_ratio"] == pytest.approx(0.15, rel=1e-3)
+
     def test_simulate_archetype_inconnu_fallback_default(self, db_session):
         """Archetype hors dict → fallback DEFAULT (facteur_forme 0.40, mult 1.09)."""
         _, site = _make_org_site(db_session, annual_kwh=500_000.0, archetype_code="ARCHETYPE_INEXISTANT")

--- a/backend/tests/test_achat_cost_simulator_endpoint.py
+++ b/backend/tests/test_achat_cost_simulator_endpoint.py
@@ -230,6 +230,22 @@ def test_endpoint_demo_site_key_404_explicite(_site_org_factory):
     )
 
 
+def test_endpoint_pydantic_extra_forbid_catch_drift(_site_org_factory, _fake_cost_simulation):
+    """Drift détection : une clé inconnue dans `hypotheses` → 500 (extra='forbid')."""
+    client, _, site, _ = _site_org_factory()
+    _fake_cost_simulation["site_id"] = str(site.id)
+    # Ajout d'une clé non déclarée dans CostHypotheses — doit être rejetée par Pydantic
+    _fake_cost_simulation["hypotheses"]["nouvelle_cle_inconnue"] = "valeur_drift"
+
+    import services.purchase.cost_simulator_2026 as cost_mod
+
+    with patch.object(cost_mod, "simulate_annual_cost_2026", return_value=_fake_cost_simulation):
+        r = client.get(f"/api/purchase/cost-simulation/{site.id}")
+
+    # Pydantic raise ValidationError → FastAPI 500
+    assert r.status_code == 500
+
+
 def test_endpoint_schema_pydantic_exhaustif(_site_org_factory, _fake_cost_simulation):
     """Valide la structure complète du payload (tous champs requis présents)."""
     client, _, site, _ = _site_org_factory()


### PR DESCRIPTION
## Summary

Backlog post-merge PR #246 — 2 items de durcissement :

- **Pydantic `extra=\"forbid\"`** sur `CostComposantes` / `CostHypotheses` / `Baseline2024` : drift service↔schéma détectée au lieu d'un drop silencieux
- **Constantes MVP → YAML versionné** : `BASELINE_2024`, `FALLBACK_FORWARD`, `PEAK_PREMIUM_RATIO`, `VNU_IMPACT_MVP` migrés vers `tarifs_reglementaires.yaml` (section `cost_simulator_2026` + `vnu.impact_upside_mvp_eur_mwh`)

## Test plan

- [x] 28/28 backend (+2 tests : YAML load + drift detection)
- [x] 752/752 billing+pilotage verts (0 régression)
- [x] Ruff OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)