### PR TITLE
refactor(cx-p1): /simplify polish — perf index + batch cache + narrowed except

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -246,7 +246,6 @@ from routes.feedback import router as feedback_router
 
 app.include_router(feedback_router)
 
-# NPS micro-survey (Sprint CX P1 residual — scorecard 10% "NPS/CES")
 from routes.nps import router as nps_router
 
 app.include_router(nps_router)

--- a/backend/middleware/cx_logger.py
+++ b/backend/middleware/cx_logger.py
@@ -7,7 +7,8 @@ Fire-and-forget : les erreurs sont loggées mais ne bloquent pas la requête.
 import json
 import logging
 import time
-from typing import Optional
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, Optional
 
 from sqlalchemy.orm import Session
 
@@ -53,27 +54,41 @@ def _is_member_cached(db: Session, user_id: int, org_id: int, ttl_sec: int = _ME
     return is_member
 
 
-def invalidate_membership_cache(user_id: Optional[int] = None, org_id: Optional[int] = None) -> None:
+def invalidate_membership_cache(
+    user_id: Optional[int] = None,
+    org_id: Optional[int] = None,
+    user_ids: Optional[Iterable[int]] = None,
+) -> None:
     """Invalide le cache membership.
 
     - Sans argument : vide tout le cache (utile en tests).
     - Avec (user_id, org_id) : invalide cette paire.
     - Avec user_id seul : invalide toutes les paires pour cet utilisateur.
     - Avec org_id seul : invalide toutes les paires pour cette org.
+    - Avec user_ids (set/list) : invalide en une passe toutes les paires
+      (user, *) dont user ∈ user_ids — évite N × O(|cache|) scans quand on
+      purge un lot d'utilisateurs (ex. reset demo).
     """
-    if user_id is None and org_id is None:
+    if user_id is None and org_id is None and user_ids is None:
         _MEMBERSHIP_CACHE.clear()
         return
+    user_id_set = {int(u) for u in user_ids} if user_ids is not None else None
     to_delete = [
         key
         for key in _MEMBERSHIP_CACHE
-        if (user_id is None or key[0] == user_id) and (org_id is None or key[1] == org_id)
+        if (user_id is None or key[0] == user_id)
+        and (org_id is None or key[1] == org_id)
+        and (user_id_set is None or key[0] in user_id_set)
     ]
     for key in to_delete:
         _MEMBERSHIP_CACHE.pop(key, None)
 
 
-def safe_invalidate_membership_cache(user_id: Optional[int] = None, org_id: Optional[int] = None) -> None:
+def safe_invalidate_membership_cache(
+    user_id: Optional[int] = None,
+    org_id: Optional[int] = None,
+    user_ids: Optional[Iterable[int]] = None,
+) -> None:
     """Wrapper fire-and-forget autour de invalidate_membership_cache.
 
     Usage : call-sites CRUD (iam_service, admin_users, demo reset) qui veulent
@@ -81,12 +96,13 @@ def safe_invalidate_membership_cache(user_id: Optional[int] = None, org_id: Opti
     échoue (pire cas : staleness ≤ 5 min, comportement pré-wiring).
     """
     try:
-        invalidate_membership_cache(user_id=user_id, org_id=org_id)
+        invalidate_membership_cache(user_id=user_id, org_id=org_id, user_ids=user_ids)
     except Exception:
         logger.debug(
-            "invalidate_membership_cache failed (user_id=%s, org_id=%s)",
+            "invalidate_membership_cache failed (user_id=%s, org_id=%s, user_ids=%s)",
             user_id,
             org_id,
+            user_ids,
             exc_info=True,
         )
 
@@ -103,8 +119,6 @@ def has_recent_audit_event(
     pas harceler un même utilisateur. `action` doit être une des constantes
     CX_* ou un action_type d'AuditLog existant.
     """
-    from datetime import datetime, timedelta, timezone
-
     cutoff = datetime.now(timezone.utc) - timedelta(days=cooldown_days)
     existing = (
         db.query(AuditLog.id)
@@ -127,7 +141,6 @@ CX_REPORT_EXPORTED = "CX_REPORT_EXPORTED"
 CX_ONBOARDING_COMPLETED = "CX_ONBOARDING_COMPLETED"
 CX_ACTION_FROM_INSIGHT = "CX_ACTION_FROM_INSIGHT"
 CX_DASHBOARD_OPENED = "CX_DASHBOARD_OPENED"
-# Sprint CX P1 residual : NPS micro-survey (scorecard 10% "NPS/CES")
 CX_NPS_SUBMITTED = "CX_NPS_SUBMITTED"
 
 CX_EVENT_TYPES = frozenset(

--- a/backend/models/iam.py
+++ b/backend/models/iam.py
@@ -89,6 +89,10 @@ class AuditLog(Base):
             "resource_type",
             "created_at",
         ),
+        # Couvre `has_recent_audit_event(user_id, action, cooldown)` utilisé par
+        # l'anti-flood NPS/CSAT. Sans cet index le planner tombe sur ix_audit_user_id
+        # + post-filtre O(user_events), coûteux pour les admins très actifs.
+        Index("ix_audit_user_action_created", "user_id", "action", "created_at"),
         Index("ix_audit_user_id", "user_id"),
         Index("ix_audit_resource_id", "resource_id"),
     )

--- a/backend/routes/bacs.py
+++ b/backend/routes/bacs.py
@@ -4,14 +4,18 @@ Full BACS assessment, CVC system management, data quality, seed demo.
 """
 
 import json
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from database import get_db
 from middleware.auth import get_optional_auth
 from middleware.cx_logger import log_cx_event_first_only, make_dedup_key, CX_MODULE_ACTIVATED
 from services.scope_utils import resolve_org_id
+
+logger = logging.getLogger(__name__)
 
 from models import (
     Site,
@@ -212,8 +216,8 @@ def create_bacs_asset(
     db.commit()
     db.refresh(asset)
 
-    # Sprint CX 3 P0.4 : fire CX_MODULE_ACTIVATED (1ère activation BACS par l'org).
-    # Option A : dédup via `module_key=bacs` dans detail_json. Résout org_id via site.
+    # Fire CX_MODULE_ACTIVATED (1ère activation BACS par l'org). Dédup via
+    # `module_key=bacs` dans detail_json. org_id résolu via site→portefeuille→ej.
     try:
         pf = db.get(Portefeuille, site.portefeuille_id) if site and site.portefeuille_id else None
         ej = db.get(EntiteJuridique, pf.entite_juridique_id) if pf else None
@@ -228,8 +232,9 @@ def create_bacs_asset(
                 context={"module_key": "bacs", "trigger": "create_bacs_asset"},
             )
             db.commit()
-    except Exception:
-        pass  # fire-and-forget : ne casse pas la création asset
+    except SQLAlchemyError:
+        logger.debug("CX_MODULE_ACTIVATED bacs instrumentation failed", exc_info=True)
+        db.rollback()
 
     return _serialize_asset(asset)
 

--- a/backend/routes/demo.py
+++ b/backend/routes/demo.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from middleware.auth import require_admin
+from middleware.cx_logger import safe_invalidate_membership_cache
 from models import (
     Organisation,
     EntiteJuridique,
@@ -280,12 +281,8 @@ def _reset_iam_demo(db):
         db.query(UserOrgRole).filter(UserOrgRole.user_id == u.id).delete()
         db.query(User).filter(User.id == u.id).delete()
     db.commit()
-    # Sprint CX P1 residual : purge cache membership pour tous les users demo
-    # supprimés (sinon staleness ≤ 5 min post-reset).
-    from middleware.cx_logger import safe_invalidate_membership_cache
-
-    for uid in demo_user_ids:
-        safe_invalidate_membership_cache(user_id=uid)
+    if demo_user_ids:
+        safe_invalidate_membership_cache(user_ids=demo_user_ids)
     # Re-seed IAM if an org still exists
     org = db.query(Organisation).first()
     if org:

--- a/backend/routes/nps.py
+++ b/backend/routes/nps.py
@@ -1,18 +1,10 @@
 """
-PROMEOS — NPS micro-survey (Sprint CX P1 residual)
+PROMEOS — NPS micro-survey.
 
-POST /api/nps/submit — enregistre une note NPS (0-10) + verbatim optionnel.
-
-Classification industry-standard :
-  - Promoteurs : 9-10
-  - Passifs    : 7-8
-  - Détracteurs: 0-6
-
-Anti-flood : 1 seule soumission par user dans une fenêtre de 90 jours
-(check AuditLog.action == CX_NPS_SUBMITTED + user_id + created_at).
-
-Le stockage s'appuie sur AuditLog via log_cx_event (pas de nouvelle table)
-pour rester homogène avec les autres events CX (T2V, IAR, WAU/MAU...).
+POST /api/nps/submit : enregistre une note (0-10) + verbatim optionnel,
+classe en promoter (9-10) / passive (7-8) / detractor (0-6), et écrit un
+event CX_NPS_SUBMITTED dans AuditLog (pas de table dédiée — homogène avec
+T2V, IAR, WAU/MAU). Anti-flood 90 j par user via has_recent_audit_event.
 """
 
 from typing import Optional

--- a/backend/services/iam_service.py
+++ b/backend/services/iam_service.py
@@ -13,6 +13,7 @@ import bcrypt
 from jose import jwt, JWTError
 from sqlalchemy.orm import Session
 
+from middleware.cx_logger import safe_invalidate_membership_cache
 from models import (
     User,
     UserOrgRole,
@@ -422,8 +423,6 @@ def create_user(db: Session, email: str, password: str, nom: str, prenom: str) -
 
 
 def assign_role(db: Session, user_id: int, org_id: int, role: UserRole) -> UserOrgRole:
-    from middleware.cx_logger import safe_invalidate_membership_cache
-
     uor = UserOrgRole(user_id=user_id, org_id=org_id, role=role)
     db.add(uor)
     db.flush()
@@ -474,8 +473,6 @@ def remove_role(db: Session, user_id: int, org_id: int) -> bool:
         )
         if count <= 1:
             return False  # Cannot remove last DG_OWNER
-
-    from middleware.cx_logger import safe_invalidate_membership_cache
 
     db.delete(uor)
     db.flush()

--- a/backend/tests/test_cx_logger.py
+++ b/backend/tests/test_cx_logger.py
@@ -212,6 +212,26 @@ def test_membership_cache_invalidated_explicitly(db_session):
     assert _is_member_cached(db_session, 2, 2) is False
 
 
+def test_membership_cache_invalidate_user_ids_batch():
+    """Batch : invalidate_membership_cache(user_ids=...) purge toutes les paires
+    en une passe (utilisé par demo reset sur un lot d'utilisateurs)."""
+    import time as _time
+
+    invalidate_membership_cache()  # clean
+    now = _time.monotonic()
+    _MEMBERSHIP_CACHE[(10, 1)] = (True, now + 300)
+    _MEMBERSHIP_CACHE[(11, 1)] = (True, now + 300)
+    _MEMBERSHIP_CACHE[(12, 2)] = (True, now + 300)
+
+    invalidate_membership_cache(user_ids=[10, 11])
+
+    assert (10, 1) not in _MEMBERSHIP_CACHE
+    assert (11, 1) not in _MEMBERSHIP_CACHE
+    assert (12, 2) in _MEMBERSHIP_CACHE  # hors lot → conservé
+
+    invalidate_membership_cache()
+
+
 def test_membership_cache_ttl_expires(db_session):
     """P2 : au-delà du TTL, le cache re-query la DB."""
     _seed_member(db_session, user_id=3, org_id=3)

--- a/frontend/src/components/NpsModal.jsx
+++ b/frontend/src/components/NpsModal.jsx
@@ -1,21 +1,10 @@
 /**
- * PROMEOS — NpsModal (Sprint CX P1 residual)
+ * PROMEOS — NpsModal : micro-survey NPS 0-10 + verbatim.
  *
- * Micro-survey NPS (Net Promoter Score) — instrumente la mesure scorecard
- * "NPS/CES" (10% du score) orpheline avant ce sprint.
- *
- * Pattern industry-standard :
- *   - Question : "Dans quelle mesure recommanderiez-vous PROMEOS à un collègue ?"
- *   - Échelle 0-10 (11 boutons cliquables)
- *   - Verbatim optionnel
- *   - Classification promoter (9-10) / passive (7-8) / detractor (0-6)
- *
- * Self-contained : la modale décide elle-même de s'afficher (trigger J+30 via
- * shouldShowNps + délai 5 s non-intrusif), align avec CsatModal. Le caller
- * n'a qu'à mount <NpsModal orgId={...} userCreatedAt={...} /> — aucun état
- * externe.
- *
- * Anti-flood 90j côté front (localStorage) + côté back (AuditLog).
+ * Classification promoter (9-10) / passive (7-8) / detractor (0-6).
+ * Self-contained : décide elle-même de s'afficher (trigger J+30 via
+ * shouldShowNps + délai 5 s non-intrusif). Anti-flood 90 j côté front
+ * (localStorage) + côté back (AuditLog via has_recent_audit_event).
  */
 import { useEffect, useState } from 'react';
 import { X } from 'lucide-react';
@@ -71,8 +60,10 @@ export default function NpsModal({ orgId, userCreatedAt, onSubmit }) {
       setSubmitted(true);
       onSubmit?.(res);
       setTimeout(() => setIsOpen(false), 1500);
-    } catch {
-      // Silent fail — on marque quand même pour éviter boucle immédiate
+    } catch (err) {
+      // On marque submitted pour éviter une boucle immédiate, mais on log
+      // pour ne pas perdre la trace (télémétrie / debug réseau).
+      console.warn('NPS submit failed', err);
       markNpsSubmitted();
       setIsOpen(false);
     } finally {

--- a/frontend/src/pages/CommandCenter.jsx
+++ b/frontend/src/pages/CommandCenter.jsx
@@ -421,10 +421,7 @@ export default function CommandCenter() {
       {/* ── Value Counter — CX Gap #6 ── */}
       <ValueCounterCard orgId={org?.id} />
 
-      {/* ── CSAT J+14 — CX Gap #7 (fixed position bottom-right) ── */}
       <CsatModal orgId={org?.id} />
-
-      {/* ── NPS J+30 — Sprint CX P1 residual (scorecard 10% NPS/CES) ── */}
       <NpsModal orgId={org?.id} userCreatedAt={org?.created_at} />
 
       {/* ── Morning Brief — ce qui a bougé depuis la dernière visite ── */}

--- a/frontend/src/services/api/nps.js
+++ b/frontend/src/services/api/nps.js
@@ -1,11 +1,9 @@
 /**
- * PROMEOS - API NPS micro-survey (Sprint CX P1 residual)
+ * PROMEOS — API NPS micro-survey.
  *
  * POST /api/nps/submit — envoie une note NPS (0-10) + verbatim optionnel.
  * Le trigger d'affichage est piloté côté front via utils/nps.js::shouldShowNps
  * (localStorage + user.created_at), sans aller-retour réseau.
- *
- * Cible scorecard CX "NPS/CES" (mesure 10% orpheline avant ce sprint).
  */
 import api from './core';
 

--- a/frontend/src/utils/nps.js
+++ b/frontend/src/utils/nps.js
@@ -1,13 +1,10 @@
 /**
- * PROMEOS — NPS trigger helpers (Sprint CX P1 residual)
+ * PROMEOS — NPS trigger helpers : éligibilité + guards localStorage.
  *
- * shouldShowNps(userCreatedAt, now) :
- *   - Renvoie true si user > 30j ET pas de submission localStorage < 90j
- *   - Clé localStorage : promeos_nps_last_submit (ISO string)
- *   - Clé localStorage : promeos_nps_dismissed_until (ISO, optionnel)
- *
- * markNpsSubmitted()  : écrit la date courante dans localStorage
- * markNpsDismissed(days) : reporte la re-proposition de N jours
+ *   shouldShowNps(userCreatedAt, now) : true si user ≥ 30 j ET pas de
+ *     submission < 90 j ET pas de dismiss encore actif.
+ *   markNpsSubmitted()       : écrit la date courante dans localStorage.
+ *   markNpsDismissed(days)   : reporte la re-proposition de N jours.
  */
 
 export const NPS_LAST_SUBMIT_KEY = 'promeos_nps_last_submit';


### PR DESCRIPTION
## Summary

Post-merge `/simplify` polish sur PR #254 (squash `603037e4`). Audit 3 agents parallèles → 4 P1 + 2 P2 appliqués.

### P1 perf
- **`AuditLog.ix_audit_user_action_created`** : nouvel index composite `(user_id, action, created_at)` — couvre la query `has_recent_audit_event(user_id, action, cooldown)` utilisée par l'anti-flood NPS/CSAT. Sans, le planner tombait sur `ix_audit_user_id` seul + post-filtre O(user_events), coûteux pour les users très actifs.
- **`invalidate_membership_cache(user_ids=...)`** : batch variant single-pass. Remplace dans `demo._reset_iam_demo` le pattern N × O(|cache|) (50 users × 1k entrées = 50k comparaisons) par 1 seule passe.

### P1 quality
- **`routes/bacs.py`** : `except Exception: pass` → `except SQLAlchemyError: logger.debug(..., exc_info=True); db.rollback()`. L'ancien bare-except masquait les erreurs DB du second commit (après asset déjà persisté).
- **`NpsModal.jsx`** : `catch { }` → `catch (err) { console.warn(...) }`. Silent fail empêchait toute trace de submit NPS cassé côté télémétrie/debug réseau.

### P2 style
- Hoist lazy imports (`iam_service.py` ×2, `demo.py` ×1, `cx_logger.py` datetime).
- Suppression des 5 commentaires narrant "Sprint CX P1 residual …" (main.py, cx_logger.py, CommandCenter.jsx, NpsModal.jsx, utils/nps.js, api/nps.js, routes/nps.py) — les docstrings conservent le WHY, pas le tag sprint.

### Findings non retenus (backlog)
- Extraction `SurveyModal` commune à NpsModal + CsatModal (~60% structural overlap) — refacto hors scope.
- `safeLocalStorage` util commun (9ème copie du pattern try/catch localStorage dans le frontend) — backlog transverse.
- `ErrorCode` StrEnum au lieu de strings `business_error(\"SITE_NOT_FOUND\")` — backlog.
- Migration CSAT vers AuditLog + `has_recent_audit_event` (actuellement table `CsatResponse` dédiée) — discussion métier requise.

## Test plan

- [x] Backend : 62 tests verts (cx_logger 12 incl. nouveau `test_membership_cache_invalidate_user_ids_batch` + events 9 + wiring 5 + nps 7 + bacs_api 24 + flex_routes 5)
- [x] Frontend : 24 tests verts (NpsModal 10 + utils 13 + API 1)
- [x] Ruff format/check clean · Prettier clean
- [ ] CI — Quality Gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)