### PR TITLE
fix(conformite): expose framework labels and remove APER fallback

### DIFF
--- a/backend/services/compliance_score_service.py
+++ b/backend/services/compliance_score_service.py
@@ -70,6 +70,39 @@ FRAMEWORK_WEIGHTS: dict[str, float] = _scoring_cfg.get(
     },
 )
 
+# ── Labels FR canoniques des frameworks (SoT backend) ──────────────────────
+# Hotfix 2026-05-24 — ComplianceScoreHeader.jsx fallback "APER" cassait
+# l'affichage de audit_sme, iso_50001, solar_toiture (tous étiquetés "APER"
+# côté FE). Doctrine §8.1 « zero business logic frontend » : le label
+# code→FR est métier réglementaire, il doit venir du backend.
+#
+# Mapping exhaustif des frameworks V2 adaptatif (cf. _compute_v2_adaptive)
+# + BEGES (futur, déjà acronyme PROMEOS reconnu).
+# Fallback : code brut (formatFrameworkCode côté FE) pour tout framework
+# qui apparaîtrait avant son ajout ici — JAMAIS de fallback métier faux.
+FRAMEWORK_LABELS_FR: dict[str, str] = {
+    "tertiaire_operat": "Décret Tertiaire",
+    "bacs": "BACS",
+    "aper": "APER",
+    "audit_sme": "Audit SMÉ",
+    "iso_50001": "ISO 50001",
+    "solar_toiture": "Solarisation toiture",
+    "beges": "BEGES",
+}
+
+
+def get_framework_label_fr(framework_code: str) -> str:
+    """Retourne le label FR d'un framework réglementaire.
+
+    Doctrine §8.1 : le label code→FR est métier réglementaire, exposé
+    par le backend pour éviter tout mapping métier côté FE.
+
+    Si le code n'est pas dans FRAMEWORK_LABELS_FR, retourne le code brut
+    (jamais de fallback métier comme "APER" qui tromperait le DAF).
+    """
+    return FRAMEWORK_LABELS_FR.get(framework_code, framework_code)
+
+
 # ── Pénalité findings critiques ─────────────────────────────────────────────
 _crit_cfg = _scoring_cfg.get("critical_penalty", {})
 MAX_CRITICAL_PENALTY: float = float(_crit_cfg.get("max_pts", 20.0))
@@ -101,9 +134,12 @@ class ComplianceScoreResult:
     formula: str = "Moyenne pondérée (Tertiaire 45% + BACS 30% + APER 25%) − pénalité findings critiques (max −20 pts)"
 
     def to_dict(self) -> dict:
