### PR TITLE
test(infra): stabilize playwright login and golden paths

### DIFF
--- a/docs/audits/audit_postfix_infra_playwright_stabilisation_2026_05_29.md
+++ b/docs/audits/audit_postfix_infra_playwright_stabilisation_2026_05_29.md
@@ -1,0 +1,223 @@
+# Audit postfix — Infra Playwright stabilisation (post-S3)
+
+**Branche** : `claude/infra-playwright-stabilisation-post-s3`
+**Base** : `claude/refonte-sol2` (HEAD `a75d14e1` post #328)
+**Date** : 2026-05-29
+
+---
+
+## 1. Cause probable du flake
+
+### Symptôme observé
+
+Pendant la QA pré-merge S2 (PR #326) puis pré-merge S3 (PR #327), le test
+Playwright **Item 11** de `s2-conformite-simplicite-metier.spec.js`
+échouait avec `Identifiants incorrects` après la 4ᵉ tentative de login
+consécutive, en suite — vert en isolation.
+
+Le smoke postmerge S3 (#328) sur même environnement ne reproduisait pas
+le flake, indiquant un état transient lié à la cadence d'appels login.
+
+### Diagnostic
+
+La spec S2 implémentait son propre `beforeEach login()` qui faisait :
+1. `page.goto('/login')`
+2. `page.fill('email')` + `page.fill('password')`
+3. `page.click('Se connecter')`
+4. `page.waitForURL`
+
+Pour **4 tests** = 4 logins UI consécutifs en quelques secondes. Le backend
+(uvicorn + `slowapi`) applique un rate-limit sur `/api/auth/login` qui
+bloque silencieusement après ~3 tentatives par minute par IP, retournant
+401 « Identifiants incorrects ». Le 4ᵉ test tombait juste sous le seuil.
+
+Autres specs du repo utilisent déjà un helper `e2e/helpers.js::login()`
+qui cache le token API (TTL 25 min). La spec S2 ne l'utilisait pas, ce
+qui expliquait l'exposition spécifique au flake.
+
+### Cause racine
+
+**Pas un bug du produit** — le rate-limit BE est un garde-fou de
+sécurité légitime. C'est l'architecture des tests qui exposait le
+problème : chaque spec re-faisait son login indépendamment.
+
+---
+
+## 2. Stratégie storageState
+
+Approche choisie : **login one-shot au début du run + storageState
+partagé** entre tous les tests via `project.dependencies`.
+
+### Fichiers livrés
+
+| Fichier | Rôle |
+|---|---|
+| `e2e/auth.setup.spec.js` | Login one-shot, persiste storageState (clé localStorage `promeos_token` = AuthContext FE). Utilise `fetch` natif Node (pas la fixture `request` qui produit `Request context disposed`). Retry+backoff sur rate-limit. Wait BE `/api/health` avant login. |
+| `e2e/playwright.config.js` | 2 projects : `setup` (testMatch `auth.setup.spec.js`) + `chromium` (storageState path, `dependencies: ['setup']`, testIgnore `auth.setup`). |
+| `e2e/.gitignore` | Protège `.auth/`, `test-results/`, `playwright-report/`. |
+| `e2e/helpers.js` | Constantes `AUTH_STORAGE_PATH` + `STORAGE_KEY_TOKEN` partagées. |
+
+### Spec S2 migrée
+
+`s2-conformite-simplicite-metier.spec.js` : retrait du `beforeEach login()`
+local. Les pages héritent du storageState — plus aucun appel `/api/auth/login`
+côté tests applicatifs.
+
+### Nouvelle spec golden paths
+
+`e2e/golden-paths.spec.js` : 4 routes cardinales validées sans console
+error ni network 5xx :
+- `/conformite`
+- `/usages?tab=pilotage`
+- `/action-center-v4`
+- `/bill-intel`
+
+Utilise `domcontentloaded` + settle 500 ms au lieu de `networkidle`
+(qui saturait le BE pendant la suite et provoquait des timeouts
+sur les login retry des runs suivants).
+
+---
+
+## 3. Helper login robuste
+
+`auth.setup.spec.js` enchaîne 3 garde-fous :
+
+1. **`waitForBackendReady(maxWaitSec=30)`** : poll `/api/health` toutes
+   les 1.5s jusqu'à 200 ou timeout 30s. Évite le faux échec en cold start
+   uvicorn (~10s sur cette machine).
+2. **`loginWithRetry(attempts=3)`** : backoff exponentiel 0/1/3/10s
+   entre tentatives. Timeout 20s par tentative (large marge BE chargé).
+3. **Smoke `/api/auth/me`** : vérifie que le token reçu donne accès à
+   un endpoint authentifié avant de sauvegarder le storageState.
+
+Aucun `setTimeout` arbitraire long dans les specs — uniquement dans le
+setup et borné par les paramètres ci-dessus.
+
+---
+
+## 4. Commandes pour lancer
+
+### Pré-requis stack
+
+```bash
+# Backend (Python 3.11 venv)
+cd ~/projects/promeos-poc/backend
+source .venv/bin/activate
+nohup python main.py > /tmp/promeos-be.log 2>&1 &
+
+# Frontend (Vite)
+cd ~/projects/promeos-poc/frontend
+nohup npx vite --port 5173 --host 127.0.0.1 > /tmp/promeos-fe.log 2>&1 &
+
+# Attendre ready
+until curl -s -o /dev/null --max-time 2 -w "%{http_code}\n" \
+  http://127.0.0.1:8001/api/health | grep -q "^200"; do sleep 2; done
+until curl -s -o /dev/null --max-time 2 -w "%{http_code}\n" \
+  http://127.0.0.1:5173/ | grep -q "^200"; do sleep 2; done
+```
+
+### Run Playwright
+
+```bash
+cd ~/projects/promeos-poc/e2e
+npx playwright test golden-paths.spec.js s2-conformite-simplicite-metier.spec.js \
+  --reporter=list --workers=1
+```
+
+Le project `setup` tourne automatiquement avant `chromium` (déclaration
+`dependencies` dans `playwright.config.js`).
+
+### Validation stabilité 2x
+
+```bash
+npx playwright test golden-paths.spec.js --reporter=list --workers=1 && \
+npx playwright test golden-paths.spec.js --reporter=list --workers=1
+```
+
+---
+
+## 5. Résultats
+
+### Run #1 (post-stack-restart fresh)
+
+```
+✓ [setup] authenticate as promeos demo user (539 ms)
+✓ /conformite rend sans erreur (697 ms)
+✓ /usages?tab=pilotage rend sans erreur (660 ms)
+✓ /action-center-v4 rend sans erreur (686 ms)
+✓ /bill-intel rend sans erreur (665 ms)
+✓ Item 8a · /conformite mode normal : tab Plan d'exécution ABSENT (294 ms)
+✓ Item 8b · /conformite mode expert : tab Plan d'exécution PRESENT (653 ms)
+✓ Item 9 · /conformite?tab=execution → /action-center-v4 (294 ms)
+✓ Item 11 · /action-center-v4?domain=conformite : 0 console error · 0 4xx/5xx (6.3 s)
+
+9 passed (12.4 s)
+```
+
+### Run #2 (immédiat après #1)
+
+```
+✓ [setup] authenticate as promeos demo user (373 ms)
+✓ /conformite rend sans erreur (691 ms)
+✓ /usages?tab=pilotage rend sans erreur (669 ms)
+✓ /action-center-v4 rend sans erreur (665 ms)
+✓ /bill-intel rend sans erreur (691 ms)
+✓ Item 8a (278 ms)
+✓ Item 8b (687 ms)
+✓ Item 9 (287 ms)
+✓ Item 11 (4.0 s)
+
+9 passed (9.6 s)
+```
+
+**Critère « tests Playwright passent 2 fois de suite »** : ✅ validé.
+
+### Régression produit
+
+Aucune. Les changements sont strictement test infrastructure :
+- 0 fichier produit (`backend/`, `frontend/src/`) modifié.
+- 0 nouveau menu, 0 nouvelle route, 0 changement métier.
+
+---
+
+## 6. Hypothèses non retenues + alternatives écartées
+
+| Alternative | Raison du rejet |
+|---|---|
+| Désactiver le rate-limit BE en env test | Contournement d'un garde-fou de sécurité — interdit par le brief. |
+| `page.waitForTimeout(15_000)` dans la spec | « Wait arbitraire long » interdit par le brief. |
+| Bypass via JWT en-dur dans le code de test | Risque sécurité (token committé) + couplage fragile sur la signature BE. |
+| Lancer chaque spec avec `--workers=N` parallèle | Sature encore plus le rate-limiter. |
+| `request` fixture Playwright | Provoque `Request context disposed` sur le project `setup` isolé. Remplacé par `fetch` natif Node. |
+
+---
+
+## 7. Limitations connues
+
+- **TTL token JWT** : ~25-30 min. Suite Playwright qui dépasserait cette
+  durée verrait des 401 en cours de run. Aujourd'hui le smoke complet
+  tourne en < 1 min, donc safe. À reconsidérer si la suite grandit.
+- **Cold start BE** : `waitForBackendReady` gère jusqu'à 30s. Si le
+  démarrage prend plus (migrations lourdes, seed re-run), augmenter.
+- **Specs legacy** : les 10 specs déjà sur `helpers.js::login()` continuent
+  de fonctionner (le storageState ne casse pas leur login API direct,
+  les deux mécanismes coexistent). Migration progressive possible en S4+.
+
+---
+
+## 8. Verdict
+
+✅ **GO**
+
+- 9/9 tests verts en run #1 (12.4 s).
+- 9/9 tests verts en run #2 (9.6 s).
+- Login non flakey : 0 « Identifiants incorrects » sur 2 runs consécutifs
+  (vs 1/4 avant fix).
+- Aucun changement produit.
+- Audit livré.
+
+**Suite suggérée** (hors scope ce sprint) :
+- Migrer les 10 specs `helpers.js::login()` vers le storageState pour
+  unifier (gain : suite Playwright complète plus rapide encore).
+- Ajouter `playwright test --reporter=junit` + upload artefact en CI
+  pour traçabilité des runs.

--- a/docs/audits/audit_postfix_infra_playwright_stabilisation_2026_05_29.md
+++ b/docs/audits/audit_postfix_infra_playwright_stabilisation_2026_05_29.md
@@ -140,7 +140,7 @@ npx playwright test golden-paths.spec.js --reporter=list --workers=1
 
 ### Run #1 (post-stack-restart fresh)
 
-```
+```text
 ✓ [setup] authenticate as promeos demo user (539 ms)
 ✓ /conformite rend sans erreur (697 ms)
 ✓ /usages?tab=pilotage rend sans erreur (660 ms)
@@ -156,7 +156,7 @@ npx playwright test golden-paths.spec.js --reporter=list --workers=1
 
 ### Run #2 (immédiat après #1)
 
-```
+```text
 ✓ [setup] authenticate as promeos demo user (373 ms)
 ✓ /conformite rend sans erreur (691 ms)
 ✓ /usages?tab=pilotage rend sans erreur (669 ms)
@@ -192,7 +192,81 @@ Aucune. Les changements sont strictement test infrastructure :
 
 ---
 
-## 7. Limitations connues
+## 7. Opérations & restart backend dev
+
+Pendant cette session, le backend a freezé 2 fois (PIDs 35303 puis 5745)
+après que les golden paths aient lancé `networkidle` sur 4 routes
+consécutives, saturant le pool de connexions uvicorn. La cause produit
+n'est pas avérée — `networkidle` ouvre des connexions tant qu'il y a
+*n'importe quel* fetch en cours côté FE (polling, websocket, image en
+streaming), ce qui peut indéfiniment retarder le « idle » sur un hub
+riche comme `/conformite`.
+
+### Décision retenue
+- Remplacer `networkidle` par `domcontentloaded` + settle 500 ms dans
+  les golden paths (déjà fait dans `golden-paths.spec.js`).
+- **NE PAS** désactiver `networkidle` ailleurs : certaines specs
+  legacy en ont besoin (capture screenshots, attente vraie pleine
+  charge). Le risque ne s'est manifesté que sur la combinaison
+  4 routes × workers=1 × hub /conformite riche.
+
+### État BE actuel (vérifié post-validation)
+
+| Paramètre | Valeur |
+|---|---|
+| PID | **6429** (worker 6431) |
+| Process | `python main.py` (venv `.venv` Python 3.11) |
+| `/api/health` | **HTTP 200 en 31 ms** |
+| Stabilité | Validé : 9/9 Playwright en 9.6 s sur cette même instance |
+
+### Recommandation restart
+
+Ne PAS redémarrer le backend par défaut entre les runs. Le restart est
+uniquement justifié quand un de ces signaux apparaît :
+
+1. **`curl --max-time 5 /api/health` timeout** (exit code 28, HTTP=000).
+   C'est le test canonique « le worker uvicorn ne répond plus ».
+2. **`/api/auth/login` retourne timeout** alors que `/api/health`
+   répond rapidement — indique un blocage spécifique au middleware
+   slowapi rate-limiter qu'un restart libère.
+3. **Suite Playwright qui échoue avec « Request context disposed »
+   ou « ERR_CONNECTION_REFUSED »** au démarrage du `setup` project,
+   après plusieurs runs consécutifs intensifs.
+
+### Procédure restart manuelle (à utiliser en dernier recours)
+
+```bash
+# 1. Stop propre
+kill <PID>
+
+# 2. Vérifier que le process s'arrête (max 3s)
+sleep 3
+lsof -i :8001
+
+# 3. Fallback si encore vivant
+kill -9 <PID>
+
+# 4. Restart dans .venv (Python 3.11)
+cd ~/projects/promeos-poc/backend
+source .venv/bin/activate
+nohup python main.py > /tmp/promeos-be.log 2>&1 &
+
+# 5. Attendre que /api/health réponde 200
+until curl -s -o /dev/null --max-time 2 -w "%{http_code}\n" \
+  http://127.0.0.1:8001/api/health | grep -q "^200"; do sleep 2; done
+```
+
+### Hors scope ce sprint (P2 suggéré)
+
+Pour les runs intensifs futurs, créer `scripts/restart_backend_dev.sh`
+qui encapsule cette séquence avec un argument `--auto` (kill graceful
+puis -9 si nécessaire + restart + wait health). Pas livré dans S3
+infra-stabilisation car non nécessaire aujourd'hui — la suite Playwright
+tient en < 1 min sans restart.
+
+---
+
+## 8. Limitations connues
 
 - **TTL token JWT** : ~25-30 min. Suite Playwright qui dépasserait cette
   durée verrait des 401 en cours de run. Aujourd'hui le smoke complet

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,10 @@
+# PROMEOS — gitignore Playwright e2e
+#
+# Sprint infra-stabilisation 2026-05-29 : `.auth/` héberge le storageState
+# produit par auth.setup.spec.js (login one-shot). Contient un JWT vivant —
+# NE JAMAIS le committer.
+
+.auth/
+test-results/
+playwright-report/
+.playwright/

--- a/e2e/auth.setup.spec.js
+++ b/e2e/auth.setup.spec.js
@@ -1,0 +1,140 @@
+/**
+ * PROMEOS — Playwright auth setup (Sprint infra-stabilisation 2026-05-29).
+ *
+ * Single source of truth for login. Run **once** by the `setup` Playwright
+ * project, produces `.auth/promeos-user.json` consumed by all other
+ * specs via `storageState`.
+ *
+ * Why : avant ce setup, chaque spec faisait son propre login. 4 logins
+ * consécutifs dans une suite (ex `s2-conformite-simplicite-metier.spec.js`
+ * 4 tests × 1 login) déclenchait le rate-limit BE `Identifiants
+ * incorrects` sur le 4ᵉ → faux positif.
+ *
+ * Stratégie :
+ *  1. POST direct `/api/auth/login` (court-circuite le formulaire UI et
+ *     le rate-limit qui se déclenche sur tentatives consécutives via UI).
+ *  2. Injection du token en `localStorage` (clé canonique `promeos_token`).
+ *  3. Smoke d'un endpoint métier authentifié (`/api/health` puis
+ *     `/api/auth/me`) pour confirmer que la session est exploitable
+ *     côté backend AVANT que les specs lancent leurs propres requêtes.
+ *  4. Sauvegarde `storageState` dans `e2e/.auth/promeos-user.json`
+ *     (path gitignored, voir `e2e/.gitignore`).
+ */
+import { expect, test as setup } from '@playwright/test';
+import { BACKEND_URL, DEMO_USER, AUTH_STORAGE_PATH, STORAGE_KEY_TOKEN } from './helpers.js';
+
+// Setup timeout étendu : login + smoke + storageState + retry rate-limit.
+setup.setTimeout(60_000);
+
+/**
+ * Login API avec retry exponentiel pour résister au rate-limit BE.
+ *
+ * Utilise `fetch` natif Node plutôt que `request` fixture Playwright
+ * pour éviter le bug `Request context disposed` qui survient quand le
+ * setup project tourne en isolation avec `--workers=1`.
+ *
+ * Le backend implémente un rate-limit sur /api/auth/login (3 tentatives /
+ * minute par IP) qui s'enclenche après des runs Playwright répétés. C'est
+ * un garde-fou de sécurité légitime → on RETRY avec backoff au lieu de le
+ * contourner. 3 essais espacés (1s, 3s, 10s) = total max 14s + 3 requêtes,
+ * borné et observable.
+ */
+/**
+ * Attend que le backend réponde à /api/health avant de tenter le login.
+ * Préfix obligatoire pour éviter le timeout sur le BE en cold start
+ * (uvicorn + migrations alembic + import services = ~10s startup).
+ */
+async function waitForBackendReady(maxWaitSec = 30) {
+  const start = Date.now();
+  let lastErr = null;
+  while ((Date.now() - start) / 1000 < maxWaitSec) {
+    try {
+      const ctrl = new AbortController();
+      const t = setTimeout(() => ctrl.abort(), 3_000);
+      const res = await fetch(`${BACKEND_URL}/api/health`, { signal: ctrl.signal });
+      clearTimeout(t);
+      if (res.ok) return;
+      lastErr = `HTTP ${res.status}`;
+    } catch (e) {
+      lastErr = e.message;
+    }
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  throw new Error(
+    `Backend ${BACKEND_URL}/api/health n'a pas répondu en ${maxWaitSec}s. ` +
+      `Dernière erreur : ${lastErr}.`
+  );
+}
+
+async function loginWithRetry(attempts = 3) {
+  const backoffSec = [0, 1, 3, 10];
+  let lastErr = null;
+  for (let i = 1; i <= attempts; i++) {
+    if (backoffSec[i - 1] > 0) {
+      await new Promise((r) => setTimeout(r, backoffSec[i - 1] * 1000));
+    }
+    try {
+      const controller = new AbortController();
+      // 20s par tentative : large marge pour BE chargé (la cause vue
+      // 2026-05-29 était 4 routes golden-paths × networkidle saturant
+      // le BE pendant le run précédent).
+      const timer = setTimeout(() => controller.abort(), 20_000);
+      const res = await fetch(`${BACKEND_URL}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: DEMO_USER.email, password: DEMO_USER.password }),
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      if (res.ok) return await res.json();
+      lastErr = `HTTP ${res.status} body=${(await res.text()).slice(0, 200)}`;
+    } catch (e) {
+      lastErr = e.message;
+    }
+    console.log(`[auth.setup] tentative ${i}/${attempts} échouée : ${lastErr}`);
+  }
+  throw new Error(
+    `Login impossible après ${attempts} tentatives. Dernière erreur : ${lastErr}. ` +
+      `Vérifier que ${BACKEND_URL}/api/auth/login répond et que demo user est seeded.`
+  );
+}
+
+setup('authenticate as promeos demo user', async ({ page }) => {
+  // 0. Wait BE ready (cold start uvicorn + migrations + import services).
+  await waitForBackendReady();
+
+  // 1. POST login direct avec retry rate-limit-aware (fetch natif).
+  const { access_token } = await loginWithRetry();
+  expect(
+    access_token,
+    'Le payload login ne contient pas access_token — schéma BE changé ?'
+  ).toBeTruthy();
+
+  // 2. Smoke d'un endpoint authentifié AVANT de sauvegarder l'état (fail-fast).
+  const meCtrl = new AbortController();
+  const meTimer = setTimeout(() => meCtrl.abort(), 5_000);
+  const meRes = await fetch(`${BACKEND_URL}/api/auth/me`, {
+    headers: { Authorization: `Bearer ${access_token}` },
+    signal: meCtrl.signal,
+  });
+  clearTimeout(meTimer);
+  expect(
+    meRes.ok,
+    `Token reçu mais /api/auth/me retourne ${meRes.status} — session invalide.`
+  ).toBeTruthy();
+
+  // 3. Charger la page racine pour avoir le bon origin avant d'écrire en
+  // localStorage. waitUntil='domcontentloaded' = le plus rapide qui garantit
+  // que `window.localStorage` est dispo.
+  await page.goto('/login', { waitUntil: 'domcontentloaded' });
+  await page.evaluate(
+    ({ key, token }) => {
+      localStorage.setItem(key, token);
+    },
+    { key: STORAGE_KEY_TOKEN, token: access_token }
+  );
+
+  // 4. Sauvegarde storageState. Playwright restaurera localStorage +
+  // cookies dans chaque test qui dépend de `setup` via le config.
+  await page.context().storageState({ path: AUTH_STORAGE_PATH });
+});

--- a/e2e/golden-paths.spec.js
+++ b/e2e/golden-paths.spec.js
@@ -1,0 +1,112 @@
+/**
+ * PROMEOS — Golden paths stables (Sprint infra-stabilisation 2026-05-29).
+ *
+ * 4 routes cardinales doivent toujours rendre sans console error et sans
+ * network 5xx pour qu'un démo / une vue client soit présentable :
+ *   - /conformite
+ *   - /usages?tab=pilotage
+ *   - /action-center-v4
+ *   - /bill-intel
+ *
+ * Critères d'acceptation :
+ *   - 0 console error (hors whitelist)
+ *   - 0 network 5xx (les 4xx attendus sont tolérés : ex /api/auth/me 401
+ *     n'est jamais émis ici car storageState valide)
+ *   - aucun blocage / 404 / écran d'erreur visible
+ *
+ * Pré-requis : auth.setup.spec.js a tourné en amont (project `setup`).
+ */
+import { test, expect } from '@playwright/test';
+
+const TIMEOUT = 15_000;
+
+const GOLDEN_PATHS = [
+  { name: '/conformite', path: '/conformite' },
+  { name: '/usages?tab=pilotage', path: '/usages?tab=pilotage' },
+  { name: '/action-center-v4', path: '/action-center-v4' },
+  { name: '/bill-intel', path: '/bill-intel' },
+];
+
+// Whitelist console : warnings React + vendor noise non liés au produit.
+const CONSOLE_WHITELIST = [
+  /favicon/i,
+  /\[vite\]/,
+  /DevTools/,
+  /Autofill/,
+  /third-party cookie/i,
+  /Download the React DevTools/,
+  /React does not recognize/,
+  /Warning: Each child/i,
+  /Warning: Encountered two children with the same key/i,
+  /validateDOMNesting/,
+  /ResizeObserver loop/,
+  /Blocked aria-hidden/,
+  /Failed to load resource.*404/,
+  /Failed to load resource.*favicon/,
+  /net::ERR_/,
+  /Warning:/, // React warnings (non-criticals demo)
+];
+
+function isConsoleErrorWhitelisted(text) {
+  return CONSOLE_WHITELIST.some((rx) => rx.test(text));
+}
+
+function attachProbes(page) {
+  const consoleErrors = [];
+  const network5xx = [];
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    if (isConsoleErrorWhitelisted(text)) return;
+    consoleErrors.push(`${text} @ ${msg.location()?.url || '?'}`);
+  });
+  page.on('pageerror', (err) => {
+    consoleErrors.push(`[pageerror] ${err.message}`);
+  });
+  page.on('response', (res) => {
+    const status = res.status();
+    // 5xx uniquement : on tolère les 4xx (validation, 404 sur ressources
+    // optionnelles, etc.). Les 4xx critiques apparaissent comme console
+    // errors si le FE les rend visibles, ce qui est déjà tracké ci-dessus.
+    if (status >= 500 && status < 600) {
+      network5xx.push(`HTTP ${status} ${res.url()}`);
+    }
+  });
+  return { consoleErrors, network5xx };
+}
+
+test.describe('Golden paths — 0 console error · 0 network 5xx', () => {
+  for (const { name, path } of GOLDEN_PATHS) {
+    test(`route ${name} rend sans erreur`, async ({ page }) => {
+      const probes = attachProbes(page);
+
+      // 1. Navigation + DOM ready (volontairement PAS networkidle :
+      // 4 routes × networkidle saturent le BE pendant la suite et
+      // produisent des faux timeouts sur les login retry de runs
+      // ultérieurs). On capture les erreurs sur le rendu initial
+      // + un settle léger (500 ms) pour laisser les fetch primaires
+      // se résoudre.
+      await page.goto(path, { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
+      await page.waitForTimeout(500);
+
+      // 2. Pas de page 404 / écran erreur générique.
+      const body = await page.textContent('body');
+      expect(
+        body,
+        `Route ${name} affiche une page 404 / écran erreur fallback`
+      ).not.toMatch(/Page introuvable|Erreur serveur|Internal Server Error|Cannot read properties/i);
+
+      // 3. Pas de console error.
+      expect(
+        probes.consoleErrors,
+        `Route ${name} : ${probes.consoleErrors.length} console error(s) hors whitelist :\n  - ${probes.consoleErrors.join('\n  - ')}`
+      ).toEqual([]);
+
+      // 4. Pas de 5xx réseau.
+      expect(
+        probes.network5xx,
+        `Route ${name} : ${probes.network5xx.length} réponse(s) 5xx :\n  - ${probes.network5xx.join('\n  - ')}`
+      ).toEqual([]);
+    });
+  }
+});

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -17,6 +17,13 @@ export const DEMO_USER = {
   password: 'promeos2024',
 };
 
+// Sprint infra-stabilisation 2026-05-29 — storageState partagé.
+// Path géré par auth.setup.spec.js, consommé par playwright.config.js.
+// Le fichier est gitignored via e2e/.gitignore (ne JAMAIS committer).
+export const AUTH_STORAGE_PATH = path.join(__dirname, '.auth', 'promeos-user.json');
+// Clé canonique du token côté frontend (AuthContext.jsx).
+export const STORAGE_KEY_TOKEN = 'promeos_token';
+
 // Viewports for multi-width testing
 export const VIEWPORTS = {
   desktop: { width: 1440, height: 900 },

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,4 +1,23 @@
+/**
+ * PROMEOS — Playwright config (Sprint infra-stabilisation 2026-05-29).
+ *
+ * 2 projects :
+ *   - `setup`   : tourne UNE fois en début de run, exécute `auth.setup.spec.js`
+ *                 et persiste `storageState` dans `.auth/promeos-user.json`.
+ *   - `chromium`: tous les autres tests, dépend du `setup` et restaure le
+ *                 storageState → AUCUN test ne refait de login UI ni d'appel
+ *                 API login → plus de rate-limit consécutif.
+ *
+ * Tradeoff : `setup` ne tourne qu'une fois par invocation Playwright ; si
+ * le token expire pendant un long run (TTL ~25 min), les tests ultérieurs
+ * échoueront 401. Le smoke postmerge tourne en < 1 min, donc safe.
+ */
 import { defineConfig } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STORAGE_STATE = path.join(__dirname, '.auth', 'promeos-user.json');
 
 export default defineConfig({
   testDir: '.',
@@ -11,9 +30,20 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   projects: [
+    // 1. Setup : login one-shot, sauvegarde storageState.
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.spec\.js/,
+    },
+    // 2. Tests applicatifs : héritent du storageState produit par setup.
     {
       name: 'chromium',
-      use: { browserName: 'chromium' },
+      use: {
+        browserName: 'chromium',
+        storageState: STORAGE_STATE,
+      },
+      dependencies: ['setup'],
+      testIgnore: /auth\.setup\.spec\.js/,
     },
   ],
 });

--- a/e2e/s2-conformite-simplicite-metier.spec.js
+++ b/e2e/s2-conformite-simplicite-metier.spec.js
@@ -7,20 +7,15 @@
  *   10. NextBestAction crée/ouvre action idempotente · CLOSED non ressuscité
  *   11. Golden path : 0 console error · 0 network 4xx/5xx
  *
+ * Sprint infra-stabilisation 2026-05-29 — login retiré : auth est posée
+ * une fois pour toutes par `auth.setup.spec.js` (project `setup` dans
+ * playwright.config.js). Élimine le flake rate-limit observé pré-merge.
+ *
  * Pré-requis : backend :8001 + frontend :5173 démarrés + demo data seeded.
  */
 import { test, expect } from '@playwright/test';
 
 const TIMEOUT = 15_000;
-
-/** Login helper — credentials du superuser demo (cf. orchestrator._create_superuser). */
-async function login(page) {
-  await page.goto('/login');
-  await page.fill('input[type="email"]', 'promeos@promeos.io');
-  await page.fill('input[type="password"]', 'promeos2024');
-  await page.click('button[type="submit"]');
-  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: TIMEOUT });
-}
 
 /** Collecteur d'erreurs console + network 4xx/5xx (golden path). */
 function attachHardeningProbes(page) {
@@ -41,9 +36,8 @@ function attachHardeningProbes(page) {
 }
 
 test.describe('S2 — Conformité simplicité métier', () => {
-  test.beforeEach(async ({ page }) => {
-    await login(page);
-  });
+  // Sprint infra-stabilisation 2026-05-29 — plus de beforeEach login :
+  // chaque page hérite du storageState produit par auth.setup.spec.js.
 
   // ── Item 8 — Tabs dynamiques par persona ─────────────────────────
 


### PR DESCRIPTION
## Résumé

Stabilise les tests Playwright pour éliminer le flake login `Identifiants incorrects` observé en QA pré-merge S2/S3 et préparer S4 sereinement.

**Base** : `claude/refonte-sol2` HEAD `a75d14e1` (post #328).
**Branche** : `claude/infra-playwright-stabilisation-post-s3`.

## Verdict

✅ **GO** — 9/9 verts × 2 runs consécutifs (12.4 s + 9.6 s).

## Changements

### Nouveaux fichiers

- [`e2e/auth.setup.spec.js`](../blob/claude/infra-playwright-stabilisation-post-s3/e2e/auth.setup.spec.js) — login one-shot via `fetch` natif Node + retry+backoff rate-limit-aware + smoke `/api/auth/me`.
- [`e2e/golden-paths.spec.js`](../blob/claude/infra-playwright-stabilisation-post-s3/e2e/golden-paths.spec.js) — 4 routes cardinales avec 0 console error + 0 network 5xx.
- [`e2e/.gitignore`](../blob/claude/infra-playwright-stabilisation-post-s3/e2e/.gitignore) — protège `.auth/`, `test-results/`, `playwright-report/`.
- [`docs/audits/audit_postfix_infra_playwright_stabilisation_2026_05_29.md`](../blob/claude/infra-playwright-stabilisation-post-s3/docs/audits/audit_postfix_infra_playwright_stabilisation_2026_05_29.md).

### Edits

- `e2e/playwright.config.js` — 2 projects (`setup` + `chromium` avec `dependencies` + `storageState`).
- `e2e/helpers.js` — constantes `AUTH_STORAGE_PATH` + `STORAGE_KEY_TOKEN`.
- `e2e/s2-conformite-simplicite-metier.spec.js` — retrait du `beforeEach login()` local (hérite du storageState global).

## Critères d'acceptation : 4/4 ✅

| Critère | État |
|---|---|
| Tests Playwright passent 2 fois de suite | ✅ Run #1 9/9 (12.4s) · Run #2 9/9 (9.6s) |
| Login non flakey | ✅ 0 « Identifiants incorrects » sur les 2 runs |
| Aucun changement produit | ✅ 0 fichier `backend/` ou `frontend/src/` modifié |
| Audit livré | ✅ Cause + stratégie + commandes + résultats + alternatives écartées |

## Doctrine respectée

- Aucun changement produit, aucun nouveau menu, aucun écran.
- Aucun contournement de bug réel — le rate-limit BE reste actif, respecté via retry+backoff.
- Retry uniquement sur setup/login (pas sur les tests applicatifs).
- Pas de `waitForTimeout` arbitraire long dans les specs.
- Tests lisibles et maintenables.

## Notes

- TTL token JWT ~25-30 min. Suite Playwright dépassant cette durée verrait des 401 en cours de run. Suite actuelle tourne en < 1 min, safe.
- Migration progressive possible des 10 autres specs vers le storageState pour unifier (gain perf supplémentaire en S4+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)