### PR TITLE
chore(energie-p2-4): ajouter source-guard provenance frontend

### DIFF
--- a/backend/tests/source_guards/test_frontend_energy_provenance_visible_source_guard.py
+++ b/backend/tests/source_guards/test_frontend_energy_provenance_visible_source_guard.py
@@ -1,0 +1,267 @@
+"""
+PROMEOS — Source-guard : provenance visible obligatoire côté frontend Énergie.
+
+Sprint Énergie P2.4 (2026-05-30).
+
+Doctrine traçabilité étendue P1.S7 → P2.4 :
+- P1.S7 a livré couverture provenance 100 % KPI (backend + frontend) via
+  `EnergyProvenanceCoverage.test.jsx` (16 tests vitest) +
+  `TestProvenanceCoveragePolishP1S7` (+17 tests pytest schémas Pydantic).
+- P2.4 ajoute ce source-guard STATIQUE Python qui scanne tous les
+  composants `frontend/src/ui/energy/*.jsx` et vérifie qu'un composant
+  qui accepte une prop métier (kpi, kpis, scenario, scenarios, simulation,
+  priceDecomposition, topExpensiveHours, favorableHours,
+  baseloadComparison, matrix, points avec provenance backend) rend AU
+  MOINS un marqueur provenance visible.
+
+Marqueurs acceptés :
+- `KpiCardWithProvenance` (composant canonique délégation)
+- `data-testid="*-provenance*"` ou contenant le mot `provenance`
+- `ScenarioProvenanceDot` / `SimulationProvenanceDot` (composants dédiés)
+- `aria-label` contenant `provenance` ou `Provenance`
+- usage explicite de `provenance.source` ou `provenance.formula`
+- whitelist explicite documentée (non-KPI, navigation, EmptyState pure)
+
+Tout composant qui :
+- accepte une prop métier listée
+- ET ne rend AUCUN marqueur
+- ET n'est pas dans la whitelist
+
+→ FAIT ÉCHOUER ce guard avec message d'erreur explicite.
+
+Doctrine : retirer de la WHITELIST dès qu'un composant peut rendre
+visible sa provenance (correction minimale : ajouter testid + texte
+sobre dans un footer).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ENERGY_UI = REPO_ROOT / "frontend" / "src" / "ui" / "energy"
+
+
+# Props qui DÉCLENCHENT l'obligation d'un marqueur provenance.
+# Tous ces noms correspondent à des structures backend qui exposent
+# `provenance` (cf. schémas Pydantic /api/energy/*).
+METIER_PROPS = (
+    "kpi",
+    "kpis",
+    "scenarios",
+    "simulation",
+    "priceDecomposition",
+    "topExpensiveHours",
+    "favorableHours",
+    "baseloadComparison",
+    "activeContract",
+    "topPeaks",
+)
+
+
+# Marqueurs provenance reconnus (regex compilées).
+PROVENANCE_MARKERS = [
+    re.compile(r"KpiCardWithProvenance"),
+    re.compile(r'data-testid=["\'][^"\']*provenance[^"\']*["\']', re.IGNORECASE),
+    re.compile(r"ScenarioProvenanceDot"),
+    re.compile(r"SimulationProvenanceDot"),
+    re.compile(r"ProvenanceTooltip"),
+    re.compile(r"ProvenanceDot"),
+    re.compile(r"""aria-label=["'][^"']*[Pp]rovenance[^"']*["']"""),
+    re.compile(r"provenance\.source"),
+    re.compile(r"provenance\.formula"),
+    re.compile(r"provenance\.service"),
+]
+
+
+# WHITELIST — composants explicitement non-métier OU pure
+# layout/navigation. Chaque entrée DOIT documenter sa raison + cible
+# de suppression si dette réelle.
+NON_METIER_WHITELIST: dict[str, str] = {
+    "EnergyCrossLinks.jsx": (
+        "Composant de navigation pure (livré P1.S7, étendu P2.2). Accepte "
+        "uniquement `links` (array de {kind, to, label}) — aucune donnée "
+        "métier énergie. Pas de dette."
+    ),
+    "EnergyFilterBar.jsx": (
+        "Composant filtre UI pur (livré P1.S3a). Accepte `scope`, "
+        "`period`, `granularity`, `compare`, `display` — aucune donnée "
+        "métier énergie (les filtres pilotent les requêtes API). "
+        "Pas de dette."
+    ),
+    "SiteRequiredState.jsx": (
+        "EmptyState métier (livré P1.S6 fix UX scope). Accepte `title`, "
+        "`text`, `ctaLabel`, `onChooseSite` — aucune donnée KPI. "
+        "Pas de dette."
+    ),
+    "LoadCurveChart.jsx": (
+        "Composant chart Recharts pur (livré P1.S3a). Accepte `series` "
+        "(données points temporels) ; la provenance racine du payload "
+        "`/api/energy/loadcurve` est rendue par le parent `LoadCurveTab` "
+        "via les 4 KPI `KpiCardWithProvenance`. Pas de dette frontend ; "
+        "exposer provenance directement dans le chart = redondance UX."
+    ),
+    "TopPeaksTable.jsx": (
+        "Placeholder EmptyState « Top pics indisponible dans cette version » "
+        "(livré P1.S3a). L'API `/api/energy/loadcurve` n'expose pas encore "
+        "`top_peaks` côté backend. Cible : extension API backend (P3.x) "
+        "puis ajout marqueur provenance et retrait whitelist."
+    ),
+}
+
+
+def _iter_energy_components() -> list[Path]:
+    """Liste tous les composants Énergie à scanner."""
+    if not ENERGY_UI.exists():
+        return []
+    return sorted(ENERGY_UI.glob("*.jsx"))
+
+
+def _component_accepts_metier_prop(content: str) -> tuple[bool, list[str]]:
+    """Détecte si le composant accepte au moins une prop métier."""
+    detected: list[str] = []
+    # Cherche les destructurations du type `export default function X({ kpi, ... })`
+    # ou `function X({ provenance, ... })`.
+    # Pattern simple : nom de prop dans une déstructuration `{ ... }`.
+    for prop in METIER_PROPS:
+        # Match `{...prop,` ou `{ prop,` ou `{ prop }` ou `{...prop=`
+        pattern = re.compile(
+            rf"\b{re.escape(prop)}\b\s*(?:[,=}}]|\s*=\s*\[)",
+            re.MULTILINE,
+        )
+        if pattern.search(content):
+            detected.append(prop)
+    return bool(detected), detected
+
+
+def _component_renders_provenance_marker(content: str) -> tuple[bool, list[str]]:
+    """Détecte si le composant rend au moins un marqueur provenance."""
+    matched: list[str] = []
+    for pattern in PROVENANCE_MARKERS:
+        if pattern.search(content):
+            matched.append(pattern.pattern[:60])
+    return bool(matched), matched
+
+
+class TestFrontendEnergyProvenanceVisible:
+    """Sprint Énergie P2.4 — provenance visible obligatoire frontend.
+
+    Garde-fou statique : tout composant `frontend/src/ui/energy/*.jsx`
+    qui accepte une prop métier doit rendre au moins un marqueur
+    provenance, sauf entrée explicite WHITELIST.
+    """
+
+    def test_energy_ui_directory_exists(self):
+        """Sanity check : le dossier composants Énergie existe."""
+        assert ENERGY_UI.exists(), f"frontend/src/ui/energy/ introuvable : {ENERGY_UI}"
+
+    def test_at_least_one_energy_component_present(self):
+        """Sanity check : au moins 10 composants attendus."""
+        files = _iter_energy_components()
+        assert len(files) >= 10, (
+            f"Moins de 10 composants Énergie trouvés ({len(files)}) — régression de l'arborescence ui/energy/ probable."
+        )
+
+    def test_all_metier_components_render_provenance_marker(self):
+        """Tout composant métier rend ≥ 1 marqueur provenance ou est whitelisté."""
+        violations: list[str] = []
+        for path in _iter_energy_components():
+            name = path.name
+            content = path.read_text(encoding="utf-8")
+
+            # Skip whitelist
+            if name in NON_METIER_WHITELIST:
+                continue
+
+            # Accepte une prop métier ?
+            accepts_metier, detected_props = _component_accepts_metier_prop(content)
+            if not accepts_metier:
+                # Pas de prop métier → ce composant pourrait être whitelistable
+                # mais on tolère silencieusement (peut-être un wrapper).
+                continue
+
+            # Rend un marqueur provenance ?
+            renders_marker, matched_markers = _component_renders_provenance_marker(content)
+            if not renders_marker:
+                violations.append(f"  {name} accepte {detected_props} mais ne rend AUCUN marqueur provenance visible.")
+
+        if violations:
+            msg = (
+                "\n\n🔴 P2.4 — Composants Énergie sans provenance visible :\n\n"
+                + "\n".join(violations)
+                + "\n\nAction : ajouter un marqueur provenance — soit\n"
+                "  - `KpiCardWithProvenance` ou autre composant délégation ;\n"
+                '  - `data-testid="*-provenance"` + texte sobre rendu ;\n'
+                "  - `ScenarioProvenanceDot` / `SimulationProvenanceDot` ;\n"
+                "  - `aria-label` Provenance ;\n"
+                "  - usage explicite `provenance.source` / `provenance.formula`.\n"
+                "\nSi composant légitimement sans provenance (filtre, EmptyState, "
+                "navigation pure) : ajouter à NON_METIER_WHITELIST avec justification.\n"
+            )
+            pytest.fail(msg)
+
+    def test_whitelist_entries_exist_on_disk(self):
+        """Toute entrée whitelist correspond à un fichier réel."""
+        for name in NON_METIER_WHITELIST:
+            path = ENERGY_UI / name
+            assert path.exists(), (
+                f"WHITELIST entry '{name}' référence un fichier inexistant : {path}. "
+                "Retirer l'entrée si le composant a été supprimé."
+            )
+
+    def test_whitelist_entries_have_justification(self):
+        """Toute entrée whitelist a une justification non vide."""
+        for name, reason in NON_METIER_WHITELIST.items():
+            assert reason and reason.strip(), f"WHITELIST entry '{name}' a une justification vide."
+            assert len(reason) >= 50, (
+                f"WHITELIST entry '{name}' justification trop courte "
+                f"({len(reason)} chars) — documenter le pourquoi + cible "
+                "de suppression."
+            )
+
+    def test_whitelisted_components_explicitly_dont_accept_kpi_provenance(self):
+        """Les composants whitelistés ne doivent pas accepter `provenance` ou `kpi`
+        en prop (cohérence avec la justification non-métier)."""
+        ALLOW_PROP = {"LoadCurveChart.jsx", "TopPeaksTable.jsx"}
+        for name in NON_METIER_WHITELIST:
+            if name in ALLOW_PROP:
+                # Ces composants reçoivent des données métier mais ont une
+                # raison documentée (chart pur, placeholder).
+                continue
+            path = ENERGY_UI / name
+            content = path.read_text(encoding="utf-8")
+            # `provenance` ou `kpi/kpis` ne doivent pas apparaître en
+            # déstructuration de props pour les composants non-métier purs.
+            for prop in ("kpi", "kpis", "provenance"):
+                pattern = re.compile(rf"\b{prop}\b\s*[,=}}]", re.MULTILINE)
+                if pattern.search(content):
+                    pytest.fail(
+                        f"🔴 P2.4 — {name} est whitelisté comme non-métier "
+                        f"mais accepte la prop `{prop}`. "
+                        "Soit corriger la justification, soit retirer de la "
+                        "whitelist + ajouter un marqueur provenance."
+                    )
+
+    def test_canonical_kpi_card_with_provenance_renders_5_axes(self):
+        """`KpiCardWithProvenance` rend les 5 axes provenance canoniques."""
+        path = ENERGY_UI / "KpiCardWithProvenance.jsx"
+        content = path.read_text(encoding="utf-8")
+        for axis in ("Source", "Service", "Formule", "Période", "Confiance"):
+            assert axis in content, (
+                f"KpiCardWithProvenance.jsx ne rend pas l'axe canonique « {axis} ». Régression P1.S7."
+            )
+
+    def test_p2_4_corrected_favorable_hours_panel(self):
+        """Sprint P2.4 — FavorableHoursPanel expose désormais un marqueur provenance."""
+        path = ENERGY_UI / "FavorableHoursPanel.jsx"
+        content = path.read_text(encoding="utf-8")
+        assert "favorable-hours-provenance" in content, (
+            'FavorableHoursPanel.jsx doit exposer data-testid="favorable-hours-provenance" (correction P2.4).'
+        )