+        # Hotfix 2026-05-24 — enrichir chaque entrée breakdown avec label_fr
+        # depuis FRAMEWORK_LABELS_FR (SoT backend). Le FE consomme directement
+        # fw.label_fr et n'a plus aucun mapping métier réglementaire.
         return {
             "score": self.score,
-            "breakdown": [asdict(f) for f in self.breakdown],
+            "breakdown": [{**asdict(f), "label_fr": get_framework_label_fr(f.framework)} for f in self.breakdown],
             "critical_penalty": self.critical_penalty,
             "confidence": self.confidence,
             "frameworks_evaluated": self.frameworks_evaluated,
@@ -394,6 +430,13 @@ def compute_portfolio_compliance(db: Session, org_id: int) -> dict:
 
     breakdown_avg = {fw: round(fw_sums[fw] / fw_counts[fw], 1) for fw in fw_sums if fw_counts.get(fw, 0) > 0}
 
+    # Hotfix 2026-05-24 — ajout `breakdown_avg_labeled` liste typée avec
+    # label_fr. Le FE consomme cette liste pour rendre chaque framework.
+    # `breakdown_avg` (dict legacy) est conservé pour rétro-compatibilité.
+    breakdown_avg_labeled = [
+        {"framework": fw, "label_fr": get_framework_label_fr(fw), "score": breakdown_avg[fw]} for fw in breakdown_avg
+    ]
+
     high_conf = sum(1 for _, r in results if r.confidence == "high")
 
     return {
@@ -404,6 +447,7 @@ def compute_portfolio_compliance(db: Session, org_id: int) -> dict:
         "high_confidence_count": high_conf,
         "worst_sites": worst_sites,
         "breakdown_avg": breakdown_avg,
+        "breakdown_avg_labeled": breakdown_avg_labeled,
     }
 
 

--- a/backend/tests/test_compliance_framework_labels_hotfix.py
+++ b/backend/tests/test_compliance_framework_labels_hotfix.py
@@ -1,0 +1,256 @@
+"""
+Hotfix 2026-05-24 — Labels FR canoniques des frameworks réglementaires.
+
+Couvre :
+1. `get_framework_label_fr()` retourne le label FR pour chaque framework
+   V2 adaptatif (DT, BACS, APER, audit_sme, iso_50001, solar_toiture, beges).
+2. Un framework inconnu retourne le code brut (PAS un label métier faux
+   comme "APER" — c'était le bug pré-hotfix côté FE).
+3. `FrameworkScore.to_dict()` enrichit chaque entrée breakdown avec `label_fr`.
+4. `compute_portfolio_compliance()` retourne `breakdown_avg_labeled` (liste
+   typée) en plus de `breakdown_avg` (dict legacy rétro-compat).
+5. L'endpoint `/api/compliance/portfolio/score` expose `breakdown_avg_labeled`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from database import get_db  # noqa: E402
+from main import app  # noqa: E402
+from models import Base, EntiteJuridique, Organisation, Portefeuille, Site, TypeSite  # noqa: E402
+from services.compliance_score_service import (  # noqa: E402
+    FRAMEWORK_LABELS_FR,
+    FrameworkScore,
+    compute_portfolio_compliance,
+    get_framework_label_fr,
+)
+
+
+# ─── 1. get_framework_label_fr — exhaustivité + fallback ──────────────
+
+
+class TestGetFrameworkLabelFr:
+    """SoT backend des labels FR — pas de fallback métier faux."""
+
+    def test_tertiaire_operat(self):
+        assert get_framework_label_fr("tertiaire_operat") == "Décret Tertiaire"
+
+    def test_bacs(self):
+        assert get_framework_label_fr("bacs") == "BACS"
+
+    def test_aper(self):
+        assert get_framework_label_fr("aper") == "APER"
+
+    def test_audit_sme(self):
+        # Cœur du bug pré-hotfix : audit_sme s'affichait "APER" côté FE.
+        assert get_framework_label_fr("audit_sme") == "Audit SMÉ"
+
+    def test_iso_50001(self):
+        assert get_framework_label_fr("iso_50001") == "ISO 50001"
+
+    def test_solar_toiture(self):
+        # 2e victime du bug pré-hotfix — étiqueté "APER" alors qu'il s'agit
+        # de l'obligation de solarisation des toitures.
+        assert get_framework_label_fr("solar_toiture") == "Solarisation toiture"
+
+    def test_beges_futur(self):
+        # BEGES n'est pas encore dans V2 mais doit être couvert pour éviter
+        # une régression dès que l'évaluateur sera activé.
+        assert get_framework_label_fr("beges") == "BEGES"
+
+    def test_unknown_framework_returns_code(self):
+        # Garde-fou cardinal : un framework inconnu NE DOIT JAMAIS retourner
+        # un label métier existant (DT/BACS/APER). Il retourne le code brut.
+        result = get_framework_label_fr("framework_inexistant_2030")
+        assert result == "framework_inexistant_2030"
+        assert result != "APER"  # exactement le bug pré-hotfix
+        assert result != "BACS"
+        assert result != "Décret Tertiaire"
+
+    def test_dict_has_all_v2_frameworks(self):
+        # Les 6 frameworks de _compute_v2_adaptive + BEGES (futur) = 7.
+        expected = {
+            "tertiaire_operat",
+            "bacs",
+            "aper",
+            "audit_sme",
+            "iso_50001",
+            "solar_toiture",
+            "beges",
+        }
+        assert expected.issubset(set(FRAMEWORK_LABELS_FR.keys()))
+
+
+# ─── 2. FrameworkScore.to_dict() — label_fr injecté ──────────────────
+
+
+class TestFrameworkScoreToDict:
+    """Chaque entrée breakdown contient label_fr."""
+
+    def test_breakdown_entries_have_label_fr(self):
+        from services.compliance_score_service import ComplianceScoreResult
+
+        result = ComplianceScoreResult(
+            score=70.0,
+            breakdown=[
+                FrameworkScore(framework="audit_sme", score=0.0, weight=0.15, available=True, source="v2_adaptive"),
+                FrameworkScore(
+                    framework="solar_toiture", score=50.0, weight=0.10, available=True, source="v2_adaptive"
+                ),
+            ],
+        )
+        d = result.to_dict()
+        labels = {e["framework"]: e["label_fr"] for e in d["breakdown"]}
+        assert labels["audit_sme"] == "Audit SMÉ"
+        assert labels["solar_toiture"] == "Solarisation toiture"
+
+    def test_breakdown_preserves_score_and_weight(self):
+        from services.compliance_score_service import ComplianceScoreResult
+
+        result = ComplianceScoreResult(
+            score=42.0,
+            breakdown=[
+                FrameworkScore(framework="iso_50001", score=33.3, weight=0.25, available=True, source="v2_adaptive"),
+            ],
+        )
+        d = result.to_dict()
+        entry = d["breakdown"][0]
+        assert entry["framework"] == "iso_50001"
+        assert entry["label_fr"] == "ISO 50001"
+        assert entry["score"] == 33.3
+        assert entry["weight"] == 0.25
+
+
+# ─── 3. compute_portfolio_compliance + endpoint live ──────────────────
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def client(db):
+    def _override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _seed_org_with_site(db):
+    """Crée 1 org + 1 EJ + 1 PF + 1 site assujetti à 3 obligations
+    (suffit pour avoir un breakdown non vide)."""
+    org = Organisation(nom="Org Hotfix", siren="999999999", actif=True)
+    db.add(org)
+    db.flush()
+    ej = EntiteJuridique(organisation_id=org.id, nom="EJ", siren="999999999")
+    db.add(ej)
+    db.flush()
+    pf = Portefeuille(entite_juridique_id=ej.id, nom="PF")
+    db.add(pf)
+    db.flush()
+    site = Site(
+        portefeuille_id=pf.id,
+        nom="Site Hotfix",
+        type=TypeSite.BUREAU,
+        adresse="x",
+        code_postal="75001",
+        ville="Paris",
+        actif=True,
+        surface_m2=1500.0,  # > 1000 → DT assujetti
+        aper_assujetti=True,
+    )
+    db.add(site)
+    db.commit()
+    return org, site
+
+
+class TestPortfolioBreakdownLabeled:
+    """compute_portfolio_compliance ajoute breakdown_avg_labeled."""
+
+    def test_payload_contains_breakdown_avg_labeled(self, db):
+        org, _ = _seed_org_with_site(db)
+        result = compute_portfolio_compliance(db, org.id)
+        # Le champ existe et est une liste
+        assert "breakdown_avg_labeled" in result
+        assert isinstance(result["breakdown_avg_labeled"], list)
+        # Rétro-compat : l'ancien champ dict est conservé
+        assert "breakdown_avg" in result
+        assert isinstance(result["breakdown_avg"], dict)
+
+    def test_each_labeled_entry_has_framework_label_fr_score(self, db):
+        org, _ = _seed_org_with_site(db)
+        result = compute_portfolio_compliance(db, org.id)
+        for entry in result["breakdown_avg_labeled"]:
+            assert "framework" in entry
+            assert "label_fr" in entry
+            assert "score" in entry
+            # Le label n'est jamais vide
+            assert entry["label_fr"] and isinstance(entry["label_fr"], str)
+            # Le label correspond au mapping FRAMEWORK_LABELS_FR
+            assert entry["label_fr"] == get_framework_label_fr(entry["framework"])
+
+    def test_audit_sme_never_labeled_as_aper(self, db):
+        # Régression cardinale : si un site assujetti à audit_sme est
+        # présent, son label DOIT être "Audit SMÉ" — JAMAIS "APER".
+        org, site = _seed_org_with_site(db)
+        # Force audit_sme assujetti via models.audit_sme s'il existe
+        # (sinon le test se contente de vérifier qu'AUCUNE entrée APER
+        # n'apparaît pour un code non-aper).
+        result = compute_portfolio_compliance(db, org.id)
+        for entry in result["breakdown_avg_labeled"]:
+            if entry["framework"] != "aper":
+                assert entry["label_fr"] != "APER", f"Régression : framework={entry['framework']} étiqueté 'APER'"
+
+
+class TestPortfolioScoreEndpoint:
+    """GET /api/compliance/portfolio/score expose breakdown_avg_labeled."""
+
+    def test_endpoint_returns_breakdown_avg_labeled(self, client, db):
+        org, _ = _seed_org_with_site(db)
+        r = client.get("/api/compliance/portfolio/score", headers={"X-Org-Id": str(org.id)})
+        assert r.status_code == 200
+        body = r.json()
+        assert "breakdown_avg_labeled" in body
+        assert isinstance(body["breakdown_avg_labeled"], list)
+        # Chaque entrée a label_fr
+        for entry in body["breakdown_avg_labeled"]:
+            assert "label_fr" in entry
+            assert entry["label_fr"]  # non vide
+
+    def test_endpoint_aper_label_unique_when_only_aper(self, client, db):
+        # Anti-régression visuelle : si UN seul framework APER existe, on
+        # ne doit pas voir plusieurs labels "APER" (le bug FE pré-hotfix
+        # affichait 3 lignes APER pour aper + audit_sme + solar_toiture).
+        org, _ = _seed_org_with_site(db)
+        r = client.get("/api/compliance/portfolio/score", headers={"X-Org-Id": str(org.id)})
+        body = r.json()
+        aper_labels = [e for e in body["breakdown_avg_labeled"] if e["label_fr"] == "APER"]
+        # Au plus 1 entrée APER (puisque le mapping BE est 1:1 avec le code)
+        assert len(aper_labels) <= 1

--- a/docs/audits/audit_postfix_hotfix_conformite_framework_labels_2026_05_24.md
+++ b/docs/audits/audit_postfix_hotfix_conformite_framework_labels_2026_05_24.md
@@ -1,0 +1,152 @@
+# Audit postfix — Hotfix labels frameworks réglementaires (2026-05-25)
+
+**Branche** : `claude/hotfix-conformite-framework-labels`
+**Base** : `claude/refonte-sol2` (post merge #296+#297+#298+#299+#300)
+**Verdict** : 🟢 **GO** — 11/11 contrôles hotfix verts (1 endpoint 500 hors scope sur `/api/kb/apply`)
+
+## Contexte du bug
+
+Capture utilisateur (avant fix) : **3 lignes APER** dans le bloc « Score conformité » de `/conformite` alors qu'il n'y a qu'une obligation APER.
+
+```
+Décret Tertiaire ──────────── 70
+BACS ──────────────────────── 70
+APER ──────────  50        ← vrai APER
+APER                    0   ← en fait audit_sme (étiqueté APER par bug FE)
+APER                    0   ← en fait solar_toiture (étiqueté APER par bug FE)
+```
+
+### Cause racine
+
+[ComplianceScoreHeader.jsx:94-99](../../frontend/src/components/conformite/ComplianceScoreHeader.jsx#L94-L99) (pré-hotfix) utilisait un mapping ternaire avec **fallback métier faux** :
+
+```js
+const fwCode =
+  fw.framework === 'tertiaire_operat' ? 'Décret Tertiaire'
+  : fw.framework === 'bacs' ? 'BACS'
+  : 'APER';   // ← tout framework non-DT/non-BACS étiqueté "APER"
+```
+
+Le backend `_compute_v2_adaptive()` ([compliance_score_service.py:739-842](../../backend/services/compliance_score_service.py#L739-L842)) (Sprint C-1 V2) émet jusqu'à 7 frameworks : `tertiaire_operat`, `bacs`, `aper`, `audit_sme`, `iso_50001`, `solar_toiture`, `beges`. Le FE n'en mappait que 3 — les 4 autres devenaient "APER".
+
+**Doctrine §8.1 violée** : zero business logic frontend. Le mapping code→label est métier réglementaire et doit venir du backend.
+
+## Chantiers livrés (6/6)
+
+| # | Chantier | Fichier(s) clé(s) |
+|---|---|---|
+| C1 | Backend : `FRAMEWORK_LABELS_FR` (SoT) + `get_framework_label_fr()` + `label_fr` injecté dans `FrameworkScore.to_dict()` + `breakdown_avg_labeled[]` ajouté au portfolio | [compliance_score_service.py:73-105, 113-127, 405-413](../../backend/services/compliance_score_service.py) |
+| C2 | Frontend : suppression fallback `: 'APER'`, ajout `formatFrameworkCode()` neutre + utilisation `fw.label_fr` | [ComplianceScoreHeader.jsx](../../frontend/src/components/conformite/ComplianceScoreHeader.jsx) |
+| C3 | Source-guard test interdisant pattern `: 'APER'` + vérification SoT backend exhaustive (7 frameworks) | [conformite_framework_labels_hotfix.test.js](../../frontend/src/__tests__/source_guards/conformite_framework_labels_hotfix.test.js) — 7 tests ✅ |
+| C4 | Tests backend (`label_fr` exhaustif pour les 7 frameworks + fallback code brut pour inconnu + portfolio + endpoint live) | [test_compliance_framework_labels_hotfix.py](../../backend/tests/test_compliance_framework_labels_hotfix.py) — 16 tests ✅ |
+| C5 | Tests frontend (render Audit SMÉ / Solarisation toiture / ISO 50001 / BEGES + APER unique + fallback legacy) | [ComplianceScoreHeader_framework_labels.test.jsx](../../frontend/src/components/conformite/__tests__/ComplianceScoreHeader_framework_labels.test.jsx) — 9 tests ✅ |
+| C6 | Audit Playwright postfix (ce document + script) | [audit_postfix_hotfix_framework_labels.mjs](../../scripts/audit_postfix_hotfix_framework_labels.mjs) — 11/11 verts hotfix |
+
+## Mapping FR canonique (SoT backend)
+
+```python
+FRAMEWORK_LABELS_FR: dict[str, str] = {
+    "tertiaire_operat": "Décret Tertiaire",
+    "bacs": "BACS",
+    "aper": "APER",
+    "audit_sme": "Audit SMÉ",
+    "iso_50001": "ISO 50001",
+    "solar_toiture": "Solarisation toiture",
+    "beges": "BEGES",
+}
+```
+
+Frameworks inconnus → `formatFrameworkCode(code)` côté FE (humanisation neutre : `new_obligation_2027` → `New Obligation 2027`). **Jamais de fallback "APER"**.
+
+## Avant / Après — capture HELIOS portfolio
+
+### Backend `/api/compliance/portfolio/score` (avant)
+```json
+{
+  "breakdown_avg": {
+    "tertiaire_operat": 70.0,
+    "bacs": 70.0,
+    "aper": 50.0,
+    "audit_sme": 0.0,
+    "solar_toiture": 0.0
+  }
+}
+```
+
+### Backend (après hotfix — rétro-compat preservée)
+```json
+{
+  "breakdown_avg": { ... identique ... },
+  "breakdown_avg_labeled": [
+    { "framework": "tertiaire_operat", "label_fr": "Décret Tertiaire", "score": 70.0 },
+    { "framework": "bacs",             "label_fr": "BACS",             "score": 70.0 },
+    { "framework": "aper",             "label_fr": "APER",             "score": 50.0 },
+    { "framework": "audit_sme",        "label_fr": "Audit SMÉ",        "score": 0.0  },
+    { "framework": "solar_toiture",    "label_fr": "Solarisation toiture", "score": 0.0  }
+  ]
+}
+```
+
+### Frontend rendu (après hotfix)
+```
+Décret Tertiaire ──────────── 70
+BACS ──────────────────────── 70
+APER ──────────  50
+Audit SMÉ                  0
+Solarisation toiture       0
+```
+
+APER apparaît **une seule fois**. Plus aucune ambiguïté pour le DAF.
+
+## Tests
+
+| Suite | Avant | Après | Δ |
+|---|---|---|---|
+| Source-guard `conformite_framework_labels_hotfix.test.js` (NEW) | — | 7 ✓ | +7 |
+| BE `test_compliance_framework_labels_hotfix.py` (NEW) | — | 16 ✓ | +16 |
+| FE `ComplianceScoreHeader_framework_labels.test.jsx` (NEW) | — | 9 ✓ | +9 |
+| **Total nouveaux verts** | — | **32** | **+32** |
+| Suite FE complète (non-régression) | 5302 ✓ + 3 fails | 5325 ✓ + 3 fails | 0 régression (les 3 fails sont pré-existants : CompliancePage.jsx not found, taxes_mismatch CSPE) |
+| Suite BE billing+cockpit+compliance hotfix | — | **595 ✓** + 7 pré-existants (`test_billing_v68` PDF/shadow) | 0 régression |
+
+## Audit Playwright postfix (11/11 verts hotfix)
+
+```
+✅ Backend /api/compliance/portfolio/score → 200
+✅ portfolio expose breakdown_avg_labeled (liste typée)
+✅ chaque breakdown_avg_labeled.label_fr est non-vide (0 manquant)
+✅ audit_sme → label_fr="Audit SMÉ"
+✅ solar_toiture → label_fr="Solarisation toiture"
+✅ Backend /api/compliance/sites/1/score → 200
+✅ chaque site breakdown[].label_fr est non-vide (0 manquant sur 5)
+✅ 5 lignes breakdown affichées (>= 3 attendu)
+✅ audit_sme rendu : "Audit SMÉ"
+✅ solar_toiture rendu : "Solarisation toiture"
+✅ APER apparaît au plus 1 fois (compté 1)
+⚠️  1 endpoint 500 hors scope : /api/kb/apply (problème pré-existant KB, sans lien avec le hotfix)
+```
+
+## Critères d'acceptation (8/8 ✅)
+
+| # | Critère | État |
+|---|---|---|
+| 1 | Plus aucune répétition APER injustifiée | ✅ |
+| 2 | audit_sme affiche "Audit SMÉ" | ✅ |
+| 3 | solar_toiture affiche "Solarisation toiture" | ✅ |
+| 4 | iso_50001 affiche "ISO 50001" | ✅ (testé render FE) |
+| 5 | beges futur est couvert | ✅ (FRAMEWORK_LABELS_FR + tests FE/BE) |
+| 6 | Aucun mapping métier dur dans ComplianceScoreHeader | ✅ (source-guard 7/7) |
+| 7 | Tests nouveaux verts | ✅ (32 tests) |
+| 8 | Non-régression Conformité, Cockpit, Patrimoine | ✅ (FE 5325 + BE 595 verts, 0 régression hotfix) |
+
+## Doctrine respectée
+
+- ✅ Zero business logic frontend (§8.1) : le mapping est dans le backend, le FE ne fait que rendre `fw.label_fr`
+- ✅ Aucun fallback métier faux (formatFrameworkCode humanise sans introduire de label réglementaire)
+- ✅ Aucun nouveau menu, aucun écran fantôme
+- ✅ Français clair (Audit SMÉ avec accent, Solarisation toiture, ISO 50001)
+- ✅ Tests obligatoires (16 BE + 9 FE render + 7 source-guard)
+
+## Verdict
+
+🟢 **GO** — le bug visuel signalé (3 lignes APER) est intégralement corrigé. Le mapping est maintenant centralisé backend, futur-proof pour BEGES et tout nouveau framework v2 (il suffit d'ajouter une ligne à `FRAMEWORK_LABELS_FR` sans toucher le FE).

--- a/frontend/src/__tests__/source_guards/conformite_framework_labels_hotfix.test.js
+++ b/frontend/src/__tests__/source_guards/conformite_framework_labels_hotfix.test.js
@@ -1,0 +1,104 @@
+/**
+ * Source-guard hotfix 2026-05-24 — labels frameworks réglementaires.
+ *
+ * Garde-fou cardinal : ComplianceScoreHeader.jsx ne doit plus contenir
+ * de fallback métier `: 'APER'` (bug pré-hotfix qui étiquetait audit_sme,
+ * iso_50001, solar_toiture, beges comme APER).
+ *
+ * Doctrine §8.1 « zero business logic frontend » : le label code→FR est
+ * métier réglementaire et doit venir du backend (`fw.label_fr`,
+ * FRAMEWORK_LABELS_FR dans compliance_score_service.py).
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const ROOT = resolve(__dirname, '../../../');
+const COMPONENT = resolve(ROOT, 'src/components/conformite/ComplianceScoreHeader.jsx');
+const BACKEND_SERVICE = resolve(ROOT, '../backend/services/compliance_score_service.py');
+
+/** Enleve commentaires JS pour éviter faux positifs sur la justification du fix. */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('ComplianceScoreHeader — anti-régression mapping fallback APER', () => {
+  const src = readFileSync(COMPONENT, 'utf-8');
+  const cleaned = stripComments(src);
+
+  it("ne contient PLUS de fallback ternaire `: 'APER'` (bug pré-hotfix)", () => {
+    // Match : `: 'APER'` ou `: "APER"` à la fin d'un ternaire (fallback).
+    expect(cleaned).not.toMatch(/:\s*['"]APER['"]\s*[,;)]/);
+    // Match : `? 'BACS' : 'APER'` (ancien pattern du bug)
+    expect(cleaned).not.toMatch(/['"]BACS['"]\s*\n?\s*:\s*['"]APER['"]/);
+  });
+
+  it('ne contient PLUS de mapping ternaire framework→label (logique métier interdite)', () => {
+    // Pattern interdit : `framework === 'X' ? 'LabelA' : ...`
+    // (le mapping doit venir du backend `fw.label_fr`)
+    expect(cleaned).not.toMatch(/framework\s*===\s*['"]tertiaire_operat['"]\s*\?\s*['"]/);
+    expect(cleaned).not.toMatch(/fw\s*===\s*['"]tertiaire_operat['"]\s*\?\s*['"]/);
+  });
+
+  it('utilise fw.label_fr (label venant du backend)', () => {
+    expect(cleaned).toMatch(/fw\.label_fr/);
+  });
+
+  it('définit un fallback NEUTRE `formatFrameworkCode` (sans logique métier)', () => {
+    expect(cleaned).toMatch(/formatFrameworkCode/);
+    // Le fallback doit s'appliquer aux deux blocs (breakdown + breakdown_avg)
+    const matches = cleaned.match(/formatFrameworkCode\(fw\.framework\)/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('formatFrameworkCode ne retourne JAMAIS un label métier hardcodé', () => {
+    // Garde-fou : la fonction de format ne doit faire que du formatage
+    // typographique (replace _, capitalize) — pas de mapping métier.
+    const fnMatch = cleaned.match(/function formatFrameworkCode\([^)]*\)\s*\{([\s\S]*?)^\}/m);
+    expect(fnMatch).not.toBeNull();
+    const body = fnMatch[1];
+    expect(body).not.toMatch(/['"]Décret Tertiaire['"]/);
+    expect(body).not.toMatch(/['"]BACS['"]/);
+    expect(body).not.toMatch(/['"]APER['"]/);
+    expect(body).not.toMatch(/['"]Audit SM/);
+    expect(body).not.toMatch(/['"]ISO 50001['"]/);
+    expect(body).not.toMatch(/['"]BEGES['"]/);
+  });
+});
+
+describe('Backend FRAMEWORK_LABELS_FR — SoT exhaustivité', () => {
+  // On lit le service backend en clair pour vérifier que tous les codes
+  // émis par _compute_v2_adaptive ont bien un label FR.
+  let backendSrc = '';
+  try {
+    backendSrc = readFileSync(BACKEND_SERVICE, 'utf-8');
+  } catch {
+    // Si le backend n'est pas accessible depuis le contexte FE tests,
+    // on skip ce describe (sera couvert par les tests backend).
+  }
+
+  it('FRAMEWORK_LABELS_FR contient les 7 frameworks attendus', () => {
+    if (!backendSrc) return;
+    expect(backendSrc).toMatch(/FRAMEWORK_LABELS_FR/);
+    for (const code of [
+      'tertiaire_operat',
+      'bacs',
+      'aper',
+      'audit_sme',
+      'iso_50001',
+      'solar_toiture',
+      'beges',
+    ]) {
+      expect(backendSrc).toMatch(new RegExp(`["']${code}["']\\s*:`));
+    }
+  });
+
+  it('aucun code framework V2 sans label_fr (audit_sme, iso_50001, solar_toiture)', () => {
+    if (!backendSrc) return;
+    // Ces 3 codes étaient le cœur du bug : ils doivent maintenant avoir
+    // un label_fr explicite dans FRAMEWORK_LABELS_FR.
+    expect(backendSrc).toMatch(/["']audit_sme["']\s*:\s*["']Audit SMÉ["']/);
+    expect(backendSrc).toMatch(/["']iso_50001["']\s*:\s*["']ISO 50001["']/);
+    expect(backendSrc).toMatch(/["']solar_toiture["']\s*:\s*["']Solarisation toiture["']/);
+  });
+});

--- a/frontend/src/components/conformite/ComplianceScoreHeader.jsx
+++ b/frontend/src/components/conformite/ComplianceScoreHeader.jsx
@@ -1,5 +1,18 @@
 /**
  * ComplianceScoreHeader — Unified compliance score display with breakdown bars.
+ *
+ * Hotfix 2026-05-24 — Bug cardinal corrigé : le mapping ternaire
+ *   fw.framework === 'tertiaire_operat' ? 'Décret Tertiaire'
+ *   : fw.framework === 'bacs' ? 'BACS'
+ *   : 'APER'
+ * étiquetait audit_sme, iso_50001, solar_toiture, beges comme "APER" → 3
+ * lignes APER visibles côté DAF alors qu'il n'y a qu'une obligation APER.
+ *
+ * Doctrine §8.1 « zero business logic frontend » : le label code→FR est
+ * métier réglementaire, fourni par le backend via `label_fr`
+ * (FRAMEWORK_LABELS_FR dans compliance_score_service.py). Fallback FE =
+ * `formatFrameworkCode(fw.framework)` (code brut humanisé) — JAMAIS un
+ * label métier faux.
  */
 import { getComplianceScoreColor, COMPLIANCE_SCORE_THRESHOLDS } from '../../lib/constants';
 import { CONFIDENCE_DATA_LABELS } from '../../domain/compliance/complianceLabels.fr';
@@ -10,6 +23,18 @@ import {
 import NonApplicableLabel from '../NonApplicableLabel';
 import { Explain } from '../../ui';
 import SolAcronym from '../../ui/sol/SolAcronym';
+
+/**
+ * Fallback purement présentation : transforme un code framework brut
+ * (ex: `solar_toiture`) en label humainement lisible (`Solar toiture`)
+ * sans aucune connaissance métier. Utilisé UNIQUEMENT si le backend
+ * n'a pas fourni `label_fr` — ne doit jamais retourner un label métier
+ * existant (DT/BACS/APER/SMÉ/...) sous peine de tromper le lecteur.
+ */
+function formatFrameworkCode(code) {
+  if (!code || typeof code !== 'string') return '—';
+  return code.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 export default function ComplianceScoreHeader({ complianceScore, segProfile }) {
   if (!complianceScore) return null;
@@ -88,21 +113,22 @@ export default function ComplianceScoreHeader({ complianceScore, segProfile }) {
             </>
           )}
         </div>
-        {/* Breakdown bars */}
+        {/* Breakdown bars — site detail (breakdown[]) ou portfolio
+            (breakdown_avg_labeled[]). Les deux exposent `label_fr` depuis
+            le backend (FRAMEWORK_LABELS_FR). Fallback FE =
+            formatFrameworkCode (jamais un label métier faux). */}
         <div className="flex-1 space-y-2">
           {(complianceScore.breakdown || []).map((fw) => {
-            const fwCode =
-              fw.framework === 'tertiaire_operat'
-                ? 'Décret Tertiaire'
-                : fw.framework === 'bacs'
-                  ? 'BACS'
-                  : 'APER';
+            const fwLabel = fw.label_fr || formatFrameworkCode(fw.framework);
             const weightPct = fw.weight != null ? `${Math.round(fw.weight * 100)}%` : '';
             const isAvailable = fw.available !== false && fw.source !== 'default';
             return (
               <div key={fw.framework} className="flex items-center gap-2">
-                <span className="text-xs text-gray-500 w-36 truncate">
-                  <SolAcronym code={fwCode} />
+                <span
+                  className="text-xs text-gray-500 w-36 truncate"
+                  data-testid={`framework-label-${fw.framework}`}
+                >
+                  <SolAcronym code={fwLabel} />
                   {weightPct && isAvailable ? ` (${weightPct})` : ''}
                 </span>
                 {isAvailable ? (
@@ -125,27 +151,38 @@ export default function ComplianceScoreHeader({ complianceScore, segProfile }) {
               </div>
             );
           })}
-          {/* Fallback: show breakdown_avg from portfolio if no breakdown */}
+          {/* Portfolio scope : utilise breakdown_avg_labeled (liste typée
+              avec label_fr). Fallback sur l'ancien breakdown_avg (dict)
+              uniquement si le BE n'a pas encore migré — sans mapping métier
+              FE, on rend formatFrameworkCode(code) pour les codes inconnus. */}
           {!complianceScore.breakdown &&
-            complianceScore.breakdown_avg &&
-            Object.entries(complianceScore.breakdown_avg).map(([fw, score]) => {
-              const fwCode =
-                fw === 'tertiaire_operat' ? 'Décret Tertiaire' : fw === 'bacs' ? 'BACS' : 'APER';
+            (
+              complianceScore.breakdown_avg_labeled ||
+              Object.entries(complianceScore.breakdown_avg || {}).map(([framework, score]) => ({
+                framework,
+                label_fr: null,
+                score,
+              }))
+            ).map((fw) => {
+              const fwLabel = fw.label_fr || formatFrameworkCode(fw.framework);
               return (
-                <div key={fw} className="flex items-center gap-2">
-                  <span className="text-xs text-gray-500 w-36 truncate">
-                    <SolAcronym code={fwCode} />
+                <div key={fw.framework} className="flex items-center gap-2">
+                  <span
+                    className="text-xs text-gray-500 w-36 truncate"
+                    data-testid={`framework-label-${fw.framework}`}
+                  >
+                    <SolAcronym code={fwLabel} />
                   </span>
                   <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
                     <div
-                      className={`h-full rounded-full ${score >= COMPLIANCE_SCORE_THRESHOLDS.ok ? 'bg-green-500' : score >= COMPLIANCE_SCORE_THRESHOLDS.warn ? 'bg-amber-500' : 'bg-red-500'}`}
-                      style={{ width: `${Math.min(100, score)}%` }}
+                      className={`h-full rounded-full ${fw.score >= COMPLIANCE_SCORE_THRESHOLDS.ok ? 'bg-green-500' : fw.score >= COMPLIANCE_SCORE_THRESHOLDS.warn ? 'bg-amber-500' : 'bg-red-500'}`}
+                      style={{ width: `${Math.min(100, fw.score)}%` }}
                     />
                   </div>
                   <span
-                    className={`text-xs font-semibold w-10 text-right ${getComplianceScoreColor(score)}`}
+                    className={`text-xs font-semibold w-10 text-right ${getComplianceScoreColor(fw.score)}`}
                   >
-                    {Math.round(score)}
+                    {Math.round(fw.score)}
                   </span>
                 </div>
               );

--- a/frontend/src/components/conformite/__tests__/ComplianceScoreHeader_framework_labels.test.jsx
+++ b/frontend/src/components/conformite/__tests__/ComplianceScoreHeader_framework_labels.test.jsx
@@ -1,0 +1,295 @@
+// @vitest-environment jsdom
+/**
+ * Hotfix 2026-05-24 — ComplianceScoreHeader rend les labels FR depuis
+ * `fw.label_fr` (backend) sans aucun mapping métier côté FE.
+ *
+ * Bug pré-hotfix : fallback ternaire `: 'APER'` étiquetait audit_sme,
+ * iso_50001, solar_toiture, beges comme APER → 3 lignes APER côté DAF.
+ *
+ * Tests render (jsdom) — vérifient le DOM réel produit.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+
+import ComplianceScoreHeader from '../ComplianceScoreHeader';
+
+afterEach(() => cleanup());
+
+describe('ComplianceScoreHeader — labels FR canoniques depuis backend', () => {
+  const baseScore = {
+    score: 36,
+    confidence: 'medium',
+    frameworks_evaluated: 5,
+    frameworks_total: 5,
+  };
+
+  describe('Site scope (breakdown[])', () => {
+    it('rend "Décret Tertiaire" pour tertiaire_operat', () => {
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            breakdown: [
+              {
+                framework: 'tertiaire_operat',
+                label_fr: 'Décret Tertiaire',
+                score: 70,
+                weight: 0.45,
+                available: true,
+                source: 'v2_adaptive',
+              },
+            ],
+          }}
+        />
+      );
+      expect(screen.getByTestId('framework-label-tertiaire_operat')).toHaveTextContent(
+        'Décret Tertiaire'
+      );
+    });
+
+    it('rend "Audit SMÉ" pour audit_sme (régression cardinale pré-hotfix)', () => {
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            breakdown: [
+              {
+                framework: 'audit_sme',
+                label_fr: 'Audit SMÉ',
+                score: 0,
+                weight: 0.15,
+                available: true,
+                source: 'v2_adaptive',
+              },
+            ],
+          }}
+        />
+      );
+      const cell = screen.getByTestId('framework-label-audit_sme');
+      expect(cell).toHaveTextContent('Audit SMÉ');
+      expect(cell).not.toHaveTextContent(/^APER$/);
+    });
+
+    it('rend "Solarisation toiture" pour solar_toiture', () => {
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            breakdown: [
+              {
+                framework: 'solar_toiture',
+                label_fr: 'Solarisation toiture',
+                score: 0,
+                weight: 0.1,
+                available: true,
+                source: 'v2_adaptive',
+              },
+            ],
+          }}
+        />
+      );
+      const cell = screen.getByTestId('framework-label-solar_toiture');
+      expect(cell).toHaveTextContent('Solarisation toiture');
+      expect(cell).not.toHaveTextContent(/^APER$/);
+    });
+
+    it('rend "ISO 50001" pour iso_50001', () => {
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            breakdown: [
+              {
+                framework: 'iso_50001',
+                label_fr: 'ISO 50001',
+                score: 50,
+                weight: 0.2,
+                available: true,
+                source: 'v2_adaptive',
+              },
+            ],
+          }}
+        />
+      );
+      expect(screen.getByTestId('framework-label-iso_50001')).toHaveTextContent('ISO 50001');
+    });
+
+    it('rend "BEGES" pour beges (futur)', () => {
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            breakdown: [
+              {
+                framework: 'beges',
+                label_fr: 'BEGES',
+                score: 80,
+                weight: 0.1,
+                available: true,
+                source: 'v2_adaptive',
+              },
+            ],
+          }}
+        />
+      );
+      expect(screen.getByTestId('framework-label-beges')).toHaveTextContent('BEGES');
+    });
+
+    it('rend formatFrameworkCode (humanisé neutre) si label_fr absent', () => {
+      // Cas hypothétique : un nouveau framework backend pas encore mappé.
+      // Le FE ne doit JAMAIS fallback sur "APER".
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            breakdown: [
+              {
+                framework: 'new_obligation_2027',
+                score: 42,
+                weight: 0.1,
+                available: true,
+                source: 'v2_adaptive',
+              },
+              // label_fr omis volontairement
+            ],
+          }}
+        />
+      );
+      const cell = screen.getByTestId('framework-label-new_obligation_2027');
+      expect(cell).toHaveTextContent('New Obligation 2027');
+      expect(cell).not.toHaveTextContent(/APER/);
+    });
+
+    it('APER apparaît UNE SEULE fois quand un seul framework aper est présent (anti-régression bug 3 lignes)', () => {
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            breakdown: [
+              {
+                framework: 'tertiaire_operat',
+                label_fr: 'Décret Tertiaire',
+                score: 70,
+                weight: 0.45,
+                available: true,
+                source: 'v2_adaptive',
+              },
+              {
+                framework: 'bacs',
+                label_fr: 'BACS',
+                score: 70,
+                weight: 0.3,
+                available: true,
+                source: 'v2_adaptive',
+              },
+              {
+                framework: 'aper',
+                label_fr: 'APER',
+                score: 50,
+                weight: 0.25,
+                available: true,
+                source: 'v2_adaptive',
+              },
+              {
+                framework: 'audit_sme',
+                label_fr: 'Audit SMÉ',
+                score: 0,
+                weight: 0.1,
+                available: true,
+                source: 'v2_adaptive',
+              },
+              {
+                framework: 'solar_toiture',
+                label_fr: 'Solarisation toiture',
+                score: 0,
+                weight: 0.1,
+                available: true,
+                source: 'v2_adaptive',
+              },
+            ],
+          }}
+        />
+      );
+      // 5 lignes, 5 labels distincts, et "APER" seulement 1 fois.
+      expect(screen.getByTestId('framework-label-tertiaire_operat')).toBeInTheDocument();
+      expect(screen.getByTestId('framework-label-bacs')).toBeInTheDocument();
+      expect(screen.getByTestId('framework-label-aper')).toHaveTextContent(/^APER\b/);
+      expect(screen.getByTestId('framework-label-audit_sme')).toHaveTextContent('Audit SMÉ');
+      expect(screen.getByTestId('framework-label-solar_toiture')).toHaveTextContent(
+        'Solarisation toiture'
+      );
+
+      // Comptage APER : strict — chercher TOUS les éléments dont le texte
+      // contient exactement "APER" comme mot isolé dans la colonne label.
+      const allLabelCells = document.querySelectorAll('[data-testid^="framework-label-"]');
+      let aperCount = 0;
+      allLabelCells.forEach((el) => {
+        if (
+          /\bAPER\b/.test(el.textContent) &&
+          !/Décret|BACS|Audit|Solarisation|ISO/.test(el.textContent)
+        ) {
+          aperCount += 1;
+        }
+      });
+      expect(aperCount).toBe(1);
+    });
+  });
+
+  describe('Portfolio scope (breakdown_avg_labeled[])', () => {
+    it('itère sur breakdown_avg_labeled si breakdown absent', () => {
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            // pas de breakdown[] (portfolio scope)
+            breakdown_avg_labeled: [
+              { framework: 'tertiaire_operat', label_fr: 'Décret Tertiaire', score: 70 },
+              { framework: 'bacs', label_fr: 'BACS', score: 70 },
+              { framework: 'aper', label_fr: 'APER', score: 50 },
+              { framework: 'audit_sme', label_fr: 'Audit SMÉ', score: 0 },
+              { framework: 'solar_toiture', label_fr: 'Solarisation toiture', score: 0 },
+            ],
+          }}
+        />
+      );
+      // Tous les labels portfolios doivent être rendus distinctement.
+      expect(screen.getByTestId('framework-label-audit_sme')).toHaveTextContent('Audit SMÉ');
+      expect(screen.getByTestId('framework-label-solar_toiture')).toHaveTextContent(
+        'Solarisation toiture'
+      );
+      // L'ancien bug visible : 3 lignes APER. Ici on doit en avoir 1 max.
+      const aperOnly = screen
+        .getAllByTestId(/^framework-label-/)
+        .filter(
+          (el) => /\bAPER\b/.test(el.textContent) && !/Audit|Solarisation/.test(el.textContent)
+        );
+      expect(aperOnly.length).toBe(1);
+    });
+
+    it('fallback sur breakdown_avg legacy (dict) avec formatFrameworkCode si pas de label_fr', () => {
+      // Rétro-compat : un payload BE legacy (pré-hotfix) avec breakdown_avg
+      // sans label_fr — le FE ne doit JAMAIS rendre "APER" pour audit_sme.
+      render(
+        <ComplianceScoreHeader
+          complianceScore={{
+            ...baseScore,
+            breakdown_avg: {
+              tertiaire_operat: 70,
+              bacs: 70,
+              aper: 50,
+              audit_sme: 0,
+              solar_toiture: 0,
+            },
+          }}
+        />
+      );
+      const auditSme = screen.getByTestId('framework-label-audit_sme');
+      expect(auditSme).toHaveTextContent('Audit Sme'); // formatFrameworkCode neutre
+      expect(auditSme).not.toHaveTextContent(/^APER$/);
+      const solar = screen.getByTestId('framework-label-solar_toiture');
+      expect(solar).toHaveTextContent('Solar Toiture');
+      expect(solar).not.toHaveTextContent(/^APER$/);
+    });
+  });
+});

--- a/scripts/audit_postfix_hotfix_framework_labels.mjs
+++ b/scripts/audit_postfix_hotfix_framework_labels.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Audit postfix — Hotfix labels frameworks réglementaires (2026-05-24).
+ *
+ * Vérifie en bout-en-bout :
+ * 1. /api/compliance/portfolio/score retourne breakdown_avg_labeled avec label_fr.
+ * 2. /api/compliance/sites/{id}/score retourne breakdown[] avec label_fr.
+ * 3. /conformite affiche "Audit SMÉ" et "Solarisation toiture" (pas "APER").
+ * 4. APER n'apparaît qu'UNE seule fois.
+ * 5. 0 console error, 0 network 5xx.
+ */
+import { chromium } from 'playwright';
+
+const FE = process.env.FE || 'http://localhost:5175';
+const BE = process.env.BE || 'http://localhost:8001';
+const results = [];
+let exitCode = 0;
+
+function record(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  if (!ok) exitCode = 1;
+  console.log(`${ok ? '✅' : '❌'} ${name}${detail ? ' — ' + detail : ''}`);
+}
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+const page = await ctx.newPage();
+
+const consoleErrors = [];
+const networkFailures = [];
+page.on('console', (m) => {
+  if (m.type() === 'error') consoleErrors.push(m.text());
+});
+page.on('response', (r) => {
+  const s = r.status();
+  if (s >= 400 && s < 600) networkFailures.push(`${s} ${r.url()}`);
+});
+
+try {
+  // ─── 1. Login + curl portfolio ───────────────────────────────────
+  const loginRes = await page.request.post(`${FE}/api/auth/demo-login`);
+  const loginData = await loginRes.json();
+  const token = loginData.access_token;
+
+  const portfolioRes = await page.request.get(`${BE}/api/compliance/portfolio/score`, {
+    headers: { Authorization: `Bearer ${token}`, 'X-Org-Id': '1' },
+  });
+  record(`Backend /api/compliance/portfolio/score → ${portfolioRes.status()}`, portfolioRes.status() === 200);
+  const portfolioPayload = await portfolioRes.json();
+  record(
+    'portfolio expose breakdown_avg_labeled (liste typée)',
+    Array.isArray(portfolioPayload.breakdown_avg_labeled)
+  );
+  // Chaque entrée a label_fr non vide
+  const portfolioMissing = (portfolioPayload.breakdown_avg_labeled || []).filter(
+    (e) => !e.label_fr || typeof e.label_fr !== 'string'
+  );
+  record(
+    `chaque breakdown_avg_labeled.label_fr est non-vide (${portfolioMissing.length} manquant)`,
+    portfolioMissing.length === 0
+  );
+  // Mapping correct pour audit_sme + solar_toiture (cœur du bug)
+  const auditSme = (portfolioPayload.breakdown_avg_labeled || []).find(
+    (e) => e.framework === 'audit_sme'
+  );
+  if (auditSme) {
+    record(
+      `audit_sme → label_fr="${auditSme.label_fr}"`,
+      auditSme.label_fr === 'Audit SMÉ'
+    );
+  } else {
+    record('audit_sme absent du portfolio HELIOS (skip)', true, 'pas de site assujetti');
+  }
+  const solarToiture = (portfolioPayload.breakdown_avg_labeled || []).find(
+    (e) => e.framework === 'solar_toiture'
+  );
+  if (solarToiture) {
+    record(
+      `solar_toiture → label_fr="${solarToiture.label_fr}"`,
+      solarToiture.label_fr === 'Solarisation toiture'
+    );
+  }
+
+  // ─── 2. Curl site detail ────────────────────────────────────────
+  // Récupérer le 1er site du portfolio
+  const sitesRes = await page.request.get(`${BE}/api/patrimoine/sites?limit=1`, {
+    headers: { Authorization: `Bearer ${token}`, 'X-Org-Id': '1' },
+  });
+  const sitesData = await sitesRes.json();
+  const firstSiteId =
+    sitesData?.sites?.[0]?.id ?? sitesData?.items?.[0]?.id ?? sitesData?.[0]?.id ?? null;
+  if (firstSiteId) {
+    const siteScoreRes = await page.request.get(
+      `${BE}/api/compliance/sites/${firstSiteId}/score`,
+      { headers: { Authorization: `Bearer ${token}`, 'X-Org-Id': '1' } }
+    );
+    record(`Backend /api/compliance/sites/${firstSiteId}/score → ${siteScoreRes.status()}`, siteScoreRes.status() === 200);
+    const sitePayload = await siteScoreRes.json();
+    const breakdown = sitePayload.breakdown || [];
+    const siteMissing = breakdown.filter((e) => !e.label_fr);
+    record(
+      `chaque site breakdown[].label_fr est non-vide (${siteMissing.length} manquant sur ${breakdown.length})`,
+      siteMissing.length === 0 && breakdown.length > 0
+    );
+  }
+
+  // ─── 3. Playwright /conformite — rendu visuel ────────────────────
+  await page.goto(`${FE}/login`, { waitUntil: 'domcontentloaded' });
+  await page.evaluate((t) => localStorage.setItem('promeos_token', t), token);
+
+  await page.goto(`${FE}/conformite`, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.waitForTimeout(3000);
+
+  // Le composant rend des spans avec data-testid="framework-label-<code>"
+  const labelCells = await page.locator('[data-testid^="framework-label-"]').all();
+  record(
+    `${labelCells.length} ligne(s) breakdown affichée(s) (>= 3 attendu)`,
+    labelCells.length >= 3
+  );
+
+  const labelMap = {};
+  for (const cell of labelCells) {
+    const tid = await cell.getAttribute('data-testid');
+    const code = tid?.replace('framework-label-', '') || 'unknown';
+    const text = (await cell.textContent())?.trim() || '';
+    labelMap[code] = text;
+  }
+  console.log('Labels rendus :', JSON.stringify(labelMap, null, 2));
+
+  // 4. audit_sme s'affiche "Audit SMÉ" (PAS "APER")
+  if (labelMap.audit_sme !== undefined) {
+    record(
+      `audit_sme rendu : "${labelMap.audit_sme}"`,
+      /Audit SMÉ/.test(labelMap.audit_sme) && !/^APER\b/.test(labelMap.audit_sme)
+    );
+  }
+  // 5. solar_toiture s'affiche "Solarisation toiture"
+  if (labelMap.solar_toiture !== undefined) {
+    record(
+      `solar_toiture rendu : "${labelMap.solar_toiture}"`,
+      /Solarisation/.test(labelMap.solar_toiture) && !/^APER\b/.test(labelMap.solar_toiture)
+    );
+  }
+  // 6. APER apparaît au plus 1 fois (anti-régression bug 3 lignes APER)
+  const aperLines = Object.entries(labelMap).filter(([code, text]) =>
+    /\bAPER\b/.test(text) && !/Audit|Solarisation|ISO/.test(text)
+  );
+  record(
+    `APER apparaît au plus 1 fois (compté ${aperLines.length})`,
+    aperLines.length <= 1
+  );
+
+  // ─── 7. Console + Network ───────────────────────────────────────
+  const blockingErrors = consoleErrors.filter(
+    (e) => !e.includes('React Router Future Flag') && !e.includes('Download the React DevTools')
+  );
+  record(
+    `0 console error bloquant (${blockingErrors.length} / ${consoleErrors.length} total)`,
+    blockingErrors.length === 0,
+    blockingErrors.slice(0, 3).join(' | ')
+  );
+  const blocking5xx = networkFailures.filter((f) => /^5\d\d /.test(f));
+  record(
+    `0 network 5xx bloquant (${blocking5xx.length} / ${networkFailures.length} total)`,
+    blocking5xx.length === 0,
+    blocking5xx.slice(0, 3).join(' | ')
+  );
+} catch (e) {
+  record('Audit terminé sans crash', false, e.message);
+} finally {
+  console.log('\n─── BILAN ───');
+  console.log(`Passed: ${results.filter((r) => r.ok).length}/${results.length}`);
+  await browser.close();
+  process.exit(exitCode);
+}


### PR DESCRIPTION
## Hotfix critique — ComplianceScoreHeader affichait 3 lignes APER

**Branch base** : \`claude/refonte-sol2\` (post-merge #296 #297 #298 #299 #300)
**Verdict audit postfix** : 🟢 **GO** — 11/11 contrôles hotfix verts

## Le bug

Capture utilisateur : 3 lignes APER dans le score conformité alors qu'il n'y a qu'une obligation APER.

```
Décret Tertiaire ─── 70
BACS ─────────────── 70
APER ─────  50         ← vrai APER
APER             0     ← en fait audit_sme étiqueté APER (BUG)
APER             0     ← en fait solar_toiture étiqueté APER (BUG)
```

### Cause racine

[ComplianceScoreHeader.jsx](frontend/src/components/conformite/ComplianceScoreHeader.jsx) (pré-hotfix) utilisait :
```js
const fwCode =
  fw.framework === 'tertiaire_operat' ? 'Décret Tertiaire'
  : fw.framework === 'bacs' ? 'BACS'
  : 'APER';   // ← fallback métier faux
```

Le backend V2 adaptatif émet jusqu'à 7 frameworks : DT, BACS, APER, **audit_sme, iso_50001, solar_toiture, beges**. Les 4 derniers étaient étiquetés "APER" côté FE.

**Doctrine §8.1 violée** : le mapping code→label réglementaire est métier et doit venir du backend.

## Chantiers livrés (6/6)

| # | Chantier | Fichier(s) |
|---|---|---|
| C1 | Backend FRAMEWORK_LABELS_FR (SoT) + label_fr injecté dans FrameworkScore + breakdown_avg_labeled | [compliance_score_service.py](backend/services/compliance_score_service.py) |
| C2 | Frontend formatFrameworkCode neutre + utilisation fw.label_fr (zero mapping métier FE) | [ComplianceScoreHeader.jsx](frontend/src/components/conformite/ComplianceScoreHeader.jsx) |
| C3 | Source-guard test interdisant pattern \`: 'APER'\` + exhaustivité backend (7 tests) | [conformite_framework_labels_hotfix.test.js](frontend/src/__tests__/source_guards/conformite_framework_labels_hotfix.test.js) |
| C4 | Tests backend exhaustivité label_fr + framework inconnu jamais APER (16 tests) | [test_compliance_framework_labels_hotfix.py](backend/tests/test_compliance_framework_labels_hotfix.py) |
| C5 | Tests frontend render jsdom : Audit SMÉ / Solarisation / ISO 50001 / BEGES / APER unique (9 tests) | [ComplianceScoreHeader_framework_labels.test.jsx](frontend/src/components/conformite/__tests__/ComplianceScoreHeader_framework_labels.test.jsx) |
| C6 | Audit postfix Playwright + doc | [audit_postfix_hotfix_conformite_framework_labels_2026_05_24.md](docs/audits/audit_postfix_hotfix_conformite_framework_labels_2026_05_24.md) |

## Mapping FR canonique (SoT backend)

```python
FRAMEWORK_LABELS_FR = {
    "tertiaire_operat": "Décret Tertiaire",
    "bacs": "BACS",
    "aper": "APER",
    "audit_sme": "Audit SMÉ",
    "iso_50001": "ISO 50001",
    "solar_toiture": "Solarisation toiture",
    "beges": "BEGES",
}
```

Frameworks inconnus → \`formatFrameworkCode(code)\` (humanisation neutre). **Jamais "APER"**.

## Test plan

- [x] **32 nouveaux tests verts** : 16 BE + 9 FE render + 7 source-guard
- [x] **Non-régression FE** : 5325/5329 (3 fails pré-existants hors scope : CompliancePage.jsx not found x2 + taxes_mismatch CSPE)
- [x] **Non-régression BE** : 595/602 (7 fails pré-existants test_billing_v68 shadow v2 / PDF)
- [x] **Curl backend** : portfolio + site detail retournent label_fr pour 5/5 frameworks
- [x] **Playwright /conformite** : 5 labels distincts rendus (Décret Tertiaire / BACS / APER / Audit SMÉ / Solarisation toiture), APER apparaît **1 seule fois**
- [x] **0 console error bloquant** durant la navigation hotfix
- [x] **0 network 5xx bloquant** lié au hotfix (1 endpoint \`/api/kb/apply\` 500 hors scope, pré-existant KB)

## Critères d'acceptation (8/8 ✅)

| # | Critère | État |
|---|---|---|
| 1 | Plus aucune répétition APER injustifiée | ✅ |
| 2 | audit_sme affiche "Audit SMÉ" | ✅ |
| 3 | solar_toiture affiche "Solarisation toiture" | ✅ |
| 4 | iso_50001 affiche "ISO 50001" | ✅ |
| 5 | beges futur couvert | ✅ |
| 6 | Aucun mapping métier dur dans ComplianceScoreHeader | ✅ |
| 7 | Tests nouveaux verts | ✅ (32) |
| 8 | Non-régression Conformité/Cockpit/Patrimoine | ✅ |

## Rétro-compat préservée

\`breakdown_avg\` (dict legacy) conservé dans le payload portfolio. Tous les consommateurs existants (autres composants, tests, intégrations) continuent de fonctionner. Le nouveau champ \`breakdown_avg_labeled\` (liste typée avec label_fr) est additif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)