### PR TITLE
cleanup(achat-pipeline): audit /simplify 3-agents — 3 P1 cohérence post-10-PRs

### DIFF
--- a/backend/config/tarifs_reglementaires.yaml
+++ b/backend/config/tarifs_reglementaires.yaml
@@ -478,7 +478,6 @@ tva:
 vnu:
   seuil_1_eur_mwh: 78.0
   seuil_2_eur_mwh: 110.0
-  impact_upside_mvp_eur_mwh: 2.0
   statut: "EN VIGUEUR — DORMANT (prix marché ~60 €/MWh < seuil 78)"
   source: "Loi de souveraineté énergétique — VNU au 01/01/2026 (Décret 2026-55, CRE 2026-52)"
   valid_from: "2026-01-01"
@@ -499,6 +498,7 @@ cost_simulator_2026:
   baseline_eur_mwh: 80.0  # ARENH 42 × 50% + complément spot 2024 (~120 × 50%)
   fallback_forward_eur_mwh: 68.0  # Si mkt_prices vide (= prix_reference.elec_eur_kwh × 1000)
   peak_premium_ratio: 0.15  # Majoration HP/HC baseload, calibrée Observatoire CRE T4 2025
+  vnu_impact_upside_mvp_eur_mwh: 2.0  # Estimation MVP impact VNU si actif (hors section réglementaire vnu)
   source: "PROMEOS MVP post-ARENH — calibration Observatoire CRE T4 2025 + baromètre CRE bulletin marchés de gros 2025"
   valid_from: "2026-01-01"
   valid_to: null

--- a/backend/services/purchase/cost_simulator_2026.py
+++ b/backend/services/purchase/cost_simulator_2026.py
@@ -73,7 +73,7 @@ VNU_SEUIL_DEFAUT_EUR_MWH = 78.0
 # compatibilité stable à la BC.
 FALLBACK_FORWARD_EUR_MWH = 68.0  # YAML: cost_simulator_2026.fallback_forward_eur_mwh
 BASELINE_2024_EUR_MWH_FALLBACK = 80.0  # YAML: cost_simulator_2026.baseline_eur_mwh
-VNU_IMPACT_MVP_EUR_MWH_FALLBACK = 2.0  # YAML: vnu.impact_upside_mvp_eur_mwh
+VNU_IMPACT_MVP_EUR_MWH_FALLBACK = 2.0  # YAML: cost_simulator_2026.vnu_impact_upside_mvp_eur_mwh
 PEAK_PREMIUM_RATIO_FALLBACK = 0.15  # YAML: cost_simulator_2026.peak_premium_ratio
 
 # Facteur de forme typique par archétype (E_an / (P_max × 8760h)).
@@ -91,10 +91,6 @@ ARCHETYPE_FACTEUR_FORME = {
     "INDUSTRIE_LEGERE": 0.50,
     "DEFAULT": 0.40,
 }
-
-# Alias historique utilisé par `test_achat_cost_simulator_2026.py`. Valeur
-# effective toujours lue depuis YAML via `_load_simulator_params`.
-BASELINE_2024_EUR_MWH = BASELINE_2024_EUR_MWH_FALLBACK
 
 # Segment TURPE par défaut (C4_BT = tertiaire moyen, majoritaire dans portefeuille PME).
 # Si `Meter.tariff_type` renseigne C5 / C3, on bascule.
@@ -270,15 +266,21 @@ def _resolve_accise_code(site) -> str:
 
 
 def _resolve_vnu_seuil() -> tuple[float, Optional[str], float]:
