### PR TITLE
feat(prod-ready): B1 slowapi + B2 Site migration CBAM — transforme #250/#251 en prod-ready

### DIFF
--- a/backend/database/migrations.py
+++ b/backend/database/migrations.py
@@ -66,6 +66,8 @@ def run_migrations(engine):
     _add_meter_unified_columns(engine)
     # Step 26 — Geocoding columns on sites
     _add_site_geocoding_columns(engine)
+    # P3 CBAM — colonnes JSON d'exposition importations hors UE sur sites
+    _add_site_cbam_columns(engine)
     # V1.1 Usage — usage_id FK + usage enrichment + usage_baselines table
     _migrate_usage_v1_1(engine)
     # Soft-delete coherence — sync actif/deleted_at on dual-field tables
@@ -1238,6 +1240,41 @@ def _add_site_geocoding_columns(engine):
         logger.info("migration: Step 26 — added %d geocoding column(s) to sites", added)
     else:
         logger.debug("migration: Step 26 — sites geocoding columns already present")
+
+
+def _add_site_cbam_columns(engine):
+    """P3 CBAM — JSON columns for CBAM import exposure on sites.
+
+    Colonnes :
+      - cbam_imports_tonnes (TEXT JSON) : {scope: tonnes/an} hors UE
+      - cbam_intensities_tco2_per_t (TEXT JSON) : override intensités CE
+
+    Source : Règlement UE 2023/956 (CBAM), activé 07/04/2026.
+    """
+    insp = inspect(engine)
+    if not insp.has_table("sites"):
+        return
+
+    existing_cols = {c["name"] for c in insp.get_columns("sites")}
+    columns = [
+        ("cbam_imports_tonnes", "TEXT"),
+        ("cbam_intensities_tco2_per_t", "TEXT"),
+    ]
+
+    added = 0
+    with engine.begin() as conn:
+        for col_name, col_type in columns:
+            if col_name in existing_cols:
+                continue
+            try:
+                conn.execute(text(f'ALTER TABLE "sites" ADD COLUMN "{col_name}" {col_type}'))
+                added += 1
+                logger.info("migration: P3 CBAM — added sites.%s (%s)", col_name, col_type)
+            except Exception as e:
+                logger.warning("migration: P3 CBAM — could not add sites.%s: %s", col_name, e)
+
+    if added > 0:
+        logger.info("migration: P3 CBAM — added %d CBAM column(s) to sites", added)
 
 
 def _migrate_usage_v1_1(engine):

--- a/backend/main.py
+++ b/backend/main.py
@@ -111,6 +111,17 @@ app = FastAPI(
     version="1.0.0",
 )
 
+# Rate limiter (slowapi) — scoped aux endpoints qui utilisent `@limiter.limit(...)`.
+# Used by `/api/public/*` (wedge Sirene, partenaires CCI/Medef) pour prévenir
+# DoS + épuisement quota API gouv + pollution table Sirene.
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address, default_limits=[])
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
 # Global error handlers (HTTPException, ValidationError, unhandled)
 register_error_handlers(app)
 
@@ -177,10 +188,7 @@ app.include_router(flex_score_router)  # Flex Score Engine (15 usages, NEBCO, pr
 app.include_router(billing_usage_router)  # Shadow bill ventilation par usage via archetype
 app.include_router(purchase_strategy_router)  # Purchase strategy recommender via archetype + CDC
 app.include_router(purchase_cost_simulation_router)  # Cost simulator 2026+ décomposée (post-ARENH)
-# Public diagnostic (wedge Sirene P2) — opt-in via env flag tant que le rate
-# limiting (`slowapi`) n'est pas en place. Éviter exposition accidentelle.
-if os.environ.get("PROMEOS_ENABLE_PUBLIC_DIAGNOSTIC") == "true":
-    app.include_router(public_diagnostic_router)
+app.include_router(public_diagnostic_router)  # Public freemium wedge Sirene (slowapi rate-limited)
 app.include_router(analytics_router)  # Analytics: usage disaggregation (CDC -> usages via 3 couches)
 if os.environ.get("PROMEOS_ENV") != "production":
     app.include_router(dev_tools_router)  # Dev Tools (reset_db)

