### PR TITLE
fix(achat-audit): P0 CTA dead-link + cleanup doctrine/aliases/UI confiance

### DIFF
--- a/backend/services/purchase/cost_simulator_2026.py
+++ b/backend/services/purchase/cost_simulator_2026.py
@@ -5,7 +5,8 @@ Répond à la question "combien coûtera ma facture énergie en 2026 / 2027 ?"
 avec une décomposition par composante réglementaire post-ARENH :
     - fourniture (forward baseload × CDC annuel)
     - TURPE 7 (part fixe + variable)
-    - VNU (dormant si prix < 78 EUR/MWh, upside sinon)
+    - VNU (statut informatif : dormant/actif selon seuil CRE ; facture client
+      = 0 dans les 2 cas — upside tracé dans `hypotheses.vnu_risque_upside_*`)
     - mécanisme capacité RTE (enchères PL-4/PL-1 centralisées nov. 2026)
     - CBAM scope (non applicable à la conso élec directe — documenté)
     - taxes agrégées (accise + CTA + TVA)
@@ -18,8 +19,8 @@ Doctrine :
 - MVP indicatif, confiance = "indicative"
 - Fallbacks défensifs traçables (clé `source_calibration`)
 - Jamais "flex" standalone dans les strings exposées (doctrine wording)