--- a/docs/audits/p2_4_frontend_provenance_guard_2026_05_30.md
+++ b/docs/audits/p2_4_frontend_provenance_guard_2026_05_30.md
@@ -1,0 +1,140 @@
+# Sprint Énergie P2.4 — Source-guard FE provenance visible (rapport)
+
+**Date** : 2026-05-30
+**Sprint** : P2.4 — Source-guard statique frontend Énergie provenance visible obligatoire
+**Branche** : `claude/energie-p2-4-fe-provenance-guard` depuis `6fd30492`
+**Périmètre** : backend (source-guard) + 1 correction frontend (FavorableHoursPanel)
+
+## 1. Composants audités (15 composants `frontend/src/ui/energy/*.jsx`)
+
+| Composant | Type | Props détectées | Provenance rendue | Statut |
+|---|---|---|---|---|
+| KpiCardWithProvenance.jsx | KPI card | provenance, value, label | `kpi-provenance-tooltip` + 5 axes canoniques | ✅ canonique |
+| MonitoringSynthesisStrip.jsx | wrapper KPI | scope, period, compare | délègue à KpiCardWithProvenance ×10 | ✅ OK |
+| LoadCurveChart.jsx | chart Recharts | series, display, granularity | provenance racine rendue par parent | ✅ whitelist (chart pur) |
+| TopPeaksTable.jsx | placeholder | points (null actuellement) | API top_peaks pas encore exposé | ✅ whitelist (cible P3.x) |
+| WeekProfileHeatmap.jsx | heatmap | matrix, provenance | `heatmap-provenance` | ✅ OK |
+| CostVsContractCard.jsx | scénarios | scenarios, recommendation, activeContract | `scenario-provenance` (ScenarioProvenanceDot) | ✅ OK |
+| PriceDecompositionTable.jsx | table prix | priceDecomposition | `price-component-provenance` | ✅ OK |
+| ExposureScoreGauge.jsx | KPI gauge | score, state, provenance | `exposure-score-provenance` | ✅ OK |
+| TopExpensiveHoursTable.jsx | table heures | topExpensiveHours | `top-hour-provenance` | ✅ OK |
+| **FavorableHoursPanel.jsx** | **liste métier** | **favorableHours** | **❌ AVANT P2.4 : aucun marqueur** | **🔧 corrigé P2.4** |
+| BaseloadComparisonCard.jsx | KPI baseload | baseloadComparison | `baseload-provenance` | ✅ OK |
+| DisplacementSimulationCard.jsx | simulation | simulation | `simulation-provenance` (SimulationProvenanceDot) | ✅ OK |
+| EnergyCrossLinks.jsx | navigation | links | non-KPI | ✅ whitelist |
+| SiteRequiredState.jsx | EmptyState | title, text, ctaLabel | non-KPI | ✅ whitelist |
+| EnergyFilterBar.jsx | filtre UI | filters | non-KPI | ✅ whitelist |
+
+## 2. Composants couverts (12 sur 15)
+
+**10 composants métier** avec marqueur provenance visible :
+- KpiCardWithProvenance (canonique + 5 axes)
+- MonitoringSynthesisStrip (délégation)
+- WeekProfileHeatmap (`heatmap-provenance`)
+- CostVsContractCard (`scenario-provenance` × 4 scénarios)
+- PriceDecompositionTable (`price-component-provenance` par composante)
+- ExposureScoreGauge (`exposure-score-provenance`)
+- TopExpensiveHoursTable (`top-hour-provenance` par heure)
+- BaseloadComparisonCard (`baseload-provenance`)
+- DisplacementSimulationCard (`simulation-provenance`)
+- FavorableHoursPanel (`favorable-hours-provenance` — **ajouté P2.4**)
+
+**2 composants** délégant la provenance à un parent ou ayant une donnée non métier :
+- LoadCurveChart (chart pur, provenance rendue par parent via KpiCardWithProvenance)
+- TopPeaksTable (placeholder en attente API)
+
+**3 composants non-métier** explicitement whitelistés :
+- EnergyCrossLinks (navigation pure)
+- SiteRequiredState (EmptyState métier)
+- EnergyFilterBar (filtre UI)
+
+## 3. Whitelist finale (5 entrées documentées)
+
+`NON_METIER_WHITELIST` dans `backend/tests/source_guards/test_frontend_energy_provenance_visible_source_guard.py` :
+
+| Fichier | Raison | Cible suppression |
+|---|---|---|
+| `EnergyCrossLinks.jsx` | Composant navigation pure (P1.S7 + P2.2), prop `links` non métier | Pas de dette |
+| `EnergyFilterBar.jsx` | Composant filtre UI pur (P1.S3a), props filtres pilotent les requêtes API | Pas de dette |
+| `SiteRequiredState.jsx` | EmptyState métier (P1.S6 fix UX), aucune donnée KPI | Pas de dette |
+| `LoadCurveChart.jsx` | Chart Recharts pur (P1.S3a), provenance rendue par parent `LoadCurveTab` via KpiCardWithProvenance | Pas de dette frontend ; rendre provenance dans chart = redondance UX |
+| `TopPeaksTable.jsx` | Placeholder « Top pics indisponible » (P1.S3a), API `top_peaks` pas encore exposé | Cible P3.x : extension API backend + ajout marqueur + retrait whitelist |
+
+## 4. Corrections minimales (1 fichier)
+
+### `frontend/src/ui/energy/FavorableHoursPanel.jsx`
+
+**AVANT P2.4** : composant rendait les 3 groupes catégorisés (« prix bas » / « prix négatif » / « heure solaire ») avec leurs heures mais **aucun marqueur provenance** alors que chaque `EnergyFavorableHour` backend porte `provenance` (cf. P1.S6).
+
+**P2.4 — correction minimale** (3 lignes ajoutées en pied de panel) :
+
+```jsx
+// Marqueur provenance visible (source-guard statique).
+// Toutes les heures favorables partagent la même provenance backend.
+const commonProvenance = favorableHours[0]?.provenance;
+// ... (rendu groupes) ...
+{commonProvenance?.service && (
+  <p
+    className="text-[9px] text-gray-400 font-mono italic"
+    data-testid="favorable-hours-provenance"
+    aria-label={`Provenance : ${commonProvenance.service}`}
+  >
+    Source : {commonProvenance.service}
+  </p>
+)}
+```
+
+**Impact visuel** : 1 ligne discrète en bas du panel, taille `text-[9px]`, gris clair italique, format `Source : market_exposure._compute_favorable_hours`. Conforme au brief P2.4 (« ajout invisible/inoffensif »).
+
+**Aucun calcul métier** ajouté — lecture pure de la provenance backend depuis `favorableHours[0].provenance`.
+
+## 5. Tests exécutés
+
+| Suite | Résultat |
+|---|---|
+| `pytest tests/source_guards/test_frontend_energy_provenance_visible_source_guard.py -v` | **8/8 ✅** (nouveau) |
+| `pytest tests/source_guards/ -k "frontend_no_business or energy_orchestration or market_price or cdc_timezone or frontend_energy_provenance"` | **66/66 ✅** (+8 vs P2.3) |
+| `vitest src/__tests__/EnergyProvenanceCoverage.test.jsx` | **31/31 ✅** (+15 vs P1.S7 — section P2.4 ajoutée) |
+| `vitest src/__tests__/` (full suite frontend) | **1951/1951 ✅** (+15 vs P2.3, 3 skipped) |
+| `playwright p1_energy_final_smoke.spec.js` | **7/7 ✅** (8.3 s) — aucune régression sur 5 vues brique Énergie |
+
+### Détails source-guard P2.4 (8 tests)
+
+1. `test_energy_ui_directory_exists` — sanity check
+2. `test_at_least_one_energy_component_present` — au moins 10 composants
+3. `test_all_metier_components_render_provenance_marker` — règle principale (15 composants scannés)
+4. `test_whitelist_entries_exist_on_disk` — pas d'entrée orpheline
+5. `test_whitelist_entries_have_justification` — justification ≥ 50 chars
+6. `test_whitelisted_components_explicitly_dont_accept_kpi_provenance` — cohérence whitelist
+7. `test_canonical_kpi_card_with_provenance_renders_5_axes` — 5 axes canoniques (Source / Service / Formule / Période / Confiance)
+8. `test_p2_4_corrected_favorable_hours_panel` — vérifie la correction P2.4 spécifique
+
+## 6. Risques restants
+
+| Risque | Sévérité | Mitigation |
+|---|---|---|
+| Détection prop métier basée sur regex de déstructuration — un composant peut accepter une prop sans utiliser le pattern reconnu | Faible | Whitelist explicite documentée + tests vitest complémentaires sur composants nommés |
+| Faux négatif sur composant qui rend `data-testid` provenance dans un sous-composant non détecté par regex | Faible | Whitelist `LoadCurveChart` documente ce cas (provenance déléguée au parent) |
+| Évolution future : nouveau composant Énergie créé sans provenance visible | Géré | Le guard scanne automatiquement tous les `*.jsx` de `ui/energy/` ; doit être à jour pour tout nouveau composant (CI feedback immédiat) |
+| Whitelist `TopPeaksTable` dette résiduelle | Moyenne | Cible P3.x : extension API `/api/energy/loadcurve.top_peaks` puis ajout marqueur provenance + retrait whitelist |
+
+## 7. Recommandation P2.5
+
+**P2.5 — Audit bundle size brique Énergie** :
+- 12 composants UI Énergie + 5 Tabs lazy-loaded
+- Cible : ≤ 250 kB gzipped par route
+- Mesurer : `frontend/src/pages/{MonitoringPage, consumption/LoadCurveTab, consumption/CostContractTab, consumption/MarketExposureTab, usages/WeekProfileTab}.jsx` après lazy load
+- Outils suggérés : `vite-bundle-visualizer` + `source-map-explorer`
+- Si dépassement : split + dynamic import des composants UI lourds (Recharts, Lucide-react)
+
+**Prérequis P2.5 validés** :
+- ✅ HELPER_WHITELIST FE à 2 entrées (P2.1)
+- ✅ Cross-links transverses 5/5 vues (P2.2)
+- ✅ MarketPrice legacy durcie (P2.3)
+- ✅ Source-guard FE provenance visible (P2.4)
+
+**Aucun blocant identifié** pour démarrer P2.5.
+
+---
+
+Rapport généré le 2026-05-30 dans le cadre du sprint P2.4.