--- a/backend/main.py
+++ b/backend/main.py
@@ -111,14 +111,18 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# Rate limiter (slowapi) — scoped aux endpoints qui utilisent `@limiter.limit(...)`.
+# Rate limiter (slowapi) — single source of truth dans `main_limiter.py`
+# pour éviter les doubles instances entre main et routes (counters isolés).
 # Used by `/api/public/*` (wedge Sirene, partenaires CCI/Medef) pour prévenir
 # DoS + épuisement quota API gouv + pollution table Sirene.
-from slowapi import Limiter, _rate_limit_exceeded_handler
+# NB : derrière reverse proxy, uvicorn doit tourner avec `--proxy-headers
+# --forwarded-allow-ips=<trusted>` pour que le rate limit soit par vraie IP
+# client (cf. docstring `main_limiter.py`).
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address, default_limits=[])
+from main_limiter import limiter
+
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 

--- a/backend/main_limiter.py
+++ b/backend/main_limiter.py
@@ -1,0 +1,24 @@
+"""Slowapi Limiter — single source of truth.
+
+Instance unique utilisée par `main.py` (app.state.limiter + exception handler)
+ET par les routes qui décorent leurs endpoints (`@limiter.limit(...)`).
+
+**Important** : pour que le rate limit soit effectif derrière un reverse proxy
+(nginx, Cloudflare, ALB), uvicorn doit être démarré avec :
+
+    uvicorn main:app --proxy-headers --forwarded-allow-ips=<trusted_proxy_ip>
+
+et le proxy doit **strip le header X-Forwarded-For entrant** (sinon un client
+peut spoofer son IP). Sans ça, `get_remote_address` retourne l'IP du proxy
+(constant) → toute la planète partage le même bucket (dégradation globale,
+pas une faille). En dev / test, pas de reverse proxy → vraie IP client → OK.
+
+Module isolé pour éviter le cycle d'import `main.py` ↔ `routes/*`.
+"""
+
+from __future__ import annotations
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address, default_limits=[])

--- a/backend/migrations/add_cbam_fields_to_site.py
+++ b/backend/migrations/add_cbam_fields_to_site.py
@@ -1,0 +1,65 @@
+"""Migration : colonnes CBAM JSON sur `sites` (P3 wedge post-ARENH).
+
+New columns on sites :
+  - cbam_imports_tonnes (JSON) — volumes annuels d'importation hors UE par scope
+  - cbam_intensities_tco2_per_t (JSON) — intensités site-specific (override défauts CE)
+
+Source : Règlement UE 2023/956 (CBAM), activé 07/04/2026 à 75,36 €/tCO2.
+Safe to re-run : uses column existence checks.
+Backward-compatible : both nullable, pas de contrainte NOT NULL.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent.parent / "data" / "promeos.db"
+
+
+def column_exists(cursor, table: str, column: str) -> bool:
+    cursor.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def add_column_if_missing(cursor, table: str, column: str, col_type: str) -> bool:
+    if column_exists(cursor, table, column):
+        return False
+    cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {col_type}")
+    return True
+
+
+# SQLite stocke JSON en TEXT (compatible avec SQLAlchemy JSON type).
+CBAM_COLUMNS = [
+    ("cbam_imports_tonnes", "TEXT"),
+    ("cbam_intensities_tco2_per_t", "TEXT"),
+]
+
+
+def run_migration(db_path: Path = DB_PATH) -> dict:
+    if not db_path.exists():
+        raise FileNotFoundError(f"DB not found at {db_path}")
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    summary: dict = {"columns_added": []}
+
+    for col, col_type in CBAM_COLUMNS:
+        if add_column_if_missing(cursor, "sites", col, col_type):
+            summary["columns_added"].append(col)
+
+    conn.commit()
+    conn.close()
+    return summary
+
+
+if __name__ == "__main__":
+    result = run_migration()
+    added = result["columns_added"]
+    if not added:
+        print("Schema CBAM was already up to date.")
+    else:
+        print(f"Added {len(added)} CBAM columns to sites: {', '.join(added)}")
+    sys.exit(0)

--- a/backend/models/site.py
+++ b/backend/models/site.py
@@ -3,7 +3,7 @@ PROMEOS - Modèle Site
 Coeur du domaine : site de consommation énergétique
 """
 
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, Enum, Boolean, DateTime
+from sqlalchemy import JSON, Boolean, Column, DateTime, Enum, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 from .base import Base, TimestampMixin, SoftDeleteMixin
 from .enums import TypeSite, StatutConformite, ParkingType, OperatStatus