-- Réutilise `ParameterStore` + `resolve_archetype` + `tarif_loader`
-- Interface stable : agents B (endpoint) et C (frontend) s'y reposent
+- Réutilise `ParameterStore` (billing_engine), `resolve_archetype` (flex),
+  `load_yaml_section` (tarifs_reglementaires.yaml)
 
 Sources :
 - Post-ARENH au 01/01/2026 (art. L. 336-1 Code énergie, Loi souveraineté
@@ -90,11 +91,9 @@ ARCHETYPE_FACTEUR_FORME = {
     "DEFAULT": 0.40,
 }
 
-# Ces constantes sont conservées comme alias pour imports rétro-compatibles.
-# Les valeurs effectives proviennent de YAML (cf. `_load_simulator_params`).
+# Alias historique utilisé par `test_achat_cost_simulator_2026.py`. Valeur
+# effective toujours lue depuis YAML via `_load_simulator_params`.
 BASELINE_2024_EUR_MWH = BASELINE_2024_EUR_MWH_FALLBACK
-PEAK_PREMIUM_RATIO = PEAK_PREMIUM_RATIO_FALLBACK
-VNU_IMPACT_MVP_EUR_MWH = VNU_IMPACT_MVP_EUR_MWH_FALLBACK
 
 # Segment TURPE par défaut (C4_BT = tertiaire moyen, majoritaire dans portefeuille PME).
 # Si `Meter.tariff_type` renseigne C5 / C3, on bascule.

--- a/backend/tests/test_achat_cost_simulator_2026.py
+++ b/backend/tests/test_achat_cost_simulator_2026.py
@@ -206,7 +206,7 @@ class TestSimulateFacture2026:
         # Risque upside tracé dans les hypothèses
         assert result["hypotheses"]["vnu_risque_upside_eur_mwh"] > 0
         # Seuil exposé
-        assert result["hypotheses"]["vnu_seuil_active_eur_mwh"] >= VNU_SEUIL_DEFAUT_EUR_MWH
+        assert result["hypotheses"]["vnu_seuil_active_eur_mwh"] == VNU_SEUIL_DEFAUT_EUR_MWH
         # Note pédagogique présente pour auditeur
         assert "taxe redistributive sur EDF" in result["hypotheses"]["vnu_note"]
 

--- a/frontend/src/__tests__/purchase_cost_simulation_card.test.js
+++ b/frontend/src/__tests__/purchase_cost_simulation_card.test.js
@@ -55,9 +55,12 @@ describe('CostSimulationCard — imports partages', () => {
     expect(codeOnly).not.toMatch(/const\s+fmtEuro\s*=/);
   });
 
-  it('utilise useNavigate + toSite (pattern achats)', () => {
+  it('utilise useNavigate + toPurchase (fix audit — tab achat absent de Site360)', () => {
     expect(cardSrc).toMatch(/useNavigate/);
-    expect(cardSrc).toMatch(/toSite\(resolvedSiteId/);
+    expect(cardSrc).toMatch(/toPurchase\(\{/);
+    // Ne doit PAS rester un reliquat vers toSite(site_id, { tab: 'achats' }) :
+    // Site360 TABS n'expose pas 'achats' → fallback silencieux sur 'resume'.
+    expect(cardSrc).not.toMatch(/tab:\s*['"]achats['"]/);
   });
 });
 
@@ -221,6 +224,20 @@ describe('CostSimulationCard — accessibilité', () => {
     expect(cardSrc).toMatch(/role=["']group["']/);
     expect(cardSrc).toMatch(/aria-label=["']Année de projection["']/);
     expect(cardSrc).toMatch(/aria-pressed=\{selected\}/);
+  });
+});
+
+// ── Badge projection extrapolée (forward fallback) ──────────────────
+describe('CostSimulationCard — badge confiance si forward fallback', () => {
+  it('détecte `forward_indisponible` dans hypotheses.source_calibration', () => {
+    expect(cardSrc).toMatch(/hasForwardFallback/);
+    expect(cardSrc).toMatch(/forward_indisponible/);
+  });
+
+  it('rend un badge "Projection extrapolée" avec aria-label explicite', () => {
+    expect(cardSrc).toMatch(/Projection extrapolée/);
+    expect(cardSrc).toMatch(/cost-sim-forward-fallback-badge/);
+    expect(cardSrc).toMatch(/aria-label=\{`Projection \$\{selectedYear\}/);
   });
 });
 

--- a/frontend/src/components/purchase/CostSimulationCard.jsx
+++ b/frontend/src/components/purchase/CostSimulationCard.jsx
@@ -20,7 +20,7 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowRight, AlertTriangle } from 'lucide-react';
 import { getCostSimulation2026 } from '../../services/api/purchase';
 import { useScope } from '../../contexts/ScopeContext';
-import { toSite } from '../../services/routes';
+import { toPurchase } from '../../services/routes';
 import { fmtEur } from '../../utils/format';
 import { Skeleton, InfoTip } from '../../ui';
 
@@ -176,7 +176,9 @@ export default function CostSimulationCard({ siteId: siteIdProp, year: yearProp 
   }, [resolvedSiteId, selectedYear]);
 
   const handleCta = () => {
-    navigate(resolvedSiteId ? toSite(resolvedSiteId, { tab: 'achats' }) : '/achat-energie');
+    // `/sites/{id}` n'expose pas d'onglet achat — on route vers la page Achat
+    // énergie avec `site_id` en query pour pré-sélection du site.
+    navigate(toPurchase({ site_id: resolvedSiteId, tab: 'simulation' }));
   };
 
   // ── Loading ────────────────────────────────────────────────────────────
@@ -243,6 +245,13 @@ export default function CostSimulationCard({ siteId: siteIdProp, year: yearProp 
 
   const deltaIsNegative = deltaPct != null && deltaPct < 0;
   const deltaIsPositive = deltaPct != null && deltaPct > 0;
+
+  // Confiance dégradée si l'endpoint a dû tomber sur un fallback (pas de
+  // forward marché pour l'année sélectionnée, pas d'annual_kwh, etc.).
+  const sourceCalibration = hypotheses?.source_calibration || [];
+  const hasForwardFallback = sourceCalibration.some((t) =>
+    String(t).startsWith('forward_indisponible')
+  );
 
   return (
     <div
@@ -323,11 +332,26 @@ export default function CostSimulationCard({ siteId: siteIdProp, year: yearProp 
 
       {/* ── Hero big number ──────────────────────────────────────────── */}
       <div>
-        <div
-          className="text-3xl font-bold text-indigo-700 leading-tight"
-          data-testid="cost-sim-total"
-        >
-          {fmtEur(total)}
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <div
+            className="text-3xl font-bold text-indigo-700 leading-tight"
+            data-testid="cost-sim-total"
+          >
+            {fmtEur(total)}
+          </div>
+          {hasForwardFallback && (
+            <span
+              className="inline-flex items-center gap-1 bg-amber-50 text-amber-800 text-[10px] font-medium px-2 py-0.5 rounded-full"
+              data-testid="cost-sim-forward-fallback-badge"
+              aria-label={`Projection ${selectedYear} sans forward marché : extrapolation sur prix de référence`}
+            >
+              <AlertTriangle size={10} aria-hidden="true" />
+              Projection extrapolée
+              <InfoTip
+                content={`Aucun forward ${selectedYear} n'est disponible dans mkt_prices. Le simulateur utilise le prix de référence PROMEOS (${68} €/MWh) — utile pour cadrer un budget, pas pour un engagement commercial.`}
+              />
+            </span>
+          )}
         </div>
         <p className="text-[11px] text-gray-500 mt-1">
           Facture totale estimée · 6 composantes réglementaires


### PR DESCRIPTION
## Summary

Audit consolidé 3-agents SDK sur le pipeline Achat post-ARENH (PRs #239 + #246 + #248 merged) a trouvé **1 P0 demo-killer + 4 P1 réels**.

- **P0 CTA dead-linké** : `toSite(..., {tab: 'achats'})` → tab inexistant dans Site360, fallback silencieux sur 'resume'. Fix via `toPurchase({site_id, tab: 'simulation'})` = `/achat-energie?site_id=N&tab=simulation`
- **P1 Docstrings stale** : `tarif_loader` pas importé + VNU "upside sinon" contredit `vnu_eur=0`
- **P1 Dead aliases** : `PEAK_PREMIUM_RATIO` + `VNU_IMPACT_MVP_EUR_MWH` (zéro import externe)
- **P1 Assertion laxe** : `>=` → `==` sur vnu_seuil_active_eur_mwh
- **P1 UI confiance** : badge amber "Projection extrapolée" avec AlertTriangle + InfoTip quand `source_calibration` contient `forward_indisponible_*` (cas 2028-2030 démo)

## Test plan

- [x] 28 backend + 41 frontend (27→39→41 avec 2 new badge guards) + 24 routeHelpers verts
- [x] 798 billing+pilotage+achat+market_prices régression verte
- [x] Ruff + ESLint OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)