--- a/frontend/src/__tests__/EnergyProvenanceCoverage.test.jsx
+++ b/frontend/src/__tests__/EnergyProvenanceCoverage.test.jsx
@@ -116,3 +116,75 @@ describe('Provenance coverage — état confidenceDisplay P2.1 (déplacement eff
     expect(src).not.toContain('confidenceDisplay');
   });
 });
+
+describe('Sprint P2.4 — Provenance visible obligatoire (extension P1.S7)', () => {
+  it('FavorableHoursPanel expose désormais data-testid="favorable-hours-provenance"', () => {
+    const src = readSrc('../ui/energy/FavorableHoursPanel.jsx');
+    expect(src).toContain('data-testid="favorable-hours-provenance"');
+    expect(src).toMatch(/aria-label=\{[^}]*[Pp]rovenance/);
+  });
+
+  it('CostVsContractCard scenarios — ScenarioProvenanceDot exposé', () => {
+    const src = readSrc('../ui/energy/CostVsContractCard.jsx');
+    expect(src).toContain('ScenarioProvenanceDot');
+    expect(src).toContain('data-testid="scenario-provenance"');
+  });
+
+  it('DisplacementSimulationCard — SimulationProvenanceDot exposé', () => {
+    const src = readSrc('../ui/energy/DisplacementSimulationCard.jsx');
+    expect(src).toContain('SimulationProvenanceDot');
+    expect(src).toContain('data-testid="simulation-provenance"');
+  });
+
+  const METIER_COMPONENTS_WITH_PROVENANCE = [
+    { file: '../ui/energy/BaseloadComparisonCard.jsx', testid: 'baseload-provenance' },
+    { file: '../ui/energy/CostVsContractCard.jsx', testid: 'scenario-provenance' },
+    { file: '../ui/energy/DisplacementSimulationCard.jsx', testid: 'simulation-provenance' },
+    { file: '../ui/energy/ExposureScoreGauge.jsx', testid: 'exposure-score-provenance' },
+    { file: '../ui/energy/FavorableHoursPanel.jsx', testid: 'favorable-hours-provenance' },
+    { file: '../ui/energy/PriceDecompositionTable.jsx', testid: 'price-component-provenance' },
+    { file: '../ui/energy/TopExpensiveHoursTable.jsx', testid: 'top-hour-provenance' },
+    { file: '../ui/energy/WeekProfileHeatmap.jsx', testid: 'heatmap-provenance' },
+  ];
+
+  for (const { file, testid } of METIER_COMPONENTS_WITH_PROVENANCE) {
+    it(`${file.split('/').pop()} expose data-testid="${testid}"`, () => {
+      const src = readSrc(file);
+      expect(src).toContain(`data-testid="${testid}"`);
+    });
+  }
+
+  it('KpiCardWithProvenance reste le composant canonique délégation', () => {
+    const tabsAndStrips = [
+      '../ui/energy/MonitoringSynthesisStrip.jsx',
+      '../pages/consumption/LoadCurveTab.jsx',
+      '../pages/usages/WeekProfileTab.jsx',
+      '../pages/consumption/CostContractTab.jsx',
+      '../pages/consumption/MarketExposureTab.jsx',
+    ];
+    for (const file of tabsAndStrips) {
+      const src = readSrc(file);
+      expect(src).toMatch(/import\s+KpiCardWithProvenance/);
+    }
+  });
+
+  const NON_METIER_WHITELIST = [
+    '../ui/energy/EnergyCrossLinks.jsx',
+    '../ui/energy/EnergyFilterBar.jsx',
+    '../ui/energy/SiteRequiredState.jsx',
+  ];
+
+  for (const file of NON_METIER_WHITELIST) {
+    it(`${file.split('/').pop()} (non-métier whitelist) n'accepte pas \`kpi\`/\`provenance\` en prop`, () => {
+      const src = readSrc(file);
+      // Vérifie que le composant ne déclare pas ces props (signature default function)
+      const exportMatch = src.match(/export\s+default\s+function\s+\w+\s*\(([^)]*)\)/);
+      if (exportMatch) {
+        const props = exportMatch[1];
+        expect(props).not.toMatch(/\bkpi\b/);
+        expect(props).not.toMatch(/\bkpis\b/);
+        expect(props).not.toMatch(/\bprovenance\b/);
+      }
+    });
+  }
+});

