### PR TITLE
chore(energie-p2-3): durcir migration market price canonique

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -291,9 +291,15 @@ from .action_template import ActionTemplate
 # Onboarding Progress (V113)
 from .onboarding_progress import OnboardingProgress
 
-# Market Prices — DEPRECATED: legacy table 'market_prices' (Step 17)
-# Tous les nouveaux développements doivent utiliser MktPrice (table 'mkt_prices')
-from .market_price import MarketPrice  # legacy, ne pas utiliser dans du nouveau code
+# Market Prices — DEPRECATED Sprint Énergie P2.3 (2026-05-30)
+# Table legacy 'market_prices' (Step 17). SOURCE DE VÉRITÉ canonique :
+# MktPrice (table 'mkt_prices') exposé ci-dessous depuis market_models.
+# Cet import est conservé UNIQUEMENT pour que SQLAlchemy reconnaisse la
+# table legacy existante en DB (préservation data — cf. brief P2.3
+# « Ne pas dropper la table MarketPrice legacy »).
+# Tout nouvel usage applicatif est INTERDIT (source-guard
+# test_market_price_canonical_source_guards.py).
+from .market_price import MarketPrice  # noqa: F401 — DEPRECATED, conservé pour compat ORM table legacy
 
 # Market Data V2 — source de vérité
 from .market_models import (

--- a/backend/models/market_price.py
+++ b/backend/models/market_price.py
@@ -1,11 +1,43 @@
 """
-PROMEOS — MarketPrice model (DEPRECATED)
-Prix marché énergie (EPEX Spot, forwards, etc.)
+PROMEOS — MarketPrice model (DEPRECATED — Step 17 legacy, conservation
+data-only).
 
-⚠️ DEPRECATED: Ce modèle mappe vers la table legacy 'market_prices' (Step 17).
-La source de vérité est désormais MktPrice (table 'mkt_prices') dans market_models.py.
-Ne pas utiliser dans du nouveau code. Sera supprimé dans une future migration
-après vérification que la table legacy peut être droppée.
+╔════════════════════════════════════════════════════════════════════╗
+║ ⚠️  DEPRECATED — Sprint Énergie P2.3 (2026-05-30)                   ║
+║                                                                    ║
+║ Ce modèle SQLAlchemy mappe vers la table legacy `market_prices`    ║
+║ (introduite Step 17). La SOURCE DE VÉRITÉ canonique pour les prix  ║
+║ marché énergie est désormais `MktPrice` (table `mkt_prices`)       ║
+║ exposé par `backend/models/market_models.py`.                      ║
+║                                                                    ║
+║ INTERDIT (vérifié par source-guard                                 ║
+## `backend/tests/source_guards/test_market_price_canonical_source_guards.py`) :
+║ - Tout import applicatif de `MarketPrice` dans                     ║
+║   `backend/services/` (hors commentaires et warnings).             ║
+║ - Tout import dans `backend/routes/`.                              ║
+║ - Tout test métier NOUVEAU fondé sur `MarketPrice`.                ║
+║                                                                    ║
+║ AUTORISÉ (whitelist documentée) :                                  ║
+║ - `backend/models/__init__.py` — export pour compat ORM (import    ║
+║   nécessaire pour que SQLAlchemy reconnaisse la table existante).  ║
+║ - `backend/tests/test_step17_market_prices.py` — tests legacy      ║
+║   explicites du modèle Step 17 (préservation data).                ║
+║ - Migrations Alembic — historique non modifiable.                  ║
+║ - Source-guard lui-même qui interdit les imports.                  ║
+║                                                                    ║
+║ CIBLE DE SUPPRESSION (P2.x ultérieur) : table `market_prices`      ║
+║ droppée après vérification :                                       ║
+║   1. Aucune donnée orpheline qui n'est pas dans `mkt_prices`.      ║
+║   2. Backup data triple-artefact (cf. ADR Cutover Mois 4).         ║
+║   3. Source-guard 0 violation pendant 2 sprints consécutifs.       ║
+║                                                                    ║
+║ Migration de référence pour P2.3 → cible :                         ║
+║ - Modèle canonique : `from models.market_models import MktPrice`   ║
+║ - Champs canoniques : `market_type`, `zone`, `delivery_start`,     ║
+║   `delivery_end`, `price_eur_mwh`, `quality_status`,               ║
+║   `publication_datetime`.                                          ║
+║ - Service abstraction : `backend/services/market_data_service.py`. ║
+╚════════════════════════════════════════════════════════════════════╝
 """
 
 from sqlalchemy import Column, Integer, String, Float, Date, UniqueConstraint
@@ -14,7 +46,11 @@ from .base import Base, TimestampMixin
 
 
 class MarketPrice(Base, TimestampMixin):
-    """Prix marché énergie (EPEX Spot FR, EEX CAL, etc.)"""
+    """Prix marché énergie LEGACY (EPEX Spot FR, EEX CAL, etc.).
+
+    ⚠️ DEPRECATED — utiliser `MktPrice` depuis `models.market_models`
+    pour tout nouveau code. Cf. doctrine in-file ci-dessus.
+    """
 
     __tablename__ = "market_prices"
     __table_args__ = (UniqueConstraint("market", "date", "energy_type", name="uq_market_date_energy"),)

--- a/backend/services/billing_service.py
+++ b/backend/services/billing_service.py
@@ -173,7 +173,9 @@ def get_reference_price(
     Resolve the reference price for a site, with clear priority:
       0. Active V2 ContratCadre annexe → resolve_pricing() cascade
       1. Active EnergyContract covering the invoice period
-      2. MarketPrice moyenne 30 jours (EPEX Spot FR)
+      2. MktPrice moyenne 30 jours (EPEX Spot FR — table canonique
+         'mkt_prices' depuis Sprint Énergie P1.S2d ; remplace l'ancien
+         MarketPrice legacy marqué DEPRECATED P2.3)
       3. SiteTariffProfile for the site
       4. Config fallback (0.068 elec, 0.045 gaz)
     Returns: (price_eur_per_kwh, source_label)

--- a/backend/tests/source_guards/test_market_price_canonical_source_guards.py
+++ b/backend/tests/source_guards/test_market_price_canonical_source_guards.py
@@ -152,3 +152,137 @@ class TestMarketPriceCanonical:
         """Toute entrée whitelist doit avoir une justification non vide."""
         for path, reason in LEGACY_MARKET_PRICE_WHITELIST.items():
             assert reason and reason.strip(), f"WHITELIST entry '{path}' has empty justification."
+
+
+class TestMarketPriceCanonicalP2_3:
+    """Sprint Énergie P2.3 (2026-05-30) — durcissement migration MarketPrice.
+
+    Couverture renforcée :
+    - aucun fichier `backend/services/energy_orchestration/*` n'importe
+      `MarketPrice` (vérifie le SoT orchestration énergie).
+    - `market_data_service.py` n'importe pas MarketPrice si présent.
+    - `billing_service.py` n'importe pas MarketPrice.
+    - le modèle legacy porte le marquage DEPRECATED P2.3 explicite.
+    """
+
+    def test_energy_orchestration_no_market_price_import(self):
+        """Aucun import MarketPrice dans backend/services/energy_orchestration/.
+
+        Le SoT canonique pour la brique Énergie est MktPrice (cf. P1.S2d).
+        """
+        orchestration_dir = BACKEND / "services" / "energy_orchestration"
+        assert orchestration_dir.exists(), (
+            "backend/services/energy_orchestration/ introuvable — répertoire SoT brique Énergie manquant."
+        )
+        for py_file in sorted(orchestration_dir.rglob("*.py")):
+            rel = py_file.relative_to(REPO_ROOT).as_posix()
+            content = py_file.read_text(encoding="utf-8")
+            for pattern in FORBIDDEN_IMPORT_PATTERNS:
+                # Skip if just a comment mentioning the name (no import)
+                for match in pattern.finditer(content):
+                    line_no = content[: match.start()].count("\n") + 1
+                    line = content.split("\n")[line_no - 1]
+                    if line.strip().startswith("#"):
+                        continue
+                    pytest.fail(
+                        f"🔴 P2.3 — Import legacy MarketPrice dans SoT Énergie : "
+                        f"{rel}:{line_no} → « {match.group(0)[:80]} ». "
+                        f"Utiliser MktPrice depuis models.market_models."
+                    )
+
+    def test_billing_service_no_market_price_import(self):
+        """billing_service.py n'importe pas le modèle legacy MarketPrice.
+
+        Vérifié P2.3 : billing_service utilise MktPrice canonique pour
+        le calcul prix référence (priority 2 du resolve_reference_price).
+        """
+        billing = BACKEND / "services" / "billing_service.py"
+        if not billing.exists():
+            return
+        content = billing.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_IMPORT_PATTERNS:
+            for match in pattern.finditer(content):
+                line_no = content[: match.start()].count("\n") + 1
+                line = content.split("\n")[line_no - 1]
+                if line.strip().startswith("#"):
+                    continue
+                pytest.fail(
+                    f"🔴 P2.3 — billing_service.py importe MarketPrice legacy "
+                    f"ligne {line_no} : « {match.group(0)[:80]} ». "
+                    f"Utiliser MktPrice canonique."
+                )
+
+    def test_market_data_service_uses_canonical_if_exists(self):
+        """Si market_data_service existe, il utilise MktPrice (pas legacy)."""
+        candidates = [
+            BACKEND / "services" / "market_data_service.py",
+            BACKEND / "services" / "market_data" / "service.py",
+        ]
+        for path in candidates:
+            if not path.exists():
+                continue
+            content = path.read_text(encoding="utf-8")
+            for pattern in FORBIDDEN_IMPORT_PATTERNS:
+                for match in pattern.finditer(content):
+                    line_no = content[: match.start()].count("\n") + 1
+                    line = content.split("\n")[line_no - 1]
+                    if line.strip().startswith("#"):
+                        continue
+                    rel = path.relative_to(REPO_ROOT).as_posix()
+                    pytest.fail(f"🔴 P2.3 — {rel}:{line_no} importe MarketPrice legacy. Utiliser MktPrice canonique.")
+
+    def test_legacy_model_has_p2_3_deprecation_marker(self):
+        """Le modèle legacy porte le marquage DEPRECATED P2.3 renforcé."""
+        legacy_model = BACKEND / "models" / "market_price.py"
+        if not legacy_model.exists():
+            return
+        content = legacy_model.read_text(encoding="utf-8")
+        # Marqueur P2.3 explicite
+        assert "P2.3" in content, (
+            "models/market_price.py manque le marqueur Sprint P2.3 dans la "
+            "doctrine DEPRECATED. Ajouter référence sprint pour traçabilité."
+        )
+        # Lien vers source-guard
+        assert "test_market_price_canonical_source_guards" in content, (
+            "models/market_price.py doit référencer le nom du source-guard qui interdit ses imports applicatifs."
+        )
+
+    def test_models_init_marks_legacy_import_as_compat(self):
+        """models/__init__.py marque l'import legacy comme compat-only."""
+        init = BACKEND / "models" / "__init__.py"
+        content = init.read_text(encoding="utf-8")
+        # Doit avoir un commentaire DEPRECATED + un noqa: F401
+        # (l'import est nécessaire pour SQLAlchemy mais non utilisé directement)
+        idx = content.find("from .market_price import MarketPrice")
+        assert idx > -1, "Import MarketPrice attendu dans models/__init__.py."
+        # Le commentaire DEPRECATED P2.3 doit précéder l'import
+        preceding = content[max(0, idx - 600) : idx]
+        assert "DEPRECATED" in preceding.upper(), (
+            "models/__init__.py — l'import MarketPrice doit être précédé d'un commentaire DEPRECATED explicite."
+        )
+        # noqa: F401 nécessaire car l'import sert pour ORM seulement
+        line_after = content[idx : idx + 200]
+        assert "noqa" in line_after or "legacy" in line_after.lower(), (
+            "models/__init__.py — l'import MarketPrice doit porter `noqa: F401` "
+            "(import compat ORM, jamais utilisé directement) ou mention `legacy`."
+        )
+
+    def test_p2_3_doc_references_canonical_fields(self):
+        """La doctrine in-file mentionne les champs canoniques attendus."""
+        legacy_model = BACKEND / "models" / "market_price.py"
+        if not legacy_model.exists():
+            return
+        content = legacy_model.read_text(encoding="utf-8")
+        # Au moins 2 champs canoniques cités
+        canonical_fields = [
+            "market_type",
+            "zone",
+            "delivery_start",
+            "price_eur_mwh",
+        ]
+        found = sum(1 for f in canonical_fields if f in content)
+        assert found >= 3, (
+            f"La doctrine de market_price.py doit citer les champs canoniques "
+            f"MktPrice attendus (au moins 3 sur {canonical_fields}). "
+            f"Actuellement : {found}."
+        )

--- a/docs/audits/p2_3_market_price_legacy_2026_05_30.md
+++ b/docs/audits/p2_3_market_price_legacy_2026_05_30.md
@@ -1,0 +1,121 @@
+# Sprint Énergie P2.3 — Migration MarketPrice legacy (rapport)
+
+**Date** : 2026-05-30
+**Sprint** : P2.3 — Migration progressive `MarketPrice` legacy vers `MktPrice` canonique
+**Branche** : `claude/energie-p2-3-market-price-legacy` depuis `b1732c32`
+**Périmètre** : backend uniquement (aucune modification FE ni UI)
+
+## 1. Usages `MarketPrice` audités
+
+Grep complet `rg "MarketPrice" backend/` + `rg "from models.market_price"` :
+
+| Fichier | Ligne(s) | Type d'usage | Action P2.3 |
+|---|---|---|---|
+| `backend/models/market_price.py` | 16 | définition classe legacy | **DEPRECATED renforcé** |
+| `backend/models/__init__.py` | 296, 607 | import + export `__all__` | **DEPRECATED renforcé + noqa: F401** |
+| `backend/tests/test_step17_market_prices.py` | 25, 30, 32, 69 | tests legacy explicites | conservé (whitelist) |
+| `backend/tests/source_guards/test_market_price_canonical_source_guards.py` | 7, 14, 23, 39, 64, 67, 68, 73 | source-guard lui-même | conservé (whitelist) |
+| `backend/tests/api/test_energy_market_exposure_endpoint.py` | 511, 518, 527, 529 | test API asserte ABSENCE | conservé |
+| `backend/services/billing_service.py` | 176 | commentaire docstring obsolète | **mis à jour vers MktPrice** |
+| `backend/services/energy_orchestration/market_exposure.py` | 643 | commentaire dans warning | conservé (commentaire informatif) |
+
+## 2. Usages migrés (P2.3)
+
+| Fichier | Avant | Après |
+|---|---|---|
+| `backend/services/billing_service.py:176` | « 2. MarketPrice moyenne 30 jours (EPEX Spot FR) » | « 2. MktPrice moyenne 30 jours (EPEX Spot FR — table canonique 'mkt_prices' depuis Sprint Énergie P1.S2d ; remplace l'ancien MarketPrice legacy marqué DEPRECATED P2.3) » |
+| `backend/models/market_price.py` (docstring) | mention DEPRECATED minimale + 6 lignes | doctrine 40+ lignes encadrée : interdits, autorisés (whitelist), cible suppression, migration de référence vers `MktPrice` |
+| `backend/models/__init__.py:294-296` | 3 lignes commentaire + import | 7 lignes commentaire + `noqa: F401` (import compat ORM table legacy) |
+| `backend/models/market_price.py` (classe) | docstring 1 ligne | docstring renforcée + référence vers doctrine in-file |
+
+**Aucun usage applicatif `MarketPrice` n'a été détecté hors whitelist** — la migration applicative `MktPrice` est complète depuis P1.S2d (cf. `services/energy_orchestration/market_exposure.py` qui utilise déjà `from models.market_models import MktPrice`).
+
+## 3. Usages legacy conservés
+
+| Fichier | Justification |
+|---|---|
+| `backend/models/market_price.py` | Modèle DEPRECATED conservé pour préservation data (table `market_prices` non droppée — cf. brief P2.3 « Ne pas dropper »). |
+| `backend/models/__init__.py` | Import compat ORM nécessaire pour que SQLAlchemy reconnaisse la table legacy en DB. Marqué `noqa: F401` (jamais utilisé directement). |
+| `backend/tests/test_step17_market_prices.py` | Tests legacy explicites Step 17 — préservation data testée. |
+| `backend/tests/source_guards/test_market_price_canonical_source_guards.py` | Source-guard lui-même — référence le nom interdit pour le détecter. |
+| `backend/services/demo_seed/gen_market_prices.py` | Seed démo legacy. À migrer vers `mkt_prices` avant DROP TABLE (cible P2.x ultérieur). |
+
+## 4. Whitelist finale
+
+`LEGACY_MARKET_PRICE_WHITELIST` (dans `test_market_price_canonical_source_guards.py`) — **3 entrées documentées** :
+
+1. `backend/models/market_price.py` — modèle lui-même (DEPRECATED docstring)
+2. `backend/tests/source_guards/test_market_price_canonical_source_guards.py` — source-guard lui-même
+3. `backend/services/demo_seed/gen_market_prices.py` — seed démo legacy (à migrer ultérieurement)
+
+## 5. Source-guard renforcé
+
+Nouvelle classe `TestMarketPriceCanonicalP2_3` ajoute **6 tests** :
+
+- `test_energy_orchestration_no_market_price_import` — aucun import dans `services/energy_orchestration/*`
+- `test_billing_service_no_market_price_import` — `billing_service.py` n'importe pas `MarketPrice`
+- `test_market_data_service_uses_canonical_if_exists` — `market_data_service.py` (si existe) utilise `MktPrice`
+- `test_legacy_model_has_p2_3_deprecation_marker` — modèle legacy porte le marqueur Sprint P2.3 + référence source-guard
+- `test_models_init_marks_legacy_import_as_compat` — `models/__init__.py` documente l'import legacy comme compat-only
+- `test_p2_3_doc_references_canonical_fields` — la doctrine in-file cite ≥ 3 champs canoniques (`market_type`, `zone`, `delivery_start`, `price_eur_mwh`)
+
+## 6. Tests verts
+
+| Suite | Résultat |
+|---|---|
+| `pytest tests/source_guards/ -k "market_price or energy_orchestration or frontend_no_business or cdc_timezone"` | **58/58 ✅** (+6 vs P2.2 : tests `TestMarketPriceCanonicalP2_3`) |
+| `pytest tests/api/test_energy_market_exposure_endpoint.py` | **27/27 ✅** (aucune régression endpoint Marché & exposition) |
+
+Détails endpoint `/api/energy/market-exposure` :
+- ✅ HTTP 200 sur site valide
+- ✅ Coût spot théorique calculé (€)
+- ✅ Prix spot pondéré sans division par zéro
+- ✅ Écart vs baseload disponible
+- ✅ Top heures chères triées
+- ✅ Prix négatifs détectés
+- ✅ Score exposition borné [0,100]
+- ✅ Provenance complète par KPI
+
+## 7. Risques restants
+
+| Risque | Sévérité | Mitigation |
+|---|---|---|
+| Données orphelines dans `market_prices` qui ne sont pas dans `mkt_prices` | Faible | Avant DROP TABLE Alembic (P2.x ultérieur) : script de migration data `market_prices` → `mkt_prices` avec validation. |
+| Seed démo `gen_market_prices.py` peuple encore la table legacy | Moyenne | Migrer le seed vers `mkt_prices` en même temps que DROP TABLE. Whitelist temporaire documentée. |
+| Import compat ORM dans `models/__init__.py` reste obligatoire | Faible | Tant que la table existe, SQLAlchemy a besoin du modèle pour son metadata. Disparaîtra avec le DROP. |
+| Test `test_step17_market_prices.py` continuera à valider le modèle legacy | Faible | À supprimer après DROP TABLE. Validation préservation data utile en attendant. |
+
+## 8. Recommandation pour suppression future
+
+**Cible P2.x ultérieur (post-P2.5)** : DROP TABLE `market_prices` + suppression complète du modèle.
+
+**Critères préalables** (à valider AVANT DROP) :
+
+1. **Audit data orpheline** : `SELECT count(*) FROM market_prices WHERE NOT EXISTS (SELECT 1 FROM mkt_prices WHERE ...)` — résultat doit être 0 OU plan de migration data documenté.
+2. **Backup triple-artefact** : binaire DB + dump SQL + JSON export (cf. ADR Cutover Mois 4 — Q2-α : backup hors Git non négociable).
+3. **Source-guard 0 violation pendant 2 sprints consécutifs** : la whitelist a été réduite à 0 (seed migré).
+4. **Migration Alembic** : `DROP TABLE market_prices` avec `--no-rollback` désactivé (revert possible 24h).
+5. **Tests legacy supprimés** : `test_step17_market_prices.py` retiré dans le même commit.
+
+**Bénéfices attendus** :
+- Réduction surface de code legacy (~50 LoC modèle + ~30 LoC test)
+- HELPER_WHITELIST source-guard à 2 entrées (modèle + source-guard) au lieu de 3
+- Doctrine « source de vérité unique » 100 % effective
+
+## 9. Verdict
+
+🟢 **P2.3 COMPLET** :
+
+- ✅ Modèle legacy marqué DEPRECATED P2.3 renforcé (doctrine 40+ lignes)
+- ✅ `models/__init__.py` import compat ORM documenté (noqa: F401)
+- ✅ `billing_service.py` commentaire docstring corrigé (MarketPrice → MktPrice)
+- ✅ Source-guard renforcé (+6 tests P2.3, 58/58 total verts)
+- ✅ Tests API endpoint Marché & exposition 27/27 verts (aucune régression)
+- ✅ Whitelist documentée 3 entrées, dont 1 à migrer (seed démo)
+- ✅ Aucun usage applicatif `MarketPrice` détecté hors whitelist
+
+**Migration data** non couverte par P2.3 (préservation table legacy conservée selon brief). Cible P2.x ultérieur post-validation critères §8.
+
+---
+
+Rapport généré le 2026-05-30 dans le cadre du sprint P2.3.


### PR DESCRIPTION
## Sprint Énergie P2.3 — Migration progressive `MarketPrice` legacy

Durcissement de la migration `MarketPrice` (table legacy `market_prices`) vers `MktPrice` canonique (table `mkt_prices`). **Backend-only — aucune modification FE ni UI.**

### Récap final — DoD P2.3

| # | Critère | Statut |
|---|---|---|
| 1 | Usages MarketPrice audités | ✅ 7 occurrences classifiées (0 applicative à migrer) |
| 2 | Usages applicatifs migrés | ✅ aucun (déjà 100 % `MktPrice` depuis P1.S2d) |
| 3 | Legacy conservé et marqué DEPRECATED | ✅ doctrine 40+ lignes + marqueur P2.3 + référence source-guard |
| 4 | Source-guard renforcé | ✅ +6 tests `TestMarketPriceCanonicalP2_3` |
| 5 | Tests verts | ✅ source-guards 58/58 + API endpoint 27/27 |
| 6 | Doctrine respectée | ✅ table legacy conservée, aucune migration destructive |

### Fichiers modifiés / créés

| Fichier | LoC | Statut |
|---|---|---|
| `backend/models/market_price.py` | +42 | doctrine DEPRECATED P2.3 renforcée (encadrée 40 lignes) |
| `backend/models/__init__.py` | +7 / -1 | commentaire compat ORM + `noqa: F401` |
| `backend/services/billing_service.py` | +3 / -1 | commentaire docstring corrigé MarketPrice → MktPrice |
| `backend/tests/source_guards/test_market_price_canonical_source_guards.py` | +117 | classe `TestMarketPriceCanonicalP2_3` (6 tests) |
| `docs/audits/p2_3_market_price_legacy_2026_05_30.md` | 9 sections | rapport de migration |

Commit `3167302d` — 5 fichiers, 310 insertions, 11 suppressions.

### Audit complet — Aucun usage applicatif

`rg "MarketPrice" backend/` :

| Fichier | Type | Action |
|---|---|---|
| `models/market_price.py` | modèle | DEPRECATED renforcé |
| `models/__init__.py` | import compat ORM | DEPRECATED renforcé |
| `tests/test_step17_market_prices.py` | tests legacy explicites | conservé (whitelist) |
| `tests/source_guards/test_market_price_canonical_source_guards.py` | source-guard | renforcé |
| `tests/api/test_energy_market_exposure_endpoint.py` | assert ABSENCE | conservé |
| `services/energy_orchestration/market_exposure.py:643` | commentaire warning | conservé |
| `services/billing_service.py:176` | commentaire docstring obsolète | **corrigé** |

**Aucun usage applicatif `MarketPrice` hors whitelist** — la migration code applicative est complète depuis P1.S2d. Le code (`billing_service.py:223`) utilise déjà `MktPrice.price_eur_mwh` canonique ; seul le commentaire docstring de `resolve_reference_price` était obsolète.

### Source-guard renforcé

Nouvelle classe `TestMarketPriceCanonicalP2_3` (6 tests) :

1. `test_energy_orchestration_no_market_price_import` — aucun import dans `services/energy_orchestration/*` (SoT brique Énergie)
2. `test_billing_service_no_market_price_import` — `billing_service.py` n'importe pas (au-delà du commentaire)
3. `test_market_data_service_uses_canonical_if_exists` — service marché utilise `MktPrice`
4. `test_legacy_model_has_p2_3_deprecation_marker` — marqueur Sprint P2.3 + référence source-guard
5. `test_models_init_marks_legacy_import_as_compat` — `models/__init__.py` DEPRECATED + noqa
6. `test_p2_3_doc_references_canonical_fields` — doctrine in-file cite ≥ 3 champs canoniques (`market_type`, `zone`, `delivery_start`, `price_eur_mwh`)

### Whitelist finale — 3 entrées documentées

1. `backend/models/market_price.py` — modèle lui-même DEPRECATED
2. `backend/tests/source_guards/test_market_price_canonical_source_guards.py` — guard lui-même
3. `backend/services/demo_seed/gen_market_prices.py` — seed démo (à migrer P2.x avant DROP TABLE)

### Tests exécutés

- **Source-guards backend** : **58/58 ✅** (+6 vs P2.2) :
  - `market_price_canonical` (10, +6 P2.3)
  - `energy_orchestration_provenance` (42)
  - `frontend_no_business_calc` (3) — HELPER_WHITELIST stable à 2 entrées
  - `cdc_timezone_paris` (3)
- **Tests API endpoint Marché & exposition** : **27/27 ✅** — aucune régression
  - HTTP 200 site valide
  - Coût spot théorique calculé €
  - Prix spot pondéré sans division par zéro
  - Écart vs baseload + Top heures chères + Prix négatifs détectés
  - Score exposition borné [0,100]
  - Provenance complète par KPI

### Doctrine respectée

- ✅ Ne pas dropper la table `MarketPrice` legacy → conservée
- ✅ Ne pas supprimer migration Alembic existante → intact
- ✅ Ne pas casser `/api/energy/market-exposure` → 27/27 verts
- ✅ Ne pas modifier l'UI → 0 fichier frontend touché
- ✅ Ne pas modifier rail Énergie → backend-only
- ✅ Pas de migration destructive de données → aucune migration SQL
- ✅ Pas de nouvelle route → 0 endpoint modifié

### Dette restante

- Seed démo `backend/services/demo_seed/gen_market_prices.py` peuple encore la table legacy → cible migration P2.x avant DROP TABLE
- Table `market_prices` conservée en DB (préservation data) → cible DROP TABLE P3.x ou ultérieur après validation des 5 critères du rapport §8

### Rapport complet

`docs/audits/p2_3_market_price_legacy_2026_05_30.md` — 9 sections : audit + classification + migration + whitelist + source-guard + tests + risques + recommandation suppression future.

### Verdict GO/NO-GO pour P2.4

🟢 **GO P2.4 source-guard composant FE provenance visible obligatoire** :
- Migration `MarketPrice` durcie sans impact applicatif
- Aucun blocant identifié pour démarrer le source-guard FE provenance visible

### Refs

- P1.S2d — création modèle canonique `MktPrice` + endpoint market-exposure
- P1.S6 — UI Marché & exposition (consomme `MktPrice` via API)
- P1.S7 — source-guard `market_price_canonical` initial
- **P2.3 (ce sprint) — durcissement migration MarketPrice legacy**
- P2.4 (next) — source-guard composant FE provenance visible obligatoire

🤖 Generated with [Claude Code](https://claude.com/claude-code)