### PR TITLE
feat(energie-p1-s6): ajouter marche exposition consommations

### DIFF
--- a/e2e/p1_market_exposure.spec.js
+++ b/e2e/p1_market_exposure.spec.js
@@ -1,0 +1,114 @@
+/**
+ * PROMEOS — e2e Sprint Énergie P1.S6.
+ *
+ * Vérifie que /consommations/marche est l'onglet « Marché & exposition » :
+ * - le composant MarketExposureTab est rendu ;
+ * - scope=org (pas de site) affiche SiteRequiredState proprement
+ *   (aucun ENERGY_SCOPE_INVALID rouge) ;
+ * - avec site sélectionné : consomme /api/energy/market-exposure ;
+ * - rail Énergie inchangé ;
+ * - capture desktop 1440×900.
+ */
+import { expect, test } from '@playwright/test';
+
+const FRONTEND_URL = process.env.E2E_FRONTEND_URL || 'http://127.0.0.1:5175';
+
+test.describe('Sprint Énergie P1.S6 — Marché & exposition /consommations', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('Onglet « Marché & exposition » visible + consomme /api/energy/market-exposure (site mode)', async ({
+    page,
+  }) => {
+    const calls = [];
+    page.on('request', (req) => {
+      const url = req.url();
+      if (url.includes('/api/energy/market-exposure')) calls.push(url);
+    });
+
+    await page.goto(`${FRONTEND_URL}/consommations`, { waitUntil: 'domcontentloaded' });
+
+    const tabLink = page.getByRole('link', { name: /Marché & exposition/i });
+    await expect(tabLink).toBeVisible({ timeout: 10_000 });
+    await tabLink.click();
+
+    const tab = page.getByTestId('market-exposure-tab');
+    await expect(tab).toBeVisible({ timeout: 10_000 });
+
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toContain('/marche');
+
+    // Soit on est en mode org → SiteRequiredState (pas d'appel), soit en
+    // mode site → appel API + score gauge OU empty/error documenté.
+    await page.waitForFunction(
+      () => {
+        const root = document.querySelector('[data-testid="market-exposure-tab"]');
+        if (!root) return false;
+        return (
+          root.querySelector('[data-testid="site-required-state"]') ||
+          root.querySelector('[data-testid="exposure-score-gauge"]') ||
+          root.querySelector('[data-testid="market-exposure-error"]') ||
+          root.textContent?.includes('Aucune exposition marché')
+        );
+      },
+      { timeout: 12_000 }
+    );
+
+    // Capture le résultat
+    await page.screenshot({
+      path: 'playwright-report/p1-s6-market-exposure-1440.png',
+      fullPage: true,
+    });
+
+    // Si une grille KPI est rendue (mode site avec data), un appel API doit avoir eu lieu
+    const gridVisible = await tab
+      .getByTestId('market-exposure-kpis-grid')
+      .isVisible()
+      .catch(() => false);
+    if (gridVisible) {
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[0]).toMatch(/scope=site/);
+      expect(calls[0]).toMatch(/period=12m/);
+      expect(calls[0]).toMatch(/market=day_ahead/);
+      expect(calls[0]).toMatch(/zone=FR/);
+    }
+  });
+
+  test('Deep-link /consommations/marche charge directement l\'onglet', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/consommations/marche`, { waitUntil: 'domcontentloaded' });
+    const tab = page.getByTestId('market-exposure-tab');
+    await expect(tab).toBeVisible({ timeout: 10_000 });
+    const header = page.getByTestId('market-exposure-header');
+    await expect(header).toContainText('Marché & exposition');
+    await expect(header).toContainText('Votre profil face aux prix spot');
+  });
+
+  test('Scope=org sans site → SiteRequiredState propre (pas d\'erreur rouge)', async ({
+    page,
+  }) => {
+    await page.goto(`${FRONTEND_URL}/consommations/marche`, { waitUntil: 'domcontentloaded' });
+    const tab = page.getByTestId('market-exposure-tab');
+    await expect(tab).toBeVisible({ timeout: 10_000 });
+
+    // Si on est par défaut sur scope=org sans site → SiteRequiredState
+    const siteRequired = tab.getByTestId('site-required-state');
+    const visible = await siteRequired.isVisible().catch(() => false);
+    if (visible) {
+      // Aucune erreur rouge ENERGY_SCOPE_INVALID ne doit apparaître
+      const errorBox = tab.getByTestId('market-exposure-error');
+      expect(await errorBox.count()).toBe(0);
+      // Le message FR métier est bien là
+      await expect(siteRequired).toContainText(/Sélectionnez un site/i);
+    } else {
+      test.info().annotations.push({
+        type: 'note',
+        description: 'Site déjà sélectionné par défaut — SiteRequiredState non vérifiable',
+      });
+    }
+  });
+
+  test('Rail Énergie inchangé (aucun « Marché & exposition » top-level)', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/consommations`, { waitUntil: 'domcontentloaded' });
+    const railLabels = await page.locator('nav a').allTextContents();
+    const topLevel = railLabels.filter((l) => l.length < 30);
+    expect(topLevel.filter((l) => /^Marché & exposition$/i.test(l)).length).toBe(0);
+  });
+});

--- a/e2e/playwright.p1_market_exposure.config.js
+++ b/e2e/playwright.p1_market_exposure.config.js
@@ -1,0 +1,32 @@
+/**
+ * PROMEOS — Config Playwright Sprint P1.S6 (Marché & exposition).
+ * Réutilise auth.setup.spec.js pour storageState partagé.
+ */
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STORAGE_STATE = path.join(__dirname, '.auth', 'promeos-user.json');
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: /(auth\.setup|p1_market_exposure)\.spec\.js$/,
+  timeout: 60_000,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:5175',
+    headless: true,
+    viewport: { width: 1440, height: 900 },
+  },
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.spec\.js$/ },
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium', storageState: STORAGE_STATE },
+      dependencies: ['setup'],
+      testMatch: /p1_market_exposure\.spec\.js$/,
+    },
+  ],
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -79,6 +79,9 @@ const LoadCurveTab = lazy(() => import('./pages/consumption/LoadCurveTab'));
 // Sprint Énergie P1.S5 (2026-05-30) — onglet Coût & contrat branché sur
 // /api/energy/cost-vs-contract. Route nested sous /consommations.
 const CostContractTab = lazy(() => import('./pages/consumption/CostContractTab'));
+// Sprint Énergie P1.S6 (2026-05-30) — onglet Marché & exposition branché
+// sur /api/energy/market-exposure. Route nested sous /consommations.
+const MarketExposureTab = lazy(() => import('./pages/consumption/MarketExposureTab'));
 const ActivationPage = lazy(() => import('./pages/ActivationPage'));
 const TertiaireDashboardPage = lazy(() => import('./pages/tertiaire/TertiaireDashboardPage'));
 const TertiaireWizardPage = lazy(() => import('./pages/tertiaire/TertiaireWizardPage'));
@@ -472,6 +475,17 @@ function App() {
                                         element={
                                           <PageSuspense>
                                             <CostContractTab />
+                                          </PageSuspense>
+                                        }
+                                      />
+                                      {/* Sprint Énergie P1.S6 (2026-05-30) —
+                                          onglet Marché & exposition branché sur
+                                          /api/energy/market-exposure. */}
+                                      <Route
+                                        path="marche"
+                                        element={
+                                          <PageSuspense>
+                                            <MarketExposureTab />
                                           </PageSuspense>
                                         }
                                       />

--- a/frontend/src/__tests__/BaseloadComparisonCard.test.jsx
+++ b/frontend/src/__tests__/BaseloadComparisonCard.test.jsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+/**
+ * PROMEOS — Tests BaseloadComparisonCard (Sprint P1.S6).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import BaseloadComparisonCard from '../ui/energy/BaseloadComparisonCard';
+
+const PROV = {
+  source: 'PROMEOS energy_orchestration',
+  service: 'market_exposure._compute_baseload_comparison',
+};
+
+afterEach(() => cleanup());
+
+describe('BaseloadComparisonCard', () => {
+  it('rend les 3 cellules : profil réel, baseload, écart', () => {
+    render(
+      <BaseloadComparisonCard
+        baseloadComparison={{
+          real_profile_cost_eur: 34000,
+          baseload_cost_eur: 31200,
+          delta_eur: 2800,
+          delta_eur_mwh: 14.5,
+          formula: 'coût spot pondéré réel - consommation plate équivalente',
+          provenance: PROV,
+        }}
+      />
+    );
+    expect(screen.getByTestId('baseload-real-profile')).toBeTruthy();
+    expect(screen.getByTestId('baseload-cost')).toBeTruthy();
+    expect(screen.getByTestId('baseload-delta')).toBeTruthy();
+  });
+
+  it('delta positif rendu en rouge (profil plus coûteux)', () => {
+    render(
+      <BaseloadComparisonCard
+        baseloadComparison={{
+          real_profile_cost_eur: 34000,
+          baseload_cost_eur: 31200,
+          delta_eur: 2800,
+          delta_eur_mwh: 14.5,
+          formula: '...',
+          provenance: PROV,
+        }}
+      />
+    );
+    const delta = screen.getByTestId('baseload-delta-eur');
+    expect(delta.getAttribute('data-sign')).toBe('positive');
+    expect(delta.textContent).toMatch(/\+2\s?800/);
+  });
+
+  it('delta négatif rendu en vert (profil moins coûteux)', () => {
+    render(
+      <BaseloadComparisonCard
+        baseloadComparison={{
+          real_profile_cost_eur: 28000,
+          baseload_cost_eur: 31200,
+          delta_eur: -3200,
+          delta_eur_mwh: -16.5,
+          formula: '...',
+          provenance: PROV,
+        }}
+      />
+    );
+    const delta = screen.getByTestId('baseload-delta-eur');
+    expect(delta.getAttribute('data-sign')).toBe('negative');
+    expect(delta.textContent).toMatch(/-3\s?200/);
+  });
+
+  it('formule backend affichée', () => {
+    render(
+      <BaseloadComparisonCard
+        baseloadComparison={{
+          real_profile_cost_eur: 100,
+          baseload_cost_eur: 90,
+          delta_eur: 10,
+          delta_eur_mwh: 1,
+          formula: 'coût spot pondéré profil réel vs ruban baseload équivalent',
+          provenance: PROV,
+        }}
+      />
+    );
+    expect(screen.getByTestId('baseload-formula').textContent).toContain(
+      'coût spot pondéré profil réel'
+    );
+  });
+
+  it('retourne null si baseloadComparison absent', () => {
+    const { container } = render(<BaseloadComparisonCard baseloadComparison={null} />);
+    expect(container.textContent).toBe('');
+  });
+});
+
+describe('BaseloadComparisonCard — doctrine zéro calcul métier', () => {
+  it('ne contient aucun calcul de delta ni de baseload FE', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../ui/energy/BaseloadComparisonCard.jsx'), 'utf8');
+    // Pas de calcul delta = real - baseload
+    expect(src).not.toMatch(/delta_eur\s*=\s*\w+\.real_profile_cost_eur\s*-/);
+    // Pas de calcul ruban baseload (total_kwh / nb_hours * spot_avg)
+    expect(src).not.toMatch(/baseload_cost_eur\s*=\s*\w+\s*[*/]/);
+  });
+});

--- a/frontend/src/__tests__/CostContractTab.test.jsx
+++ b/frontend/src/__tests__/CostContractTab.test.jsx
@@ -23,12 +23,23 @@ vi.mock('../services/api/energy', () => ({
   getCostVsContract: vi.fn(),
 }));
 
+const mockSetSite = vi.fn();
+let _mockScopeOverride = null;
+
 vi.mock('../contexts/ScopeContext', () => ({
-  useScope: () => ({
-    selectedSiteId: 42,
-    scope: { orgId: 1, entiteId: null, portefeuilleId: null, siteId: 42 },
-  }),
+  useScope: () =>
+    _mockScopeOverride
+      ? { ...{ setSite: mockSetSite }, ..._mockScopeOverride }
+      : {
+          selectedSiteId: 42,
+          scope: { orgId: 1, entiteId: null, portefeuilleId: null, siteId: 42 },
+          setSite: mockSetSite,
+        },
 }));
