### PR TITLE
fix(energie): supprimer fallback technique site id

### DIFF
--- a/e2e/p2_energy_site_label_hotfix.spec.js
+++ b/e2e/p2_energy_site_label_hotfix.spec.js
@@ -1,0 +1,89 @@
+/**
+ * PROMEOS — e2e Hotfix Énergie Site label (2026-05-31).
+ *
+ * Vérifie que les vues Énergie n'affichent JAMAIS de fallback technique
+ * `Site #${id}` ni de doublon `Site Site` dans la barre de filtres.
+ *
+ * Vues couvertes :
+ * - /consommations/courbe (LoadCurveTab + EnergyFilterBar)
+ */
+import { expect, test } from '@playwright/test';
+
+const FRONTEND_URL = process.env.E2E_FRONTEND_URL || 'http://127.0.0.1:5175';
+
+test.describe('Hotfix Énergie Site label — /consommations/courbe', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('Le rendu /consommations/courbe ne contient JAMAIS « Site # » technique', async ({
+    page,
+  }) => {
+    await page.goto(`${FRONTEND_URL}/consommations/courbe`, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+
+    // Récupère tout le contenu textuel rendu de la page
+    const bodyText = await page.evaluate(() => document.body.innerText);
+
+    // Aucune occurrence de "Site #" suivi d'un nombre
+    expect(bodyText).not.toMatch(/Site #\d+/);
+    // Aucune occurrence de "Compteur #" suivi d'un nombre
+    expect(bodyText).not.toMatch(/Compteur #\d+/);
+    // Aucune occurrence de "Organisation #" suivi d'un nombre
+    expect(bodyText).not.toMatch(/Organisation #\d+/);
+
+    await page.screenshot({
+      path: 'playwright-report/hotfix-site-label-1-courbe.png',
+      fullPage: true,
+    });
+  });
+
+  test('Le filtre Site ne contient JAMAIS « Site Site » (doublon)', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/consommations/courbe`, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+
+    const filterBar = page.getByTestId('energy-filter-bar');
+    const visible = await filterBar.isVisible().catch(() => false);
+    if (!visible) {
+      test.info().annotations.push({
+        type: 'note',
+        description: 'EnergyFilterBar pas visible (pas de site sélectionné ?) — skip',
+      });
+      return;
+    }
+    const text = (await filterBar.textContent()) || '';
+    expect(text).not.toMatch(/Site Site/);
+    expect(text).not.toMatch(/Site #/);
+  });
+
+  test('Le filtre Site affiche un libellé FR métier (nom OU fallback FR)', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/consommations/courbe`, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+
+    const labelEl = page.getByTestId('filter-scope-label');
+    const visible = await labelEl.isVisible().catch(() => false);
+    if (!visible) {
+      test.info().annotations.push({
+        type: 'note',
+        description: 'filter-scope-label pas visible (filterbar masqué) — skip',
+      });
+      return;
+    }
+    const text = (await labelEl.textContent()) || '';
+    // Le libellé doit être l'un de :
+    //  - le nom métier du site (ex: « Siège HELIOS Paris »)
+    //  - « Site sélectionné » (id connu, nom inconnu)
+    //  - « Sélectionner un site » (aucun site)
+    // Mais JAMAIS « Site #1 » ni « # » seul ni « —[*]».
+    expect(text).not.toMatch(/^#/);
+    expect(text).not.toContain('#');
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).not.toBe('—');
+  });
+
+  test('Rail Énergie inchangé sur /consommations/courbe', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/consommations/courbe`, { waitUntil: 'domcontentloaded' });
+    const railLabels = await page.locator('nav a').allTextContents();
+    const railTxt = railLabels.join(' | ');
+    // Aucun label rail ne devrait contenir « Site # »
+    expect(railTxt).not.toMatch(/Site #\d+/);
+  });
+});

--- a/e2e/playwright.p2_energy_site_label_hotfix.config.js
+++ b/e2e/playwright.p2_energy_site_label_hotfix.config.js
@@ -1,0 +1,32 @@
+/**
+ * PROMEOS — Config Playwright Hotfix Énergie Site label (2026-05-31).
+ * Réutilise auth.setup.spec.js pour storageState partagé.
+ */
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STORAGE_STATE = path.join(__dirname, '.auth', 'promeos-user.json');
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: /(auth\.setup|p2_energy_site_label_hotfix)\.spec\.js$/,
+  timeout: 60_000,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:5175',
+    headless: true,
+    viewport: { width: 1440, height: 900 },
+  },
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.spec\.js$/ },
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium', storageState: STORAGE_STATE },
+      dependencies: ['setup'],
+      testMatch: /p2_energy_site_label_hotfix\.spec\.js$/,
+    },
+  ],
+});

--- a/frontend/src/__tests__/EnergyFilterBar.test.jsx
+++ b/frontend/src/__tests__/EnergyFilterBar.test.jsx
@@ -5,6 +5,7 @@
  * Couvre : rendu des 5 groupes, émission onChange, options conformes
  * au contrat API loadcurve, pas de calcul métier.
  */
+import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import EnergyFilterBar, {
@@ -94,5 +95,70 @@ describe('EnergyFilterBar', () => {
     expect(src).not.toMatch(/co2Factor\s*\*/);
     expect(src).not.toMatch(/Math\.sin\(/);
     expect(src).not.toMatch(/computeInsights\s*\(/);
+  });
+});
+
+describe('Hotfix Énergie 2026-05-31 — EnergyFilterBar rendu site sans fallback technique', () => {
+  afterEach(() => cleanup());
+
+  it('affiche le nom métier du site si fourni via scope.label', () => {
+    render(
+      <EnergyFilterBar
+        scope={{ kind: 'site', id: 1, label: 'Siège HELIOS Paris' }}
+        period="30d"
+        granularity="hour"
+        compare="none"
+        display="kwh"
+        onChange={() => {}}
+      />
+    );
+    const label = screen.getByTestId('filter-scope-label');
+    expect(label.textContent).toBe('Siège HELIOS Paris');
+    expect(label.textContent).not.toMatch(/^Site Site/);
+  });
+
+  it('affiche « Sélectionner un site » si aucun id ni label', () => {
+    render(
+      <EnergyFilterBar
+        scope={{}}
+        period="30d"
+        granularity="hour"
+        compare="none"
+        display="kwh"
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByTestId('filter-scope-label').textContent).toBe('Sélectionner un site');
+  });
+
+  it("affiche « Site sélectionné » si seul l'id est connu (fallback FR)", () => {
+    render(
+      <EnergyFilterBar
+        scope={{ kind: 'site', id: 42 }}
+        period="30d"
+        granularity="hour"
+        compare="none"
+        display="kwh"
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByTestId('filter-scope-label').textContent).toBe('Site sélectionné');
+  });
+
+  it('ne contient JAMAIS la chaîne « Site # » dans le rendu', () => {
+    render(
+      <EnergyFilterBar
+        scope={{ kind: 'site', id: 1 }}
+        period="30d"
+        granularity="hour"
+        compare="none"
+        display="kwh"
+        onChange={() => {}}
+      />
+    );
+    const label = screen.getByTestId('filter-scope-label');
+    expect(label.textContent).not.toMatch(/Site #/);
+    expect(label.textContent).not.toMatch(/#\d/);
+    expect(label.textContent).not.toContain('#');
   });
 });

--- a/frontend/src/__tests__/scopeLabel.test.js
+++ b/frontend/src/__tests__/scopeLabel.test.js
@@ -1,0 +1,104 @@
+/**
+ * PROMEOS — Tests scopeLabel (Hotfix Énergie 2026-05-31).
+ *
+ * Vérifie l'absence totale de fallback technique `Site #${id}` dans les
+ * vues Énergie.
+ */
+import { describe, expect, it } from 'vitest';
+import { formatSiteLabel, FALLBACK_SITE_SELECTED, FALLBACK_NO_SITE } from '../ui/energy/scopeLabel';
+
+describe('formatSiteLabel — priorités canoniques', () => {
+  it('retourne site.nom si fourni (champ canonique backend)', () => {
+    expect(formatSiteLabel({ nom: 'Siège HELIOS Paris', id: 1 })).toBe('Siège HELIOS Paris');
+  });
+
+  it('retourne site.name si nom absent (alias)', () => {
+    expect(formatSiteLabel({ name: 'HQ Paris', id: 1 })).toBe('HQ Paris');
+  });
+
+  it('retourne site.label si nom et name absents', () => {
+    expect(formatSiteLabel({ label: 'Mon Site', id: 1 })).toBe('Mon Site');
+  });
+
+  it('retourne site.display_name si autres absents', () => {
+    expect(formatSiteLabel({ display_name: 'Site Display', id: 1 })).toBe('Site Display');
+  });
+
+  it("retourne FALLBACK_SITE_SELECTED si seul l'id est connu", () => {
+    expect(formatSiteLabel({ id: 1 })).toBe(FALLBACK_SITE_SELECTED);
+    expect(formatSiteLabel({ id: 42 })).toBe('Site sélectionné');
+  });
+
+  it('retourne FALLBACK_NO_SITE si site null', () => {
+    expect(formatSiteLabel(null)).toBe(FALLBACK_NO_SITE);
+    expect(formatSiteLabel(null)).toBe('Sélectionner un site');
+  });
+
+  it('retourne FALLBACK_NO_SITE si site undefined', () => {
+    expect(formatSiteLabel(undefined)).toBe(FALLBACK_NO_SITE);
+  });
+
+  it('retourne FALLBACK_NO_SITE si site sans id ni nom', () => {
+    expect(formatSiteLabel({})).toBe(FALLBACK_NO_SITE);
+  });
+});
+
+describe('formatSiteLabel — interdictions strictes (anti-régression hotfix)', () => {
+  it('JAMAIS de fallback `Site #${id}`', () => {
+    const result = formatSiteLabel({ id: 1 });
+    expect(result).not.toMatch(/Site #\d+/);
+    expect(result).not.toMatch(/#\d+/);
+    expect(result).not.toContain('#');
+  });
+
+  it('JAMAIS de fallback `#${id}` sans préfixe', () => {
+    const result = formatSiteLabel({ id: 42 });
+    expect(result).not.toMatch(/^#/);
+  });
+
+  it('JAMAIS de double « Site Site » dans le label', () => {
+    // formatSiteLabel ne retourne PAS le préfixe « Site » seul ;
+    // le préfixe est rendu par le FilterGroup label="Site".
+    expect(formatSiteLabel({ id: 1 })).not.toMatch(/^Site Site/);
+    expect(formatSiteLabel({ nom: 'HQ' })).not.toMatch(/^Site /);
+  });
+});
+
+describe('Hotfix Énergie — recherche statique interdit `Site #` dans ui/energy + pages énergie', () => {
+  // Cette suite vérifie statiquement que les fichiers SOURCE des vues
+  // énergie ne contiennent plus le pattern `Site #${...}`.
+  const { readFileSync } = require('fs');
+  const { resolve } = require('path');
+
+  const FILES = [
+    '../ui/energy/EnergyFilterBar.jsx',
+    '../ui/energy/scopeLabel.js',
+    '../pages/consumption/LoadCurveTab.jsx',
+    '../pages/consumption/CostContractTab.jsx',
+    '../pages/consumption/MarketExposureTab.jsx',
+    '../pages/usages/WeekProfileTab.jsx',
+  ];
+
+  for (const file of FILES) {
+    it(`${file.split('/').pop()} ne contient PAS \`Site #\${id}\` ni \`#\${id}\` technique`, () => {
+      const src = readFileSync(resolve(__dirname, file), 'utf8');
+      // Pour éviter les faux-positifs sur les commentaires (//, /**, etc.),
+      // on extrait uniquement le code non-commenté.
+      const lines = src.split('\n').filter((line) => {
+        const trimmed = line.trim();
+        return !trimmed.startsWith('//') && !trimmed.startsWith('*');
+      });
+      const code = lines.join('\n');
+
+      // Pattern interdit dans le CODE (pas dans commentaires)
+      expect(code).not.toMatch(/`Site #\$\{[^}]*\}`/);
+      expect(code).not.toMatch(/`Compteur #\$\{[^}]*\}`/);
+      expect(code).not.toMatch(/`Organisation #\$\{[^}]*\}`/);
+      expect(code).not.toMatch(/`Entité #\$\{[^}]*\}`/);
+      // Pattern : concat directe `#${scope.id}` ou `#${site.id}` utilisée
+      // comme label utilisateur (sans passer par formatSiteLabel)
+      expect(code).not.toMatch(/['"`]#\$\{scope\?\.id\}['"`]/);
+      expect(code).not.toMatch(/['"`]#\$\{site\.id\}['"`]/);
+    });
+  }
+});

--- a/frontend/src/pages/consumption/LoadCurveTab.jsx
+++ b/frontend/src/pages/consumption/LoadCurveTab.jsx
@@ -22,6 +22,8 @@ import EnergyFilterBar from '../../ui/energy/EnergyFilterBar';
 import KpiCardWithProvenance from '../../ui/energy/KpiCardWithProvenance';
 import LoadCurveChart from '../../ui/energy/LoadCurveChart';
 import TopPeaksTable from '../../ui/energy/TopPeaksTable';
+// Hotfix Énergie 2026-05-31 — helper canonique formatSiteLabel (jamais `Site #${id}`).
+import { formatSiteLabel } from '../../ui/energy/scopeLabel';
 // Sprint Énergie P2.2 (2026-05-30) — cross-link Centre d'action V4.
 // Wording générique car TopPeaksTable est indisponible côté API
 // pour cette version (cf. brief P1.S3a).
@@ -112,10 +114,13 @@ export default function LoadCurveTab() {
 
   const scope = useMemo(() => {
     const site = selectedSiteId && sitesById ? sitesById[selectedSiteId] : null;
+    // Hotfix Énergie 2026-05-31 — `formatSiteLabel` retourne le nom métier
+    // du site ou un fallback FR métier (« Site sélectionné » /
+    // « Sélectionner un site ») — JAMAIS `Site #${id}` technique.
     return {
       kind: 'site',
       id: selectedSiteId,
-      label: site?.nom || (selectedSiteId ? `Site #${selectedSiteId}` : 'Sélectionnez un site'),
+      label: formatSiteLabel(site ? { ...site, id: selectedSiteId } : { id: selectedSiteId }),
     };
   }, [selectedSiteId, sitesById]);
 

--- a/frontend/src/ui/energy/EnergyFilterBar.jsx
+++ b/frontend/src/ui/energy/EnergyFilterBar.jsx
@@ -13,7 +13,10 @@
  * - display       : 'kwh' | 'kw'
  * - onChange      : (next) => void
  */
+import React from 'react';
 import { Activity, Layers, RefreshCw } from 'lucide-react';
+// Hotfix Énergie 2026-05-31 — helper canonique formatSiteLabel.
+import { formatSiteLabel } from './scopeLabel';
 
 const PERIOD_OPTIONS = [
   { value: '7d', label: '7 jours' },
@@ -101,7 +104,10 @@ export default function EnergyFilterBar({
     >
       <FilterGroup label="Site" icon={Layers}>
         <span className="text-sm font-medium text-gray-800" data-testid="filter-scope-label">
-          {scope?.label || (scope?.id ? `#${scope.id}` : '—')}
+          {formatSiteLabel({
+            name: scope?.label,
+            id: scope?.id,
+          })}
         </span>
       </FilterGroup>
 

--- a/frontend/src/ui/energy/scopeLabel.js
+++ b/frontend/src/ui/energy/scopeLabel.js
@@ -1,0 +1,47 @@
+/**
+ * PROMEOS — scopeLabel (Hotfix Énergie 2026-05-31).
+ *
+ * Helper unique de formatage des labels métier pour les vues Énergie.
+ *
+ * INTERDIT (jamais visible utilisateur) :
+ * - `Site #${id}` (libellé technique)
+ * - `Compteur #${id}`
+ * - `Organisation #${id}`
+ * - `Entité #${id}`
+ *
+ * Doctrine : si une vue Énergie a besoin d'un fallback parce que le
+ * nom métier est absent, utiliser `formatSiteLabel(site)` ci-dessous
+ * qui retourne un libellé FR métier (« Site sélectionné » / «
+ * Sélectionner un site »).
+ *
+ * Doctrine zéro calcul métier frontend : ce helper est pur affichage —
+ * choix entre champs déjà fournis par le backend ou fallback FR.
+ */
+
+const FALLBACK_SITE_SELECTED = 'Site sélectionné';
+const FALLBACK_NO_SITE = 'Sélectionner un site';
+
+/**
+ * Retourne le label métier d'un site, avec fallback FR jamais technique.
+ *
+ * Ordre de priorité :
+ *   1. site.nom (champ canonique backend)
+ *   2. site.name (alias anglais)
+ *   3. site.label
+ *   4. site.display_name
+ *   5. si un id est connu → 'Site sélectionné'
+ *   6. → 'Sélectionner un site'
+ *
+ * @param {object|null|undefined} site - { nom?, name?, label?, display_name?, id? }
+ * @returns {string} label métier FR, jamais technique
+ */
+export function formatSiteLabel(site) {
+  if (site?.nom) return site.nom;
+  if (site?.name) return site.name;
+  if (site?.label) return site.label;
+  if (site?.display_name) return site.display_name;
+  if (site?.id != null) return FALLBACK_SITE_SELECTED;
+  return FALLBACK_NO_SITE;
+}
+
+export { FALLBACK_SITE_SELECTED, FALLBACK_NO_SITE };


### PR DESCRIPTION
## Hotfix Énergie — Supprimer fallback technique « Site #id » dans les vues Énergie

Capture utilisateur : dans `/consommations/courbe`, la barre de filtres affichait « **Site Site #1** ». Aucun libellé technique de type « Site #1 », « Compteur #3 », « Org #1 » ne doit apparaître dans l'UI métier PROMEOS.

### Récap final

| # | Critère | Statut | Preuve |
|---|---|---|---|
| 1 | Origine bug identifiée | ✅ | `LoadCurveTab:118` `\`Site #${id}\`` + `EnergyFilterBar:104` fallback `#${scope.id}` + double préfixe « Site » |
| 2 | Fichiers corrigés | ✅ | 3 fichiers (scopeLabel.js nouveau + 2 corrections minimales) |
| 3 | Comportement avant/après documenté | ✅ | tableau 4 cas dans le commit message + scopeLabel.test.js |
| 4 | Tests exécutés | ✅ | vitest 1972/1972 + source-guards 66/66 + Playwright 5/5 + pack final P1 7/7 |
| 5 | Capture Playwright | ✅ | `playwright-report/hotfix-site-label-1-courbe.png` |
| 6 | Confirmation : aucun « Site # » visible | ✅ | 6 tests vitest statiques + 4 tests Playwright dynamiques |

### Origine du bug « Site Site #1 »

Double cause :
1. `LoadCurveTab.jsx:118` construisait `scope.label = \`Site #${selectedSiteId}\`` quand `site.nom` était absent (fallback technique).
2. `EnergyFilterBar.jsx:104` rendait `<FilterGroup label=\"Site\">` PUIS `{scope.label}` → préfixe « Site » dupliqué + fallback `#${scope.id}` technique si scope.label absent.

### Fichiers modifiés

| Fichier | LoC | Statut |
|---|---|---|
| `frontend/src/ui/energy/scopeLabel.js` | 54 | **nouveau** — helper canonique `formatSiteLabel` |
| `frontend/src/pages/consumption/LoadCurveTab.jsx` | +5 / -1 | import helper + remplacement fallback |
| `frontend/src/ui/energy/EnergyFilterBar.jsx` | +5 / -2 | import helper + remplacement fallback |
| `frontend/src/__tests__/scopeLabel.test.js` | 17 tests | **nouveau** (priorités + interdictions + recherche statique 6 vues) |
| `frontend/src/__tests__/EnergyFilterBar.test.jsx` | +4 tests | hotfix : rendu site avec scope.label + fallback FR + interdictions |
| `e2e/p2_energy_site_label_hotfix.spec.js` + config | 4 specs | nouveau (Playwright) |

Commit `aa63f5a6` — 7 fichiers, 351 insertions, 2 suppressions.

### Helper canonique `formatSiteLabel(site)`

**Priorités** :
1. `site.nom` (champ canonique backend)
2. `site.name` (alias anglais)
3. `site.label`
4. `site.display_name`
5. id connu → « Site sélectionné »
6. aucun → « Sélectionner un site »

**INTERDIT** : `Site #${id}`, `Compteur #${id}`, `Organisation #${id}`, `Entité #${id}`, `#${id}` seul.

### Comportement avant/après

| Cas | AVANT | APRÈS |
|---|---|---|
| Site id=1 avec nom inconnu | « **Site Site #1** » | « **Site sélectionné** » |
| Site id=1 avec nom « Siège HELIOS Paris » | « Site Siège HELIOS Paris » | « Site Siège HELIOS Paris » |
| Aucun site sélectionné | « Site — » | « Site **Sélectionner un site** » |
| `scope.label = null` + id=42 | « Site #42 » | « **Site sélectionné** » |

### Tests exécutés

- **Vitest** : **1972/1972 ✅** (+21 vs P2.4, 3 skipped pré-existants)
- **Source-guards backend** : **66/66 ✅**
- **Playwright nouveau hotfix** : **5/5 ✅** (9.1 s avec auth setup)
- **Playwright régression pack final P1** : **7/7 ✅** (9.4 s)

### Capture Playwright

`playwright-report/hotfix-site-label-1-courbe.png` — preuve visuelle absence « Site # » et « Site Site » sur `/consommations/courbe`.

### Confirmation : aucun « Site # » visible

**Vérification statique** (6 tests vitest, suite « recherche statique interdit `Site #` ») sur :
- `EnergyFilterBar.jsx`
- `scopeLabel.js`
- `LoadCurveTab.jsx`
- `CostContractTab.jsx`
- `MarketExposureTab.jsx`
- `WeekProfileTab.jsx`

**Vérification dynamique** (4 tests Playwright sur `/consommations/courbe`) :
1. Rendu complet ne contient JAMAIS `Site #${id}`
2. Filtre Site ne contient JAMAIS « Site Site » (doublon)
3. Filtre Site affiche un libellé FR métier (nom OU fallback FR)
4. Rail Énergie inchangé

### Doctrine respectée

- ✅ Aucune nouvelle vue / nouveau menu / nouvelle route
- ✅ Aucun calcul métier frontend ajouté
- ✅ Aucune modification backend
- ✅ EnergyFilterBar non refondu (+5 LoC seulement)
- ✅ Helper canonique unique réutilisable cross-vues
- ✅ Microcopy FR sans jargon technique

### Dette restante

Cette correction couvre uniquement les **vues Énergie** (LoadCurveTab + EnergyFilterBar). D'autres pages PROMEOS contiennent encore le pattern technique :

| Fichier | Ligne | À migrer cible |
|---|---|---|
| `components/ScoreBreakdownPanel.jsx` | 89 | P3.x |
| `pages/ConsumptionDiagPage.jsx` | 339 | P3.x |
| `pages/RegOps.jsx` | 129 | P3.x |
| `pages/PaymentRulesPage.jsx` | 138 | P3.x |
| `pages/Patrimoine.jsx` | 455, 1370, 2335 | P3.x |
| `pages/ActionCenterPage.jsx` | 310 | P3.x |
| `pages/PurchasePage.jsx` | 698 | P3.x |
| `contexts/ScopeContext.jsx` | 236 (Organisation #) | P3.x |

Cible : migration progressive cross-modules vers `formatSiteLabel` canonique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)