### PR TITLE
fix(pilotage): M2-5.12 polish — accord singulier 'décision'/'blocage'

### DIFF
--- a/frontend/src/pages/action-center-v4/components/EditorialNarrativeBlock.jsx
+++ b/frontend/src/pages/action-center-v4/components/EditorialNarrativeBlock.jsx
@@ -95,7 +95,9 @@ export function EditorialNarrativeBlock({
           >
             {decisionsCount}
           </span>{' '}
-          {PILOTAGE_COPY.editorialDecisionsSuffix}
+          {decisionsCount > 1
+            ? PILOTAGE_COPY.editorialDecisionsSuffix
+            : PILOTAGE_COPY.editorialDecisionSuffixSingular}
           <span style={{ color: 'var(--sol-ink-700)' }}>
             {PILOTAGE_COPY.editorialDecisionsTodaySuffix}
           </span>
@@ -110,7 +112,9 @@ export function EditorialNarrativeBlock({
               >
                 {blockersCount}
               </span>{' '}
-              {PILOTAGE_COPY.editorialBlockersSuffix}
+              {blockersCount > 1
+                ? PILOTAGE_COPY.editorialBlockersSuffix
+                : PILOTAGE_COPY.editorialBlockerSuffixSingular}
             </>
           ) : (
             <span style={{ color: 'var(--sol-ink-700)' }}>{PILOTAGE_COPY.editorialNoBlockers}</span>

--- a/frontend/src/pages/action-center-v4/constants.js
+++ b/frontend/src/pages/action-center-v4/constants.js
@@ -513,8 +513,12 @@ export const PILOTAGE_COPY = {
   // count_p0 + count_p1 pour "N décisions", count_at_risk pour "N blocages",
   // qualité données pour le tag final. Sans calcul métier — composition.
   editorialDecisionsSuffix: 'décisions à traiter',
+  // M2-5.12 polish — singulier pour count ≤ 1 (français Académie : 0 et 1 prennent
+  // le singulier). Convention alignée Masthead `sitesCount > 1 ? 'SITES' : 'SITE'`.
+  editorialDecisionSuffixSingular: 'décision à traiter',
   editorialDecisionsTodaySuffix: " aujourd'hui",
   editorialBlockersSuffix: 'blocages',
+  editorialBlockerSuffixSingular: 'blocage',
   editorialNoBlockers: 'aucun blocage en cours',
   editorialDataQualityOK: 'qualité données OK',
   editorialDataQualityDegraded: 'qualité données dégradée',


### PR DESCRIPTION
## Contexte

Bug éditorial mineur repéré sur capture Marie Leclerc post-merge PR #287 :
`1 blocages` rendu au pluriel dans la phrase narrative `EditorialNarrativeBlock`.

Incohérence doctrine §5 vs Masthead qui distingue déjà `'SITE'/'SITES'` correctement.

## Fix

| Fichier | Changement |
|---|---|
| `constants.js` | Ajout `editorialDecisionSuffixSingular` + `editorialBlockerSuffixSingular` |
| `EditorialNarrativeBlock.jsx` | Ternaire `count > 1` (convention Masthead) |

**Règle Académie française** : 0 et 1 prennent le singulier (`0 décision`, `1 blocage`).

## Tests

- ✅ NarrativeBar 8/8
- ✅ ActionCenterV4PilotagePage 9/9
- ✅ action-center-v4 complet 421/421

## STOP GATE M2

Dernier polish avant clôture officielle Sprint M2 (tag `m2-sprint-5-done`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)