+
+function setScope(next) {
+  _mockScopeOverride = next;
+}
 
 import CostContractTab, {
   KPI_ORDER,
@@ -124,6 +135,8 @@ const SAMPLE_PAYLOAD = {
 describe('CostContractTab — checklist QA S5', () => {
   beforeEach(() => {
     getCostVsContract.mockReset();
+    mockSetSite.mockReset();
+    setScope(null);
   });
   afterEach(() => cleanup());
 
@@ -248,6 +261,17 @@ describe('CostContractTab — checklist QA S5', () => {
     const banner = screen.getByTestId('cost-contract-partial').textContent || '';
     expect(banner).toContain('Simulation partielle');
     expect(banner).toContain('prix spot fallback');
+  });
+
+  it('Sprint P1.S6 — scope=org (pas de site) : SiteRequiredState rendu, aucun appel API', () => {
+    setScope({
+      selectedSiteId: null,
+      scope: { orgId: 1, entiteId: null, portefeuilleId: null, siteId: null },
+    });
+    render(<CostContractTab />);
+    expect(screen.getByTestId('site-required-state')).toBeTruthy();
+    expect(screen.getByText(/Sélectionnez un site/i)).toBeTruthy();
+    expect(getCostVsContract).not.toHaveBeenCalled();
   });
 
   it('Header microcopy FR conforme brief', async () => {

--- a/frontend/src/__tests__/ExposureScoreGauge.test.jsx
+++ b/frontend/src/__tests__/ExposureScoreGauge.test.jsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+/**
+ * PROMEOS — Tests ExposureScoreGauge (Sprint P1.S6).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import ExposureScoreGauge from '../ui/energy/ExposureScoreGauge';
+
+const PROV = {
+  source: 'PROMEOS energy_orchestration',
+  service: 'market_exposure._compute_exposure_score',
+  formula: 'clamp_score_0_100(top10pct_share + neg_share*0.5)',
+  period: '12 mois glissants',
+  confidence: 0.78,
+};
+
+afterEach(() => cleanup());
+
+describe('ExposureScoreGauge', () => {
+  it('rend le score et le state propagé via data-state', () => {
+    render(<ExposureScoreGauge score={42} state="vigilance" provenance={PROV} />);
+    const gauge = screen.getByTestId('exposure-score-gauge');
+    expect(gauge.getAttribute('data-state')).toBe('vigilance');
+    expect(screen.getByTestId('exposure-score-value').textContent).toContain('42');
+  });
+
+  it('rend les 4 states canoniques', () => {
+    const states = ['sain', 'vigilance', 'critique', 'inactif'];
+    for (const s of states) {
+      cleanup();
+      render(<ExposureScoreGauge score={50} state={s} provenance={PROV} />);
+      expect(screen.getByTestId('exposure-score-gauge').getAttribute('data-state')).toBe(s);
+    }
+  });
+
+  it('état inactif par défaut si score null', () => {
+    render(<ExposureScoreGauge score={null} provenance={PROV} />);
+    expect(screen.getByTestId('exposure-score-gauge').getAttribute('data-state')).toBe('inactif');
+    expect(screen.getByTestId('exposure-score-value').textContent).toContain('—');
+  });
+
+  it('provenance backend exposée', () => {
+    render(<ExposureScoreGauge score={67} state="sain" provenance={PROV} />);
+    expect(screen.getByTestId('exposure-score-provenance')).toBeTruthy();
+  });
+
+  it('label state affiché', () => {
+    render(<ExposureScoreGauge score={80} state="critique" provenance={PROV} />);
+    expect(screen.getByTestId('exposure-score-state-label').textContent).toContain('Critique');
+  });
+});
+
+describe('ExposureScoreGauge — doctrine zéro calcul métier', () => {
+  it('ne contient aucun recalcul du state ni du score', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../ui/energy/ExposureScoreGauge.jsx'), 'utf8');
+    // Pas de calcul state = (score > X ? ...)
+    expect(src).not.toMatch(/state\s*=\s*\(\s*\w+\s*[<>]/);
+    // Pas de clamp manuel score
+    expect(src).not.toMatch(/Math\.min\s*\(\s*100\s*,\s*Math\.max/);
+    // Pas de CO₂
+    expect(src).not.toMatch(/kwhToCo2|emission_factor/);
+  });
+});

--- a/frontend/src/__tests__/FavorableHoursPanel.test.jsx
+++ b/frontend/src/__tests__/FavorableHoursPanel.test.jsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+/**
+ * PROMEOS — Tests FavorableHoursPanel (Sprint P1.S6).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import FavorableHoursPanel from '../ui/energy/FavorableHoursPanel';
+
+const PROV = {
+  source: 'PROMEOS energy_orchestration',
+  service: 'market_exposure._compute_favorable_hours',
+};
+
+const HOURS = [
+  {
+    timestamp: '2026-03-02T03:00:00+01:00',
+    spot_price_eur_mwh: 12.5,
+    kwh: 14.0,
+    reason: 'prix bas',
+    provenance: PROV,
+  },
+  {
+    timestamp: '2026-03-15T13:00:00+01:00',
+    spot_price_eur_mwh: -5.0,
+    kwh: 22.0,
+    reason: 'prix négatif',
+    provenance: PROV,
+  },
+  {
+    timestamp: '2026-04-10T13:00:00+02:00',
+    spot_price_eur_mwh: 8.0,
+    kwh: 30.0,
+    reason: 'heure solaire',
+    provenance: PROV,
+  },
+];
+
+afterEach(() => cleanup());
+
+describe('FavorableHoursPanel', () => {
+  it('rend les 3 groupes catégorisés backend', () => {
+    render(<FavorableHoursPanel favorableHours={HOURS} />);
+    expect(screen.getByTestId('favorable-group-prix-bas')).toBeTruthy();
+    expect(screen.getByTestId('favorable-group-prix-négatif')).toBeTruthy();
+    expect(screen.getByTestId('favorable-group-heure-solaire')).toBeTruthy();
+  });
+
+  it('chaque heure exposée via data-reason', () => {
+    render(<FavorableHoursPanel favorableHours={HOURS} />);
+    const rows = document.querySelectorAll('[data-reason]');
+    expect(rows.length).toBe(3);
+    const reasons = Array.from(rows).map((r) => r.getAttribute('data-reason'));
+    expect(reasons).toContain('prix bas');
+    expect(reasons).toContain('prix négatif');
+    expect(reasons).toContain('heure solaire');
+  });
+
+  it('retourne null si pas de données', () => {
+    const { container } = render(<FavorableHoursPanel favorableHours={[]} />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('groupe vide masqué', () => {
+    const onlyBas = HOURS.filter((h) => h.reason === 'prix bas');
+    render(<FavorableHoursPanel favorableHours={onlyBas} />);
+    expect(screen.getByTestId('favorable-group-prix-bas')).toBeTruthy();
+    expect(screen.queryByTestId('favorable-group-prix-négatif')).toBeNull();
+    expect(screen.queryByTestId('favorable-group-heure-solaire')).toBeNull();
+  });
+});
+
+describe('FavorableHoursPanel — doctrine zéro calcul métier', () => {
+  it('ne contient pas de détection prix négatif ni de tri solaire FE', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../ui/energy/FavorableHoursPanel.jsx'), 'utf8');
+    // Pas de détection prix négatif FE
+    expect(src).not.toMatch(/spot_price_eur_mwh\s*<\s*0/);
+    // Pas de détection solaire FE (heure du jour, mois, etc.)
+    expect(src).not.toMatch(/getMonth\s*\(\s*\)/);
+    expect(src).not.toMatch(/getHours\s*\(\s*\)\s*[<>=]/);
+  });
+});

--- a/frontend/src/__tests__/MarketExposureTab.test.jsx
+++ b/frontend/src/__tests__/MarketExposureTab.test.jsx
@@ -1,0 +1,410 @@
+// @vitest-environment jsdom
+/**
+ * PROMEOS — Tests MarketExposureTab (Sprint P1.S6).
+ *
+ * Couvre la checklist QA :
+ * 1. onglet visible dans /consommations ;
+ * 2. scope=org → SiteRequiredState + aucun appel API ;
+ * 3. getMarketExposure appelé si site sélectionné ;
+ * 4. loading ;
+ * 5. empty ;
+ * 6. error code + hint + correlation_id ;
+ * 7. 8 KPI + provenance ;
+ * 8. exposure score visible ;
+ * 9. top heures chères visibles ;
+ * 10. prix négatifs / heures favorables visibles ;
+ * 11. baseload comparison visible ;
+ * 12. warning simulation indicative visible ;
+ * 13. zéro calcul métier interdit.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('../services/api/energy', () => ({
+  getMarketExposure: vi.fn(),
+}));
+
+const mockSetSite = vi.fn();
+let _scopeOverride = null;
+
+vi.mock('../contexts/ScopeContext', () => ({
+  useScope: () =>
+    _scopeOverride
+      ? { ...{ setSite: mockSetSite }, ..._scopeOverride }
+      : {
+          selectedSiteId: 42,
+          scope: { orgId: 1, entiteId: null, portefeuilleId: null, siteId: 42 },
+          setSite: mockSetSite,
+        },
+}));
+
+function setScope(next) {
+  _scopeOverride = next;
+}
+
+import MarketExposureTab, {
+  KPI_ORDER,
+  DEFAULT_PERIOD,
+  DEFAULT_MARKET,
+  DEFAULT_ZONE,
+} from '../pages/consumption/MarketExposureTab';
+import { getMarketExposure } from '../services/api/energy';
+
+const PROV = (service) => ({
+  source: 'PROMEOS energy_orchestration',
+  service,
+  formula: 'spot_cost = Σ(kwh × spot_price / 1000)',
+  period: '12 mois glissants',
+  confidence: 0.78,
+  assumptions: ['EPEX day-ahead FR', 'timezone Europe/Paris'],
+});
+
+const KPI = (key, label, value, unit, state = 'sain') => ({
+  key,
+  label,
+  value,
+  unit,
+  state,
+  scope: { kind: 'site', scope_id: 42, org_id: 1 },
+  period: { label: '12m', days: 365, timezone: 'Europe/Paris' },
+  provenance: PROV(`market_exposure._kpi (${key})`),
+});
+
+const TOP_HOUR = (rank, ts, price, kwh, cost, action) => ({
+  timestamp: ts,
+  spot_price_eur_mwh: price,
+  kwh,
+  cost_eur: cost,
+  rank,
+  recommended_action: action,
+  provenance: PROV(`market_exposure._compute_top_expensive_hours`),
+});
+
+const FAV_HOUR = (ts, price, reason) => ({
+  timestamp: ts,
+  spot_price_eur_mwh: price,
+  kwh: 20.0,
+  reason,
+  provenance: PROV(`market_exposure._compute_favorable_hours`),
+});
+
+const SAMPLE_PAYLOAD = {
+  scope: { kind: 'site', scope_id: 42, org_id: 1 },
+  period: { label: '12m', days: 365, timezone: 'Europe/Paris' },
+  market: {
+    type: 'day_ahead',
+    zone: 'FR',
+    source: 'MktPrice canonique',
+    price_unit: '€/MWh',
+    provenance: PROV('mkt_price.canonical'),
+  },
+  kpis: {
+    spot_cost_theoretical_eur: KPI('spot_cost_theoretical_eur', 'Coût spot théorique', 33200, '€'),
+    spot_avg_simple_eur_mwh: KPI('spot_avg_simple_eur_mwh', 'Spot moyen simple', 168.0, '€/MWh'),
+    spot_avg_weighted_eur_mwh: KPI(
+      'spot_avg_weighted_eur_mwh',
+      'Spot moyen pondéré',
+      176.4,
+      '€/MWh'
+    ),
+    baseload_cost_eur: KPI('baseload_cost_eur', 'Coût ruban baseload', 31200, '€'),
+    delta_vs_baseload_eur: KPI(
+      'delta_vs_baseload_eur',
+      'Écart vs baseload',
+      2000,
+      '€',
+      'vigilance'
+    ),
+    top_10pct_expensive_hours_cost_pct: KPI(
+      'top_10pct_expensive_hours_cost_pct',
+      'Top 10 % heures chères',
+      27.5,
+      '%',
+      'vigilance'
+    ),
+    negative_price_consumption_pct: KPI(
+      'negative_price_consumption_pct',
+      'Conso heures prix négatif',
+      2.1,
+      '%'
+    ),
+    exposure_score: KPI('exposure_score', "Score d'exposition spot", 58, '/100', 'vigilance'),
+  },
+  series: [],
+  top_expensive_hours: [
+    TOP_HOUR(
+      1,
+      '2026-01-15T19:00:00+01:00',
+      420.5,
+      85.4,
+      35.91,
+      'Éviter démarrage cycle process intensif.'
+    ),
+    TOP_HOUR(
+      2,
+      '2026-02-08T08:00:00+01:00',
+      380.0,
+      72.1,
+      27.4,
+      'Décaler chauffage électrique vers 10h.'
+    ),
+  ],
+  favorable_hours: [
+    FAV_HOUR('2026-03-02T03:00:00+01:00', 12.5, 'prix bas'),
+    FAV_HOUR('2026-03-15T13:00:00+01:00', -5.0, 'prix négatif'),
+    FAV_HOUR('2026-04-10T13:00:00+02:00', 8.0, 'heure solaire'),
+  ],
+  baseload_comparison: {
+    real_profile_cost_eur: 33200,
+    baseload_cost_eur: 31200,
+    delta_eur: 2000,
+    delta_eur_mwh: 10.2,
+    formula: 'coût spot pondéré profil réel vs consommation plate équivalente',
+    provenance: PROV('market_exposure._compute_baseload_comparison'),
+  },
+  simulation: {
+    label: 'Déplacement indicatif',
+    flexible_share_pct: 20.0,
+    estimated_delta_eur: -850,
+    warning: "Simulation indicative — ne constitue pas une promesse d'économie.",
+    provenance: PROV('market_exposure._simulate_displacement'),
+  },
+  warnings: [],
+  provenance: PROV('market_exposure.build_market_exposure'),
+};
+
+describe('MarketExposureTab — checklist QA S6', () => {
+  beforeEach(() => {
+    getMarketExposure.mockReset();
+    mockSetSite.mockReset();
+    setScope(null);
+  });
+  afterEach(() => cleanup());
+
+  it('Critère 2 : scope=org (pas de site) → SiteRequiredState, aucun appel API', () => {
+    setScope({
+      selectedSiteId: null,
+      scope: { orgId: 1, entiteId: null, portefeuilleId: null, siteId: null },
+    });
+    render(<MarketExposureTab />);
+    expect(screen.getByTestId('site-required-state')).toBeTruthy();
+    expect(screen.getByText(/Sélectionnez un site/i)).toBeTruthy();
+    expect(getMarketExposure).not.toHaveBeenCalled();
+  });
+
+  it('Critère 3 : appelle getMarketExposure avec scope=site + period=12m + market=day_ahead + zone=FR + baseload=true', async () => {
+    getMarketExposure.mockResolvedValueOnce(SAMPLE_PAYLOAD);
+    render(<MarketExposureTab />);
+    await waitFor(() => expect(getMarketExposure).toHaveBeenCalledTimes(1));
+    const args = getMarketExposure.mock.calls[0][0];
+    expect(args.scope).toBe('site');
+    expect(args.scope_id).toBe(42);
+    expect(args.period).toBe(DEFAULT_PERIOD);
+    expect(DEFAULT_PERIOD).toBe('12m');
+    expect(args.market).toBe(DEFAULT_MARKET);
+    expect(DEFAULT_MARKET).toBe('day_ahead');
+    expect(args.zone).toBe(DEFAULT_ZONE);
+    expect(DEFAULT_ZONE).toBe('FR');
+    expect(args.baseload).toBe(true);
+    expect(args.org_id).toBe(1);
+  });
+
+  it('Critère 4 : loading state visible avant la réponse', async () => {
+    let resolveFn;
+    const pending = new Promise((res) => {
+      resolveFn = res;
+    });
+    getMarketExposure.mockReturnValueOnce(pending);
+    render(<MarketExposureTab />);
+    expect(screen.getByTestId('market-exposure-loading')).toBeTruthy();
+    resolveFn(SAMPLE_PAYLOAD);
+    await waitFor(() => screen.getByTestId('market-exposure-kpis-grid'));
+  });
+
+  it('Critère 5 : empty state si pas de KPI/scénarios/baseload/heures', async () => {
+    getMarketExposure.mockResolvedValueOnce({
+      ...SAMPLE_PAYLOAD,
+      kpis: {},
+      top_expensive_hours: [],
+      favorable_hours: [],
+      baseload_comparison: null,
+      simulation: null,
+    });
+    render(<MarketExposureTab />);
+    await waitFor(() => expect(screen.queryByTestId('market-exposure-kpis-grid')).toBeNull());
+    expect(screen.getByText(/Aucune exposition marché disponible/i)).toBeTruthy();
+    expect(screen.getByText('Élargir la période')).toBeTruthy();
+  });
+
+  it('Critère 6 : error state code + hint + correlation_id', async () => {
+    const err = new Error('Request failed');
+    err.response = {
+      status: 400,
+      data: {
+        detail: {
+          code: 'ENERGY_MARKET_UNKNOWN',
+          message: "market='lol' inconnu",
+          hint: 'valeurs : day_ahead | intraday | future_baseload | future_peakload',
+          correlation_id: 'corr-mkt-9876',
+        },
+      },
+    };
+    getMarketExposure.mockRejectedValueOnce(err);
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('market-exposure-error'));
+    expect(screen.getByTestId('error-code').textContent).toContain('ENERGY_MARKET_UNKNOWN');
+    expect(screen.getByTestId('error-hint').textContent).toContain('day_ahead');
+    expect(screen.getByTestId('error-correlation-id').textContent).toContain('corr-mkt-9876');
+  });
+
+  it('Critère 7 : 8 KPI rendus avec provenance', async () => {
+    getMarketExposure.mockResolvedValueOnce(SAMPLE_PAYLOAD);
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('market-exposure-kpis-grid'));
+    for (const key of KPI_ORDER) {
+      expect(screen.getByTestId(`market-exposure-kpi-${key}`)).toBeTruthy();
+    }
+    // 8 tooltips de cartes KPI (KpiCardWithProvenance) + 1 tooltip
+    // ExposureScoreGauge (qui ré-affiche exposure_score) + tooltips
+    // BaseloadComparisonCard / TopExpensiveHoursTable autres.
+    const tooltips = screen.getAllByTestId('kpi-provenance-tooltip');
+    expect(tooltips.length).toBe(8);
+  });
+
+  it('Critère 7 bis : KPI_ORDER canonique (8 entrées)', () => {
+    expect(KPI_ORDER).toEqual([
+      'spot_cost_theoretical_eur',
+      'spot_avg_simple_eur_mwh',
+      'spot_avg_weighted_eur_mwh',
+      'baseload_cost_eur',
+      'delta_vs_baseload_eur',
+      'top_10pct_expensive_hours_cost_pct',
+      'negative_price_consumption_pct',
+      'exposure_score',
+    ]);
+  });
+
+  it('Critère 8 : ExposureScoreGauge rendue avec score+state backend', async () => {
+    getMarketExposure.mockResolvedValueOnce(SAMPLE_PAYLOAD);
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('exposure-score-gauge'));
+    const gauge = screen.getByTestId('exposure-score-gauge');
+    expect(gauge.getAttribute('data-state')).toBe('vigilance');
+    expect(gauge.getAttribute('data-score')).toBe('58');
+  });
+
+  it('Critère 9 : top heures chères visibles', async () => {
+    getMarketExposure.mockResolvedValueOnce(SAMPLE_PAYLOAD);
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('top-expensive-hours-table'));
+    expect(screen.getByTestId('top-hour-row-1')).toBeTruthy();
+    expect(screen.getByTestId('top-hour-row-2')).toBeTruthy();
+  });
+
+  it('Critère 10 : prix négatif + heures favorables visibles', async () => {
+    getMarketExposure.mockResolvedValueOnce(SAMPLE_PAYLOAD);
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('favorable-hours-panel'));
+    expect(screen.getByTestId('favorable-group-prix-bas')).toBeTruthy();
+    expect(screen.getByTestId('favorable-group-prix-négatif')).toBeTruthy();
+    expect(screen.getByTestId('favorable-group-heure-solaire')).toBeTruthy();
+  });
+
+  it('Critère 11 : baseload comparison visible', async () => {
+    getMarketExposure.mockResolvedValueOnce(SAMPLE_PAYLOAD);
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('baseload-comparison-card'));
+    expect(screen.getByTestId('baseload-real-profile')).toBeTruthy();
+    expect(screen.getByTestId('baseload-cost')).toBeTruthy();
+    expect(screen.getByTestId('baseload-delta')).toBeTruthy();
+  });
+
+  it('Critère 12 : warning « Simulation indicative » visible si simulation fournie', async () => {
+    getMarketExposure.mockResolvedValueOnce(SAMPLE_PAYLOAD);
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('simulation-warning'));
+    const warning = screen.getByTestId('simulation-warning').textContent || '';
+    expect(warning).toContain('Simulation indicative');
+    expect(warning).toContain("ne constitue pas une promesse d'économie");
+  });
+
+  it('Partial : bandeau warnings affiché si backend renvoie warnings', async () => {
+    getMarketExposure.mockResolvedValueOnce({
+      ...SAMPLE_PAYLOAD,
+      warnings: ['12 heures sans prix spot', 'fallback day_ahead utilisé'],
+    });
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('market-exposure-partial'));
+    const banner = screen.getByTestId('market-exposure-partial').textContent || '';
+    expect(banner).toContain('Analyse partielle');
+    expect(banner).toContain('12 heures sans prix spot');
+  });
+
+  it('Header microcopy + market context affichés', async () => {
+    getMarketExposure.mockResolvedValueOnce(SAMPLE_PAYLOAD);
+    render(<MarketExposureTab />);
+    await waitFor(() => screen.getByTestId('market-exposure-header'));
+    const header = screen.getByTestId('market-exposure-header').textContent || '';
+    expect(header).toContain('Marché & exposition');
+    expect(header).toContain('Votre profil face aux prix spot');
+    expect(header).toContain('Repérez les heures chères');
+    expect(header).toContain('day_ahead');
+    expect(header).toContain('FR');
+    expect(header).toContain('MktPrice canonique');
+  });
+});
+
+describe('MarketExposureTab — doctrine zéro calcul métier (critère 13)', () => {
+  it('MarketExposureTab.jsx ne contient aucun calcul métier interdit', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(
+      resolve(__dirname, '../pages/consumption/MarketExposureTab.jsx'),
+      'utf8'
+    );
+    // Pas de calcul spot_cost = kwh * spot / 1000
+    expect(src).not.toMatch(/spot_cost\s*=\s*\w+\.kwh\s*\*/);
+    // Pas de calcul baseload FE
+    expect(src).not.toMatch(/baseload_cost_eur\s*=\s*\w+\s*[*/]/);
+    // Pas de calcul delta FE
+    expect(src).not.toMatch(/delta_eur\s*=\s*\w+\s*-\s*\w+/);
+    // Pas de calcul score expo FE
+    expect(src).not.toMatch(/exposure_score\s*=\s*Math\./);
+    // Pas de calcul top 10 % FE
+    expect(src).not.toMatch(/quantile|percentile/i);
+    // Pas de détection prix négatif FE
+    expect(src).not.toMatch(/spot_price_eur_mwh\s*<\s*0/);
+    // Pas de CO₂
+    expect(src).not.toMatch(/kwhToCo2|emission_factor/);
+    // L'appel API et le rendu KPI fournis backend sont OK
+    expect(src).toContain('getMarketExposure');
+    expect(src).toContain('KpiCardWithProvenance');
+  });
+
+  it('ConsommationsPage déclare le tab marche', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../pages/ConsommationsPage.jsx'), 'utf8');
+    expect(src).toContain('/consommations/marche');
+    expect(src).toContain("'Marché & exposition'");
+  });
+
+  it('App.jsx déclare la route nested marche avec lazy import', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../App.jsx'), 'utf8');
+    expect(src).toMatch(
+      /lazy\(\(\) =>\s*import\(['"]\.\/pages\/consumption\/MarketExposureTab['"]/
+    );
+    expect(src).toMatch(/path="marche"/);
+  });
+
+  it('Rail NavRegistry inchangé (pas de top-level Marché & exposition)', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../layout/NavRegistry.js'), 'utf8');
+    expect(src).not.toMatch(/label:\s*['"]Marché & exposition['"]/);
+    expect(src).not.toMatch(/path:\s*['"]marche['"]/);
+    expect(src).not.toMatch(/to:\s*['"]\/?marche['"]/);
+  });
+});

--- a/frontend/src/__tests__/TopExpensiveHoursTable.test.jsx
+++ b/frontend/src/__tests__/TopExpensiveHoursTable.test.jsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+/**
+ * PROMEOS — Tests TopExpensiveHoursTable (Sprint P1.S6).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import TopExpensiveHoursTable from '../ui/energy/TopExpensiveHoursTable';
+
+const PROV = {
+  source: 'PROMEOS energy_orchestration',
+  service: 'market_exposure._compute_top_expensive_hours',
+  formula: 'Q90 via compute_quantiles',
+};
+
+const HOURS = [
+  {
+    timestamp: '2026-01-15T19:00:00+01:00',
+    spot_price_eur_mwh: 420.5,
+    kwh: 85.4,
+    cost_eur: 35.91,
+    rank: 1,
+    recommended_action: 'Éviter démarrage cycle process intensif.',
+    provenance: PROV,
+  },
+  {
+    timestamp: '2026-02-08T08:00:00+01:00',
+    spot_price_eur_mwh: 380.0,
+    kwh: 72.1,
+    cost_eur: 27.4,
+    rank: 2,
+    recommended_action: 'Décaler chauffage électrique vers 10h.',
+    provenance: PROV,
+  },
+  {
+    timestamp: '2026-01-22T18:00:00+01:00',
+    spot_price_eur_mwh: 365.5,
+    kwh: 68.0,
+    cost_eur: 24.85,
+    rank: 3,
+    recommended_action: 'Surveiller pic récurrent (-1h).',
+    provenance: PROV,
+  },
+];
+
+afterEach(() => cleanup());
+
+describe('TopExpensiveHoursTable', () => {
+  it('rend les 3 lignes', () => {
+    render(<TopExpensiveHoursTable topExpensiveHours={HOURS} />);
+    expect(screen.getByTestId('top-hour-row-1')).toBeTruthy();
+    expect(screen.getByTestId('top-hour-row-2')).toBeTruthy();
+    expect(screen.getByTestId('top-hour-row-3')).toBeTruthy();
+  });
+
+  it('tri visuel par rank si fourni par API (ordre 1→3 préservé)', () => {
+    // Backend renvoie potentiellement dans le désordre.
+    const shuffled = [HOURS[2], HOURS[0], HOURS[1]];
+    render(<TopExpensiveHoursTable topExpensiveHours={shuffled} />);
+    const rows = document.querySelectorAll('[data-rank]');
+    expect(rows[0].getAttribute('data-rank')).toBe('1');
+    expect(rows[1].getAttribute('data-rank')).toBe('2');
+    expect(rows[2].getAttribute('data-rank')).toBe('3');
+  });
+
+  it('affiche recommended_action backend (jamais générée FE)', () => {
+    render(<TopExpensiveHoursTable topExpensiveHours={HOURS} />);
+    expect(screen.getByText('Éviter démarrage cycle process intensif.')).toBeTruthy();
+    expect(screen.getByText('Décaler chauffage électrique vers 10h.')).toBeTruthy();
+  });
+
+  it('affiche spot_price_eur_mwh et cost_eur depuis API', () => {
+    render(<TopExpensiveHoursTable topExpensiveHours={HOURS} />);
+    const row1 = screen.getByTestId('top-hour-row-1');
+    expect(row1.textContent).toContain('420,5');
+    expect(row1.textContent).toMatch(/35,?91|36/);
+  });
+
+  it('retourne null si pas de données', () => {
+    const { container } = render(<TopExpensiveHoursTable topExpensiveHours={[]} />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('provenance par ligne exposée', () => {
+    render(<TopExpensiveHoursTable topExpensiveHours={HOURS} />);
+    expect(screen.getAllByTestId('top-hour-provenance').length).toBe(3);
+  });
+});
+
+describe('TopExpensiveHoursTable — doctrine zéro calcul métier', () => {
+  it('ne contient pas de calcul de cost ni de tri métier sans rank', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../ui/energy/TopExpensiveHoursTable.jsx'), 'utf8');
+    // Pas de calcul cost_eur = kwh * price/1000
+    expect(src).not.toMatch(/cost_eur\s*=\s*\w+\.kwh\s*\*/);
+    // Pas de Q90/quantiles FE
+    expect(src).not.toMatch(/quantile|percentile/i);
+    // Pas de recommended_action générée FE
+    expect(src).not.toMatch(/recommended_action\s*=\s*['"`]/);
+  });
+});

--- a/frontend/src/__tests__/WeekProfileTab.test.jsx
+++ b/frontend/src/__tests__/WeekProfileTab.test.jsx
@@ -22,12 +22,23 @@ vi.mock('../services/api/energy', () => ({
   getWeekProfile: vi.fn(),
 }));
 
+const mockSetSite = vi.fn();
+let _mockScopeOverride = null;
+
 vi.mock('../contexts/ScopeContext', () => ({
-  useScope: () => ({
-    selectedSiteId: 42,
-    scope: { orgId: 1, entiteId: null, portefeuilleId: null, siteId: 42 },
-  }),
+  useScope: () =>
+    _mockScopeOverride
+      ? { ...{ setSite: mockSetSite }, ..._mockScopeOverride }
+      : {
+          selectedSiteId: 42,
+          scope: { orgId: 1, entiteId: null, portefeuilleId: null, siteId: 42 },
+          setSite: mockSetSite,
+        },
 }));
+
+function setScope(next) {
+  _mockScopeOverride = next;
+}
 
 import WeekProfileTab, { KPI_ORDER, DEFAULT_DAYS } from '../pages/usages/WeekProfileTab';
 import { getWeekProfile } from '../services/api/energy';
@@ -92,6 +103,8 @@ const SAMPLE_PAYLOAD = {
 describe('WeekProfileTab — checklist QA S4', () => {
   beforeEach(() => {
     getWeekProfile.mockReset();
+    mockSetSite.mockReset();
+    setScope(null);
   });
   afterEach(() => cleanup());
 
@@ -209,6 +222,17 @@ describe('WeekProfileTab — checklist QA S4', () => {
     const banner = screen.getByTestId('week-profile-partial').textContent || '';
     expect(banner).toContain('Données partielles');
     expect(banner).toContain('12 cellules estimées');
+  });
+
+  it('Sprint P1.S6 — scope=org (pas de site) : SiteRequiredState rendu, aucun appel API', () => {
+    setScope({
+      selectedSiteId: null,
+      scope: { orgId: 1, entiteId: null, portefeuilleId: null, siteId: null },
+    });
+    render(<WeekProfileTab />);
+    expect(screen.getByTestId('site-required-state')).toBeTruthy();
+    expect(screen.getByText(/Sélectionnez un site/i)).toBeTruthy();
+    expect(getWeekProfile).not.toHaveBeenCalled();
   });
 
   it('Header microcopy FR conforme au brief', async () => {

--- a/frontend/src/pages/ConsommationsPage.jsx
+++ b/frontend/src/pages/ConsommationsPage.jsx
@@ -10,7 +10,7 @@
  * reste accessible via module admin NavRegistry + ⌘K search.
  */
 import { NavLink, Outlet } from 'react-router-dom';
-import { Activity, BarChart3, ReceiptText, Upload, Zap, Building2 } from 'lucide-react';
+import { Activity, BarChart3, LineChart, ReceiptText, Upload, Zap, Building2 } from 'lucide-react';
 import { PageShell } from '../ui';
 import { useScope } from '../contexts/ScopeContext';
 
@@ -19,11 +19,15 @@ import { useScope } from '../contexts/ScopeContext';
 // rail modifié — onglet interne sous /consommations (architecture nested).
 // Sprint Énergie P1.S5 (2026-05-30) — ajout onglet « Coût & contrat »
 // branché sur /api/energy/cost-vs-contract. Doctrine zéro calcul métier FE.
+// Sprint Énergie P1.S6 (2026-05-30) — ajout onglet « Marché & exposition »
+// branché sur /api/energy/market-exposure (score expo, top heures chères,
+// baseload comparison, heures favorables). Doctrine zéro calcul métier FE.
 const TABS = [
   { to: '/consommations/portfolio', label: 'Portefeuille', icon: Building2 },
   { to: '/consommations/explorer', label: 'Explorer', icon: BarChart3 },
   { to: '/consommations/courbe', label: 'Courbe de charge', icon: Activity },
   { to: '/consommations/cout-contrat', label: 'Coût & contrat', icon: ReceiptText },
+  { to: '/consommations/marche', label: 'Marché & exposition', icon: LineChart },
   { to: '/consommations/import', label: 'Import', icon: Upload },
 ];
 

--- a/frontend/src/pages/consumption/CostContractTab.jsx
+++ b/frontend/src/pages/consumption/CostContractTab.jsx
@@ -26,6 +26,7 @@ import { getCostVsContract } from '../../services/api/energy';
 import KpiCardWithProvenance from '../../ui/energy/KpiCardWithProvenance';
 import CostVsContractCard from '../../ui/energy/CostVsContractCard';
 import PriceDecompositionTable from '../../ui/energy/PriceDecompositionTable';
+import SiteRequiredState from '../../ui/energy/SiteRequiredState';
 import { EmptyState, SkeletonCard } from '../../ui';
 
 const KPI_ORDER = [
@@ -144,9 +145,13 @@ export default function CostContractTab({
   period = DEFAULT_PERIOD,
   scenarios = DEFAULT_SCENARIOS,
 }) {
-  const { selectedSiteId, scope } = useScope();
+  const { selectedSiteId, scope, setSite } = useScope();
   const orgId = scope?.orgId;
   const siteId = selectedSiteId;
+  // Sprint P1.S6 — la vue Coût & contrat n'est servie qu'au niveau
+  // site/meter (un contrat est rattaché à un site). Si pas de site
+  // sélectionné, on n'appelle pas l'API et on affiche SiteRequiredState.
+  const hasSite = siteId != null;
 
   const [payload, setPayload] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -154,15 +159,21 @@ export default function CostContractTab({
   const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
+    if (!hasSite) {
+      setPayload(null);
+      setError(null);
+      setLoading(false);
+      return undefined;
+    }
     let cancelled = false;
     setLoading(true);
     setError(null);
     const params = {
-      scope: siteId ? 'site' : 'org',
+      scope: 'site',
+      scope_id: siteId,
       period,
       scenarios,
     };
-    if (siteId != null) params.scope_id = siteId;
     if (orgId != null) params.org_id = orgId;
     getCostVsContract(params)
       .then((data) => {
@@ -178,13 +189,26 @@ export default function CostContractTab({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [siteId, orgId, period, scenarios, reloadToken]);
+  }, [hasSite, siteId, orgId, period, scenarios, reloadToken]);
 
   const kpis = payload?.kpis || {};
   const orderedKpis = useMemo(
     () => KPI_ORDER.filter((key) => kpis[key]).map((key) => ({ key, kpi: kpis[key] })),
     [kpis]
   );
+
+  if (!hasSite) {
+    return (
+      <div data-testid="cost-contract-tab">
+        <TabHeader />
+        <div className="mt-4">
+          <SiteRequiredState
+            onChooseSite={typeof setSite === 'function' ? () => setSite(null) : undefined}
+          />
+        </div>
+      </div>
+    );
+  }
 
   if (loading && !payload) {
     return (

--- a/frontend/src/pages/consumption/MarketExposureTab.jsx
+++ b/frontend/src/pages/consumption/MarketExposureTab.jsx
@@ -1,0 +1,323 @@
+/**
+ * PROMEOS — MarketExposureTab (Sprint P1.S6).
+ *
+ * Onglet « Marché & exposition » sous `/consommations/marche`. Branché
+ * sur `/api/energy/market-exposure` (livré P1.S2d).
+ *
+ * Affiche :
+ * - hook produit FR (« Repérez les heures chères, les prix négatifs et
+ *   l'écart vs un ruban baseload. ») ;
+ * - 8 KPI canoniques via KpiCardWithProvenance :
+ *     spot_cost_theoretical_eur, spot_avg_simple_eur_mwh,
+ *     spot_avg_weighted_eur_mwh, baseload_cost_eur,
+ *     delta_vs_baseload_eur, top_10pct_expensive_hours_cost_pct,
+ *     negative_price_consumption_pct, exposure_score
+ * - ExposureScoreGauge (score [0,100] borné backend) ;
+ * - BaseloadComparisonCard (delta_eur, delta_eur_mwh, formule) ;
+ * - TopExpensiveHoursTable (rang + action conseillée backend) ;
+ * - FavorableHoursPanel (prix bas / prix négatif / heure solaire) ;
+ * - DisplacementSimulationCard avec warning obligatoire si fournie.
+ *
+ * UX scope-site-required :
+ * - si pas de site sélectionné → SiteRequiredState (pas d'appel API).
+ *
+ * Doctrine : zéro calcul métier frontend.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { AlertCircle, AlertTriangle, LineChart } from 'lucide-react';
+import { useScope } from '../../contexts/ScopeContext';
+import { getMarketExposure } from '../../services/api/energy';
+import KpiCardWithProvenance from '../../ui/energy/KpiCardWithProvenance';
+import ExposureScoreGauge from '../../ui/energy/ExposureScoreGauge';
+import TopExpensiveHoursTable from '../../ui/energy/TopExpensiveHoursTable';
+import FavorableHoursPanel from '../../ui/energy/FavorableHoursPanel';
+import BaseloadComparisonCard from '../../ui/energy/BaseloadComparisonCard';
+import DisplacementSimulationCard from '../../ui/energy/DisplacementSimulationCard';
+import SiteRequiredState from '../../ui/energy/SiteRequiredState';
+import { EmptyState, SkeletonCard } from '../../ui';
+
+const KPI_ORDER = [
+  'spot_cost_theoretical_eur',
+  'spot_avg_simple_eur_mwh',
+  'spot_avg_weighted_eur_mwh',
+  'baseload_cost_eur',
+  'delta_vs_baseload_eur',
+  'top_10pct_expensive_hours_cost_pct',
+  'negative_price_consumption_pct',
+  'exposure_score',
+];
+
+const DEFAULT_PERIOD = '12m';
+const DEFAULT_MARKET = 'day_ahead';
+const DEFAULT_ZONE = 'FR';
+
+function ApiErrorState({ error, onRetry }) {
+  const detail = error?.response?.data?.detail || {};
+  const code = detail.code || 'ENERGY_UNKNOWN';
+  const message = detail.message || error?.message || 'Erreur inconnue';
+  const hint = detail.hint;
+  const correlationId = detail.correlation_id;
+  return (
+    <div
+      className="rounded-xl border border-red-200 bg-red-50 p-4 space-y-2"
+      role="alert"
+      data-testid="market-exposure-error"
+    >
+      <div className="flex items-start gap-2">
+        <AlertCircle size={16} className="text-red-600 shrink-0 mt-0.5" aria-hidden="true" />
+        <div className="flex-1 space-y-1">
+          <p className="text-sm font-semibold text-red-800" data-testid="error-message">
+            {message}
+          </p>
+          {hint && (
+            <p className="text-xs text-red-700" data-testid="error-hint">
+              {hint}
+            </p>
+          )}
+          <div className="flex flex-wrap items-center gap-3 text-[10px] text-red-500 mt-1">
+            <span data-testid="error-code">code: {code}</span>
+            {correlationId && (
+              <span data-testid="error-correlation-id">correlation_id: {correlationId}</span>
+            )}
+          </div>
+        </div>
+      </div>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="text-xs font-medium text-red-700 hover:underline"
+        >
+          Réessayer
+        </button>
+      )}
+    </div>
+  );
+}
+
+function PartialDataBanner({ warnings }) {
+  if (!Array.isArray(warnings) || warnings.length === 0) return null;
+  return (
+    <div
+      className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 flex items-start gap-2"
+      role="status"
+      data-testid="market-exposure-partial"
+    >
+      <AlertTriangle size={14} className="shrink-0 mt-0.5" aria-hidden="true" />
+      <div className="space-y-0.5">
+        <p className="font-semibold">
+          Analyse partielle — certaines heures n'ont pas de prix marché ou de mesure alignée.
+        </p>
+        {warnings.slice(0, 3).map((w, i) => (
+          <p key={i} className="text-amber-700">
+            {w}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TabHeader({ market }) {
+  return (
+    <div className="px-1 pt-2 pb-3 border-b border-gray-100" data-testid="market-exposure-header">
+      <div className="flex items-center gap-2 text-gray-800">
+        <LineChart size={16} className="text-blue-600" aria-hidden="true" />
+        <h2 className="text-sm font-semibold">Marché & exposition</h2>
+      </div>
+      <p className="text-xs text-gray-500 mt-1">Votre profil face aux prix spot</p>
+      <p className="text-xs text-gray-400 mt-0.5">
+        Repérez les heures chères, les prix négatifs et l'écart vs un ruban baseload.
+      </p>
+      {market?.source && (
+        <p className="text-[10px] text-gray-400 mt-1 font-mono" data-testid="market-context">
+          Marché : {market.type} · Zone : {market.zone} · Source : {market.source}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function LoadingBlock() {
+  return (
+    <div className="space-y-4 mt-4" data-testid="market-exposure-loading">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+      <SkeletonCard />
+      <SkeletonCard />
+    </div>
+  );
+}
+
+export default function MarketExposureTab({
+  period = DEFAULT_PERIOD,
+  market = DEFAULT_MARKET,
+  zone = DEFAULT_ZONE,
+}) {
+  const { selectedSiteId, scope, setSite } = useScope();
+  const orgId = scope?.orgId;
+  const siteId = selectedSiteId;
+  const hasSite = siteId != null;
+
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const [requestedPeriod, setRequestedPeriod] = useState(period);
+
+  useEffect(() => {
+    if (!hasSite) {
+      setPayload(null);
+      setError(null);
+      setLoading(false);
+      return undefined;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const params = {
+      scope: 'site',
+      scope_id: siteId,
+      period: requestedPeriod,
+      market,
+      zone,
+      baseload: true,
+    };
+    if (orgId != null) params.org_id = orgId;
+    getMarketExposure(params)
+      .then((data) => {
+        if (!cancelled) setPayload(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasSite, siteId, orgId, requestedPeriod, market, zone, reloadToken]);
+
+  const kpis = payload?.kpis || {};
+  const orderedKpis = useMemo(
+    () => KPI_ORDER.filter((key) => kpis[key]).map((key) => ({ key, kpi: kpis[key] })),
+    [kpis]
+  );
+
+  if (!hasSite) {
+    return (
+      <div data-testid="market-exposure-tab">
+        <TabHeader />
+        <div className="mt-4">
+          <SiteRequiredState
+            onChooseSite={typeof setSite === 'function' ? () => setSite(null) : undefined}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (loading && !payload) {
+    return (
+      <div data-testid="market-exposure-tab">
+        <TabHeader />
+        <LoadingBlock />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div data-testid="market-exposure-tab">
+        <TabHeader />
+        <div className="mt-4">
+          <ApiErrorState error={error} onRetry={() => setReloadToken((t) => t + 1)} />
+        </div>
+      </div>
+    );
+  }
+
+  const exposureKpi = kpis.exposure_score;
+  const hasAnyKpi = orderedKpis.length > 0;
+  const hasTopHours = (payload?.top_expensive_hours?.length || 0) > 0;
+  const hasFavorable = (payload?.favorable_hours?.length || 0) > 0;
+  const hasBaseload = Boolean(payload?.baseload_comparison);
+  const hasContent = hasAnyKpi || hasTopHours || hasFavorable || hasBaseload;
+
+  if (!hasContent) {
+    return (
+      <div data-testid="market-exposure-tab">
+        <TabHeader market={payload?.market} />
+        <div className="mt-4">
+          <EmptyState
+            variant="empty"
+            icon={LineChart}
+            title="Aucune exposition marché disponible pour ce site sur la période."
+            text={
+              payload?.empty_state ||
+              "Élargissez la période ou vérifiez l'alignement courbe de charge ↔ prix spot."
+            }
+            ctaLabel="Élargir la période"
+            onCta={() => setRequestedPeriod((p) => (p === '12m' ? '90d' : '12m'))}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="market-exposure-tab">
+      <TabHeader market={payload?.market} />
+      <div className="mt-4 space-y-4">
+        <PartialDataBanner warnings={payload?.warnings} />
+
+        {/* Score d'exposition mis en avant + baseload comparison */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+          <ExposureScoreGauge
+            score={exposureKpi?.value}
+            state={exposureKpi?.state}
+            provenance={exposureKpi?.provenance}
+            label={exposureKpi?.label || "Score d'exposition spot"}
+          />
+          {hasBaseload && (
+            <div className="lg:col-span-2">
+              <BaseloadComparisonCard baseloadComparison={payload.baseload_comparison} />
+            </div>
+          )}
+        </div>
+
+        {hasAnyKpi && (
+          <div
+            className="grid grid-cols-2 lg:grid-cols-4 gap-3"
+            data-testid="market-exposure-kpis-grid"
+          >
+            {orderedKpis.map(({ key, kpi }) => (
+              <KpiCardWithProvenance
+                key={key}
+                label={kpi.label}
+                value={kpi.value}
+                unit={kpi.unit}
+                state={kpi.state}
+                provenance={kpi.provenance}
+                testId={`market-exposure-kpi-${key}`}
+              />
+            ))}
+          </div>
+        )}
+
+        {hasTopHours && <TopExpensiveHoursTable topExpensiveHours={payload.top_expensive_hours} />}
+
+        {hasFavorable && <FavorableHoursPanel favorableHours={payload.favorable_hours} />}
+
+        {payload?.simulation && <DisplacementSimulationCard simulation={payload.simulation} />}
+      </div>
+    </div>
+  );
+}
+
+export { KPI_ORDER, DEFAULT_PERIOD, DEFAULT_MARKET, DEFAULT_ZONE };

--- a/frontend/src/pages/usages/WeekProfileTab.jsx
+++ b/frontend/src/pages/usages/WeekProfileTab.jsx
@@ -22,6 +22,7 @@ import { useScope } from '../../contexts/ScopeContext';
 import { getWeekProfile } from '../../services/api/energy';
 import KpiCardWithProvenance from '../../ui/energy/KpiCardWithProvenance';
 import WeekProfileHeatmap from '../../ui/energy/WeekProfileHeatmap';
+import SiteRequiredState from '../../ui/energy/SiteRequiredState';
 import { EmptyState, SkeletonCard } from '../../ui';
 
 const KPI_ORDER = ['highest_day', 'highest_hour', 'night_baseload_kw', 'weekend_consumption_pct'];
@@ -124,10 +125,14 @@ function LoadingBlock() {
 }
 
 export default function WeekProfileTab({ days = DEFAULT_DAYS, daysOverride }) {
-  const { selectedSiteId, scope } = useScope();
+  const { selectedSiteId, scope, setSite } = useScope();
   const orgId = scope?.orgId;
   const siteId = selectedSiteId;
   const effectiveDays = daysOverride ?? days;
+  // Sprint P1.S6 — la vue Semaine type n'est servie qu'au niveau site/meter.
+  // Si pas de site sélectionné, on n'appelle pas l'API (évite remontée
+  // ENERGY_SCOPE_INVALID en rouge) et on affiche un SiteRequiredState métier.
+  const hasSite = siteId != null;
 
   const [payload, setPayload] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -136,14 +141,20 @@ export default function WeekProfileTab({ days = DEFAULT_DAYS, daysOverride }) {
   const [requestedDays, setRequestedDays] = useState(effectiveDays);
 
   useEffect(() => {
+    if (!hasSite) {
+      setPayload(null);
+      setError(null);
+      setLoading(false);
+      return undefined;
+    }
     let cancelled = false;
     setLoading(true);
     setError(null);
     const params = {
-      scope: siteId ? 'site' : 'org',
+      scope: 'site',
+      scope_id: siteId,
       days: requestedDays,
     };
-    if (siteId != null) params.scope_id = siteId;
     if (orgId != null) params.org_id = orgId;
     getWeekProfile(params)
       .then((data) => {
@@ -159,13 +170,26 @@ export default function WeekProfileTab({ days = DEFAULT_DAYS, daysOverride }) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [siteId, orgId, requestedDays, reloadToken]);
+  }, [hasSite, siteId, orgId, requestedDays, reloadToken]);
 
   const kpis = payload?.kpis || {};
   const orderedKpis = useMemo(
     () => KPI_ORDER.filter((key) => kpis[key]).map((key) => ({ key, kpi: kpis[key] })),
     [kpis]
   );
+
+  if (!hasSite) {
+    return (
+      <div data-testid="week-profile-tab">
+        <TabHeader />
+        <div className="p-5">
+          <SiteRequiredState
+            onChooseSite={typeof setSite === 'function' ? () => setSite(null) : undefined}
+          />
+        </div>
+      </div>
+    );
+  }
 
   if (loading && !payload) {
     return (

--- a/frontend/src/services/api/energy.js
+++ b/frontend/src/services/api/energy.js
@@ -569,3 +569,31 @@ export const getCostVsContract = async (params = {}) => {
   const response = await api.get('/energy/cost-vs-contract', { params });
   return response.data;
 };
+
+/**
+ * GET /api/energy/market-exposure — vue Marché & exposition
+ * (score exposition, top heures chères, baseload comparison,
+ * heures favorables, simulation indicative).
+ *
+ * Sprint Énergie P1.S6 — helper canonique consommé par
+ * `frontend/src/pages/consumption/MarketExposureTab.jsx`. Aucun calcul
+ * métier frontend : tout (KPI, score, top heures, prix négatifs,
+ * baseload, simulation) vient du backend.
+ *
+ * @param {object} params - { scope, scope_id, period, market, zone,
+ *                            baseload, org_id }
+ *   - scope     : 'site' | 'meter' (org NON supporté côté backend)
+ *   - scope_id  : id du périmètre
+ *   - period    : '7d' | '30d' | '90d' | '12m' (défaut '12m')
+ *   - market    : 'day_ahead' | 'intraday' | 'future_baseload' |
+ *                 'future_peakload' (défaut 'day_ahead')
+ *   - zone      : 'FR' | 'DE_LU' | 'BE' | 'ES' | 'NL' | 'GB' | 'CH' |
+ *                 'IT_NORTH' (défaut 'FR')
+ *   - baseload  : bool — inclure la comparaison baseload (défaut true)
+ *   - org_id    : optionnel — force l'org-scoping côté backend
+ * @returns {Promise<EnergyMarketExposureResponse>}
+ */
+export const getMarketExposure = async (params = {}) => {
+  const response = await api.get('/energy/market-exposure', { params });
+  return response.data;
+};

--- a/frontend/src/ui/energy/BaseloadComparisonCard.jsx
+++ b/frontend/src/ui/energy/BaseloadComparisonCard.jsx
@@ -1,0 +1,158 @@
+/**
+ * PROMEOS — BaseloadComparisonCard (Sprint P1.S6).
+ *
+ * Affiche `baseload_comparison` du payload `/api/energy/market-exposure` :
+ *   - real_profile_cost_eur (coût spot pondéré profil réel)
+ *   - baseload_cost_eur     (coût spot ruban baseload équivalent)
+ *   - delta_eur             (real - baseload ; > 0 = profil plus coûteux)
+ *   - delta_eur_mwh         (delta moyen €/MWh)
+ *   - formula               (description backend de la formule)
+ *   - provenance
+ *
+ * Doctrine : aucun calcul métier FE. delta, ratio, signes sont tous
+ * fournis par le backend.
+ */
+import { Layers, HelpCircle } from 'lucide-react';
+
+function fmtEur(v, decimals = 0) {
+  if (v === null || v === undefined) return '—';
+  return Number(v).toLocaleString('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: decimals,
+  });
+}
+
+function fmtEurPerMwh(v) {
+  if (v === null || v === undefined) return '—';
+  return `${Number(v).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} €/MWh`;
+}
+
+function fmtDelta(v) {
+  if (v === null || v === undefined) return null;
+  const num = Number(v);
+  const sign = num > 0 ? '+' : '';
+  const colour = num > 0 ? 'text-red-700' : num < 0 ? 'text-emerald-700' : 'text-gray-500';
+  return (
+    <span
+      className={`font-mono ${colour}`}
+      data-testid="baseload-delta-eur"
+      data-sign={num >= 0 ? 'positive' : 'negative'}
+    >
+      {sign}
+      {Number(num).toLocaleString('fr-FR', {
+        style: 'currency',
+        currency: 'EUR',
+        maximumFractionDigits: 0,
+      })}
+    </span>
+  );
+}
+
+function fmtDeltaMwh(v) {
+  if (v === null || v === undefined) return null;
+  const num = Number(v);
+  const sign = num > 0 ? '+' : '';
+  return `${sign}${Number(num).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} €/MWh`;
+}
+
+function ProvenanceTooltip({ provenance, formula }) {
+  if (!provenance && !formula) return null;
+  return (
+    <span className="relative inline-block group" data-testid="baseload-provenance">
+      <HelpCircle size={13} className="text-gray-300 hover:text-gray-500 cursor-help" />
+      <div className="absolute right-0 top-5 z-10 hidden group-hover:block w-72 rounded-lg border border-gray-200 bg-white p-3 text-xs text-gray-700 shadow-lg">
+        {provenance?.source && (
+          <>
+            <p className="text-gray-500">Source</p>
+            <p className="font-mono break-words">{provenance.source}</p>
+          </>
+        )}
+        {provenance?.service && (
+          <>
+            <p className="text-gray-500 mt-1">Service</p>
+            <p className="font-mono text-[11px] break-words">{provenance.service}</p>
+          </>
+        )}
+        {formula && (
+          <>
+            <p className="text-gray-500 mt-1">Formule</p>
+            <p className="text-[11px]">{formula}</p>
+          </>
+        )}
+      </div>
+    </span>
+  );
+}
+
+export default function BaseloadComparisonCard({
+  baseloadComparison,
+  className = '',
+  testId = 'baseload-comparison-card',
+}) {
+  if (!baseloadComparison) return null;
+  const {
+    real_profile_cost_eur,
+    baseload_cost_eur,
+    delta_eur,
+    delta_eur_mwh,
+    formula,
+    provenance,
+  } = baseloadComparison;
+
+  return (
+    <div
+      className={`rounded-xl border border-gray-200 bg-white p-4 ${className}`}
+      data-testid={testId}
+    >
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <h3 className="text-sm font-semibold text-gray-800 flex items-center gap-1.5">
+          <Layers size={14} className="text-blue-600" aria-hidden="true" />
+          Comparaison baseload
+        </h3>
+        <ProvenanceTooltip provenance={provenance} formula={formula} />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs">
+        <div
+          className="rounded-lg border border-gray-200 bg-gray-50 p-3"
+          data-testid="baseload-real-profile"
+        >
+          <p className="text-[10px] uppercase tracking-wide text-gray-500 font-medium">
+            Coût profil réel
+          </p>
+          <p className="text-lg font-bold font-mono text-gray-800 mt-1">
+            {fmtEur(real_profile_cost_eur)}
+          </p>
+        </div>
+        <div
+          className="rounded-lg border border-blue-200 bg-blue-50 p-3"
+          data-testid="baseload-cost"
+        >
+          <p className="text-[10px] uppercase tracking-wide text-blue-700 font-medium">
+            Coût ruban baseload
+          </p>
+          <p className="text-lg font-bold font-mono text-blue-800 mt-1">
+            {fmtEur(baseload_cost_eur)}
+          </p>
+        </div>
+        <div
+          className="rounded-lg border border-gray-200 bg-white p-3"
+          data-testid="baseload-delta"
+        >
+          <p className="text-[10px] uppercase tracking-wide text-gray-500 font-medium">
+            Écart vs baseload
+          </p>
+          <p className="text-lg font-bold mt-1">{fmtDelta(delta_eur)}</p>
+          {delta_eur_mwh != null && (
+            <p className="text-[10px] text-gray-500 mt-0.5">{fmtDeltaMwh(delta_eur_mwh)}</p>
+          )}
+        </div>
+      </div>
+      {formula && (
+        <p className="text-[10px] text-gray-400 italic mt-2" data-testid="baseload-formula">
+          {formula}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/ui/energy/DisplacementSimulationCard.jsx
+++ b/frontend/src/ui/energy/DisplacementSimulationCard.jsx
@@ -1,0 +1,102 @@
+/**
+ * PROMEOS — DisplacementSimulationCard (Sprint P1.S6).
+ *
+ * Affiche `simulation` (EnergyDisplacementSimulation) du payload
+ * `/api/energy/market-exposure` :
+ *   - label
+ *   - flexible_share_pct
+ *   - estimated_delta_eur
+ *   - warning (par défaut backend :
+ *     « Simulation indicative — ne constitue pas une promesse d'économie. »)
+ *
+ * Doctrine : warning OBLIGATOIRE, aucune promesse d'économie certaine,
+ * aucun calcul FE.
+ */
+import { AlertTriangle, FlaskConical } from 'lucide-react';
+
+const DEFAULT_WARNING = "Simulation indicative — ne constitue pas une promesse d'économie.";
+
+function fmtEur(v) {
+  if (v === null || v === undefined) return '—';
+  const num = Number(v);
+  const sign = num > 0 ? '+' : '';
+  return `${sign}${num.toLocaleString('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  })}`;
+}
+
+function fmtPct(v) {
+  if (v === null || v === undefined) return '—';
+  return `${Number(v).toLocaleString('fr-FR', { maximumFractionDigits: 1 })} %`;
+}
+
+export default function DisplacementSimulationCard({
+  simulation,
+  className = '',
+  testId = 'displacement-simulation-card',
+}) {
+  if (!simulation) return null;
+  const warning = simulation.warning || DEFAULT_WARNING;
+  const delta = simulation.estimated_delta_eur;
+  const deltaColour =
+    delta == null
+      ? 'text-gray-500'
+      : delta < 0
+        ? 'text-emerald-700'
+        : delta > 0
+          ? 'text-red-700'
+          : 'text-gray-500';
+
+  return (
+    <div
+      className={`rounded-xl border border-blue-200 bg-blue-50/40 p-4 space-y-3 ${className}`}
+      data-testid={testId}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <FlaskConical size={14} className="text-blue-600" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-blue-900">
+            {simulation.label || 'Simulation indicative'}
+          </h3>
+        </div>
+        <span
+          className="text-[9px] uppercase tracking-wide px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700 font-semibold"
+          data-testid="simulation-status-badge"
+        >
+          Simulation
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-xs">
+        <div>
+          <p className="text-[10px] uppercase tracking-wide text-blue-700 font-medium">
+            Part flexible
+          </p>
+          <p className="text-base font-mono font-semibold text-blue-900 mt-0.5">
+            {fmtPct(simulation.flexible_share_pct)}
+          </p>
+        </div>
+        <div>
+          <p className="text-[10px] uppercase tracking-wide text-blue-700 font-medium">
+            Delta estimé
+          </p>
+          <p
+            className={`text-base font-mono font-semibold mt-0.5 ${deltaColour}`}
+            data-testid="simulation-delta-eur"
+          >
+            {fmtEur(delta)}
+          </p>
+        </div>
+      </div>
+      <div
+        className="rounded-lg border border-amber-200 bg-amber-50 p-2.5 text-[11px] text-amber-800 flex items-start gap-2"
+        role="note"
+        data-testid="simulation-warning"
+      >
+        <AlertTriangle size={12} className="shrink-0 mt-0.5" aria-hidden="true" />
+        <p className="font-medium">{warning}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ui/energy/ExposureScoreGauge.jsx
+++ b/frontend/src/ui/energy/ExposureScoreGauge.jsx
@@ -1,0 +1,101 @@
+/**
+ * PROMEOS — ExposureScoreGauge (Sprint P1.S6).
+ *
+ * Jauge score d'exposition spot [0, 100] borné backend (clamp_score_0_100)
+ * avec état canonique `ExposureScoreState` ∈ sain | vigilance | critique
+ * | inactif. Tooltip provenance complète.
+ *
+ * Doctrine : ne recalcule jamais le state — utilise celui fourni par
+ * l'API. Si score null/undefined → état 'inactif' par défaut.
+ */
+import { HelpCircle, Gauge } from 'lucide-react';
+
+const STATE_TINT = {
+  sain: 'from-emerald-100 to-emerald-50 border-emerald-200 text-emerald-700',
+  vigilance: 'from-amber-100 to-amber-50 border-amber-200 text-amber-700',
+  critique: 'from-red-100 to-red-50 border-red-200 text-red-700',
+  inactif: 'from-gray-100 to-gray-50 border-gray-200 text-gray-500',
+};
+
+const STATE_LABEL = {
+  sain: 'Sain',
+  vigilance: 'Vigilance',
+  critique: 'Critique',
+  inactif: 'Inactif',
+};
+
+function fmtScore(v) {
+  if (v === null || v === undefined) return '—';
+  return Math.round(Number(v));
+}
+
+function ProvenanceTooltip({ provenance }) {
+  if (!provenance) return null;
+  return (
+    <span className="relative inline-block group" data-testid="exposure-score-provenance">
+      <HelpCircle size={13} className="text-gray-300 hover:text-gray-500 cursor-help" />
+      <div className="absolute right-0 top-5 z-10 hidden group-hover:block w-72 rounded-lg border border-gray-200 bg-white p-3 text-xs text-gray-700 shadow-lg">
+        <p className="text-gray-500">Source</p>
+        <p className="font-mono break-words">{provenance.source || '—'}</p>
+        <p className="text-gray-500 mt-1">Service</p>
+        <p className="font-mono text-[11px] break-words">{provenance.service || '—'}</p>
+        {provenance.formula && (
+          <>
+            <p className="text-gray-500 mt-1">Formule</p>
+            <p className="font-mono text-[11px] break-words">{provenance.formula}</p>
+          </>
+        )}
+        {provenance.period && (
+          <>
+            <p className="text-gray-500 mt-1">Période</p>
+            <p>{provenance.period}</p>
+          </>
+        )}
+        {typeof provenance.confidence === 'number' && (
+          <>
+            <p className="text-gray-500 mt-1">Confiance</p>
+            <p>{Math.round(provenance.confidence * 100)} %</p>
+          </>
+        )}
+      </div>
+    </span>
+  );
+}
+
+export default function ExposureScoreGauge({
+  score,
+  state,
+  provenance,
+  label = "Score d'exposition spot",
+  className = '',
+  testId = 'exposure-score-gauge',
+}) {
+  const effectiveState = state || (score === null || score === undefined ? 'inactif' : 'sain');
+  const tint = STATE_TINT[effectiveState] || STATE_TINT.inactif;
+  return (
+    <div
+      className={`rounded-xl border bg-gradient-to-br p-4 flex flex-col gap-2 ${tint} ${className}`}
+      data-testid={testId}
+      data-state={effectiveState}
+      data-score={score ?? ''}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide">
+          <Gauge size={13} aria-hidden="true" />
+          <span>{label}</span>
+        </div>
+        <ProvenanceTooltip provenance={provenance} />
+      </div>
+      <p className="text-4xl font-bold font-mono" data-testid="exposure-score-value">
+        {fmtScore(score)}
+        <span className="text-base font-medium opacity-60">/100</span>
+      </p>
+      <p
+        className="text-[10px] uppercase tracking-wide font-semibold opacity-80"
+        data-testid="exposure-score-state-label"
+      >
+        {STATE_LABEL[effectiveState] || effectiveState}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/ui/energy/FavorableHoursPanel.jsx
+++ b/frontend/src/ui/energy/FavorableHoursPanel.jsx
@@ -1,0 +1,116 @@
+/**
+ * PROMEOS — FavorableHoursPanel (Sprint P1.S6).
+ *
+ * Affiche `favorable_hours[]` du payload `/api/energy/market-exposure`.
+ * Catégorise visuellement par `reason` ∈ « prix bas » | « prix négatif »
+ * | « heure solaire » (FavorableHourReason backend).
+ *
+ * Doctrine : aucun calcul métier FE. La catégorisation est faite par le
+ * backend (`reason`). Le composant ne fait que regrouper visuellement.
+ */
+import { Sun, BatteryCharging, Leaf } from 'lucide-react';
+
+const TS_FMT = (ts) => {
+  try {
+    return new Date(ts).toLocaleString('fr-FR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return ts;
+  }
+};
+
+function fmtEurPerMwh(v) {
+  if (v === null || v === undefined) return '—';
+  return `${Number(v).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} €/MWh`;
+}
+
+const REASON_CONFIG = {
+  'prix bas': {
+    icon: BatteryCharging,
+    tint: 'bg-emerald-50 border-emerald-200 text-emerald-700',
+    label: 'Prix bas',
+    pedagogie: 'Plages favorables pour démarrer une recharge ou un cycle planifié.',
+  },
+  'prix négatif': {
+    icon: Leaf,
+    tint: 'bg-blue-50 border-blue-200 text-blue-700',
+    label: 'Prix négatif',
+    pedagogie: 'Prix spot négatifs — opportunité de consommer payée par le marché.',
+  },
+  'heure solaire': {
+    icon: Sun,
+    tint: 'bg-amber-50 border-amber-200 text-amber-700',
+    label: 'Heure solaire',
+    pedagogie: 'Pic photovoltaïque — corrélation prix bas + production renouvelable.',
+  },
+};
+
+function HourBadge({ hour }) {
+  const cfg = REASON_CONFIG[hour.reason] || {
+    icon: BatteryCharging,
+    tint: 'bg-gray-50 border-gray-200 text-gray-600',
+    label: hour.reason,
+    pedagogie: '',
+  };
+  const Icon = cfg.icon;
+  return (
+    <div
+      className={`rounded-lg border p-2 flex items-center gap-2 text-xs ${cfg.tint}`}
+      data-testid="favorable-hour-row"
+      data-reason={hour.reason}
+    >
+      <Icon size={14} className="shrink-0" aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <p className="font-medium truncate">{TS_FMT(hour.timestamp)}</p>
+        <p className="text-[10px] font-mono opacity-70">{fmtEurPerMwh(hour.spot_price_eur_mwh)}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function FavorableHoursPanel({
+  favorableHours,
+  className = '',
+  testId = 'favorable-hours-panel',
+}) {
+  if (!Array.isArray(favorableHours) || favorableHours.length === 0) {
+    return null;
+  }
+
+  // Regroupement par reason (ordre canonique d'affichage).
+  const REASONS_ORDER = ['prix bas', 'prix négatif', 'heure solaire'];
+  const grouped = REASONS_ORDER.map((reason) => ({
+    reason,
+    cfg: REASON_CONFIG[reason],
+    hours: favorableHours.filter((h) => h.reason === reason),
+  })).filter((g) => g.hours.length > 0);
+
+  return (
+    <div
+      className={`rounded-xl border border-gray-200 bg-white p-4 space-y-3 ${className}`}
+      data-testid={testId}
+    >
+      <h3 className="text-sm font-semibold text-gray-800">Heures favorables</h3>
+      {grouped.map(({ reason, cfg, hours }) => (
+        <div key={reason} data-testid={`favorable-group-${reason.replace(/\s+/g, '-')}`}>
+          <p className="text-[11px] text-gray-500 mb-1.5 flex items-center gap-1.5">
+            <cfg.icon size={11} aria-hidden="true" />
+            {cfg.label} <span className="font-mono">({hours.length})</span> · {cfg.pedagogie}
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+            {hours.slice(0, 8).map((h, i) => (
+              <HourBadge key={`${reason}-${i}`} hour={h} />
+            ))}
+          </div>
+          {hours.length > 8 && (
+            <p className="text-[10px] text-gray-400 italic mt-1">+{hours.length - 8} autres…</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/ui/energy/SiteRequiredState.jsx
+++ b/frontend/src/ui/energy/SiteRequiredState.jsx
@@ -1,0 +1,49 @@
+/**
+ * PROMEOS — SiteRequiredState (Sprint P1.S6).
+ *
+ * EmptyState métier utilisé par les vues énergie qui ne supportent QUE
+ * `scope=site` ou `scope=meter` côté backend (Semaine type, Coût &
+ * contrat, Marché & exposition).
+ *
+ * Au lieu d'appeler l'API et laisser remonter un `ENERGY_SCOPE_INVALID`
+ * en rouge, on guide l'utilisateur : « Sélectionnez un site pour
+ * analyser cette vue. »
+ *
+ * Doctrine : aucun calcul métier — c'est uniquement de l'UX.
+ */
+import { Building2, MapPin } from 'lucide-react';
+import { EmptyState } from '../index';
+
+const DEFAULT_TITLE = 'Sélectionnez un site pour analyser cette vue.';
+const DEFAULT_TEXT =
+  "Cette analyse n'est disponible qu'au niveau d'un site (ou d'un compteur). Choisissez un site dans le sélecteur de périmètre.";
+
+export default function SiteRequiredState({
+  title = DEFAULT_TITLE,
+  text = DEFAULT_TEXT,
+  ctaLabel = 'Choisir un site',
+  onChooseSite,
+  className = '',
+  testId = 'site-required-state',
+}) {
+  return (
+    <div className={className} data-testid={testId}>
+      <EmptyState
+        variant="unconfigured"
+        icon={Building2}
+        title={title}
+        text={text}
+        ctaLabel={onChooseSite ? ctaLabel : undefined}
+        onCta={onChooseSite}
+        actions={
+          !onChooseSite ? (
+            <p className="text-[11px] text-gray-400 inline-flex items-center gap-1">
+              <MapPin size={11} aria-hidden="true" />
+              Sélecteur de scope disponible en haut de page.
+            </p>
+          ) : null
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/src/ui/energy/TopExpensiveHoursTable.jsx
+++ b/frontend/src/ui/energy/TopExpensiveHoursTable.jsx
@@ -1,0 +1,132 @@
+/**
+ * PROMEOS — TopExpensiveHoursTable (Sprint P1.S6).
+ *
+ * Affiche `top_expensive_hours[]` du payload `/api/energy/market-exposure`.
+ * Chaque heure expose :
+ *   - timestamp
+ *   - spot_price_eur_mwh
+ *   - kwh
+ *   - cost_eur
+ *   - rank (1 = la plus coûteuse — fourni backend)
+ *   - recommended_action (string FR backend)
+ *   - provenance
+ *
+ * Doctrine : pas de tri métier FE. Si backend fournit `rank`, on s'en
+ * sert pour ordre visuel ; sinon ordre API préservé.
+ */
+import { TrendingUp, HelpCircle } from 'lucide-react';
+
+const TS_FMT = (ts) => {
+  try {
+    return new Date(ts).toLocaleString('fr-FR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return ts;
+  }
+};
+
+function fmtEur(v, decimals = 0) {
+  if (v === null || v === undefined) return '—';
+  return Number(v).toLocaleString('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: decimals,
+  });
+}
+
+function fmtEurPerMwh(v) {
+  if (v === null || v === undefined) return '—';
+  return `${Number(v).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} €/MWh`;
+}
+
+function fmtNumber(v, decimals = 1) {
+  if (v === null || v === undefined) return '—';
+  return Number(v).toLocaleString('fr-FR', { maximumFractionDigits: decimals });
+}
+
+function ProvenanceDot({ provenance }) {
+  if (!provenance?.service) return null;
+  return (
+    <span className="relative inline-block group" data-testid="top-hour-provenance">
+      <HelpCircle size={11} className="text-gray-300 hover:text-gray-500 cursor-help" />
+      <span className="absolute right-0 top-4 z-10 hidden group-hover:block w-56 rounded-lg border border-gray-200 bg-white p-2 text-[10px] text-gray-700 shadow-lg">
+        <span className="block text-gray-500">Service</span>
+        <span className="block font-mono break-words">{provenance.service}</span>
+        {provenance.formula && (
+          <>
+            <span className="block text-gray-500 mt-1">Formule</span>
+            <span className="block font-mono break-words">{provenance.formula}</span>
+          </>
+        )}
+      </span>
+    </span>
+  );
+}
+
+export default function TopExpensiveHoursTable({
+  topExpensiveHours,
+  className = '',
+  testId = 'top-expensive-hours-table',
+}) {
+  if (!Array.isArray(topExpensiveHours) || topExpensiveHours.length === 0) {
+    return null;
+  }
+
+  // Tri visuel par rank si fourni, sinon ordre API préservé.
+  const ordered = topExpensiveHours.every((h) => Number.isInteger(h.rank))
+    ? [...topExpensiveHours].sort((a, b) => a.rank - b.rank)
+    : topExpensiveHours;
+
+  return (
+    <div
+      className={`rounded-xl border border-gray-200 bg-white p-4 ${className}`}
+      data-testid={testId}
+    >
+      <h3 className="text-sm font-semibold text-gray-800 mb-3 flex items-center gap-1.5">
+        <TrendingUp size={14} className="text-red-600" aria-hidden="true" />
+        Top heures chères
+      </h3>
+      <table className="w-full text-xs">
+        <thead className="text-gray-500 border-b border-gray-100">
+          <tr>
+            <th className="text-left font-medium py-1.5 w-8">#</th>
+            <th className="text-left font-medium py-1.5">Quand</th>
+            <th className="text-right font-medium py-1.5">Spot €/MWh</th>
+            <th className="text-right font-medium py-1.5">kWh</th>
+            <th className="text-right font-medium py-1.5">Coût</th>
+            <th className="text-left font-medium py-1.5 pl-4">Action conseillée</th>
+            <th className="text-right font-medium py-1.5 w-6"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {ordered.map((h, idx) => (
+            <tr
+              key={`${h.timestamp || idx}-${h.rank ?? idx}`}
+              className="border-b border-gray-50 last:border-b-0"
+              data-testid={`top-hour-row-${h.rank ?? idx + 1}`}
+              data-rank={h.rank ?? idx + 1}
+            >
+              <td className="py-1.5 text-gray-500 font-mono">{h.rank ?? idx + 1}</td>
+              <td className="py-1.5 text-gray-800 font-medium">{TS_FMT(h.timestamp)}</td>
+              <td className="py-1.5 text-right font-mono text-gray-700">
+                {fmtEurPerMwh(h.spot_price_eur_mwh)}
+              </td>
+              <td className="py-1.5 text-right font-mono text-gray-700">{fmtNumber(h.kwh, 1)}</td>
+              <td className="py-1.5 text-right font-mono text-red-700">{fmtEur(h.cost_eur, 0)}</td>
+              <td className="py-1.5 pl-4 text-gray-600 italic line-clamp-1">
+                {h.recommended_action || '—'}
+              </td>
+              <td className="py-1.5 text-right">
+                <ProvenanceDot provenance={h.provenance} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Sprint Énergie P1.S6 — UI Marché & exposition sur /consommations

Onglet nested `/consommations/marche` branché sur `/api/energy/market-exposure` (livré P1.S2d). 8 KPI + ExposureScoreGauge + BaseloadComparisonCard + TopExpensiveHoursTable + FavorableHoursPanel + DisplacementSimulationCard avec warning « Simulation indicative ».

**Inclut fix UX scope-site-required** (prérequis brief) : WeekProfileTab, CostContractTab, MarketExposureTab affichent désormais SiteRequiredState (« Sélectionnez un site pour analyser cette vue. ») sans appel API quand scope=org. Élimine remontée `ENERGY_SCOPE_INVALID` en rouge sur Semaine type et Coût & contrat (incident post-S5).

### Checklist QA S6 — DoD

| # | Critère | Statut |
|---|---|---|
| 1 | Onglet « Marché & exposition » visible dans `/consommations` | ✅ vitest #ConsommationsPage + e2e #1 |
| 2 | `/api/energy/market-exposure` réellement consommé | ✅ vitest #3 (params `scope=site/scope_id/period=12m/market=day_ahead/zone=FR/baseload=true`) + e2e #1 |
| 3 | scope=org affiche état métier propre (pas d'erreur technique) | ✅ vitest #2 (SiteRequiredState + aucun appel API) + e2e #3 (pas de market-exposure-error) |
| 4 | 8 KPI affichés avec provenance | ✅ vitest #7 (8 tooltips) + #7bis (KPI_ORDER canonique) |
| 5 | Score exposition visible | ✅ vitest #8 (ExposureScoreGauge state+score backend) |
| 6 | Top heures chères visibles | ✅ vitest #9 (TopExpensiveHoursTable + 2 lignes) |
| 7 | Heures favorables / prix négatifs visibles | ✅ vitest #10 (3 groupes : prix bas + prix négatif + heure solaire) |
| 8 | Comparaison baseload visible | ✅ vitest #11 (BaseloadComparisonCard : profil réel + baseload + delta) |
| 9 | Warning « Simulation indicative » visible si simulation présente | ✅ vitest #12 (DisplacementSimulationCard) |
| 10 | Aucune nouvelle route top-level/menu | ✅ vitest #rail (NavRegistry intact) + e2e #4 |
| 11 | Aucun calcul métier frontend | ✅ vitest doctrine sur 6 fichiers (MarketExposureTab + 5 composants UI) |
| 12 | Source-guards verts | ✅ 33/33 backend |
| 13 | Capture Playwright 1440 validée | ✅ `e2e/p1_market_exposure.spec.js` → `playwright-report/p1-s6-market-exposure-1440.png` |

### Diff résumé

| Fichier | LoC | Statut |
|---|---|---|
| `frontend/src/services/api/energy.js` | +28 | helper `getMarketExposure` |
| `frontend/src/pages/ConsommationsPage.jsx` | +8 / -1 | tab entry + import lucide `LineChart` |
| `frontend/src/App.jsx` | +14 | lazy import + route nested `path=\"marche\"` |
| `frontend/src/pages/consumption/MarketExposureTab.jsx` | ~290 | orchestrateur (nouveau) |
| `frontend/src/pages/usages/WeekProfileTab.jsx` | +19 / -7 | fix UX scope-site-required |
| `frontend/src/pages/consumption/CostContractTab.jsx` | +22 / -7 | fix UX scope-site-required |
| `frontend/src/ui/energy/SiteRequiredState.jsx` | ~50 | EmptyState métier (nouveau) |
| `frontend/src/ui/energy/ExposureScoreGauge.jsx` | ~100 | jauge score (nouveau) |
| `frontend/src/ui/energy/TopExpensiveHoursTable.jsx` | ~130 | top heures (nouveau) |
| `frontend/src/ui/energy/FavorableHoursPanel.jsx` | ~115 | heures favorables (nouveau) |
| `frontend/src/ui/energy/BaseloadComparisonCard.jsx` | ~150 | comparaison baseload (nouveau) |
| `frontend/src/ui/energy/DisplacementSimulationCard.jsx` | ~110 | simulation + warning (nouveau) |
| 5 nouvelles suites `__tests__/` + 2 maj | 73 tests | vitest |
| `e2e/p1_market_exposure.spec.js` + config | 4 specs | e2e |

Commit `18870753` — 21 fichiers, 2 054 insertions, 17 suppressions.

### Doctrine respectée

- ✅ Zéro calcul métier FE (vérifié 6 suites de tests doctrine + source-guards backend) :
  - aucun spot_cost / prix pondéré / baseload / delta / score expo / top 10 % FE
  - aucune détection prix négatif / heure solaire FE
  - aucune simulation d'économie FE
  - aucun tri métier heures chères FE (rank backend)
- ✅ « Ne pas refondre toute ConsommationsPage » → +8 LoC seulement.
- ✅ « Pas de route top-level / pas de menu rail » → 0 changement `NavRegistry.js`.
- ✅ « Pas d'émoji » → icône Lucide `LineChart` sobre.
- ✅ Microcopy brief intégrale : « Marché & exposition / Votre profil face aux prix spot / Repérez les heures chères, les prix négatifs et l'écart vs un ruban baseload. »
- ✅ Warning OBLIGATOIRE DisplacementSimulationCard : **« Simulation indicative — ne constitue pas une promesse d'économie. »**
- ✅ HELPER_WHITELIST FE inchangée (3 entrées).

### Fix UX scope-site-required (3 onglets)

Pattern uniforme appliqué :
- si `selectedSiteId == null` → SiteRequiredState (variant unconfigured) au lieu d'appeler l'API.
- aucune erreur rouge `ENERGY_SCOPE_INVALID` ne remonte sur scope=org.
- microcopy FR : « Sélectionnez un site pour analyser cette vue. »
- CTA « Choisir un site » (déclenche `setSite(null)` qui ouvre le sélecteur).

### Tests

- **Vitest : 73/73 ✅**
  - 5 nouvelles suites : MarketExposureTab (18) + ExposureScoreGauge (6) + TopExpensiveHoursTable (7) + FavorableHoursPanel (5) + BaseloadComparisonCard (6)
  - 2 suites mises à jour : WeekProfileTab (+1 test scope=org) + CostContractTab (+1 test scope=org)
- **Source-guards backend : 33/33 ✅**
- **Playwright e2e : 5/5 ✅** (avec auth setup)

### Refs

- P1.S2d — `/api/energy/market-exposure` SoT (score expo, top heures, baseload comparison, favorable hours, simulation)
- P1.S3a — `KpiCardWithProvenance` + route nested (réutilisés)
- P1.S3b/S4/S5 — pattern composant autonome loading/empty/error/partial

### Dettes restantes / hors scope

- P1.S7 (polish transverse + provenance 100 % KPI) pas démarré.
- `confidenceDisplay.js` toujours dans HELPER_WHITELIST (dette héritée S3b — climateConf scatter Monitoring hors scope synthesis).

### Verdict GO/NO-GO pour P1.S7

🟢 **GO P1.S7 — Polish transverse + provenance 100 % KPI** :
- Toutes les vues énergie principales sont livrées (synthesis, loadcurve, week-profile, cost-vs-contract, market-exposure).
- Pattern composant autonome stabilisé (S3b → S4 → S5 → S6).
- Pattern scope-site-required uniformisé S6.
- Reste : provenance 100 % cross-KPI, finitions UX cross-vues, retrait définitif `confidenceDisplay.js` si possible.

### Definition of Done

Un utilisateur peut ouvrir `Consommations → Marché & exposition`, sélectionner un site, comprendre son exposition aux prix spot (score borné backend), voir les heures critiques (top 10 % triées backend) et les opportunités (prix bas + prix négatif + heure solaire), comparer son profil réel à un ruban baseload équivalent — avec hypothèses visibles, sans promesse d'économie certaine et sans erreur technique de scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)