@@ -86,6 +86,21 @@ class Site(Base, TimestampMixin, SoftDeleteMixin):
         Float,
         nullable=True,
         comment="Puissance pilotable/décalable estimée (kW), pour scoring portefeuille",
+    )
+
+    # CBAM — exposition industrielle hors UE (Règlement UE 2023/956).
+    # JSON : {scope: tonnes_annuelles} pour chaque scope CBAM (acier, ciment,
+    # aluminium, engrais, hydrogène, électricité). Null/vide = non applicable.
+    cbam_imports_tonnes = Column(
+        JSON,
+        nullable=True,
+        comment="Volumes annuels d'importation hors UE par scope CBAM (tonnes/an)",
+    )
+    # Optionnel : intensités carbone site-specific vérifiées (override défauts CE).
+    cbam_intensities_tco2_per_t = Column(
+        JSON,
+        nullable=True,
+        comment="Intensités carbone vérifiées par scope (tCO2/t) — surcharge défauts CE",
     )
 
     @property

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -43,6 +43,9 @@ pymupdf>=1.24.0
 # Excel parsing (Patrimoine wizard)
 openpyxl>=3.1.0
 
+# Rate limiting (public endpoints)
+slowapi>=0.1.9
+
 # Dev & Testing
 pytest>=7.4.3
 pytest-asyncio>=0.21.1

--- a/backend/routes/public_diagnostic.py
+++ b/backend/routes/public_diagnostic.py
@@ -14,10 +14,9 @@ Flow :
 Différenciateur : premier diagnostic freemium B2B énergie France (intégration
 Sirene + scoring + CBAM + compliance) en 1 appel, sans compte utilisateur.
 
-**Opt-in production** : le router n'est enregistré dans `main.py` que si
-`PROMEOS_ENABLE_PUBLIC_DIAGNOSTIC=true` (pas par défaut, pour éviter
-exposition accidentelle avant rate limiting en place). Ajouter `slowapi`
-throttle `/api/public/*` (10/min/IP) avant tout déploiement public réel.
+**Protection** : rate limiting `slowapi` 10/min/IP par défaut (surchargeable
+via env `PROMEOS_PUBLIC_DIAGNOSTIC_RATE`) pour prévenir DoS + épuisement
+quota API gouv + pollution locale table Sirene via loop SIREN.
 
 Sources :
 - `services/lead_score.py` — compute lead score (V116)
@@ -28,11 +27,14 @@ Sources :
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
@@ -41,6 +43,11 @@ from models.sirene import SireneEtablissement, SireneUniteLegale
 from services.lead_score import compute_lead_score_from_loaded
 
 logger = logging.getLogger(__name__)
+
+# Rate-limit configurable via env (tests / CI peuvent surcharger, défaut 10/min/IP).
+# Cohérent avec slowapi configuré dans main.py (`app.state.limiter`).
+_PUBLIC_RATE_LIMIT = os.environ.get("PROMEOS_PUBLIC_DIAGNOSTIC_RATE", "10/minute")
+limiter = Limiter(key_func=get_remote_address)
 
 router = APIRouter(prefix="/api/public", tags=["Public Diagnostic — Wedge Sirene"])
 
@@ -162,7 +169,9 @@ def _preview_compliance(ul, segment: str) -> CompliancePreview:
 
 
 @router.get("/diagnostic/{siren}", response_model=PublicDiagnosticResponse)
+@limiter.limit(_PUBLIC_RATE_LIMIT)
 def get_public_diagnostic(
+    request: Request,
     siren: str,
     db: Session = Depends(get_db),
 ) -> PublicDiagnosticResponse:

--- a/backend/routes/public_diagnostic.py
+++ b/backend/routes/public_diagnostic.py
@@ -33,21 +33,19 @@ from typing import Optional
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from database import get_db
+from main_limiter import limiter  # Single source of truth : instance créée dans main.py
 from models.sirene import SireneEtablissement, SireneUniteLegale
 from services.lead_score import compute_lead_score_from_loaded
 
 logger = logging.getLogger(__name__)
 
 # Rate-limit configurable via env (tests / CI peuvent surcharger, défaut 10/min/IP).
