### PR TITLE
feat(cx-p1): residual batch — invalidate_cache wiring + business_error +22 + NPS micro-survey

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -234,6 +234,11 @@ from routes.feedback import router as feedback_router
 
 app.include_router(feedback_router)
 
+# NPS micro-survey (Sprint CX P1 residual — scorecard 10% "NPS/CES")
+from routes.nps import router as nps_router
+
+app.include_router(nps_router)
+
 # Pilotage (Flex Ready® NF EN IEC 62746-4 — Baromètre Flex 2026)
 from routes.pilotage import router as pilotage_router
 

--- a/backend/middleware/cx_logger.py
+++ b/backend/middleware/cx_logger.py
@@ -73,6 +73,51 @@ def invalidate_membership_cache(user_id: Optional[int] = None, org_id: Optional[
         _MEMBERSHIP_CACHE.pop(key, None)
 
 
+def safe_invalidate_membership_cache(user_id: Optional[int] = None, org_id: Optional[int] = None) -> None:
+    """Wrapper fire-and-forget autour de invalidate_membership_cache.
+
+    Usage : call-sites CRUD (iam_service, admin_users, demo reset) qui veulent
+    purger le cache sans risquer de casser le flow métier si l'invalidation
+    échoue (pire cas : staleness ≤ 5 min, comportement pré-wiring).
+    """
+    try:
+        invalidate_membership_cache(user_id=user_id, org_id=org_id)
+    except Exception:
+        logger.debug(
+            "invalidate_membership_cache failed (user_id=%s, org_id=%s)",
+            user_id,
+            org_id,
+            exc_info=True,
+        )
+
+
+def has_recent_audit_event(
+    db: Session,
+    user_id: int,
+    action: str,
+    cooldown_days: int,
+) -> bool:
+    """Retourne True si un AuditLog `action` pour `user_id` existe dans les N derniers jours.
+
+    Pattern utilisé pour anti-flood d'events CX (NPS, CSAT, ...) où on veut ne
+    pas harceler un même utilisateur. `action` doit être une des constantes
+    CX_* ou un action_type d'AuditLog existant.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=cooldown_days)
+    existing = (
+        db.query(AuditLog.id)
+        .filter(
+            AuditLog.user_id == user_id,
+            AuditLog.action == action,
+            AuditLog.created_at >= cutoff,
+        )
+        .first()
+    )
+    return existing is not None
+
+
 # Event type constants — utiliser ces constantes plutôt que des strings hardcodés
 # pour éviter drift silencieux (la validation log_cx_event return si event_type
 # n'est pas dans CX_EVENT_TYPES, sans trace).
@@ -82,6 +127,8 @@ CX_REPORT_EXPORTED = "CX_REPORT_EXPORTED"
 CX_ONBOARDING_COMPLETED = "CX_ONBOARDING_COMPLETED"
 CX_ACTION_FROM_INSIGHT = "CX_ACTION_FROM_INSIGHT"
 CX_DASHBOARD_OPENED = "CX_DASHBOARD_OPENED"
+# Sprint CX P1 residual : NPS micro-survey (scorecard 10% "NPS/CES")
+CX_NPS_SUBMITTED = "CX_NPS_SUBMITTED"
 
 CX_EVENT_TYPES = frozenset(
     {
@@ -91,8 +138,25 @@ CX_EVENT_TYPES = frozenset(
         CX_ONBOARDING_COMPLETED,
         CX_ACTION_FROM_INSIGHT,
         CX_DASHBOARD_OPENED,
+        CX_NPS_SUBMITTED,
     }
 )
+
+
+def make_dedup_key(key: str, value: str) -> str:
+    """Construit le fragment canonique matché par log_cx_event_first_only.
+
+    Format : `"<key>": "<value>"` (doit matcher exactement la sortie json.dumps).
+    Exemple : make_dedup_key("module_key", "flex") → '"module_key": "flex"'.
+
+    Garantit l'absence de false positive (ex. "flex" vs "flexibilite") via
+    les guillemets fermants autour de la valeur.
+    """
+    if not key or not value:
+        raise ValueError("make_dedup_key requires non-empty key and value")
+    if '"' in key or '"' in value:
+        raise ValueError(f"make_dedup_key does not support double quotes in key={key!r} or value={value!r}")
+    return f'"{key}": "{value}"'
 
 
 def log_cx_event_first_only(
@@ -108,7 +172,12 @@ def log_cx_event_first_only(
 
     Fire l'event UNIQUEMENT si aucun AuditLog précédent n'existe pour ce
     couple (org_id, event_type, dedup_key). `dedup_key` est cherché dans
-    `detail_json` (match exact JSON substring — sqlite-friendly).
+    `detail_json` via LIKE (match sous-chaîne — sqlite-friendly).
+
+    ⚠ `dedup_key` DOIT être un fragment JSON canonique au format exact
+    `"<key>": "<value>"` produit par json.dumps avec terminateurs de valeur
+    (guillemets fermants) — utiliser `make_dedup_key(key, value)` pour le
+    construire et éviter les false positives ("flex" vs "flexibilite").
 
     Motivation : CX_MODULE_ACTIVATED doit signaler la *1ère* activation d'un
     module par une org (pour driver WAU-MAU / T2V). Sans dédup, chaque write
@@ -120,15 +189,13 @@ def log_cx_event_first_only(
         log_cx_event_first_only(
             db, org_id, user_id,
             CX_MODULE_ACTIVATED,
-            dedup_key=f'"module_key": "flex"',
+            dedup_key=make_dedup_key("module_key", "flex"),
             context={"module_key": "flex"},
         )
     """
     if event_type not in CX_EVENT_TYPES:
         return False
 
-    # Check si event existe déjà pour (org, event_type, module_key)
-    # On cherche la sous-chaîne dedup_key dans detail_json → compatible sqlite.
     existing = (
         db.query(AuditLog.id)
         .filter(

--- a/backend/routes/actions.py
+++ b/backend/routes/actions.py
@@ -564,7 +564,7 @@ def patch_action(
         try:
             action.realized_at = dt_date.fromisoformat(data.realized_at)
         except ValueError:
-            raise HTTPException(status_code=400, detail=f"Date invalide: {data.realized_at}")
+            raise HTTPException(**business_error("INVALID_DATE_FORMAT"))
 
     if data.category is not None:
         action.category = data.category

--- a/backend/routes/admin_users.py
+++ b/backend/routes/admin_users.py
@@ -36,6 +36,7 @@ from services.iam_service import (
 from middleware.auth import require_permission, get_current_user_role
 from models import Site, EntiteJuridique, Portefeuille
 from services.error_catalog import business_error
+from middleware.cx_logger import safe_invalidate_membership_cache
 
 
 router = APIRouter(prefix="/api/admin", tags=["Admin Users"])
@@ -271,6 +272,7 @@ def change_role(
 
     log_audit(db, None, "change_role", "user", str(user_id), {"new_role": req.role})
     db.commit()
+    safe_invalidate_membership_cache(user_id=user_id, org_id=org_id)
     return {"status": "updated", "role": new_role.value}
 
 
@@ -340,6 +342,7 @@ def delete_user(
     soft_delete_user(db, user_id)
     log_audit(db, None, "soft_delete_user", "user", str(user_id))
     db.commit()
+    safe_invalidate_membership_cache(user_id=user_id)
     return {"status": "deleted"}
 
 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -26,6 +26,7 @@ from services.iam_service import (
 )
 from middleware.auth import oauth2_scheme, get_current_user_role, require_permission, DEMO_MODE
 from middleware.rate_limit import check_rate_limit
+from services.error_catalog import business_error
 
 import logging
 
@@ -281,7 +282,7 @@ def impersonate(
 
     target = db.query(User).filter(User.email == req.email, User.actif == True).first()
     if not target:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(**business_error("USER_NOT_FOUND"))
 
     uor = db.query(UserOrgRole).filter(UserOrgRole.user_id == target.id).first()
     if not uor:

--- a/backend/routes/bacs.py
+++ b/backend/routes/bacs.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from database import get_db
 from middleware.auth import get_optional_auth
-from middleware.cx_logger import log_cx_event_first_only, CX_MODULE_ACTIVATED
+from middleware.cx_logger import log_cx_event_first_only, make_dedup_key, CX_MODULE_ACTIVATED
 from services.scope_utils import resolve_org_id
 
 from models import (
@@ -35,6 +35,7 @@ from services.bacs_engine import (
     compute_inspection_schedule,
     ENGINE_VERSION,
 )
+from services.error_catalog import business_error
 
 router = APIRouter(prefix="/api/regops/bacs", tags=["BACS Expert"])
 
@@ -50,7 +51,7 @@ def _verify_site_access(db: Session, site_id: int, request: Request, auth) -> Si
     """
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail="Site not found")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
 
     try:
         org_id = resolve_org_id(request, auth, db)
@@ -64,7 +65,7 @@ def _verify_site_access(db: Session, site_id: int, request: Request, auth) -> Si
         if pf:
             ej = db.query(EntiteJuridique).filter(EntiteJuridique.id == pf.entite_juridique_id).first()
             if ej and ej.organisation_id != org_id:
-                raise HTTPException(status_code=404, detail="Site not found")
+                raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
 
     return site
 
@@ -223,7 +224,7 @@ def create_bacs_asset(
                 org_id,
                 auth.user.id if (auth and getattr(auth, "user", None)) else None,
                 CX_MODULE_ACTIVATED,
-                dedup_key='"module_key": "bacs"',
+                dedup_key=make_dedup_key("module_key", "bacs"),
                 context={"module_key": "bacs", "trigger": "create_bacs_asset"},
             )
             db.commit()
@@ -587,7 +588,7 @@ def attach_proof_to_action(
     """Rattacher une preuve a une action corrective."""
     action = db.query(BacsRemediationAction).filter(BacsRemediationAction.id == action_id).first()
     if not action:
-        raise HTTPException(404, "Action introuvable")
+        raise HTTPException(**business_error("ACTION_NOT_FOUND", action_id=action_id))
 
     proof = BacsProofDocument(
         asset_id=action.asset_id,
@@ -620,7 +621,7 @@ def review_proof(
 
     action = db.query(BacsRemediationAction).filter(BacsRemediationAction.id == action_id).first()
     if not action:
-        raise HTTPException(404, "Action introuvable")
+        raise HTTPException(**business_error("ACTION_NOT_FOUND", action_id=action_id))
 
     if body.decision not in ("accepted", "rejected"):
         raise HTTPException(400, "Decision invalide (accepted ou rejected)")

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -51,6 +51,7 @@ from services.compliance_rules import (
 )
 from middleware.auth import get_optional_auth, AuthContext
 from services.scope_utils import resolve_org_id
+from services.error_catalog import business_error
 
 router = APIRouter(prefix="/api/compliance", tags=["Compliance"])
 
@@ -685,7 +686,7 @@ def get_site_compliance_score(
 
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail="Site non trouvé")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
 
     result = compute_site_compliance_score(db, site_id)
     return result.to_dict()

--- a/backend/routes/copilot.py
+++ b/backend/routes/copilot.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from middleware.auth import get_optional_auth, AuthContext
-from middleware.cx_logger import log_cx_event, log_cx_event_first_only, CX_MODULE_ACTIVATED
+from middleware.cx_logger import log_cx_event, log_cx_event_first_only, make_dedup_key, CX_MODULE_ACTIVATED
 from services.iam_scope import get_effective_org_id
 from models.copilot_models import CopilotAction
 from services.copilot_engine import (
@@ -107,7 +107,7 @@ def run_monthly_copilot(
         effective_org_id,
         auth.user.id if auth else None,
         CX_MODULE_ACTIVATED,
-        dedup_key='"module_key": "copilot"',
+        dedup_key=make_dedup_key("module_key", "copilot"),
         context={"module_key": "copilot", "trigger": "run_monthly_copilot"},
     )
     db.commit()

--- a/backend/routes/data_quality.py
+++ b/backend/routes/data_quality.py
@@ -19,6 +19,7 @@ from services.data_quality_service import (
     compute_portfolio_data_quality,
     compute_site_freshness,
 )
+from services.error_catalog import business_error
 
 router = APIRouter(prefix="/api/data-quality", tags=["data-quality"])
 
@@ -55,7 +56,7 @@ def get_site_data_quality(
 
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail="Site non trouvé")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
     return compute_site_data_quality(db, site_id)
 
 
@@ -69,7 +70,7 @@ def get_site_freshness(
 
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail="Site non trouvé")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
     return compute_site_freshness(db, site_id)
 
 

--- a/backend/routes/demo.py
+++ b/backend/routes/demo.py
@@ -275,10 +275,17 @@ def _reset_iam_demo(db):
     from models import User, UserOrgRole
 
     demo_users = db.query(User).filter(User.email.like("%@atlas.demo")).all()
+    demo_user_ids = [u.id for u in demo_users]
     for u in demo_users:
         db.query(UserOrgRole).filter(UserOrgRole.user_id == u.id).delete()
         db.query(User).filter(User.id == u.id).delete()
     db.commit()
+    # Sprint CX P1 residual : purge cache membership pour tous les users demo
+    # supprimés (sinon staleness ≤ 5 min post-reset).
+    from middleware.cx_logger import safe_invalidate_membership_cache
+
+    for uid in demo_user_ids:
+        safe_invalidate_membership_cache(user_id=uid)
     # Re-seed IAM if an org still exists
     org = db.query(Organisation).first()
     if org:

--- a/backend/routes/ems.py
+++ b/backend/routes/ems.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from database import get_db
 from middleware.auth import get_optional_auth, AuthContext
 from services.scope_utils import resolve_org_id
+from services.error_catalog import business_error
 
 router = APIRouter(prefix="/api/ems", tags=["EMS Explorer"])
 
@@ -23,7 +24,7 @@ def _check_site_org(db: Session, site_id: int, org_id: int):
 
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(404, "Site non trouvé")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
     if not site.portefeuille_id:
         raise HTTPException(403, "Site hors périmètre")
     pf = db.get(Portefeuille, site.portefeuille_id)
@@ -153,7 +154,7 @@ def usage_suggest(
 
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(404, "Site not found")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
 
     # Current schedule
     schedule = db.query(SiteOperatingSchedule).filter_by(site_id=site_id).first()
@@ -255,7 +256,7 @@ def ems_benchmark(
 
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(404, "Site not found")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
 
     # Get latest snapshot for target site
     target_snap = (

--- a/backend/routes/energy.py
+++ b/backend/routes/energy.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from database import get_db
 from middleware.auth import get_optional_auth, AuthContext
 from services.iam_scope import check_site_access
+from services.error_catalog import business_error
 from routes.patrimoine._helpers import _check_portfolio_belongs_to_org
 from models import (
     Site,
@@ -110,7 +111,7 @@ def create_meter(
     # Verify site exists
     site = db.query(Site).filter_by(id=meter.site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail=f"Site {meter.site_id} not found")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=meter.site_id))
 
     # Check uniqueness
     existing = db.query(Meter).filter_by(meter_id=meter.meter_id).first()
@@ -414,7 +415,7 @@ def generate_demo_data(
     check_site_access(auth, request.site_id)
     site = db.query(Site).filter_by(id=request.site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail=f"Site {request.site_id} not found")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=request.site_id))
 
     # Create meter if not exists
     meter_id_str = f"PRM-{request.site_id:06d}"

--- a/backend/routes/flex.py
+++ b/backend/routes/flex.py
@@ -16,7 +16,7 @@ from database import get_db
 from services.flex_mini import compute_flex_mini
 from services.scope_utils import resolve_org_id
 from middleware.auth import get_optional_auth, AuthContext
-from middleware.cx_logger import log_cx_event_first_only, CX_MODULE_ACTIVATED
+from middleware.cx_logger import log_cx_event_first_only, make_dedup_key, CX_MODULE_ACTIVATED
 from schemas.flex_schemas import (
     FlexAssetResponse,
     FlexAssetListResponse,
@@ -162,7 +162,7 @@ def create_flex_asset(
         org_id,
         auth.user.id if auth else None,
         CX_MODULE_ACTIVATED,
-        dedup_key='"module_key": "flex"',
+        dedup_key=make_dedup_key("module_key", "flex"),
         context={"module_key": "flex", "trigger": "create_flex_asset"},
     )
     db.commit()

--- a/backend/routes/monitoring.py
+++ b/backend/routes/monitoring.py
@@ -26,6 +26,7 @@ from models import (
     SiteOperatingSchedule,
 )
 from models.energy_models import EnergyVector
+from services.error_catalog import business_error
 
 router = APIRouter(prefix="/api/monitoring", tags=["Monitoring"])
 
@@ -324,7 +325,7 @@ def run_monitoring(request: MonitoringRunRequest, db: Session = Depends(get_db))
 
     site = db.query(Site).filter_by(id=request.site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail=f"Site {request.site_id} not found")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=request.site_id))
 
     orchestrator = MonitoringOrchestrator(db)
     result = orchestrator.run(
@@ -441,7 +442,7 @@ def acknowledge_alert(alert_id: int, request: AlertAckRequest, db: Session = Dep
     """Acknowledge an open alert."""
     alert = db.query(MonitoringAlert).filter_by(id=alert_id).first()
     if not alert:
-        raise HTTPException(status_code=404, detail=f"Alert {alert_id} not found")
+        raise HTTPException(**business_error("ALERT_NOT_FOUND"))
 
     if alert.status != AlertStatus.OPEN:
         raise HTTPException(status_code=400, detail=f"Alert is {alert.status.value}, can only ack OPEN alerts")
@@ -462,7 +463,7 @@ def resolve_alert(alert_id: int, request: AlertResolveRequest, db: Session = Dep
     """Resolve an alert (from open or acknowledged)."""
     alert = db.query(MonitoringAlert).filter_by(id=alert_id).first()
     if not alert:
-        raise HTTPException(status_code=404, detail=f"Alert {alert_id} not found")
+        raise HTTPException(**business_error("ALERT_NOT_FOUND"))
 
     if alert.status == AlertStatus.RESOLVED:
         raise HTTPException(status_code=400, detail="Alert is already resolved")
@@ -588,7 +589,7 @@ def generate_monitoring_demo(request: MonitoringDemoRequest, db: Session = Depen
     """Generate monitoring demo data (profiled pattern + weather correlation + anomalies)."""
     site = db.query(Site).filter_by(id=request.site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail=f"Site {request.site_id} not found")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=request.site_id))
 
     profile = USAGE_PROFILES.get(request.profile, USAGE_PROFILES["office"])
 

--- a/backend/routes/nps.py
+++ b/backend/routes/nps.py
@@ -1,0 +1,86 @@
+"""
+PROMEOS — NPS micro-survey (Sprint CX P1 residual)
+
+POST /api/nps/submit — enregistre une note NPS (0-10) + verbatim optionnel.
+
+Classification industry-standard :
+  - Promoteurs : 9-10
+  - Passifs    : 7-8
+  - Détracteurs: 0-6
+
+Anti-flood : 1 seule soumission par user dans une fenêtre de 90 jours
+(check AuditLog.action == CX_NPS_SUBMITTED + user_id + created_at).
+
+Le stockage s'appuie sur AuditLog via log_cx_event (pas de nouvelle table)
+pour rester homogène avec les autres events CX (T2V, IAR, WAU/MAU...).
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from database import get_db
+from middleware.auth import get_optional_auth, AuthContext
+from middleware.cx_logger import CX_NPS_SUBMITTED, has_recent_audit_event, log_cx_event
+from services.iam_scope import get_effective_org_id
+
+router = APIRouter(prefix="/api/nps", tags=["NPS"])
+
+NPS_COOLDOWN_DAYS = 90
+
+
+class NpsSubmission(BaseModel):
+    score: int = Field(..., ge=0, le=10, description="Note NPS 0-10")
+    verbatim: Optional[str] = Field(None, max_length=1000)
+
+
+def _classify(score: int) -> str:
+    if score >= 9:
+        return "promoter"
+    if score >= 7:
+        return "passive"
+    return "detractor"
+
+
+@router.post("/submit")
+def submit_nps(
+    payload: NpsSubmission = Body(...),
+    org_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: Optional[AuthContext] = Depends(get_optional_auth),
+):
+    """
+    Enregistre une note NPS pour l'utilisateur authentifié.
+
+    - Validation : score ∈ [0, 10] (enforced by pydantic Field)
+    - Anti-flood : 1 soumission / user / 90 jours
+    - Fire event CX_NPS_SUBMITTED avec context {score, has_verbatim, category}
+    """
+    effective_org_id = get_effective_org_id(auth, org_id)
+    if not effective_org_id:
+        raise HTTPException(status_code=400, detail="org_id requis")
+
+    user_id = auth.user.id if auth else None
+
+    # Anti-flood : check précédente soumission dans les 90 jours
+    # (seulement pertinent si user_id connu — en DEMO_MODE anonyme on laisse passer)
+    if user_id is not None and has_recent_audit_event(db, user_id, CX_NPS_SUBMITTED, NPS_COOLDOWN_DAYS):
+        return {"status": "already_submitted"}
+
+    category = _classify(payload.score)
+    log_cx_event(
+        db,
+        org_id=effective_org_id,
+        user_id=user_id,
+        event_type=CX_NPS_SUBMITTED,
+        context={
+            "score": payload.score,
+            "has_verbatim": bool(payload.verbatim and payload.verbatim.strip()),
+            "category": category,
+        },
+    )
+    db.commit()
+
+    return {"status": "recorded", "category": category}

--- a/backend/routes/patrimoine/_helpers.py
+++ b/backend/routes/patrimoine/_helpers.py
@@ -44,6 +44,7 @@ from models import (
     Batiment,
 )
 from middleware.auth import get_optional_auth, get_portfolio_optional_auth, AuthContext
+from services.error_catalog import business_error
 
 
 # ========================================
@@ -93,7 +94,7 @@ def _load_site_with_org_check(db: Session, site_id: int, org_id: int) -> Site:
     """Load a site and verify org ownership. Raises 404/403."""
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail=f"Site {site_id} non trouvé")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
     _check_site_belongs_to_org(db, site, org_id)
     return site
 

--- a/backend/routes/patrimoine/sites.py
+++ b/backend/routes/patrimoine/sites.py
@@ -27,6 +27,7 @@ from models import (
     Batiment,
 )
 from middleware.auth import get_optional_auth, get_portfolio_optional_auth, AuthContext
+from services.error_catalog import business_error
 
 from routes.patrimoine._helpers import (
     _get_org_id,
@@ -640,7 +641,7 @@ def get_site_snapshot_endpoint(
     _load_site_with_org_check(db, site_id, org_id)  # 404/403 si hors périmètre
     snapshot = get_site_snapshot(site_id, org_id, db)
     if snapshot is None:
-        raise HTTPException(status_code=404, detail=f"Site {site_id} non trouvé")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
     return snapshot
 
 

--- a/backend/routes/site_intelligence.py
+++ b/backend/routes/site_intelligence.py
@@ -14,6 +14,7 @@ from services.billing_service import get_reference_price
 from models import Site, Meter
 from models.energy_models import UsageProfile, Anomaly, Recommendation, RecommendationStatus
 from models.kb_models import KBArchetype
+from services.error_catalog import business_error
 
 router = APIRouter(prefix="/api/sites", tags=["site-intelligence"])
 
@@ -58,7 +59,7 @@ def get_site_intelligence(site_id: int, db: Session = Depends(get_db)):
     """Return full KB intelligence for a site: archetype, anomalies, recommendations, summary."""
     site = db.query(Site).filter(Site.id == site_id).first()
     if not site:
-        raise HTTPException(status_code=404, detail=f"Site {site_id} not found")
+        raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
 
     org_id = _resolve_org_id(db, site)
 
@@ -205,7 +206,7 @@ def get_top_recommendation(site_id: int, db: Session = Depends(get_db)):
     try:
         site = db.query(Site).filter(Site.id == site_id).first()
         if not site:
-            raise HTTPException(status_code=404, detail=f"Site {site_id} not found")
+            raise HTTPException(**business_error("SITE_NOT_FOUND", site_id=site_id))
 
         meters = db.query(Meter).filter(Meter.site_id == site_id).all()
         if not meters:

--- a/backend/services/iam_service.py
+++ b/backend/services/iam_service.py
@@ -422,9 +422,12 @@ def create_user(db: Session, email: str, password: str, nom: str, prenom: str) -
 
 
 def assign_role(db: Session, user_id: int, org_id: int, role: UserRole) -> UserOrgRole:
+    from middleware.cx_logger import safe_invalidate_membership_cache
+
     uor = UserOrgRole(user_id=user_id, org_id=org_id, role=role)
     db.add(uor)
     db.flush()
+    safe_invalidate_membership_cache(user_id=user_id, org_id=org_id)
     return uor
 
 
@@ -472,8 +475,11 @@ def remove_role(db: Session, user_id: int, org_id: int) -> bool:
         if count <= 1:
             return False  # Cannot remove last DG_OWNER
 
+    from middleware.cx_logger import safe_invalidate_membership_cache
+
     db.delete(uor)
     db.flush()
+    safe_invalidate_membership_cache(user_id=user_id, org_id=org_id)
     return True
 
 

--- a/backend/tests/test_cx_logger.py
+++ b/backend/tests/test_cx_logger.py
@@ -83,13 +83,14 @@ def test_log_cx_event_no_user(db_session):
 
 
 def test_all_cx_event_types_defined():
-    assert len(CX_EVENT_TYPES) == 6
+    assert len(CX_EVENT_TYPES) == 7
     assert "CX_INSIGHT_CONSULTED" in CX_EVENT_TYPES
     assert "CX_MODULE_ACTIVATED" in CX_EVENT_TYPES
     assert "CX_REPORT_EXPORTED" in CX_EVENT_TYPES
     assert "CX_ONBOARDING_COMPLETED" in CX_EVENT_TYPES
     assert "CX_ACTION_FROM_INSIGHT" in CX_EVENT_TYPES
     assert "CX_DASHBOARD_OPENED" in CX_EVENT_TYPES
+    assert "CX_NPS_SUBMITTED" in CX_EVENT_TYPES
 
 
 def test_log_cx_event_no_context(db_session):

--- a/backend/tests/test_invalidate_membership_cache_wiring.py
+++ b/backend/tests/test_invalidate_membership_cache_wiring.py
@@ -1,0 +1,178 @@
+"""Sprint CX P1 residual : wiring invalidate_membership_cache sur CRUD UserOrgRole.
+
+Vérifie que les mutations UserOrgRole (via service layer + routes admin) purgent
+bien le cache membership. Avant ce wiring, un user retiré d'une org continuait à
+logger des events pendant ≤ 5 min (TTL _MEMBERSHIP_CACHE).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from models import Base, Organisation
+from models.iam import User, UserOrgRole, UserRole
+from services.iam_service import assign_role, remove_role
+from middleware.cx_logger import (
+    _MEMBERSHIP_CACHE,
+    _is_member_cached,
+    invalidate_membership_cache,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    invalidate_membership_cache()  # Isole le cache entre tests (module-level)
+    yield session
+    invalidate_membership_cache()
+    session.close()
+
+
+def _seed_user_and_org(db, user_id: int, org_id: int) -> None:
+    user = User(
+        id=user_id,
+        email=f"u{user_id}@test.io",
+        hashed_password="x",
+        nom=f"U{user_id}",
+        prenom=f"F{user_id}",
+    )
+    org = Organisation(id=org_id, nom=f"Org{org_id}")
+    db.add_all([user, org])
+    db.flush()
+
+
+# ============================================================
+# assign_role invalide le cache
+# ============================================================
+
+
+def test_assign_role_invalidates_cache(db_session):
+    """Après assign_role, le cache pour (user_id, org_id) doit être vide
+    → prochain _is_member_cached re-query la DB et retourne True."""
+    _seed_user_and_org(db_session, user_id=1, org_id=1)
+
+    # Peuple le cache avec une valeur False (pas de membership encore)
+    assert _is_member_cached(db_session, 1, 1) is False
+    assert (1, 1) in _MEMBERSHIP_CACHE
+    assert _MEMBERSHIP_CACHE[(1, 1)][0] is False
+
+    # Crée le role via le service
+    assign_role(db_session, user_id=1, org_id=1, role=UserRole.DG_OWNER)
+    db_session.flush()
+
+    # Le cache doit avoir été purgé
+    assert (1, 1) not in _MEMBERSHIP_CACHE
+
+    # Prochain check → re-query DB → True
+    assert _is_member_cached(db_session, 1, 1) is True
+
+
+# ============================================================
+# remove_role invalide le cache
+# ============================================================
+
+
+def test_remove_role_invalidates_cache(db_session):
+    """Après remove_role, le cache doit être purgé → prochain check renvoie False
+    (et non la valeur mise en cache pré-révocation)."""
+    _seed_user_and_org(db_session, user_id=2, org_id=2)
+
+    # Seed 2 DG_OWNER pour éviter last-owner protection
+    assign_role(db_session, user_id=2, org_id=2, role=UserRole.DG_OWNER)
+    # 2e DG_OWNER en DB direct (pour ne pas polluer le cache avec une 2e entrée)
+    other_user = User(id=22, email="u22@test.io", hashed_password="x", nom="U22", prenom="F22")
+    db_session.add(other_user)
+    db_session.flush()
+    other_uor = UserOrgRole(user_id=22, org_id=2, role=UserRole.DG_OWNER)
+    db_session.add(other_uor)
+    db_session.flush()
+
+    # Peuple le cache (True)
+    assert _is_member_cached(db_session, 2, 2) is True
+    assert _MEMBERSHIP_CACHE[(2, 2)][0] is True
+
+    # Retire le role
+    ok = remove_role(db_session, user_id=2, org_id=2)
+    assert ok is True
+
+    # Cache doit être purgé
+    assert (2, 2) not in _MEMBERSHIP_CACHE
+
+    # Prochain check → re-query DB → False
+    assert _is_member_cached(db_session, 2, 2) is False
+
+
+def test_remove_role_not_found_does_not_crash(db_session):
+    """Si remove_role échoue (user pas membre), pas d'erreur sur l'invalidate."""
+    _seed_user_and_org(db_session, user_id=3, org_id=3)
+    # Pas de UserOrgRole → remove_role retourne False sans toucher le cache
+    ok = remove_role(db_session, user_id=3, org_id=3)
+    assert ok is False
+
+
+# ============================================================
+# Cache purge spécifique à la paire, pas global
+# ============================================================
+
+
+def test_assign_role_only_invalidates_matching_pair(db_session):
+    """L'invalidation doit cibler (user_id, org_id) uniquement — les autres
+    entrées restent intactes."""
+    _seed_user_and_org(db_session, user_id=4, org_id=4)
+    _seed_user_and_org(db_session, user_id=5, org_id=5)
+
+    # Peuple cache pour 2 paires distinctes
+    assert _is_member_cached(db_session, 4, 4) is False
+    assert _is_member_cached(db_session, 5, 5) is False
+    assert (4, 4) in _MEMBERSHIP_CACHE
+    assert (5, 5) in _MEMBERSHIP_CACHE
+
+    # Mutation sur (4, 4) uniquement
+    assign_role(db_session, user_id=4, org_id=4, role=UserRole.DG_OWNER)
+
+    # (4, 4) purgé, (5, 5) intact
+    assert (4, 4) not in _MEMBERSHIP_CACHE
+    assert (5, 5) in _MEMBERSHIP_CACHE
+
+
+# ============================================================
+# Cache vraiment vidé — pas juste refresh avec valeur stale
+# ============================================================
+
+
+def test_cache_invalidation_forces_db_requery(db_session):
+    """Prouve que l'invalidation supprime l'entrée du dict (pas juste refresh
+    la valeur). On vérifie en inspectant _MEMBERSHIP_CACHE directement."""
+    _seed_user_and_org(db_session, user_id=6, org_id=6)
+    assign_role(db_session, user_id=6, org_id=6, role=UserRole.DG_OWNER)
+
+    # Cache miss → fill
+    assert _is_member_cached(db_session, 6, 6) is True
+    assert (6, 6) in _MEMBERSHIP_CACHE
+
+    # Invalidation explicite (simule ce que font assign_role/remove_role)
+    invalidate_membership_cache(user_id=6, org_id=6)
+
+    # L'entrée doit avoir disparu du dict (pas rester avec expires_at=now)
+    assert (6, 6) not in _MEMBERSHIP_CACHE

--- a/backend/tests/test_nps.py
+++ b/backend/tests/test_nps.py
@@ -1,0 +1,218 @@
+"""
+PROMEOS — Tests NPS micro-survey (Sprint CX P1 residual)
+
+Couvre :
+  - POST /api/nps/submit : score valide → recorded + event CX_NPS_SUBMITTED
+  - Score hors range (-1, 11) → 422 pydantic
+  - Deuxième submit dans 90j → already_submitted
+  - Classification promoter/passive/detractor
+  - Event fire avec context {score, has_verbatim, category}
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ["PROMEOS_DEMO_MODE"] = "true"
+
+from models import Base  # noqa: E402
+from models.iam import AuditLog  # noqa: E402
+from middleware.cx_logger import CX_NPS_SUBMITTED, invalidate_membership_cache  # noqa: E402
+
+
+@pytest.fixture
+def client_and_db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    from main import app
+    from database import get_db
+
+    def override():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override
+    invalidate_membership_cache()
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client, SessionLocal
+    app.dependency_overrides.clear()
+    invalidate_membership_cache()
+
+
+def test_submit_valid_score_records_event(client_and_db):
+    client, SessionLocal = client_and_db
+    r = client.post("/api/nps/submit?org_id=1", json={"score": 9, "verbatim": "Super produit"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "recorded"
+    assert body["category"] == "promoter"
+
+    db = SessionLocal()
+    try:
+        entry = db.query(AuditLog).filter(AuditLog.action == CX_NPS_SUBMITTED).first()
+        assert entry is not None
+        assert entry.resource_type == "cx_event"
+        assert entry.resource_id == "1"
+        detail = json.loads(entry.detail_json)
+        assert detail["score"] == 9
+        assert detail["has_verbatim"] is True
+        assert detail["category"] == "promoter"
+    finally:
+        db.close()
+
+
+def test_submit_without_verbatim(client_and_db):
+    client, SessionLocal = client_and_db
+    r = client.post("/api/nps/submit?org_id=1", json={"score": 7})
+    assert r.status_code == 200
+    assert r.json()["category"] == "passive"
+
+    db = SessionLocal()
+    try:
+        entry = db.query(AuditLog).filter(AuditLog.action == CX_NPS_SUBMITTED).first()
+        detail = json.loads(entry.detail_json)
+        assert detail["has_verbatim"] is False
+        assert detail["category"] == "passive"
+    finally:
+        db.close()
+
+
+def test_submit_detractor_category(client_and_db):
+    client, _ = client_and_db
+    r = client.post("/api/nps/submit?org_id=1", json={"score": 3})
+    assert r.status_code == 200
+    assert r.json()["category"] == "detractor"
+
+
+def test_submit_score_out_of_range_rejected(client_and_db):
+    client, _ = client_and_db
+    # Score négatif
+    r = client.post("/api/nps/submit?org_id=1", json={"score": -1})
+    assert r.status_code == 422
+    # Score > 10
+    r = client.post("/api/nps/submit?org_id=1", json={"score": 11})
+    assert r.status_code == 422
+
+
+def test_submit_boundaries_accepted(client_and_db):
+    client, _ = client_and_db
+    # Score = 0 (détracteur extrême) accepté
+    r = client.post("/api/nps/submit?org_id=1", json={"score": 0})
+    assert r.status_code == 200
+    assert r.json()["category"] == "detractor"
+
+
+def test_second_submit_within_90d_returns_already_submitted(client_and_db):
+    """
+    Anti-flood: un user ayant soumis < 90j ne peut resoumettre.
+    On simule en créant directement un AuditLog avec user_id connu,
+    puis en authentifiant via dépendance override.
+    """
+    client, SessionLocal = client_and_db
+
+    from middleware.auth import get_optional_auth, AuthContext
+    from models.iam import User, UserOrgRole, UserRole
+    from models import Organisation
+
+    db = SessionLocal()
+    try:
+        user = User(id=42, email="u@test.io", hashed_password="x", nom="U", prenom="U")
+        org = Organisation(id=1, nom="Org1")
+        db.add_all([user, org])
+        db.flush()
+        role = UserOrgRole(user_id=42, org_id=1, role=UserRole.DG_OWNER)
+        db.add(role)
+        db.commit()
+    finally:
+        db.close()
+
+    def fake_auth():
+        db2 = SessionLocal()
+        user = db2.query(User).filter_by(id=42).first()
+        uor = db2.query(UserOrgRole).filter_by(user_id=42, org_id=1).first()
+        db2.close()
+        return AuthContext(user=user, user_org_role=uor, org_id=1, role=UserRole.DG_OWNER, site_ids=[])
+
+    from main import app
+
+    app.dependency_overrides[get_optional_auth] = fake_auth
+
+    try:
+        r1 = client.post("/api/nps/submit", json={"score": 8})
+        assert r1.status_code == 200
+        assert r1.json()["status"] == "recorded"
+
+        r2 = client.post("/api/nps/submit", json={"score": 9})
+        assert r2.status_code == 200
+        assert r2.json()["status"] == "already_submitted"
+    finally:
+        app.dependency_overrides.pop(get_optional_auth, None)
+
+
+def test_submit_beyond_90d_allowed(client_and_db):
+    """Un event > 90 jours ne bloque pas une nouvelle submission."""
+    client, SessionLocal = client_and_db
+
+    from middleware.auth import get_optional_auth, AuthContext
+    from models.iam import User, UserOrgRole, UserRole
+    from models import Organisation
+
+    db = SessionLocal()
+    try:
+        user = User(id=99, email="v@test.io", hashed_password="x", nom="V", prenom="V")
+        org = Organisation(id=2, nom="Org2")
+        db.add_all([user, org])
+        db.flush()
+        role = UserOrgRole(user_id=99, org_id=2, role=UserRole.DG_OWNER)
+        db.add(role)
+        # Event vieux de 100 jours
+        old = AuditLog(
+            user_id=99,
+            action=CX_NPS_SUBMITTED,
+            resource_type="cx_event",
+            resource_id="2",
+            detail_json='{"score": 5}',
+            created_at=datetime.utcnow() - timedelta(days=100),
+        )
+        db.add(old)
+        db.commit()
+    finally:
+        db.close()
+
+    def fake_auth():
+        db2 = SessionLocal()
+        user = db2.query(User).filter_by(id=99).first()
+        uor = db2.query(UserOrgRole).filter_by(user_id=99, org_id=2).first()
+        db2.close()
+        return AuthContext(user=user, user_org_role=uor, org_id=2, role=UserRole.DG_OWNER, site_ids=[])
+
+    from main import app
+
+    app.dependency_overrides[get_optional_auth] = fake_auth
+
+    try:
+        r = client.post("/api/nps/submit", json={"score": 10})
+        assert r.status_code == 200
+        assert r.json()["status"] == "recorded"
+        assert r.json()["category"] == "promoter"
+    finally:
+        app.dependency_overrides.pop(get_optional_auth, None)

--- a/frontend/src/components/NpsModal.jsx
+++ b/frontend/src/components/NpsModal.jsx
@@ -1,0 +1,170 @@
+/**
+ * PROMEOS — NpsModal (Sprint CX P1 residual)
+ *
+ * Micro-survey NPS (Net Promoter Score) — instrumente la mesure scorecard
+ * "NPS/CES" (10% du score) orpheline avant ce sprint.
+ *
+ * Pattern industry-standard :
+ *   - Question : "Dans quelle mesure recommanderiez-vous PROMEOS à un collègue ?"
+ *   - Échelle 0-10 (11 boutons cliquables)
+ *   - Verbatim optionnel
+ *   - Classification promoter (9-10) / passive (7-8) / detractor (0-6)
+ *
+ * Self-contained : la modale décide elle-même de s'afficher (trigger J+30 via
+ * shouldShowNps + délai 5 s non-intrusif), align avec CsatModal. Le caller
+ * n'a qu'à mount <NpsModal orgId={...} userCreatedAt={...} /> — aucun état
+ * externe.
+ *
+ * Anti-flood 90j côté front (localStorage) + côté back (AuditLog).
+ */
+import { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import { submitNps } from '../services/api/nps';
+import { markNpsSubmitted, markNpsDismissed, shouldShowNps } from '../utils/nps';
+
+const SCORES = Array.from({ length: 11 }, (_, i) => i); // 0..10
+
+function categoryOf(score) {
+  if (score >= 9) return 'promoter';
+  if (score >= 7) return 'passive';
+  return 'detractor';
+}
+
+function scoreColor(score, selected) {
+  const base = 'w-8 h-8 text-xs font-medium rounded-md border transition';
+  const cat = categoryOf(score);
+  if (selected) {
+    if (cat === 'promoter') return `${base} bg-emerald-600 text-white border-emerald-600`;
+    if (cat === 'passive') return `${base} bg-amber-500 text-white border-amber-500`;
+    return `${base} bg-rose-600 text-white border-rose-600`;
+  }
+  return `${base} bg-white text-gray-700 border-gray-200 hover:border-gray-400`;
+}
+
+export default function NpsModal({ orgId, userCreatedAt, onSubmit }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [score, setScore] = useState(null);
+  const [verbatim, setVerbatim] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!userCreatedAt) return;
+    if (!shouldShowNps(userCreatedAt)) return;
+    const timer = setTimeout(() => setIsOpen(true), 5000);
+    return () => clearTimeout(timer);
+  }, [userCreatedAt]);
+
+  if (!isOpen) return null;
+
+  const dismiss = () => {
+    markNpsDismissed(30);
+    setIsOpen(false);
+  };
+
+  const handleSubmit = async () => {
+    if (score == null) return;
+    setSubmitting(true);
+    try {
+      const res = await submitNps({ score, verbatim: verbatim.trim() || undefined, orgId });
+      markNpsSubmitted();
+      setSubmitted(true);
+      onSubmit?.(res);
+      setTimeout(() => setIsOpen(false), 1500);
+    } catch {
+      // Silent fail — on marque quand même pour éviter boucle immédiate
+      markNpsSubmitted();
+      setIsOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Enquête de satisfaction NPS"
+      className="fixed bottom-6 right-6 w-[380px] bg-white rounded-lg shadow-xl border border-gray-200 p-4 z-50"
+    >
+      <button
+        onClick={dismiss}
+        className="absolute top-2 right-2 text-gray-300 hover:text-gray-600"
+        aria-label="Ignorer pour l'instant"
+      >
+        <X size={16} />
+      </button>
+
+      {submitted ? (
+        <div className="py-4 text-center text-sm text-emerald-700 font-medium">
+          Merci pour votre retour !
+        </div>
+      ) : (
+        <>
+          <h3 className="text-sm font-semibold text-gray-900 mb-1">
+            Dans quelle mesure recommanderiez-vous PROMEOS à un collègue ?
+          </h3>
+          <p className="text-[11px] text-gray-500 mb-3">0 = Pas du tout · 10 = Absolument</p>
+
+          <div role="radiogroup" aria-label="Note NPS 0 à 10" className="flex flex-wrap gap-1 mb-3">
+            {SCORES.map((s) => (
+              <button
+                key={s}
+                type="button"
+                role="radio"
+                aria-checked={score === s}
+                aria-label={`Note ${s}`}
+                onClick={() => setScore(s)}
+                onKeyDown={(e) => {
+                  if (e.key === 'ArrowLeft' && s > 0) {
+                    e.preventDefault();
+                    setScore(s - 1);
+                  } else if (e.key === 'ArrowRight' && s < 10) {
+                    e.preventDefault();
+                    setScore(s + 1);
+                  }
+                }}
+                className={scoreColor(s, score === s)}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+
+          {score != null && (
+            <>
+              <label htmlFor="nps-verbatim" className="block text-[11px] text-gray-600 mb-1">
+                Qu'est-ce qui a le plus pesé dans votre note ? (optionnel)
+              </label>
+              <textarea
+                id="nps-verbatim"
+                value={verbatim}
+                onChange={(e) => setVerbatim(e.target.value.slice(0, 1000))}
+                placeholder="Quelques mots libres..."
+                className="w-full text-xs border border-gray-200 rounded-md p-2 mb-2 resize-none"
+                rows={2}
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={dismiss}
+                  type="button"
+                  className="flex-1 py-1.5 text-xs text-gray-600 border border-gray-200 rounded-md hover:bg-gray-50"
+                >
+                  Ignorer pour l'instant
+                </button>
+                <button
+                  onClick={handleSubmit}
+                  disabled={submitting}
+                  type="button"
+                  className="flex-1 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md disabled:opacity-50"
+                >
+                  {submitting ? 'Envoi...' : 'Envoyer'}
+                </button>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/NpsModal.test.js
+++ b/frontend/src/components/__tests__/NpsModal.test.js
@@ -1,0 +1,70 @@
+/**
+ * PROMEOS — NpsModal source-guard tests (Sprint CX P1 residual)
+ * Garantit la structure du composant sans mount React (source string grep).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const FILE = path.resolve(__dirname, '../NpsModal.jsx');
+const SRC = fs.readFileSync(FILE, 'utf8');
+
+describe('NpsModal source guard', () => {
+  it('imports submitNps from services/api/nps', () => {
+    expect(SRC).toMatch(/from '\.\.\/services\/api\/nps'/);
+    expect(SRC).toMatch(/submitNps/);
+  });
+
+  it('imports guards from utils/nps', () => {
+    expect(SRC).toMatch(/from '\.\.\/utils\/nps'/);
+    expect(SRC).toMatch(/markNpsSubmitted/);
+    expect(SRC).toMatch(/markNpsDismissed/);
+  });
+
+  it('exposes 11 score buttons (0-10)', () => {
+    // SCORES array with length 11
+    expect(SRC).toMatch(/length:\s*11/);
+  });
+
+  it('has the canonical FR question', () => {
+    expect(SRC).toContain('Dans quelle mesure recommanderiez-vous PROMEOS');
+  });
+
+  it('has 0 / 10 scale label', () => {
+    expect(SRC).toMatch(/0\s*=\s*Pas du tout/);
+    expect(SRC).toMatch(/10\s*=\s*Absolument/);
+  });
+
+  it('includes verbatim textarea with optional wording', () => {
+    expect(SRC).toMatch(/textarea/);
+    expect(SRC).toMatch(/optionnel/i);
+  });
+
+  it('has aria attributes (a11y)', () => {
+    expect(SRC).toMatch(/role="dialog"/);
+    expect(SRC).toMatch(/aria-modal="true"/);
+    expect(SRC).toMatch(/role="radiogroup"/);
+    expect(SRC).toMatch(/aria-checked/);
+    expect(SRC).toMatch(/aria-label/);
+  });
+
+  it('supports keyboard navigation on score buttons', () => {
+    expect(SRC).toMatch(/ArrowLeft/);
+    expect(SRC).toMatch(/ArrowRight/);
+  });
+
+  it('has both CTA Envoyer and Ignorer', () => {
+    expect(SRC).toMatch(/Envoyer/);
+    expect(SRC).toMatch(/Ignorer/);
+  });
+
+  it('classifies scores into promoter/passive/detractor', () => {
+    expect(SRC).toMatch(/promoter/);
+    expect(SRC).toMatch(/passive/);
+    expect(SRC).toMatch(/detractor/);
+  });
+
+  it('calls markNpsSubmitted on success to prevent re-trigger', () => {
+    expect(SRC).toMatch(/markNpsSubmitted\(\)/);
+  });
+});

--- a/frontend/src/pages/CommandCenter.jsx
+++ b/frontend/src/pages/CommandCenter.jsx
@@ -51,6 +51,7 @@ import MorningBriefCard from '../components/MorningBriefCard';
 import DeadlineBanner from '../components/DeadlineBanner';
 import ValueCounterCard from '../components/ValueCounterCard';
 import CsatModal from '../components/CsatModal';
+import NpsModal from '../components/NpsModal';
 import TodayActionsCard from './cockpit/TodayActionsCard';
 import _ModuleLaunchers from './cockpit/ModuleLaunchers';
 import _EssentialsRow from './cockpit/EssentialsRow';
@@ -422,6 +423,9 @@ export default function CommandCenter() {
 
       {/* ── CSAT J+14 — CX Gap #7 (fixed position bottom-right) ── */}
       <CsatModal orgId={org?.id} />
+
+      {/* ── NPS J+30 — Sprint CX P1 residual (scorecard 10% NPS/CES) ── */}
+      <NpsModal orgId={org?.id} userCreatedAt={org?.created_at} />
 
       {/* ── Morning Brief — ce qui a bougé depuis la dernière visite ── */}
       <MorningBriefCard alerts={alertsCount} />

--- a/frontend/src/services/api/index.js
+++ b/frontend/src/services/api/index.js
@@ -30,3 +30,4 @@ export * from './market';
 export * from './contractsV2';
 export * from './pilotage';
 export * from './cxDashboard';
+export * from './nps';

--- a/frontend/src/services/api/nps.js
+++ b/frontend/src/services/api/nps.js
@@ -1,0 +1,25 @@
+/**
+ * PROMEOS - API NPS micro-survey (Sprint CX P1 residual)
+ *
+ * POST /api/nps/submit — envoie une note NPS (0-10) + verbatim optionnel.
+ * Le trigger d'affichage est piloté côté front via utils/nps.js::shouldShowNps
+ * (localStorage + user.created_at), sans aller-retour réseau.
+ *
+ * Cible scorecard CX "NPS/CES" (mesure 10% orpheline avant ce sprint).
+ */
+import api from './core';
+
+/**
+ * Soumet une note NPS.
+ * @param {object} params
+ * @param {number} params.score — note entière 0-10
+ * @param {string} [params.verbatim] — commentaire libre optionnel (< 1000 chars)
+ * @param {number} [params.orgId] — org_id en query (fallback demo mode)
+ * @returns {Promise<{status: 'recorded'|'already_submitted', category?: string}>}
+ */
+export const submitNps = ({ score, verbatim, orgId } = {}) => {
+  const params = orgId != null ? { org_id: orgId } : {};
+  return api
+    .post('/nps/submit', { score, verbatim: verbatim || null }, { params })
+    .then((r) => r.data);
+};

--- a/frontend/src/utils/__tests__/nps.test.js
+++ b/frontend/src/utils/__tests__/nps.test.js
@@ -1,0 +1,119 @@
+/**
+ * PROMEOS — nps.js helper tests (Sprint CX P1 residual)
+ * Couvre le trigger J+30 et l'anti-resubmit 90j via localStorage.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  shouldShowNps,
+  markNpsSubmitted,
+  markNpsDismissed,
+  NPS_LAST_SUBMIT_KEY,
+  NPS_DISMISSED_KEY,
+} from '../nps';
+
+const store = {};
+const localStorageMock = {
+  getItem: vi.fn((key) => store[key] ?? null),
+  setItem: vi.fn((key, val) => {
+    store[key] = val;
+  }),
+  removeItem: vi.fn((key) => {
+    delete store[key];
+  }),
+};
+vi.stubGlobal('localStorage', localStorageMock);
+
+beforeEach(() => {
+  Object.keys(store).forEach((k) => delete store[k]);
+  vi.clearAllMocks();
+});
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('shouldShowNps', () => {
+  it('returns false when userCreatedAt is null', () => {
+    expect(shouldShowNps(null)).toBe(false);
+  });
+
+  it('returns false when userCreatedAt is invalid', () => {
+    expect(shouldShowNps('not-a-date')).toBe(false);
+  });
+
+  it('returns false when account age < 30 days', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    const created = new Date(now.getTime() - 10 * DAY); // 10 days old
+    expect(shouldShowNps(created, now)).toBe(false);
+  });
+
+  it('returns true when account age >= 30 days and no prior submission', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    const created = new Date(now.getTime() - 35 * DAY);
+    expect(shouldShowNps(created, now)).toBe(true);
+  });
+
+  it('returns false when last submission < 90 days ago', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    const created = new Date(now.getTime() - 60 * DAY);
+    store[NPS_LAST_SUBMIT_KEY] = new Date(now.getTime() - 10 * DAY).toISOString();
+    expect(shouldShowNps(created, now)).toBe(false);
+  });
+
+  it('returns true when last submission > 90 days ago', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    const created = new Date(now.getTime() - 180 * DAY);
+    store[NPS_LAST_SUBMIT_KEY] = new Date(now.getTime() - 100 * DAY).toISOString();
+    expect(shouldShowNps(created, now)).toBe(true);
+  });
+
+  it('returns false when dismissed is in the future', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    const created = new Date(now.getTime() - 60 * DAY);
+    store[NPS_DISMISSED_KEY] = new Date(now.getTime() + 10 * DAY).toISOString();
+    expect(shouldShowNps(created, now)).toBe(false);
+  });
+
+  it('returns true when dismissed is in the past', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    const created = new Date(now.getTime() - 60 * DAY);
+    store[NPS_DISMISSED_KEY] = new Date(now.getTime() - 1 * DAY).toISOString();
+    expect(shouldShowNps(created, now)).toBe(true);
+  });
+
+  it('accepts string date input', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    expect(shouldShowNps('2026-01-01T00:00:00Z', now)).toBe(true);
+  });
+});
+
+describe('markNpsSubmitted', () => {
+  it('writes ISO timestamp to localStorage', () => {
+    const now = new Date('2026-04-17T12:00:00Z');
+    markNpsSubmitted(now);
+    expect(store[NPS_LAST_SUBMIT_KEY]).toBe(now.toISOString());
+  });
+
+  it('once marked, disables shouldShowNps within 90j', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    const created = new Date(now.getTime() - 120 * DAY);
+    markNpsSubmitted(now);
+    expect(shouldShowNps(created, now)).toBe(false);
+  });
+});
+
+describe('markNpsDismissed', () => {
+  it('writes a future ISO timestamp N days ahead', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    markNpsDismissed(15, now);
+    const stored = new Date(store[NPS_DISMISSED_KEY]);
+    const diff = (stored.getTime() - now.getTime()) / DAY;
+    expect(diff).toBeCloseTo(15, 1);
+  });
+
+  it('defaults to 30 days', () => {
+    const now = new Date('2026-04-17T00:00:00Z');
+    markNpsDismissed(undefined, now);
+    const stored = new Date(store[NPS_DISMISSED_KEY]);
+    const diff = (stored.getTime() - now.getTime()) / DAY;
+    expect(diff).toBeCloseTo(30, 1);
+  });
+});

--- a/frontend/src/utils/nps.js
+++ b/frontend/src/utils/nps.js
@@ -1,0 +1,77 @@
+/**
+ * PROMEOS — NPS trigger helpers (Sprint CX P1 residual)
+ *
+ * shouldShowNps(userCreatedAt, now) :
+ *   - Renvoie true si user > 30j ET pas de submission localStorage < 90j
+ *   - Clé localStorage : promeos_nps_last_submit (ISO string)
+ *   - Clé localStorage : promeos_nps_dismissed_until (ISO, optionnel)
+ *
+ * markNpsSubmitted()  : écrit la date courante dans localStorage
+ * markNpsDismissed(days) : reporte la re-proposition de N jours
+ */
+
+export const NPS_LAST_SUBMIT_KEY = 'promeos_nps_last_submit';
+export const NPS_DISMISSED_KEY = 'promeos_nps_dismissed_until';
+export const NPS_COOLDOWN_DAYS = 90;
+export const NPS_MIN_ACCOUNT_AGE_DAYS = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function _safeGet(key) {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+  } catch {
+    return null;
+  }
+}
+
+function _safeSet(key, value) {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(key, value);
+  } catch {
+    // ignore (incognito / quota)
+  }
+}
+
+/**
+ * @param {Date|string|null} userCreatedAt — date de création du compte
+ * @param {Date} [now] — now override (tests)
+ * @returns {boolean}
+ */
+export function shouldShowNps(userCreatedAt, now = new Date()) {
+  if (!userCreatedAt) return false;
+  const created = userCreatedAt instanceof Date ? userCreatedAt : new Date(userCreatedAt);
+  if (isNaN(created.getTime())) return false;
+
+  // Compte < 30j : non éligible
+  const ageDays = (now.getTime() - created.getTime()) / DAY_MS;
+  if (ageDays < NPS_MIN_ACCOUNT_AGE_DAYS) return false;
+
+  // Déjà soumis < 90j : non éligible
+  const lastSubmit = _safeGet(NPS_LAST_SUBMIT_KEY);
+  if (lastSubmit) {
+    const last = new Date(lastSubmit);
+    if (!isNaN(last.getTime())) {
+      const daysSince = (now.getTime() - last.getTime()) / DAY_MS;
+      if (daysSince < NPS_COOLDOWN_DAYS) return false;
+    }
+  }
+
+  // Dismiss explicite non expiré : non éligible
+  const dismissedUntil = _safeGet(NPS_DISMISSED_KEY);
+  if (dismissedUntil) {
+    const until = new Date(dismissedUntil);
+    if (!isNaN(until.getTime()) && now.getTime() < until.getTime()) return false;
+  }
+
+  return true;
+}
+
+export function markNpsSubmitted(now = new Date()) {
+  _safeSet(NPS_LAST_SUBMIT_KEY, now.toISOString());
+}
+
+export function markNpsDismissed(days = 30, now = new Date()) {
+  const until = new Date(now.getTime() + days * DAY_MS);
+  _safeSet(NPS_DISMISSED_KEY, until.toISOString());
+}


### PR DESCRIPTION
## Summary

Sprint CX P1 residual — 3 scopes couvrant la dette pointée dans le bilan Sprint CX 3 (score alignement 47/100 → 62/100 post-merge CX 3, vise **~68/100** post-merge ce PR).

### Scope 1 — Wiring `invalidate_membership_cache` (commit 1)
- `iam_service.assign_role` / `remove_role` : purge (user_id, org_id)
- `admin_users.change_role` / `delete_user` : purge post-commit
- `demo._reset_iam_demo` : purge par user_id supprimé
- Nouveau helper `safe_invalidate_membership_cache` (try/except centralisé, fire-and-forget)
- Simplify hardening : `make_dedup_key(key, value)` constructeur canonique + migration `flex|copilot|bacs` pour éviter false positive "flex" vs "flexibilite"

Ferme la dette "un user qui perd accès à une org peut logger des events pendant ≤ 5 min" listée dans cx_logger.py (sprint CX 2.5-bis P2 note).

### Scope 2 — `business_error` extension (commit 2)
22 call-sites / 10 routes migrés depuis `HTTPException(status_code=..., detail=...)` → `HTTPException(**business_error("CODE", **ctx))`.

Routes : `monitoring`, `ems`, `site_intelligence`, `data_quality`, `energy`, `compliance`, `patrimoine/sites|_helpers`, `auth`, `actions`.

Codes : `SITE_NOT_FOUND`, `ACTION_NOT_FOUND`, `USER_NOT_FOUND`, `ALERT_NOT_FOUND`, `INVALID_DATE_FORMAT` — tous préexistants dans le catalog.

Adoption catalog : 46/529 → 68/529 (**8.7% → 12.9%**).

### Scope 3 — NPS micro-survey (commit 3)
Ferme la mesure **"NPS/CES" 10% scorecard CX** orpheline avant ce sprint.

**Backend** :
- `POST /api/nps/submit` : score 0-10 + verbatim optionnel, fire event `CX_NPS_SUBMITTED` (category promoter/passive/detractor)
- Anti-flood 90j via nouveau helper `has_recent_audit_event`
- 7 tests

**Frontend** :
- `<NpsModal orgId userCreatedAt>` **self-contained** — trigger J+30 + délai 5s internes à la modale (align pattern `CsatModal`)
- `utils/nps.js` : guards localStorage (shouldShowNps, markNpsSubmitted, markNpsDismissed)
- Mount dans `CommandCenter.jsx`
- 24 tests

## Simplify consensus applied (3 agents parallèles)

1. ✅ `safe_invalidate_membership_cache` — 5 call-sites dédupliqués (try/except + logger debug centralisé)
2. ✅ `GET /api/nps/should-show` supprimé (dead code — jamais appelé par le front, logic entièrement localStorage)
3. ✅ `<NpsModal>` self-contained — orchestration sortie de CommandCenter
4. ✅ `has_recent_audit_event` helper — pattern AuditLog cooldown dédupliqué, réutilisable CSAT
5. ✅ `make_dedup_key(key, value)` + assertion anti-quote — hardening format dedup_key

## Test plan

- [x] Backend : 62 tests verts (cx_logger 11 + wiring 5 + events 9 + nps 7 + business_error 30)
- [x] Frontend : 24 tests verts (NpsModal 10 + utils 13 + API 1)
- [x] Ruff format clean · Ruff check clean · Prettier clean
- [ ] CI — Quality Gate (ruff, pytest, vitest, Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)