### PR TITLE
chasse-bugs(patrimoine) Tour 5 — jargon rule_id + KPI mensonger + accents + dead imports

### DIFF
--- a/docs/audits/chasse_bugs_patrimoine_2026_05_29.md
+++ b/docs/audits/chasse_bugs_patrimoine_2026_05_29.md
@@ -1,0 +1,97 @@
+# Chasse-bugs Tour 5 — `/patrimoine`
+
+**Date** : 2026-05-29
+**Branche** : `claude/chasse-bugs-patrimoine-2026-05-29`
+**Base** : `claude/refonte-sol2` HEAD `bae2c80e` (post #341 P2.1 monitoring split)
+**Skill** : `chasse-bugs-promeos` (5e tour, cycle 1)
+
+## Périmètre audité
+
+- `frontend/src/pages/Patrimoine.jsx` (2 396 lignes)
+- `frontend/src/components/patrimoine/SitesMap.jsx`
+- `frontend/src/components/patrimoine/IncompleteBanner.jsx`
+- `frontend/src/components/PatrimoineWizard.jsx`
+- `frontend/src/components/SiteCreationWizard.jsx`
+- `frontend/src/components/QuickCreateSite.jsx`
+
+**Contexte produit** : hub de gestion du parc immobilier (sites, bâtiments, compteurs). Page sensible pour onboarding nouveau client (premier contact avec leur portefeuille).
+
+## Findings par catégorie
+
+### Cat 1 — Boutons/liens inactifs : 0 finding
+
+`navigate()` cibles valides : `/sites/:id`, `/conformite`, `/renouvellements`, `/onboarding/sirene`. Aucun bouton orphelin.
+
+### Cat 2 — Routes mortes : 0 finding
+
+### Cat 3 — Jargon technique exposé : 1 finding **CRITIQUE** ✅ fixé
+
+**[CRITIQUE]** `frontend/src/components/PatrimoineWizard.jsx:746` — `{f.rule_id}` brut affiché à l'utilisateur. Exemple : `"invalid_siret_format"` au lieu de `"Invalid siret format"` ou `"Format SIRET invalide"`. Onboarding nouveau client → impression de bug.
+
+**Fix appliqué** : humanize inline `(f.rule_id || '').replace(/_/g, ' ').replace(/^\w/, c => c.toUpperCase())`. Rend `"invalid_siret_format"` → `"Invalid siret format"`. **Imperfait** (anglais résiduel pour rule_ids construits en EN côté BE) mais infiniment meilleur que le snake_case brut.
+
+**Suite recommandée (non-trivial)** : créer dict `RULE_LABELS_FR_WIZARD` exhaustif quand l'équipe a la liste complète des rule_ids de validation wizard (cf. pattern existant dans `frontend/src/components/patrimoine/IncompleteBanner.jsx:14`).
+
+### Cat 4 — Texte non-FR : 5 findings **MINEURS** ✅ fixés
+
+**[MINEURS]** `frontend/src/components/QuickCreateSite.jsx:22,24,25,27,28` — 5 labels usage sans accents FR :
+- `'Entrepot'` → `'Entrepôt'`
+- `'Hotel'` → `'Hôtel'`
+- `'Sante'` → `'Santé'`
+- `'Copropriete'` → `'Copropriété'`
+- `'Collectivite'` → `'Collectivité'`
+
+**Note de cohérence** : `SiteCreationWizard.jsx` a les **bons accents** (lignes 49, 53, 55, 56, 57). Incohérence entre 2 composants similaires → fix appliqué pour aligner sur la version correcte.
+
+### Cat 5 — « ? » indicatifs morts : 0 finding
+
+### Cat 6 — Calculs faux ou incohérents : 1 finding documenté (déjà tracké)
+
+**[MINEUR documenté]** `frontend/src/pages/Patrimoine.jsx:899` — calcul moyenne pondérée intensité énergétique en FE (violation doctrine §8.1). **Tracking ID `D-Phase4-3-Portfolio-Intensity-Backend-001`** déjà en place (commentaire lignes 893-897), backend endpoint planifié Sprint C-3. **Pas d'action ce tour** — dette accepté MVP.
+
+### Cat 7 — KPI mensongers : 1 finding **MAJEUR** ✅ fixé
+
+**[MAJEUR]** `frontend/src/pages/Patrimoine.jsx:2204` — MetricPill "Compteurs" affiche `'0'` quand `nb_compteurs === null` (donnée manquante) :
+```jsx
+value={site.nb_compteurs != null ? site.nb_compteurs : 0}
+```
+
+**Impact** : utilisateur croit qu'il y a 0 compteur sur le site, alors qu'il s'agit d'une donnée non remontée par le backend. Critique pour onboarding (mauvais inventaire compteurs → mauvaise stratégie monitoring).
+
+**Fix appliqué** : `: 0` → `: '—'` (vocabulaire `'à qualifier'` doctrine §contrats_chiffres).
+
+### Cat 8 — Console errors : pas testé ce tour
+
+### Cat 9 — Network 4xx/5xx : pas testé ce tour
+
+### Cat 10 — Dette technique : 2 findings **MINEURS** ✅ fixés
+
+**[MINEUR]** `frontend/src/pages/Patrimoine.jsx:42` — `import ErrorState from '../ui/ErrorState'; // eslint-disable-line no-unused-vars` — vraiment inutilisé (grep confirme 1 seule occurrence = la ligne d'import).
+
+**[MINEUR]** `frontend/src/pages/Patrimoine.jsx:165` — `const { isExpert } = useExpertMode(); // eslint-disable-line no-unused-vars` — `isExpert` vraiment inutilisé (grep confirme 1 occurrence destructure).
+
+**Fix appliqué** : retrait des 2 lignes mortes + commentaire FR explicatif. `useExpertMode` import également retiré (n'était nécessaire que pour ce destructure).
+
+Note : test `V15Scope.test.js` fail toujours pré-existant (déjà reporté Tours 2 et 4, owner PR #335 P1.S4 énergie).
+
+## Décisions appliquées ce tour
+
+| Finding | Sévérité | Décision | Fichier |
+|---|---|---|---|
+| Cat 3 jargon `rule_id` | CRITIQUE | **Fixer** (humanize inline) | PatrimoineWizard.jsx (+5 lignes) |
+| Cat 7 KPI mensonger Compteurs | MAJEUR | **Fixer** | Patrimoine.jsx:2204 (1 ligne) |
+| Cat 4 accents FR USAGE_OPTIONS | MINEUR × 5 | **Fixer** | QuickCreateSite.jsx (5 lignes) |
+| Cat 10 imports inutilisés | MINEUR × 2 | **Fixer** | Patrimoine.jsx (3 lignes net) |
+| Cat 6 intensité pondérée FE | MINEUR | **Pas d'action** — déjà tracké | Patrimoine.jsx:899 |
+
+## Tests
+
+- `vitest run` full : 5 558 pass / 3 skipped / 1 fail pré-existant V15Scope — **0 régression**
+
+## Verdict tour 5
+
+✅ **GO** — 4 findings actionnables fixés (1 CRITIQUE + 1 MAJEUR + 2 MINEUR), 1 finding Cat 6 explicitement laissé (déjà tracké sprint dédié), 0 régression, page `/patrimoine` mieux préparée pour onboarding.
+
+## Suite (tour 6 selon skill)
+
+`/cockpit/*` (CockpitPilotage + sous-pages).

--- a/frontend/src/components/PatrimoineWizard.jsx
+++ b/frontend/src/components/PatrimoineWizard.jsx
@@ -743,7 +743,15 @@ const PatrimoineWizard = ({ onClose }) => {
                           >
                             {sev.label}
                           </span>
-                          <span className="text-sm font-medium text-gray-800">{f.rule_id}</span>
+                          {/* chasse-bugs 2026-05-29 — humanise rule_id (jargon technique
+                              exposé au user). Helper inline en attendant un dictionnaire
+                              FR exhaustif des rules wizard (cf. docs/audits/chasse_bugs_
+                              patrimoine_2026_05_29.md Cat 3 critique) */}
+                          <span className="text-sm font-medium text-gray-800">
+                            {(f.rule_id || '')
+                              .replace(/_/g, ' ')
+                              .replace(/^\w/, (c) => c.toUpperCase())}
+                          </span>
                           {f.resolved && <CheckCircle2 size={14} className="text-green-500" />}
                         </div>
                         {!f.resolved && <FixBtn f={f} ev={ev} onFix={doFix} />}

--- a/frontend/src/components/QuickCreateSite.jsx
+++ b/frontend/src/components/QuickCreateSite.jsx
@@ -16,16 +16,18 @@ import {
 } from 'lucide-react';
 import { quickCreateSite } from '../services/api';
 
+// chasse-bugs 2026-05-29 — accents FR ajoutés (cohérent avec SiteCreationWizard)
+// cf. docs/audits/chasse_bugs_patrimoine_2026_05_29.md Cat 4 mineur
 const USAGE_OPTIONS = [
   { value: 'bureau', label: 'Bureau' },
   { value: 'commerce', label: 'Commerce' },
-  { value: 'entrepot', label: 'Entrepot' },
+  { value: 'entrepot', label: 'Entrepôt' },
   { value: 'usine', label: 'Usine' },
-  { value: 'hotel', label: 'Hotel' },
-  { value: 'sante', label: 'Sante' },
+  { value: 'hotel', label: 'Hôtel' },
+  { value: 'sante', label: 'Santé' },
   { value: 'enseignement', label: 'Enseignement' },
-  { value: 'copropriete', label: 'Copropriete' },
-  { value: 'collectivite', label: 'Collectivite' },
+  { value: 'copropriete', label: 'Copropriété' },
+  { value: 'collectivite', label: 'Collectivité' },
   { value: 'logement_social', label: 'Logement social' },
   { value: 'magasin', label: 'Magasin' },
 ];

--- a/frontend/src/pages/Patrimoine.jsx
+++ b/frontend/src/pages/Patrimoine.jsx
@@ -39,9 +39,9 @@ import { scopeKicker } from '../utils/format';
 import { Table, Thead, Tbody, Th, Tr, Td, ThCheckbox, TdCheckbox } from '../ui';
 import { SkeletonCard, SkeletonTable } from '../ui/Skeleton';
 import { useToast } from '../ui';
-import ErrorState from '../ui/ErrorState'; // eslint-disable-line no-unused-vars
+// chasse-bugs 2026-05-29 — imports inutilisés retirés (ErrorState + useExpertMode)
+// cf. docs/audits/chasse_bugs_patrimoine_2026_05_29.md Cat 10 mineur
 import { useScope } from '../contexts/ScopeContext';
-import { useExpertMode } from '../contexts/ExpertModeContext'; // eslint-disable-line no-unused-vars
 import { useActionDrawer } from '../contexts/ActionDrawerContext';
 import PatrimoineWizard from '../components/PatrimoineWizard';
 import SiteCreationWizard from '../components/SiteCreationWizard';
@@ -162,7 +162,6 @@ export default function Patrimoine() {
   const location = useLocation();
   const [sp, setSp] = useSearchParams();
   const { scopedSites, sitesLoading, scope, org, refreshSites } = useScope();
-  const { isExpert } = useExpertMode(); // eslint-disable-line no-unused-vars
   const searchRef = useRef(null);
   const [dataVersion, setDataVersion] = useState(0);
 
@@ -2201,7 +2200,13 @@ function SiteDrawerContent({
             warn={site.risque_eur > 0}
           />
           <MetricPill label="Surface" value={fmtArea(site.surface_m2)} />
-          <MetricPill label="Compteurs" value={site.nb_compteurs != null ? site.nb_compteurs : 0} />
+          {/* chasse-bugs 2026-05-29 — KPI mensonger : '0' affiché alors que
+              donnée manquante (cf. docs/audits/chasse_bugs_patrimoine_2026_05_29.md
+              Cat 7 majeur — onboarding mauvais inventaire compteurs) */}
+          <MetricPill
+            label="Compteurs"
+            value={site.nb_compteurs != null ? site.nb_compteurs : '—'}
+          />
         </div>
       </div>
 
@@ -2393,4 +2398,3 @@ function DrawerActionBtn({ icon: Icon, color, title, desc, onClick, primary }) {
     </button>
   );
 }
-


### PR DESCRIPTION
## Contexte

Tour 5 du cycle 1 chasse-bugs (Tours 1-3 ✅ mergés, Tour 4 PR #342 Draft).
Base `claude/refonte-sol2` HEAD `bae2c80e` (post #341 P2.1 monitoring split).
Périmètre : `/patrimoine` (Patrimoine.jsx 2 396 lignes + 5 composants : SitesMap, IncompleteBanner, PatrimoineWizard, SiteCreationWizard, QuickCreateSite).

**Contexte produit** : hub de gestion du parc immobilier — page sensible pour onboarding nouveau client (premier contact avec leur portefeuille).

## Audit complet

[`docs/audits/chasse_bugs_patrimoine_2026_05_29.md`](docs/audits/chasse_bugs_patrimoine_2026_05_29.md)

| Cat | Finding | Action |
|---|---|---|
| 1, 2, 5 | 0 finding | — |
| **3** | **1 CRITIQUE** `{f.rule_id}` brut dans PatrimoineWizard | ✅ Fix : humanize inline |
| **4** | **5 MINEURS** accents FR manquants QuickCreateSite | ✅ Fix : Entrepôt/Hôtel/Santé/Copropriété/Collectivité |
| 6 | 1 finding documenté déjà tracké | — (D-Phase4-3 sprint C-3) |
| **7** | **1 MAJEUR** `'0'` au lieu de `'—'` pour nb_compteurs null | ✅ Fix : '—' |
| 8-9 | non testé | Tour Playwright dédié |
| **10** | **2 MINEURS** imports inutilisés | ✅ Fix : ErrorState + useExpertMode retirés |

## Findings fixés

### CRITIQUE Cat 3 — `{f.rule_id}` brut

`frontend/src/components/PatrimoineWizard.jsx:746` affichait l'identifiant technique brut au user (ex: `"invalid_siret_format"`). Critique pour onboarding nouveau client.

**Fix appliqué** (humanize inline) :
```jsx
{(f.rule_id || '').replace(/_/g, ' ').replace(/^\w/, c => c.toUpperCase())}
```
→ `"invalid_siret_format"` devient `"Invalid siret format"`. Imparfait (anglais résiduel pour rule_ids construits côté BE) mais infiniment meilleur que snake_case brut. **Suite non-trivial** : créer dict `RULE_LABELS_FR_WIZARD` exhaustif (cf. pattern `components/patrimoine/IncompleteBanner.jsx:14`).

### MAJEUR Cat 7 — KPI mensonger "Compteurs"

`frontend/src/pages/Patrimoine.jsx:2204` affichait `'0'` quand `nb_compteurs === null`. Utilisateur croyait qu'il y avait 0 compteur → mauvais inventaire onboarding.

**Fix appliqué** : `: 0` → `: '—'`.

### MINEUR Cat 4 — 5 accents FR

`frontend/src/components/QuickCreateSite.jsx:22-28` labels USAGE_OPTIONS sans accents. Incohérent avec `SiteCreationWizard` (qui a les bons accents). **Aligné** sur la version correcte.

### MINEUR Cat 10 — 2 imports inutilisés

`frontend/src/pages/Patrimoine.jsx:42,165` — `ErrorState` et `useExpertMode/isExpert` marqués `eslint-disable-line` mais vraiment inutilisés (grep confirme). Retirés (3 lignes net).

## Tests

```
vitest run (full)  : 5 558 pass / 3 skipped / 1 fail pré-existant V15Scope (owner #335)
```

**0 régression** de mes 4 edits.

## Verdict tour 5

✅ **GO** — 4 findings actionnables fixés (1 CRITIQUE + 1 MAJEUR + 2 MINEUR), 1 finding Cat 6 explicitement laissé (déjà tracké sprint dédié), page `/patrimoine` mieux préparée pour onboarding.

## Suite

Tour 6 = `/cockpit/*` (CockpitPilotage + sous-pages).

## Test plan reviewer

- [ ] Charger `/patrimoine` → ouvrir le drawer d'un site sans compteur connu (`nb_compteurs===null`) → vérifier que le MetricPill « Compteurs » affiche `—` (pas `0`).
- [ ] Ouvrir le PatrimoineWizard, déclencher une validation qui produit un finding (ex: SIRET invalide) → vérifier que le label est humanisé (`Invalid siret format` au lieu de `invalid_siret_format`).
- [ ] Dans QuickCreateSite, vérifier que les options « Entrepôt / Hôtel / Santé / Copropriété / Collectivité » s'affichent avec accents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)