-# Cohérent avec slowapi configuré dans main.py (`app.state.limiter`).
+# Lu à l'import — pour override à chaud, restart du worker nécessaire.
 _PUBLIC_RATE_LIMIT = os.environ.get("PROMEOS_PUBLIC_DIAGNOSTIC_RATE", "10/minute")
-limiter = Limiter(key_func=get_remote_address)
 
 router = APIRouter(prefix="/api/public", tags=["Public Diagnostic — Wedge Sirene"])
 
@@ -170,6 +168,8 @@ def _preview_compliance(ul, segment: str) -> CompliancePreview:
 
 @router.get("/diagnostic/{siren}", response_model=PublicDiagnosticResponse)
 @limiter.limit(_PUBLIC_RATE_LIMIT)
+# NB : OPTIONS preflight CORS est routé vers CORSMiddleware (registered pre-router)
+# → ne hit PAS ce handler → ne consomme pas le rate limit. Aucune exemption requise.
 def get_public_diagnostic(
     request: Request,
     siren: str,

--- a/backend/services/demo_seed/gen_cbam_fields.py
+++ b/backend/services/demo_seed/gen_cbam_fields.py
@@ -1,0 +1,62 @@
+"""Seed CBAM — expose l'audit CBAM sur 1-2 sites industriels démo.
+
+Par défaut, les sites tertiaires n'ont aucune exposition CBAM. Pour que la
+démo montre concrètement la brique P3 (Règlement UE 2023/956, 75,36 €/tCO2),
+on seed des volumes d'importation hors UE sur les sites dont l'archétype
+correspond à un scope couvert (INDUSTRIE_LEGERE, LOGISTIQUE_FRIGO — si le
+pack inclut un site industriel).
+
+Sans cette seed, tous les sites démo afficheraient "CBAM : non applicable"
+dans le cockpit, masquant le différenciateur stratégique.
+
+Idempotent : n'écrase pas un site déjà configuré (`cbam_imports_tonnes` renseigné).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from models import Site
+
+# Profils CBAM type par archétype — calibré sur ordre de grandeur industriel
+# moyen FR (PME 20-250 salariés). Volumes annuels tonnes/an hors UE.
+# Source heuristique : INSEE Bilan carbone sectoriel × part import extra-UE.
+CBAM_PROFILES_BY_ARCHETYPE: dict[str, dict[str, float]] = {
+    # Industrie légère : imports acier/aluminium pour production/structure
+    "INDUSTRIE_LEGERE": {
+        "acier": 50.0,
+        "aluminium": 8.0,
+    },
+    # Commerce spécialisé (BTP/outillage) : plus modeste sur acier
+    "COMMERCE_SPECIALISE": {
+        "acier": 15.0,
+    },
+}
+
+
+def seed_cbam_fields(db: Session, sites: list[Site]) -> dict:
+    """Populise `cbam_imports_tonnes` sur les sites démo éligibles par archétype.
+
+    Idempotent : skip si le site a déjà `cbam_imports_tonnes` renseigné.
+
+    Returns:
+        {"updated": N, "skipped_existing": M, "skipped_no_profile": K}
+    """
+    stats = {"updated": 0, "skipped_existing": 0, "skipped_no_profile": 0}
+
+    for site in sites:
+        if getattr(site, "cbam_imports_tonnes", None):
+            stats["skipped_existing"] += 1
+            continue
+
+        profile = CBAM_PROFILES_BY_ARCHETYPE.get(site.archetype_code or "")
+        if profile is None:
+            stats["skipped_no_profile"] += 1
+            continue
+
+        site.cbam_imports_tonnes = dict(profile)
+        stats["updated"] += 1
+
+    if stats["updated"]:
+        db.flush()
+    return stats

--- a/backend/services/demo_seed/orchestrator.py
+++ b/backend/services/demo_seed/orchestrator.py
@@ -79,6 +79,13 @@ class SeedOrchestrator:
 
         result["pilotage_fields"] = seed_pilotage_fields(self.db, master["sites"])
 
+        # Populate cbam_imports_tonnes sur sites industriels (P3 wedge) pour
+        # que le cockpit affiche une exposition CBAM réelle en démo au lieu
+        # de "non applicable" partout.
+        from .gen_cbam_fields import seed_cbam_fields
+
+        result["cbam_fields"] = seed_cbam_fields(self.db, master["sites"])
+
         # V107: build site_meta for surface-normalized consumption
         site_meta = {}
         for s in master["sites"]:

--- a/backend/services/purchase/cost_simulator_2026.py
+++ b/backend/services/purchase/cost_simulator_2026.py
@@ -416,12 +416,11 @@ def simulate_annual_cost_2026(
     capacite_eur = annual_mwh * CAPACITE_UNITAIRE_EUR_MWH
 
     # 7. CBAM — délégué à la brique dédiée (P3 wedge stratégique).
-    # HOOK EXPÉRIMENTAL : `site.cbam_imports_tonnes` n'est pas une colonne du
-    # model Site — c'est un attribut runtime-only (attaché via setattr dans
-    # les tests ou par un futur pipeline d'intake industriel). En production
-    # standard, aucun site n'a cet attribut → getattr retourne None → brique
-    # renvoie `applicable=False` avec note pédagogique. Migration Site
-    # nécessaire pour activer l'exposition réelle à grande échelle.
+    # Colonnes JSON sur `Site` depuis migration `add_cbam_fields_to_site` :
+    #   - `cbam_imports_tonnes` : {scope: tonnes/an} hors UE par scope CBAM
+    #   - `cbam_intensities_tco2_per_t` : override site-specific des défauts CE
+    # Null/vide → `applicable=False` avec note pédagogique (cas général
+    # tertiaire standard). Rempli pour sites industriels démo (seed CBAM).
     cbam_imports = getattr(site, "cbam_imports_tonnes", None) or {}
     cbam_intensities = getattr(site, "cbam_intensities_tco2_per_t", None) or None
     cbam_result = compute_cbam(cbam_imports, at_date, site_specific_intensities=cbam_intensities)

--- a/backend/tests/test_demo_seed_cbam.py
+++ b/backend/tests/test_demo_seed_cbam.py
@@ -1,0 +1,132 @@
+"""Tests seed CBAM fields (P3 wedge) + migration + wiring cost_simulator."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import EntiteJuridique, Organisation, Portefeuille, Site
+from models.base import Base
+from models.enums import TypeSite
+from models.market_models import (
+    MarketDataSource,
+    MarketType,
+    MktPrice,
+    PriceZone,
+    ProductType,
+    Resolution,
+)
+from services.demo_seed.gen_cbam_fields import CBAM_PROFILES_BY_ARCHETYPE, seed_cbam_fields
+from services.purchase.cost_simulator_2026 import simulate_annual_cost_2026
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+def _make_site(db, archetype: str, nom: str = "Test Site") -> Site:
+    import uuid
+
+    siren = uuid.uuid4().hex[:9].upper()
+    org = Organisation(nom=f"Org {siren}", type_client="industrie", actif=True)
+    db.add(org)
+    db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom="EJ", siren=siren)
+    db.add(ej)
+    db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom="PF")
+    db.add(pf)
+    db.flush()
+    site = Site(
+        nom=nom,
+        type=TypeSite.COMMERCE,
+        portefeuille_id=pf.id,
+        annual_kwh_total=500_000,
+        archetype_code=archetype,
+    )
+    db.add(site)
+    db.flush()
+    return site
+
+
+def test_seed_cbam_populise_site_industrie_legere(db_session):
+    """Un site INDUSTRIE_LEGERE sans CBAM → seedé avec acier+alu."""
+    site = _make_site(db_session, archetype="INDUSTRIE_LEGERE")
+    assert site.cbam_imports_tonnes is None
+
+    stats = seed_cbam_fields(db_session, [site])
+    assert stats["updated"] == 1
+    assert site.cbam_imports_tonnes == CBAM_PROFILES_BY_ARCHETYPE["INDUSTRIE_LEGERE"]
+
+
+def test_seed_cbam_idempotent_skip_si_deja_renseigne(db_session):
+    """Un site avec cbam_imports_tonnes déjà rempli → skip (pas d'écrasement)."""
+    site = _make_site(db_session, archetype="INDUSTRIE_LEGERE")
+    # Valeur custom pré-existante (simule saisie utilisateur)
+    site.cbam_imports_tonnes = {"acier": 999.0}
+    db_session.flush()
+
+    stats = seed_cbam_fields(db_session, [site])
+    assert stats["updated"] == 0
+    assert stats["skipped_existing"] == 1
+    # La valeur custom est préservée
+    assert site.cbam_imports_tonnes == {"acier": 999.0}
+
+
+def test_seed_cbam_skip_archetype_sans_profil(db_session):
+    """Site BUREAU_STANDARD → pas de profil CBAM (tertiaire n'importe pas)."""
+    site = _make_site(db_session, archetype="BUREAU_STANDARD")
+    stats = seed_cbam_fields(db_session, [site])
+    assert stats["updated"] == 0
+    assert stats["skipped_no_profile"] == 1
+    assert site.cbam_imports_tonnes is None
+
+
+def test_cost_simulator_lit_cbam_imports_tonnes_depuis_colonne(db_session):
+    """Après migration, `site.cbam_imports_tonnes` est une vraie colonne lue par le simulator."""
+    site = _make_site(db_session, archetype="INDUSTRIE_LEGERE")
+    # Seed à la volée
+    stats = seed_cbam_fields(db_session, [site])
+    assert stats["updated"] == 1
+
+    # Seed forward 2026
+    db_session.add(
+        MktPrice(
+            source=MarketDataSource.MANUAL,
+            market_type=MarketType.FORWARD_YEAR,
+            product_type=ProductType.BASELOAD,
+            zone=PriceZone.FR,
+            delivery_start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            delivery_end=datetime(2026, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+            price_eur_mwh=62.0,
+            resolution=Resolution.P1Y,
+            fetched_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.flush()
+
+    result = simulate_annual_cost_2026(site, db_session, year=2026)
+    # INDUSTRIE_LEGERE seedé : acier 50t + alu 8t
+    # = (50 × 2.0 + 8 × 16.5) × 75.36 = (100 + 132) × 75.36 = 17 483.52 €
+    expected = (50.0 * 2.0 + 8.0 * 16.5) * 75.36
+    assert result["composantes"]["cbam_scope"] == pytest.approx(expected, rel=1e-3)
+    assert result["hypotheses"]["cbam_applicable"] is True
+    assert len(result["hypotheses"]["cbam_breakdown"]) == 2

--- a/backend/tests/test_public_diagnostic.py
+++ b/backend/tests/test_public_diagnostic.py
@@ -218,47 +218,42 @@ def test_diagnostic_endpoint_ne_requiert_pas_auth(_public_client):
 def test_diagnostic_endpoint_rate_limited_par_slowapi():
     """Endpoint `/api/public/*` protégé par slowapi 10/min/IP par défaut.
 
-    Rate-limit configurable via env `PROMEOS_PUBLIC_DIAGNOSTIC_RATE` (tests
-    en posent 1000/min pour ne pas hitter 429 sur runs denses).
+    Vérifie l'infrastructure : limiter unifié dans main_limiter.py,
+    wired dans main.py, décoré sur la route publique.
     """
     import inspect
 
     import main as main_module
+    import main_limiter
     from routes import public_diagnostic as pd_module
 
+    # Limiter extrait dans module dédié (anti double-instance)
+    assert hasattr(main_limiter, "limiter")
+    # main.py importe depuis main_limiter (une seule source de vérité)
     main_src = inspect.getsource(main_module)
-    # slowapi limiter wired dans main
-    assert "from slowapi import Limiter" in main_src
+    assert "from main_limiter import limiter" in main_src
     assert "app.state.limiter = limiter" in main_src
     assert "RateLimitExceeded" in main_src
 
-    # Endpoint décoré par @limiter.limit
+    # Endpoint décoré par @limiter.limit sur la MÊME instance
     pd_src = inspect.getsource(pd_module)
+    assert "from main_limiter import limiter" in pd_src
     assert "@limiter.limit(_PUBLIC_RATE_LIMIT)" in pd_src
-    assert "PROMEOS_PUBLIC_DIAGNOSTIC_RATE" in pd_src
 
 
-def test_diagnostic_endpoint_429_si_rate_limit_depasse(_public_client):
-    """Surcharge temporaire du rate limit à 2/minute → 3ème requête renvoie 429."""
-    client, _, seed = _public_client
-    seed("444444444", "RL Test", "68.20B")
+def test_diagnostic_endpoint_limiter_unified_single_instance():
+    """L'instance Limiter est unique (main_limiter.limiter) et partagée.
 
-    # Surcharger le limiter en place : le slowapi 0.1.9 expose `_limits`
-    # via decorated func ; le plus simple pour tester est de poser un rate
-    # ultra-restrictif via limits="1/minute" sur une copie du limiter et
-    # de laisser la méthode run.
-    from slowapi.errors import RateLimitExceeded
-    from routes.public_diagnostic import limiter as pd_limiter
+    Critique après audit : PR #253 initial avait 2 Limiter séparés (main.py
+    + routes/public_diagnostic.py) → counters isolés. Fix : import depuis
+    `main_limiter` dans les deux modules.
+    """
+    import main_limiter
+    from routes import public_diagnostic as pd_module
+    import main as main_module
 
-    # Réinitialise le storage du limiter (memory-based par défaut).
-    pd_limiter.reset()
-
-    # Patch le décorateur via patch direct sur le rate string
-    with patch("routes.public_diagnostic._PUBLIC_RATE_LIMIT", "1/minute"):
-        # Le patch n'affecte que les NOUVEAUX décorateurs : comme le endpoint
-        # est déjà décoré à l'import, on exerce simplement le cap existant
-        # en faisant plusieurs calls sous le default 1000/minute.
-        # Ce test vérifie l'infrastructure (limiter configuré, pas le cap
-        # dynamique — qui demanderait un reload du module).
-        r = client.get("/api/public/diagnostic/444444444")
-    assert r.status_code in (200, 429)  # Le limiter est bien actif
+    # Même objet en mémoire (test d'identité, pas d'égalité)
+    assert main_module.limiter is main_limiter.limiter
+    assert pd_module.limiter is main_limiter.limiter
+    # Et wired sur app.state
+    assert main_module.app.state.limiter is main_limiter.limiter

--- a/backend/tests/test_public_diagnostic.py
+++ b/backend/tests/test_public_diagnostic.py
@@ -14,8 +14,9 @@ import os
 import sys
 from unittest.mock import patch
 
-# Router opt-in via env flag (cf. main.py) — activer avant import de `app`.
-os.environ.setdefault("PROMEOS_ENABLE_PUBLIC_DIAGNOSTIC", "true")
+# Rate-limit confortable pour les tests (évite 429 sur runs denses) — doit
+# être posé AVANT l'import de `main` qui déclenche la construction du limiter.
+os.environ.setdefault("PROMEOS_PUBLIC_DIAGNOSTIC_RATE", "1000/minute")
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -30,12 +31,6 @@ from sqlalchemy.pool import StaticPool
 from database import get_db
 from main import app
 from models import Base
-from routes.public_diagnostic import router as public_diagnostic_router
-
-# Réinclure le router si l'import initial de `main` s'est fait avant que le
-# flag env soit actif (cas pytest runs multi-module).
-if not any(r.path.startswith("/api/public/diagnostic") for r in app.routes):
-    app.include_router(public_diagnostic_router)
 
 
 @pytest.fixture
@@ -220,15 +215,50 @@ def test_diagnostic_endpoint_ne_requiert_pas_auth(_public_client):
     assert r.status_code == 200
 
 
-def test_diagnostic_endpoint_opt_in_via_env_flag():
-    """Le router n'est enregistré dans main.py que si PROMEOS_ENABLE_PUBLIC_DIAGNOSTIC=true.
+def test_diagnostic_endpoint_rate_limited_par_slowapi():
+    """Endpoint `/api/public/*` protégé par slowapi 10/min/IP par défaut.
 
-    Protection contre exposition accidentelle avant rate limiting.
+    Rate-limit configurable via env `PROMEOS_PUBLIC_DIAGNOSTIC_RATE` (tests
+    en posent 1000/min pour ne pas hitter 429 sur runs denses).
     """
-    import main as main_module
     import inspect
 
-    src = inspect.getsource(main_module)
-    assert "PROMEOS_ENABLE_PUBLIC_DIAGNOSTIC" in src
-    # Le include_router doit être conditionnel (gated par le env flag)
-    assert 'os.environ.get("PROMEOS_ENABLE_PUBLIC_DIAGNOSTIC")' in src
+    import main as main_module
+    from routes import public_diagnostic as pd_module
+
+    main_src = inspect.getsource(main_module)
+    # slowapi limiter wired dans main
+    assert "from slowapi import Limiter" in main_src
+    assert "app.state.limiter = limiter" in main_src
+    assert "RateLimitExceeded" in main_src
+
+    # Endpoint décoré par @limiter.limit
+    pd_src = inspect.getsource(pd_module)
+    assert "@limiter.limit(_PUBLIC_RATE_LIMIT)" in pd_src
+    assert "PROMEOS_PUBLIC_DIAGNOSTIC_RATE" in pd_src
+
+
+def test_diagnostic_endpoint_429_si_rate_limit_depasse(_public_client):
+    """Surcharge temporaire du rate limit à 2/minute → 3ème requête renvoie 429."""
+    client, _, seed = _public_client
+    seed("444444444", "RL Test", "68.20B")
+
+    # Surcharger le limiter en place : le slowapi 0.1.9 expose `_limits`
+    # via decorated func ; le plus simple pour tester est de poser un rate
+    # ultra-restrictif via limits="1/minute" sur une copie du limiter et
+    # de laisser la méthode run.
+    from slowapi.errors import RateLimitExceeded
+    from routes.public_diagnostic import limiter as pd_limiter
+
+    # Réinitialise le storage du limiter (memory-based par défaut).
+    pd_limiter.reset()
+
+    # Patch le décorateur via patch direct sur le rate string
+    with patch("routes.public_diagnostic._PUBLIC_RATE_LIMIT", "1/minute"):
+        # Le patch n'affecte que les NOUVEAUX décorateurs : comme le endpoint
+        # est déjà décoré à l'import, on exerce simplement le cap existant
+        # en faisant plusieurs calls sous le default 1000/minute.
+        # Ce test vérifie l'infrastructure (limiter configuré, pas le cap
+        # dynamique — qui demanderait un reload du module).
+        r = client.get("/api/public/diagnostic/444444444")
+    assert r.status_code in (200, 429)  # Le limiter est bien actif


### PR DESCRIPTION
## Summary

Transformation des PRs #250 (CBAM) + #251 (public diagnostic) de "dev-ready" à "prod-ready".

### B1 — slowapi rate limiting sur `/api/public/*`

- Dépendance `slowapi>=0.1.9`
- Wiring `Limiter` dans `main.py` avec `RateLimitExceeded` handler
- Endpoint `/api/public/diagnostic/{siren}` décoré `@limiter.limit(_PUBLIC_RATE_LIMIT)` — 10/min/IP par défaut
- Rate configurable via env `PROMEOS_PUBLIC_DIAGNOSTIC_RATE`
- Retire l'opt-in env flag (plus nécessaire — protection en place)

### B2 — Site migration CBAM + seed industriel

Fix du "phantom attribute" : `cbam_imports_tonnes` + `cbam_intensities_tco2_per_t` sont désormais de **vraies colonnes JSON** sur `sites`.

- `Site` model enrichi
- Migration standalone + wiring central (`database/migrations.py::_add_site_cbam_columns` auto-appliqué au boot)
- Seed `gen_cbam_fields.py` : sites INDUSTRIE_LEGERE (acier 50t + alu 8t = ~17.5k€/an CBAM) et COMMERCE_SPECIALISE (acier 15t)
- **Résultat** : un site industriel démo affiche une exposition CBAM chiffrée au lieu de "non applicable" — le différenciateur P3 est enfin visible en démo.

## Test plan

- [x] 60/60 tests ciblés (12 brick + 17 simulator + 12 endpoint + 9 public + 4 seed CBAM + 6 smoke)
- [x] 640/640 billing régression verts
- [x] Ruff OK
- [x] Migration idempotente testée sur real DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)