--- a/frontend/src/ui/energy/FavorableHoursPanel.jsx
+++ b/frontend/src/ui/energy/FavorableHoursPanel.jsx
@@ -89,6 +89,12 @@ export default function FavorableHoursPanel({
     hours: favorableHours.filter((h) => h.reason === reason),
   })).filter((g) => g.hours.length > 0);
 
+  // Sprint Énergie P2.4 — marqueur provenance visible (source-guard
+  // statique). Toutes les heures favorables partagent la même
+  // provenance backend (`market_exposure._compute_favorable_hours`).
+  // Exposée discrètement en pied de panel.
+  const commonProvenance = favorableHours[0]?.provenance;
+
   return (
     <div
       className={`rounded-xl border border-gray-200 bg-white p-4 space-y-3 ${className}`}
@@ -111,6 +117,15 @@ export default function FavorableHoursPanel({
           )}
         </div>
       ))}
+      {commonProvenance?.service && (
+        <p
+          className="text-[9px] text-gray-400 font-mono italic"
+          data-testid="favorable-hours-provenance"
+          aria-label={`Provenance : ${commonProvenance.service}`}
+        >
+          Source : {commonProvenance.service}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Sprint Énergie P2.4 — Source-guard FE provenance visible obligatoire

Source-guard statique Python qui scanne `frontend/src/ui/energy/*.jsx` et vérifie qu'un composant acceptant une prop métier rend AU MOINS un marqueur provenance visible. Extension P1.S7 (couverture provenance 100 % KPI) avec garde-fou automatique anti-régression.

### Récap final — DoD P2.4

| # | Critère | Statut |
|---|---|---|
| 1 | Composants audités | ✅ 15 composants `frontend/src/ui/energy/*.jsx` |
| 2 | Guard créé | ✅ `test_frontend_energy_provenance_visible_source_guard.py` (8 tests) |
| 3 | Whitelist finale documentée | ✅ 5 entrées avec justification ≥ 50 chars + cible suppression |
| 4 | Corrections frontend éventuelles | ✅ 1 fichier (`FavorableHoursPanel.jsx` +13 LoC marqueur provenance) |
| 5 | Tests exécutés | ✅ source-guards 66/66 + vitest 1951/1951 + Playwright 7/7 |
| 6 | Résultats | ✅ tout vert, aucune régression |
| 7 | Rapport créé | ✅ `docs/audits/p2_4_frontend_provenance_guard_2026_05_30.md` |

### Composants audités (15)

| Composant | Provenance | Statut P2.4 |
|---|---|---|
| KpiCardWithProvenance | `kpi-provenance-tooltip` + 5 axes | ✅ canonique |
| MonitoringSynthesisStrip | délègue à KpiCardWithProvenance | ✅ OK |
| WeekProfileHeatmap | `heatmap-provenance` | ✅ OK |
| CostVsContractCard | `scenario-provenance` (ScenarioProvenanceDot) | ✅ OK |
| PriceDecompositionTable | `price-component-provenance` | ✅ OK |
| ExposureScoreGauge | `exposure-score-provenance` | ✅ OK |
| TopExpensiveHoursTable | `top-hour-provenance` | ✅ OK |
| BaseloadComparisonCard | `baseload-provenance` | ✅ OK |
| DisplacementSimulationCard | `simulation-provenance` | ✅ OK |
| **FavorableHoursPanel** | **`favorable-hours-provenance`** | **🔧 corrigé P2.4** |
| LoadCurveChart | délégué au parent (chart pur) | whitelist |
| TopPeaksTable | API top_peaks pas encore exposé | whitelist (P3.x) |
| EnergyCrossLinks | navigation pure | whitelist non-métier |
| SiteRequiredState | EmptyState métier | whitelist non-métier |
| EnergyFilterBar | filtre UI pur | whitelist non-métier |

### Fichiers créés/modifiés

| Fichier | LoC | Statut |
|---|---|---|
| `backend/tests/source_guards/test_frontend_energy_provenance_visible_source_guard.py` | ~250 | nouveau (8 tests) |
| `frontend/src/ui/energy/FavorableHoursPanel.jsx` | +13 | correction P2.4 (marqueur provenance) |
| `frontend/src/__tests__/EnergyProvenanceCoverage.test.jsx` | +82 | section P2.4 (+15 tests) |
| `docs/audits/p2_4_frontend_provenance_guard_2026_05_30.md` | 7 sections | rapport |

Commit `1c02c739` — 4 fichiers, 494 insertions.

### Correction minimale FavorableHoursPanel

**AVANT P2.4** : composant rendait 3 groupes catégorisés (« prix bas » / « prix négatif » / « heure solaire ») mais **aucun marqueur provenance** alors que chaque `EnergyFavorableHour` backend porte `provenance` (cf. P1.S6).

**P2.4 correction** (3 lignes JSX en pied de panel) :
```jsx
const commonProvenance = favorableHours[0]?.provenance;
{commonProvenance?.service && (
  <p
    className="text-[9px] text-gray-400 font-mono italic"
    data-testid="favorable-hours-provenance"
    aria-label={`Provenance : ${commonProvenance.service}`}
  >
    Source : {commonProvenance.service}
  </p>
)}
```

Impact visuel discret (`text-[9px]` italique gris clair) conforme au brief P2.4 « ajout invisible/inoffensif ». **Aucun calcul métier ajouté**.

### Whitelist finale (5 entrées)

| Fichier | Raison | Cible suppression |
|---|---|---|
| `EnergyCrossLinks.jsx` | Navigation pure | Pas de dette |
| `EnergyFilterBar.jsx` | Filtre UI pur | Pas de dette |
| `SiteRequiredState.jsx` | EmptyState métier | Pas de dette |
| `LoadCurveChart.jsx` | Chart Recharts pur, provenance déléguée au parent | Pas de dette |
| `TopPeaksTable.jsx` | Placeholder API pas exposé | P3.x : extension `/api/energy/loadcurve.top_peaks` |

### Tests verts

- **Source-guards backend** : **66/66 ✅** (+8 vs P2.3)
  - `frontend_no_business_calc` (3) + `energy_orchestration_provenance` (42) + `market_price_canonical` (10) + `cdc_timezone_paris` (3) + **`frontend_energy_provenance_visible` (8, P2.4 nouveau)**
- **Vitest frontend** : **1951/1951 ✅** (+15 vs P2.3, 3 skipped pré-existants)
- **Playwright pack final P1** : **7/7 ✅** (8.3 s) — aucune régression sur 5 vues brique Énergie

### Doctrine respectée

- ✅ Aucune nouvelle vue / nouveau menu / nouvelle route top-level
- ✅ Aucun endpoint `/api/energy/*` modifié
- ✅ Aucun composant UI refondu (1 correction +13 LoC FavorableHoursPanel)
- ✅ Aucun calcul métier frontend ajouté
- ✅ Aucune modification visuelle volontaire (ajout discret marqueur)
- ✅ Whitelist documentée avec justification ≥ 50 chars + cible suppression

### Verdict GO/NO-GO pour P2.5

🟢 **GO P2.5 — Audit bundle size brique Énergie** :
- Source-guard FE provenance visible verrouille la doctrine traçabilité
- Aucune régression sur tests frontend + backend
- 4 prérequis P2.x validés (P2.1+P2.2+P2.3+P2.4)
- Aucun blocant identifié pour démarrer mesure bundle ≤ 250 kB gzipped/route

### Refs

- P1.S7 — couverture provenance 100 % KPI (frontend + backend)
- P2.1 — split MonitoringPage (HELPER_WHITELIST 3→2)
- P2.2 — cross-links transverses 5/5 vues
- P2.3 — migration MarketPrice legacy durcie
- **P2.4 (ce sprint) — source-guard FE provenance visible**
- P2.5 (next) — audit bundle size brique Énergie

🤖 Generated with [Claude Code](https://claude.com/claude-code)