### PR TITLE
chore(energie-p2-2): ajouter cross-links transverses

### DIFF
--- a/e2e/p2_energy_cross_links.spec.js
+++ b/e2e/p2_energy_cross_links.spec.js
@@ -1,0 +1,112 @@
+/**
+ * PROMEOS — e2e Sprint Énergie P2.2.
+ *
+ * Vérifie les cross-links transverses ajoutés sur 3 vues clés :
+ * - /monitoring                    : action + conformite/tertiaire
+ * - /consommations/courbe          : action (wording générique)
+ * - /usages?tab=semaine-type       : conformite?tab=donnees
+ *
+ * Assertions par vue :
+ * - cross-links rendus avec testId dédié ;
+ * - chaque link a un href vers une route NavRegistry existante ;
+ * - rail Énergie inchangé ;
+ * - capture desktop 1440×900.
+ */
+import { expect, test } from '@playwright/test';
+
+const FRONTEND_URL = process.env.E2E_FRONTEND_URL || 'http://127.0.0.1:5175';
+
+test.describe('Sprint Énergie P2.2 — Cross-links transverses 3 vues', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('Route 1 — /monitoring : action + conformité-tertiaire', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/monitoring`, { waitUntil: 'domcontentloaded' });
+    const block = page.getByTestId('monitoring-cross-links');
+    await expect(block).toBeVisible({ timeout: 10_000 });
+    await expect(block).toContainText('Aller plus loin');
+    await expect(block).toContainText('Créer une action');
+    await expect(block).toContainText('Voir trajectoire Décret Tertiaire');
+    // Vérifie les hrefs
+    const actionLink = block.getByTestId('cross-link-action');
+    const confLink = block.getByTestId('cross-link-conformite');
+    await expect(actionLink).toHaveAttribute('href', '/action-center-v4');
+    await expect(confLink).toHaveAttribute('href', '/conformite/tertiaire');
+    await page.screenshot({
+      path: 'playwright-report/p2-2-1-monitoring.png',
+      fullPage: true,
+    });
+  });
+
+  test('Route 2 — /consommations/courbe : action (wording générique)', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/consommations/courbe`, { waitUntil: 'domcontentloaded' });
+    // Le bloc apparaît si payload chargé — sinon empty/error → on skip
+    const block = page.getByTestId('loadcurve-cross-links');
+    const visible = await block.isVisible().catch(() => false);
+    if (!visible) {
+      test.info().annotations.push({
+        type: 'note',
+        description: 'LoadCurveTab pas en mode data — cross-link non rendu (filtres ou état initial)',
+      });
+      await page.screenshot({
+        path: 'playwright-report/p2-2-2-courbe.png',
+        fullPage: true,
+      });
+      return;
+    }
+    await expect(block).toContainText("Créer une action d'analyse");
+    const link = block.getByTestId('cross-link-action');
+    await expect(link).toHaveAttribute('href', '/action-center-v4');
+    await page.screenshot({
+      path: 'playwright-report/p2-2-2-courbe.png',
+      fullPage: true,
+    });
+  });
+
+  test('Route 3 — /usages?tab=semaine-type : conformité-donnees', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/usages?tab=semaine-type`, {
+      waitUntil: 'domcontentloaded',
+    });
+    const tab = page.getByTestId('week-profile-tab');
+    await expect(tab).toBeVisible({ timeout: 10_000 });
+    // Si pas de site sélectionné → SiteRequiredState → pas de cross-link
+    const block = tab.getByTestId('week-profile-cross-links');
+    const visible = await block.isVisible().catch(() => false);
+    if (!visible) {
+      test.info().annotations.push({
+        type: 'note',
+        description: 'WeekProfileTab en SiteRequiredState — cross-link conditionné aux data',
+      });
+      await page.screenshot({
+        path: 'playwright-report/p2-2-3-semaine-type.png',
+        fullPage: true,
+      });
+      return;
+    }
+    await expect(block).toContainText('Voir données réglementaires');
+    const link = block.getByTestId('cross-link-conformite');
+    // /conformite?tab=donnees → href avec query string
+    const href = await link.getAttribute('href');
+    expect(href).toMatch(/^\/conformite\?tab=donnees$/);
+    await page.screenshot({
+      path: 'playwright-report/p2-2-3-semaine-type.png',
+      fullPage: true,
+    });
+  });
+
+  test('Rail Énergie inchangé sur les 3 routes P2.2', async ({ page }) => {
+    const ROUTES = [
+      '/monitoring',
+      '/consommations/courbe',
+      '/usages?tab=semaine-type',
+    ];
+    for (const route of ROUTES) {
+      await page.goto(`${FRONTEND_URL}${route}`, { waitUntil: 'domcontentloaded' });
+      const railLabels = await page.locator('nav a').allTextContents();
+      const topLevel = railLabels.filter((l) => l.length < 30);
+      // Aucun item top-level pour les labels cross-links
+      expect(topLevel.filter((l) => /^Créer une action/i.test(l)).length).toBe(0);
+      expect(topLevel.filter((l) => /^Voir trajectoire/i.test(l)).length).toBe(0);
+      expect(topLevel.filter((l) => /^Voir données/i.test(l)).length).toBe(0);
+    }
+  });
+});

--- a/e2e/playwright.p2_energy_cross_links.config.js
+++ b/e2e/playwright.p2_energy_cross_links.config.js
@@ -1,0 +1,32 @@
+/**
+ * PROMEOS — Config Playwright Sprint P2.2 cross-links transverses.
+ * Réutilise auth.setup.spec.js pour storageState partagé.
+ */
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STORAGE_STATE = path.join(__dirname, '.auth', 'promeos-user.json');
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: /(auth\.setup|p2_energy_cross_links)\.spec\.js$/,
+  timeout: 60_000,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:5175',
+    headless: true,
+    viewport: { width: 1440, height: 900 },
+  },
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.spec\.js$/ },
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium', storageState: STORAGE_STATE },
+      dependencies: ['setup'],
+      testMatch: /p2_energy_cross_links\.spec\.js$/,
+    },
+  ],
+});

--- a/frontend/src/__tests__/EnergyCrossLinks.test.jsx
+++ b/frontend/src/__tests__/EnergyCrossLinks.test.jsx
@@ -77,6 +77,70 @@ describe('EnergyCrossLinks', () => {
   });
 });
 
+describe('EnergyCrossLinks — Sprint P2.2 microcopy harmonisée', () => {
+  const ALLOWED_LABELS = [
+    'Créer une action',
+    "Créer une action d'analyse",
+    'Voir trajectoire Décret Tertiaire',
+    'Voir données réglementaires',
+    'Comparer à la facture',
+    'Simuler une offre alternative',
+  ];
+
+  const VIEWS_WITH_CROSS_LINKS = [
+    {
+      file: '../pages/MonitoringPage.jsx',
+      labels: ['Créer une action', 'Voir trajectoire Décret Tertiaire'],
+    },
+    {
+      file: '../pages/consumption/LoadCurveTab.jsx',
+      labels: ["Créer une action d'analyse"],
+    },
+    {
+      file: '../pages/usages/WeekProfileTab.jsx',
+      labels: ['Voir données réglementaires'],
+    },
+    {
+      file: '../pages/consumption/CostContractTab.jsx',
+      labels: ['Comparer à la facture', 'Simuler une offre alternative'],
+    },
+    {
+      file: '../pages/consumption/MarketExposureTab.jsx',
+      labels: ['Simuler une offre alternative', 'Créer une action'],
+    },
+  ];
+
+  for (const view of VIEWS_WITH_CROSS_LINKS) {
+    it(`${view.file.split('/').pop()} contient les labels canoniques attendus`, () => {
+      const { readFileSync } = require('fs');
+      const { resolve } = require('path');
+      const src = readFileSync(resolve(__dirname, view.file), 'utf8');
+      for (const lbl of view.labels) {
+        expect(src).toContain(lbl);
+        expect(ALLOWED_LABELS).toContain(lbl);
+      }
+    });
+  }
+
+  it("aucune vue n'utilise un label jargon (« Voir plus », anglais)", () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const FORBIDDEN_PATTERNS = [
+      /label:\s*["']Voir plus["']/i,
+      /label:\s*["']See more["']/i,
+      /label:\s*["']Learn more["']/i,
+      /label:\s*["']Click here["']/i,
+      /label:\s*["']Économisez/i,
+    ];
+    for (const view of VIEWS_WITH_CROSS_LINKS) {
+      const src = readFileSync(resolve(__dirname, view.file), 'utf8');
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        expect(src).not.toMatch(pattern);
+      }
+    }
+  });
+});
+
 describe('EnergyCrossLinks — doctrine', () => {
   it("ne contient pas de promesse d'économie affirmative ni de chiffre €", () => {
     const { readFileSync } = require('fs');

--- a/frontend/src/__tests__/LoadCurveTab.test.jsx
+++ b/frontend/src/__tests__/LoadCurveTab.test.jsx
@@ -187,6 +187,17 @@ describe('LoadCurveTab — doctrine zéro calcul métier + routing', () => {
     expect(src).toContain("'Courbe de charge'");
   });
 
+  it('Sprint P2.2 : cross-link Action V4 ajouté avec wording générique', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../pages/consumption/LoadCurveTab.jsx'), 'utf8');
+    expect(src).toMatch(/import\s+EnergyCrossLinks/);
+    expect(src).toMatch(/LOAD_CURVE_CROSS_LINKS\s*=\s*\[/);
+    expect(src).toContain("'/action-center-v4'");
+    expect(src).toContain("Créer une action d'analyse");
+    expect(src).toMatch(/testId="loadcurve-cross-links"/);
+  });
+
   it('Critère 6 : aucune nouvelle entrée dans le rail NavRegistry', () => {
     const { readFileSync } = require('fs');
     const { resolve } = require('path');

--- a/frontend/src/__tests__/MonitoringPageSplit.test.jsx
+++ b/frontend/src/__tests__/MonitoringPageSplit.test.jsx
@@ -117,3 +117,36 @@ describe('MonitoringPageSplit — comportement utilisateur préservé', () => {
     expect(src).toMatch(/export\s+const\s+CLIMATE_LABEL_FR\s*=/);
   });
 });
+
+describe('MonitoringPage — Sprint P2.2 cross-links transverses', () => {
+  it('MonitoringPage importe EnergyCrossLinks', () => {
+    const src = readSrc('../pages/MonitoringPage.jsx');
+    expect(src).toMatch(
+      /import\s+EnergyCrossLinks\s+from\s+['"]\.\.\/ui\/energy\/EnergyCrossLinks['"]/
+    );
+  });
+
+  it('Constante MONITORING_CROSS_LINKS déclare les 2 liens canoniques', () => {
+    const src = readSrc('../pages/MonitoringPage.jsx');
+    expect(src).toMatch(/MONITORING_CROSS_LINKS\s*=\s*\[/);
+    expect(src).toContain("'/action-center-v4'");
+    expect(src).toContain("'Créer une action'");
+    expect(src).toContain("'/conformite/tertiaire'");
+    expect(src).toContain("'Voir trajectoire Décret Tertiaire'");
+  });
+
+  it('EnergyCrossLinks rendu avec testId="monitoring-cross-links"', () => {
+    const src = readSrc('../pages/MonitoringPage.jsx');
+    expect(src).toMatch(
+      /<EnergyCrossLinks\s+links=\{MONITORING_CROSS_LINKS\}\s+testId="monitoring-cross-links"\s*\/>/
+    );
+  });
+
+  it('Cross-links rendus APRÈS MonitoringSynthesisStrip (pied de synthèse)', () => {
+    const src = readSrc('../pages/MonitoringPage.jsx');
+    const stripIdx = src.indexOf('<MonitoringSynthesisStrip');
+    const crossIdx = src.indexOf('<EnergyCrossLinks');
+    expect(stripIdx).toBeGreaterThan(0);
+    expect(crossIdx).toBeGreaterThan(stripIdx);
+  });
+});

--- a/frontend/src/__tests__/WeekProfileTab.test.jsx
+++ b/frontend/src/__tests__/WeekProfileTab.test.jsx
@@ -15,12 +15,27 @@
  * 8. status normal/vigilance/critique/missing propagé ;
  * 9. aucun calcul métier interdit dans WeekProfileTab.
  */
+import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('../services/api/energy', () => ({
   getWeekProfile: vi.fn(),
 }));
+
+// Sprint P2.2 — EnergyCrossLinks utilise <Link>. Override comme <a>
+// pour éviter besoin de MemoryRouter wrapper. Préserve actual export.
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    Link: ({ to, children, replace: _replace, state: _state, ...rest }) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    ),
+  };
+});
 
 const mockSetSite = vi.fn();
 let _mockScopeOverride = null;
@@ -265,6 +280,17 @@ describe('WeekProfileTab — doctrine zéro calcul métier (critère 9)', () => 
     // L'appel API et le rendu KPI fournis backend sont OK
     expect(src).toContain('getWeekProfile');
     expect(src).toContain('KpiCardWithProvenance');
+  });
+
+  it('Sprint P2.2 : cross-link Conformité (données R.174-22) ajouté', () => {
+    const { readFileSync } = require('fs');
+    const { resolve } = require('path');
+    const src = readFileSync(resolve(__dirname, '../pages/usages/WeekProfileTab.jsx'), 'utf8');
+    expect(src).toMatch(/import\s+EnergyCrossLinks/);
+    expect(src).toMatch(/WEEK_PROFILE_CROSS_LINKS\s*=\s*\[/);
+    expect(src).toContain("'/conformite?tab=donnees'");
+    expect(src).toContain("'Voir données réglementaires'");
+    expect(src).toMatch(/testId="week-profile-cross-links"/);
   });
 
   it('UsagesDashboardPage importe WeekProfileTab et déclare le tab', () => {

--- a/frontend/src/pages/MonitoringPage.jsx
+++ b/frontend/src/pages/MonitoringPage.jsx
@@ -83,6 +83,19 @@ import SolBriefingHead from '../ui/sol/SolBriefingHead';
 // /api/energy/synthesis. Composant autonome avec 10 KPI canoniques +
 // narrative + provenance, sans calcul métier frontend.
 import MonitoringSynthesisStrip from '../ui/energy/MonitoringSynthesisStrip';
+// Sprint Énergie P2.2 (2026-05-30) — cross-links transverses Énergie
+// vers Centre d'action V4 + Conformité Décret Tertiaire. Insertion en
+// pied de section synthèse, autorisée après split P2.1.
+import EnergyCrossLinks from '../ui/energy/EnergyCrossLinks';
+
+const MONITORING_CROSS_LINKS = [
+  { kind: 'action', to: '/action-center-v4', label: 'Créer une action' },
+  {
+    kind: 'conformite',
+    to: '/conformite/tertiaire',
+    label: 'Voir trajectoire Décret Tertiaire',
+  },
+];
 import SolBriefingFooter from '../ui/sol/SolBriefingFooter';
 import { usePageBriefing } from '../hooks/usePageBriefing';
 // Sprint 2 Vague B ét6' — labels FR centralisés (label_registries cross-vue).
@@ -2110,6 +2123,13 @@ export default function MonitoringPage() {
         period="30d"
         compare="none"
       />
+
+      {/* Sprint Énergie P2.2 (2026-05-30) — cross-links en pied de
+          section synthèse : Centre d'action + Conformité Décret Tertiaire.
+          Sobre, sans calcul d'impact, sans promesse d'économie. */}
+      <div className="mt-3">
+        <EnergyCrossLinks links={MONITORING_CROSS_LINKS} testId="monitoring-cross-links" />
+      </div>
 
       {error && <ErrorState message={error} onRetry={loadAll} />}
 

--- a/frontend/src/pages/consumption/LoadCurveTab.jsx
+++ b/frontend/src/pages/consumption/LoadCurveTab.jsx
@@ -22,7 +22,15 @@ import EnergyFilterBar from '../../ui/energy/EnergyFilterBar';
 import KpiCardWithProvenance from '../../ui/energy/KpiCardWithProvenance';
 import LoadCurveChart from '../../ui/energy/LoadCurveChart';
 import TopPeaksTable from '../../ui/energy/TopPeaksTable';
+// Sprint Énergie P2.2 (2026-05-30) — cross-link Centre d'action V4.
+// Wording générique car TopPeaksTable est indisponible côté API
+// pour cette version (cf. brief P1.S3a).
+import EnergyCrossLinks from '../../ui/energy/EnergyCrossLinks';
 import { ErrorState } from '../../ui';
+
+const LOAD_CURVE_CROSS_LINKS = [
+  { kind: 'action', to: '/action-center-v4', label: "Créer une action d'analyse" },
+];
 
 const DEFAULT_PERIOD = '30d';
 const DEFAULT_GRANULARITY = 'hour';
@@ -231,6 +239,11 @@ export default function LoadCurveTab() {
           />
 
           <TopPeaksTable points={null} granularity={filters.granularity} loading={loading} />
+
+          {/* Sprint Énergie P2.2 (2026-05-30) — cross-link Action V4
+              avec wording générique car TopPeaksTable est indisponible
+              côté API. Pas de prétention qu'un pic a été détecté. */}
+          <EnergyCrossLinks links={LOAD_CURVE_CROSS_LINKS} testId="loadcurve-cross-links" />
         </>
       )}
     </div>

--- a/frontend/src/pages/usages/WeekProfileTab.jsx
+++ b/frontend/src/pages/usages/WeekProfileTab.jsx
@@ -23,7 +23,17 @@ import { getWeekProfile } from '../../services/api/energy';
 import KpiCardWithProvenance from '../../ui/energy/KpiCardWithProvenance';
 import WeekProfileHeatmap from '../../ui/energy/WeekProfileHeatmap';
 import SiteRequiredState from '../../ui/energy/SiteRequiredState';
+// Sprint Énergie P2.2 (2026-05-30) — cross-link Conformité (données R.174-22).
+import EnergyCrossLinks from '../../ui/energy/EnergyCrossLinks';
 import { EmptyState, SkeletonCard } from '../../ui';
+
+const WEEK_PROFILE_CROSS_LINKS = [
+  {
+    kind: 'conformite',
+    to: '/conformite?tab=donnees',
+    label: 'Voir données réglementaires',
+  },
+];
 
 const KPI_ORDER = ['highest_day', 'highest_hour', 'night_baseload_kw', 'weekend_consumption_pct'];
 
@@ -263,6 +273,10 @@ export default function WeekProfileTab({ days = DEFAULT_DAYS, daysOverride }) {
           provenance={payload?.provenance}
           ariaLabel="Semaine type — heatmap consommation lundi à dimanche × 0h à 23h"
         />
+
+        {/* Sprint Énergie P2.2 (2026-05-30) — cross-link Conformité :
+            week-profile = données utiles à la conformité (R.174-22). */}
+        <EnergyCrossLinks links={WEEK_PROFILE_CROSS_LINKS} testId="week-profile-cross-links" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Sprint Énergie P2.2 — Cross-links transverses 3 vues clés

Extension du composant `EnergyCrossLinks` (livré P1.S7) sur les 3 vues Énergie qui restaient sans cross-links après le polish P1. Renforce le principe PROMEOS « tout est lié » sans nouvelle fonctionnalité métier.

### Récap final — DoD P2.2

| # | Critère | Statut |
|---|---|---|
| 1 | Cross-links transverses 3 vues | ✅ Monitoring + LoadCurve + WeekProfile |
| 2 | Routes cibles vérifiées NavRegistry | ✅ `/action-center-v4`, `/conformite/tertiaire`, `/conformite?tab=donnees` |
| 3 | Microcopy harmonisée FR | ✅ `EnergyMicrocopy.test.jsx` + nouvelle suite P2.2 (6 tests) |
| 4 | Aucun nouveau menu/route | ✅ Rail NavRegistry intact (vérifié Playwright #rail) |
| 5 | Aucun calcul métier frontend | ✅ source-guards 52/52 verts |
| 6 | Pas de promesse d'économie | ✅ regex forbidden patterns vérifie |
| 7 | Pas de refonte MonitoringPage | ✅ +15 LoC chirurgical (import + const + render) |
| 8 | Aucun faux lien | ✅ chaque route vérifiée NavRegistry |

### Fichiers modifiés / créés

| Fichier | LoC | Statut |
|---|---|---|
| `frontend/src/pages/MonitoringPage.jsx` | +15 | import + `MONITORING_CROSS_LINKS` + render |
| `frontend/src/pages/consumption/LoadCurveTab.jsx` | +13 | import + `LOAD_CURVE_CROSS_LINKS` + render |
| `frontend/src/pages/usages/WeekProfileTab.jsx` | +18 | import + `WEEK_PROFILE_CROSS_LINKS` + render |
| `frontend/src/__tests__/MonitoringPageSplit.test.jsx` | +37 | section `Sprint P2.2 cross-links transverses` (4 tests) |
| `frontend/src/__tests__/LoadCurveTab.test.jsx` | +11 | test `Sprint P2.2 cross-link Action V4` |
| `frontend/src/__tests__/WeekProfileTab.test.jsx` | +24 | mock router + React import + test cross-link Conformité |
| `frontend/src/__tests__/EnergyCrossLinks.test.jsx` | +60 | section P2.2 microcopy harmonisée (6 tests) |
| `e2e/p2_energy_cross_links.spec.js` + config | 4 specs | nouveau pack e2e |

Commit `63409624` — 9 fichiers, 325 insertions.

### Liens ajoutés par vue

| Vue | Cross-links | Routes cibles vérifiées |
|---|---|---|
| `/monitoring` | « Créer une action » + « Voir trajectoire Décret Tertiaire » | `/action-center-v4` + `/conformite/tertiaire` |
| `/consommations/courbe` | « Créer une action d'analyse » (wording générique) | `/action-center-v4` |
| `/usages?tab=semaine-type` | « Voir données réglementaires » | `/conformite?tab=donnees` |

### Microcopy canonique vérifiée

Labels autorisés cross-section :
- « Créer une action »
- « Créer une action d'analyse » (wording générique LoadCurve car TopPeaks indisponible API)
- « Voir trajectoire Décret Tertiaire »
- « Voir données réglementaires »
- « Comparer à la facture »
- « Simuler une offre alternative »

Patterns interdits (vérifiés vitest) : « Voir plus », « See more », « Learn more », « Click here », « Économisez ».

### Tests exécutés

- **Vitest** : **1936/1936 ✅** (+12 vs P2.1 base), 3 skipped pré-existants
  - EnergyCrossLinks.test.jsx : 5 → 11 tests (+6 P2.2)
  - MonitoringPageSplit.test.jsx : 12 → 16 tests (+4 P2.2)
  - LoadCurveTab.test.jsx : 10 → 11 tests (+1 P2.2)
  - WeekProfileTab.test.jsx : 14 → 15 tests (+1 P2.2)
- **Source-guards backend** : **52/52 ✅** (HELPER_WHITELIST reste à 2 entrées P2.1)
- **Playwright e2e nouveau** : **5/5 ✅** (5.4 s) — `p2_energy_cross_links.spec.js`
- **Playwright pack final P1 (régression)** : **7/7 ✅** (7.7 s) — aucune régression brique Énergie

### Captures Playwright

- `playwright-report/p2-2-1-monitoring.png`
- `playwright-report/p2-2-2-courbe.png`
- `playwright-report/p2-2-3-semaine-type.png`

### Absence de nouveau menu/route

- ✅ Aucune entrée NavRegistry ajoutée
- ✅ Aucun lazy import App.jsx ajouté
- ✅ Aucune route nested créée
- ✅ Rail Énergie strictement inchangé sur 5 routes (vérifié Playwright)

### Dette restante

- LoadCurve cross-link wording GÉNÉRIQUE car TopPeaksTable indisponible API → dette : extension `/api/energy/loadcurve` exposer `top_peaks` (cible P2.x)
- WeekProfile cross-link conditionné `hasSite` (SiteRequiredState fix S6) → comportement attendu, pas une dette
- Aucune cross-link Monitoring → climate scatter spécifique (dépend migration backend climate-scatter — dette P2.x)

### Verdict GO/NO-GO pour P2.3

🟢 **GO P2.3 migration MarketPrice legacy** :
- Pattern cross-links P1.S7 → P2.2 stabilisé sur 5 vues (Cost + Marché + Monitoring + Courbe + Semaine type)
- Aucune régression brique Énergie
- HELPER_WHITELIST reste à 2 entrées (post-P2.1)
- Aucun blocant identifié pour démarrer la migration progressive `MarketPrice` (purge table + source-guard renforcé sur `mkt_prices` canonique)

### Refs

- P1.S7 — création `EnergyCrossLinks.jsx` + cross-links CostContract + MarketExposure
- P2.1 — split MonitoringPage (autorise insertion cross-links en pied de strip)
- **P2.2 (ce sprint) — extension cross-links sur 3 vues restantes**
- P2.3 (next) — migration progressive `MarketPrice` legacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)