### PR TITLE
fix(conformite): HTTP 201/200 strict on request-validation (S4.1)

### DIFF
--- a/backend/routes/tertiaire_mutualisation.py
+++ b/backend/routes/tertiaire_mutualisation.py
@@ -519,10 +519,14 @@ def export_table_1b_pdf(
 # ─── S4 — Demande de validation représentant légal via Centre d'Action ──
 
 
-@router.post("/groups/{group_id}/members/{efa_id}/request-validation")
+@router.post(
+    "/groups/{group_id}/members/{efa_id}/request-validation",
+    status_code=status.HTTP_201_CREATED,
+)
 def request_rl_validation(
     group_id: int,
     efa_id: int,
+    response: Response,
     org_id: int = Query(..., gt=0),
     db: Session = Depends(get_db),
     auth: Optional[AuthContext] = Depends(get_optional_auth),
@@ -537,6 +541,11 @@ def request_rl_validation(
     Pour S4 : pas d'envoi d'email réel — le canal canonique est le
     Centre d'Action V4. L'envoi email Brevo pourra être branché en S5+
     via le service `email_provider.py`.
+
+    Sprint S4.1 hotfix (2026-05-29) : HTTP code aligné REST strict
+    - 201 Created si nouvelle action créée
+    - 200 OK si action existante retournée (idempotent)
+    - 409 sur RL_ALREADY_VALIDATED ou EXTERNAL_REF_CLOSED
     """
     org_id = get_effective_org_id(auth, org_id)
     g = _load_groupe(db, group_id, org_id)
@@ -578,6 +587,8 @@ def request_rl_validation(
                         ),
                     },
                 )
+            # S4.1 — idempotent : action existante → bascule 201→200.
+            response.status_code = status.HTTP_200_OK
             return {
                 "id": str(existing.id),
                 "external_ref": existing.external_ref,


### PR DESCRIPTION
## Résumé

Hotfix S4.1 demandé en review de #330 — l'endpoint `POST /api/tertiaire/mutualisation/groups/{id}/members/{efa_id}/request-validation` retournait HTTP 200 dans les 2 cas (création + idempotent), avec un discriminateur `status: "created" | "existing"` dans le body. **Sémantique respectée mais code de retour non conforme à la convention REST stricte.**

Fix : 1 fichier modifié (`backend/routes/tertiaire_mutualisation.py`, +12/-1).

## Changement

- Décorateur du endpoint : `status_code=status.HTTP_201_CREATED` (nouveau)
- Injection de la fixture `Response` pour permettre le downgrade 201→200
- Branche `existing` : `response.status_code = status.HTTP_200_OK`

## Smoke live (2026-05-29 11:54 UTC, BE PID 9552)

```
1ère POST  → HTTP 201 status="created"   ✅ (attendu 201)
2ème POST  → HTTP 200 status="existing"  ✅ (attendu 200, idempotent)
```

Aucun changement de payload, aucun changement de comportement métier, juste l'alignement du status code HTTP.

## Tests

- **70/70 verts** : régression BE (`test_tertiaire_mutualisation_s4` + `test_tertiaire_mutualisation_s3` + source-guards + no-competitor).
- 0 régression FE (le wrapper `requestRlValidation` retourne `r.data`, ne dépend pas du status code).
- 0 régression UI (`MutualisationSection.jsx` n'a pas de logique sur le HTTP code).
- 409 `RL_ALREADY_VALIDATED` + 409 `EXTERNAL_REF_CLOSED` inchangés.

## Garde-fous

- 1 fichier modifié, 1 endpoint touché.
- Aucun nouveau menu, aucun écran, aucun changement de doctrine.
- Aucun nom de concurrent introduit (source-guard reste vert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)