-    """Extrait seuil + impact upside VNU depuis `tarifs_reglementaires.yaml::vnu`.
+    """Extrait seuil VNU (réglementaire) + impact upside MVP (produit).
+
+    - `seuil_1_eur_mwh` lu depuis section `vnu` (CRE-canonique).
+    - `vnu_impact_upside_mvp_eur_mwh` lu depuis section `cost_simulator_2026`
+      (valeur produit MVP, séparée de la doctrine réglementaire pour éviter
+      la dérive mix MVP / régulation dans la même section YAML).
 
     Retourne `(seuil_eur_mwh, source_ref, impact_upside_eur_mwh)`. Fallback
     hardcodé si YAML absent — warning loggé pour visibilité prod.
     """
     try:
         vnu = load_yaml_section("vnu") or {}
+        sim = load_yaml_section("cost_simulator_2026") or {}
         seuil = float(vnu.get("seuil_1_eur_mwh", VNU_SEUIL_DEFAUT_EUR_MWH))
-        impact = float(vnu.get("impact_upside_mvp_eur_mwh", VNU_IMPACT_MVP_EUR_MWH_FALLBACK))
+        impact = float(sim.get("vnu_impact_upside_mvp_eur_mwh", VNU_IMPACT_MVP_EUR_MWH_FALLBACK))
         return seuil, vnu.get("source"), impact
     except Exception as exc:
         logger.warning("cost_simulator_2026: vnu lookup failed (fallback hardcoded): %s", exc)

--- a/backend/tests/test_achat_cost_simulator_2026.py
+++ b/backend/tests/test_achat_cost_simulator_2026.py
@@ -49,7 +49,7 @@ from services.purchase.cost_simulator_2026 import (
     FALLBACK_FORWARD_EUR_MWH,
     CAPACITE_UNITAIRE_EUR_MWH,
     DEFAULT_ANNUAL_KWH,
-    BASELINE_2024_EUR_MWH,
+    BASELINE_2024_EUR_MWH_FALLBACK,
     VNU_SEUIL_DEFAUT_EUR_MWH,
 )
 
@@ -298,9 +298,9 @@ class TestSimulateFacture2026:
         # Baseline = 500 MWh × 80 EUR/MWh × peakload_mult (COMMERCE_ALIMENTAIRE 0.55)
         # mult = 1 + 0.15 × 0.45 = 1.0675 → baseline = 42 700 EUR
         peakload_mult = 1.0 + 0.15 * (1.0 - 0.55)
-        expected_baseline = 500.0 * BASELINE_2024_EUR_MWH * peakload_mult
+        expected_baseline = 500.0 * BASELINE_2024_EUR_MWH_FALLBACK * peakload_mult
         assert result["baseline_2024"]["fourniture_ht_eur"] == pytest.approx(expected_baseline, rel=1e-3)
-        assert result["baseline_2024"]["prix_moyen_pondere_eur_mwh"] == BASELINE_2024_EUR_MWH
+        assert result["baseline_2024"]["prix_moyen_pondere_eur_mwh"] == BASELINE_2024_EUR_MWH_FALLBACK
 
         # Delta HT énergie = (fourniture_2026 - baseline_2024) / baseline × 100
         # Même multiplier des deux côtés → delta isole le shift ARENH→forward

--- a/frontend/src/ui/glossary.js
+++ b/frontend/src/ui/glossary.js
@@ -79,8 +79,8 @@ export const GLOSSARY = {
   vnu: {
     term: 'VNU',
     short:
-      "Ventes au Nucléaire Unifié. Mécanisme régulant l'accès à l'électricité nucléaire historique, successeur de l'ARENH depuis le 1/1/2026.",
-    long: "La VNU remplace l'ARENH (fini 31/12/2025) dans le cadre post-bouclier tarifaire. Elle unifie les ventes d'EDF sur un marché de gros régulé (plutôt qu'un prix fixe 42 €/MWh comme ARENH). Fin 2025, l'open interest sur Y_2026 a atteint 24,1 GW (record historique) — signal fort d'anticipation par les acheteurs. PROMEOS intègre la VNU dans les scénarios d'achat Q2-Q3 2026. Source : Loi Énergie-Climat 2019, PPE3 2026–2035, bulletin CRE T4 2025.",
+      'Versement Nucléaire Universel. Taxe redistributive sur la rente nucléaire EDF (Décret 2026-55, CRE 2026-52), successeur du cadre ARENH depuis le 01/01/2026.',
+    long: "Le VNU (Versement Nucléaire Universel) est une taxe redistributive prélevée sur EDF lorsque le prix de marché dépasse les seuils CRE (78 / 110 €/MWh). Elle n'est PAS une ligne de la facture client final — c'est un transfert EDF → fournisseurs concurrents pour ré-équilibrer la rente nucléaire. Remplace le cadre ARENH (42 €/MWh × 50% quota) supprimé au 31/12/2025. Statut dormant en 2026 tant que les prix forward restent sous 78 €/MWh. PROMEOS expose le statut VNU dans hypotheses pour traçabilité auditeur. Source : Loi 2023-491 souveraineté énergétique, Décret 2026-55, CRE 2026-52.",
   },
   capacite: {
     term: 'Mécanisme de capacité',
@@ -188,7 +188,7 @@ export const GLOSSARY = {
   arenh: {
     term: 'ARENH',
     short:
-      "Accès Régulé à l'Électricité Nucléaire Historique. Prix fixe 42 €/MWh. Dispositif terminé le 31/12/2025, remplacé par le mécanisme VNU (Ventes au Nucléaire Unifié).",
+      "Accès Régulé à l'Électricité Nucléaire Historique. Prix fixe 42 €/MWh. Dispositif terminé le 31/12/2025, remplacé par le VNU (Versement Nucléaire Universel, taxe redistributive sur EDF).",
     // Source : Loi Énergie-Climat 2019, fin ARENH confirmée LFI 2023. VNU : PPE3 2026-2035.
   },
 


### PR DESCRIPTION
## Summary

Audit /simplify 3-agents SDK sur la surface Achat/CBAM/Sirene consolidée (10 PRs mergées en 48h). 3 P1 actionnables réels corrigés.

- **VNU wording glossaire frontend** : "Ventes au Nucléaire Unifié" → "Versement Nucléaire Universel" (aligné doctrine + backend)
- **YAML section fix** : `vnu.impact_upside_mvp_eur_mwh` (MVP produit) déplacé vers `cost_simulator_2026` — la section `vnu` reste purement CRE-canonique
- **Alias cosmétique** : `BASELINE_2024_EUR_MWH` supprimé (test utilise `_FALLBACK` directement)

## Backlog structurel (non-bloquant)

- H1 `add_column_if_missing` dupliqué dans 7 migration scripts
- H2 CBAM brick bypasse `ParameterStore` (doctrine V112/V114)
- M1 seed factory `seed_by_archetype` à factoriser au 3ème seed
- M2 `LeadScoreSummary` ⊂ `LeadScoreOut`
- M3 `make_org_site` → conftest
- P1 perf `ParameterStore.get()` non mémoïsé inter-call

## Tests

- 55/55 backend Achat/CBAM/Sirene verts
- 78/78 glossary frontend verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)